### PR TITLE
Removed Result return type from new function of attribute

### DIFF
--- a/matter/src/data_model/cluster_basic_information.rs
+++ b/matter/src/data_model/cluster_basic_information.rs
@@ -60,43 +60,43 @@ impl BasicInfoCluster {
                 AttrValue::Uint8(1),
                 Access::RV,
                 Quality::FIXED,
-            )?,
+            ),
             Attribute::new(
                 Attributes::VendorId as u16,
                 AttrValue::Uint16(cfg.vid),
                 Access::RV,
                 Quality::FIXED,
-            )?,
+            ),
             Attribute::new(
                 Attributes::ProductId as u16,
                 AttrValue::Uint16(cfg.pid),
                 Access::RV,
                 Quality::FIXED,
-            )?,
+            ),
             Attribute::new(
                 Attributes::HwVer as u16,
                 AttrValue::Uint16(cfg.hw_ver),
                 Access::RV,
                 Quality::FIXED,
-            )?,
+            ),
             Attribute::new(
                 Attributes::SwVer as u16,
                 AttrValue::Uint32(cfg.sw_ver),
                 Access::RV,
                 Quality::FIXED,
-            )?,
+            ),
             Attribute::new(
                 Attributes::SwVerString as u16,
                 AttrValue::Utf8(cfg.sw_ver_str),
                 Access::RV,
                 Quality::FIXED,
-            )?,
+            ),
             Attribute::new(
                 Attributes::SerialNo as u16,
                 AttrValue::Utf8(cfg.serial_no),
                 Access::RV,
                 Quality::FIXED,
-            )?,
+            ),
         ];
         cluster.base.add_attributes(&attrs[..])?;
 

--- a/matter/src/data_model/cluster_media_playback.rs
+++ b/matter/src/data_model/cluster_media_playback.rs
@@ -136,46 +136,46 @@ impl MediaPlaybackCluster {
                 AttrValue::Uint8(PlaybackState::NotPlaying as u8),
                 Access::RV,
                 Quality::PERSISTENT,
-            )?,
+            ),
             // epoch-us
             Attribute::new(
                 Attributes::StartTime as u16,
                 AttrValue::Uint64(0),
                 Access::RV,
                 Quality::PERSISTENT,
-            )?,
+            ),
             Attribute::new(
                 Attributes::Duration as u16,
                 AttrValue::Uint64(1),
                 Access::RV,
                 Quality::PERSISTENT,
-            )?,
+            ),
             // Playback-Position
             Attribute::new(
                 Attributes::SampledPosition as u16,
                 AttrValue::Custom,
                 Access::RV,
                 Quality::PERSISTENT,
-            )?,
+            ),
             // Float
             Attribute::new(
                 Attributes::PlaybackSpeed as u16,
                 AttrValue::Custom,
                 Access::RV,
                 Quality::PERSISTENT,
-            )?,
+            ),
             Attribute::new(
                 Attributes::SeekRangeEnd as u16,
                 AttrValue::Uint64(0),
                 Access::RV,
                 Quality::PERSISTENT,
-            )?,
+            ),
             Attribute::new(
                 Attributes::SeekRangeStart as u16,
                 AttrValue::Uint64(0),
                 Access::RV,
                 Quality::PERSISTENT,
-            )?,
+            ),
             // Options - probably want a custom type here for mapping cluster options to TLV bitmask
         ];
         cluster.base.add_attributes(&attrs)?;

--- a/matter/src/data_model/cluster_on_off.rs
+++ b/matter/src/data_model/cluster_on_off.rs
@@ -37,7 +37,7 @@ pub enum Commands {
     Toggle = 0x02,
 }
 
-fn attr_on_off_new() -> Result<Attribute, Error> {
+fn attr_on_off_new() -> Attribute {
     // OnOff, Value: false
     Attribute::new(
         Attributes::OnOff as u16,
@@ -56,7 +56,7 @@ impl OnOffCluster {
         let mut cluster = Box::new(OnOffCluster {
             base: Cluster::new(ID)?,
         });
-        cluster.base.add_attribute(attr_on_off_new()?)?;
+        cluster.base.add_attribute(attr_on_off_new())?;
         Ok(cluster)
     }
 }

--- a/matter/src/data_model/objects/attribute.rs
+++ b/matter/src/data_model/objects/attribute.rs
@@ -171,12 +171,7 @@ impl Default for Attribute {
 }
 
 impl Attribute {
-    pub fn new(
-        id: u16,
-        value: AttrValue,
-        access: Access,
-        quality: Quality,
-    ) -> Self {
+    pub fn new(id: u16, value: AttrValue, access: Access, quality: Quality) -> Self {
         Attribute {
             id,
             value,

--- a/matter/src/data_model/objects/attribute.rs
+++ b/matter/src/data_model/objects/attribute.rs
@@ -176,13 +176,13 @@ impl Attribute {
         value: AttrValue,
         access: Access,
         quality: Quality,
-    ) -> Result<Attribute, Error> {
-        Ok(Attribute {
+    ) -> Self {
+        Attribute {
             id,
             value,
             access,
             quality,
-        })
+        }
     }
 
     pub fn set_value(&mut self, value: AttrValue) -> Result<(), Error> {

--- a/matter/src/data_model/objects/cluster.rs
+++ b/matter/src/data_model/objects/cluster.rs
@@ -139,14 +139,14 @@ impl Cluster {
             AttrValue::Uint32(0),
             Access::RV,
             Quality::NONE,
-        )?)?;
+        ))?;
 
         self.add_attribute(Attribute::new(
             GlobalElements::AttributeList as u16,
             AttrValue::Custom,
             Access::RV,
             Quality::NONE,
-        )?)
+        ))
     }
 
     pub fn add_attributes(&mut self, attrs: &[Attribute]) -> Result<(), Error> {

--- a/matter/src/data_model/sdm/admin_commissioning.rs
+++ b/matter/src/data_model/sdm/admin_commissioning.rs
@@ -48,7 +48,7 @@ pub enum Commands {
     RevokeComm = 0x02,
 }
 
-fn attr_window_status_new() -> Result<Attribute, Error> {
+fn attr_window_status_new() -> Attribute {
     Attribute::new(
         Attributes::WindowStatus as u16,
         AttrValue::Custom,
@@ -57,7 +57,7 @@ fn attr_window_status_new() -> Result<Attribute, Error> {
     )
 }
 
-fn attr_admin_fabid_new() -> Result<Attribute, Error> {
+fn attr_admin_fabid_new() -> Attribute {
     Attribute::new(
         Attributes::AdminFabricIndex as u16,
         AttrValue::Custom,
@@ -66,7 +66,7 @@ fn attr_admin_fabid_new() -> Result<Attribute, Error> {
     )
 }
 
-fn attr_admin_vid_new() -> Result<Attribute, Error> {
+fn attr_admin_vid_new() -> Attribute {
     Attribute::new(
         Attributes::AdminVendorId as u16,
         AttrValue::Custom,
@@ -129,9 +129,9 @@ impl AdminCommCluster {
             pase_mgr,
             base: Cluster::new(ID)?,
         });
-        c.base.add_attribute(attr_window_status_new()?)?;
-        c.base.add_attribute(attr_admin_fabid_new()?)?;
-        c.base.add_attribute(attr_admin_vid_new()?)?;
+        c.base.add_attribute(attr_window_status_new())?;
+        c.base.add_attribute(attr_admin_fabid_new())?;
+        c.base.add_attribute(attr_admin_vid_new())?;
         Ok(c)
     }
 

--- a/matter/src/data_model/sdm/general_commissioning.rs
+++ b/matter/src/data_model/sdm/general_commissioning.rs
@@ -165,9 +165,8 @@ impl GenCommCluster {
         c.base
             .add_attribute(attr_reg_config_new(RegLocationType::IndoorOutdoor))?;
         // TODO: Arch-Specific
-        c.base.add_attribute(attr_location_capability_new(
-            RegLocationType::IndoorOutdoor,
-        ))?;
+        c.base
+            .add_attribute(attr_location_capability_new(RegLocationType::IndoorOutdoor))?;
         c.base.add_attribute(attr_comm_info_new())?;
 
         Ok(c)

--- a/matter/src/data_model/sdm/general_commissioning.rs
+++ b/matter/src/data_model/sdm/general_commissioning.rs
@@ -62,7 +62,7 @@ pub enum RegLocationType {
     IndoorOutdoor = 2,
 }
 
-fn attr_bread_crumb_new(bread_crumb: u64) -> Result<Attribute, Error> {
+fn attr_bread_crumb_new(bread_crumb: u64) -> Attribute {
     Attribute::new(
         Attributes::BreadCrumb as u16,
         AttrValue::Uint64(bread_crumb),
@@ -71,7 +71,7 @@ fn attr_bread_crumb_new(bread_crumb: u64) -> Result<Attribute, Error> {
     )
 }
 
-fn attr_reg_config_new(reg_config: RegLocationType) -> Result<Attribute, Error> {
+fn attr_reg_config_new(reg_config: RegLocationType) -> Attribute {
     Attribute::new(
         Attributes::RegConfig as u16,
         AttrValue::Uint8(reg_config as u8),
@@ -80,7 +80,7 @@ fn attr_reg_config_new(reg_config: RegLocationType) -> Result<Attribute, Error> 
     )
 }
 
-fn attr_location_capability_new(reg_config: RegLocationType) -> Result<Attribute, Error> {
+fn attr_location_capability_new(reg_config: RegLocationType) -> Attribute {
     Attribute::new(
         Attributes::LocationCapability as u16,
         AttrValue::Uint8(reg_config as u8),
@@ -89,7 +89,7 @@ fn attr_location_capability_new(reg_config: RegLocationType) -> Result<Attribute
     )
 }
 
-fn attr_comm_info_new() -> Result<Attribute, Error> {
+fn attr_comm_info_new() -> Attribute {
     Attribute::new(
         Attributes::BasicCommissioningInfo as u16,
         AttrValue::Custom,
@@ -160,15 +160,15 @@ impl GenCommCluster {
             failsafe,
             base: Cluster::new(ID)?,
         });
-        c.base.add_attribute(attr_bread_crumb_new(0)?)?;
+        c.base.add_attribute(attr_bread_crumb_new(0))?;
         // TODO: Arch-Specific
         c.base
-            .add_attribute(attr_reg_config_new(RegLocationType::IndoorOutdoor)?)?;
+            .add_attribute(attr_reg_config_new(RegLocationType::IndoorOutdoor))?;
         // TODO: Arch-Specific
         c.base.add_attribute(attr_location_capability_new(
             RegLocationType::IndoorOutdoor,
-        )?)?;
-        c.base.add_attribute(attr_comm_info_new()?)?;
+        ))?;
+        c.base.add_attribute(attr_comm_info_new())?;
 
         Ok(c)
     }

--- a/matter/src/data_model/sdm/noc.rs
+++ b/matter/src/data_model/sdm/noc.rs
@@ -131,25 +131,25 @@ impl NocCluster {
                 AttrValue::Custom,
                 Access::RV,
                 Quality::NONE,
-            )?,
+            ),
             Attribute::new(
                 Attributes::Fabrics as u16,
                 AttrValue::Custom,
                 Access::RV | Access::FAB_SCOPED,
                 Quality::NONE,
-            )?,
+            ),
             Attribute::new(
                 Attributes::SupportedFabrics as u16,
                 AttrValue::Uint8(MAX_SUPPORTED_FABRICS as u8),
                 Access::RV,
                 Quality::FIXED,
-            )?,
+            ),
             Attribute::new(
                 Attributes::CommissionedFabrics as u16,
                 AttrValue::Custom,
                 Access::RV,
                 Quality::NONE,
-            )?,
+            ),
         ];
         c.base.add_attributes(&attrs[..])?;
         Ok(c)

--- a/matter/src/data_model/system_model/access_control.rs
+++ b/matter/src/data_model/system_model/access_control.rs
@@ -49,11 +49,11 @@ impl AccessControlCluster {
             base: Cluster::new(ID)?,
             acl_mgr,
         });
-        c.base.add_attribute(attr_acl_new()?)?;
-        c.base.add_attribute(attr_extension_new()?)?;
-        c.base.add_attribute(attr_subjects_per_entry_new()?)?;
-        c.base.add_attribute(attr_targets_per_entry_new()?)?;
-        c.base.add_attribute(attr_entries_per_fabric_new()?)?;
+        c.base.add_attribute(attr_acl_new())?;
+        c.base.add_attribute(attr_extension_new())?;
+        c.base.add_attribute(attr_subjects_per_entry_new())?;
+        c.base.add_attribute(attr_targets_per_entry_new())?;
+        c.base.add_attribute(attr_entries_per_fabric_new())?;
         Ok(c)
     }
 
@@ -143,7 +143,7 @@ impl ClusterType for AccessControlCluster {
     }
 }
 
-fn attr_acl_new() -> Result<Attribute, Error> {
+fn attr_acl_new() -> Attribute {
     Attribute::new(
         Attributes::Acl as u16,
         AttrValue::Custom,
@@ -152,7 +152,7 @@ fn attr_acl_new() -> Result<Attribute, Error> {
     )
 }
 
-fn attr_extension_new() -> Result<Attribute, Error> {
+fn attr_extension_new() -> Attribute {
     Attribute::new(
         Attributes::Extension as u16,
         AttrValue::Custom,
@@ -161,7 +161,7 @@ fn attr_extension_new() -> Result<Attribute, Error> {
     )
 }
 
-fn attr_subjects_per_entry_new() -> Result<Attribute, Error> {
+fn attr_subjects_per_entry_new() -> Attribute {
     Attribute::new(
         Attributes::SubjectsPerEntry as u16,
         AttrValue::Uint16(acl::SUBJECTS_PER_ENTRY as u16),
@@ -170,7 +170,7 @@ fn attr_subjects_per_entry_new() -> Result<Attribute, Error> {
     )
 }
 
-fn attr_targets_per_entry_new() -> Result<Attribute, Error> {
+fn attr_targets_per_entry_new() -> Attribute {
     Attribute::new(
         Attributes::TargetsPerEntry as u16,
         AttrValue::Uint16(acl::TARGETS_PER_ENTRY as u16),
@@ -179,7 +179,7 @@ fn attr_targets_per_entry_new() -> Result<Attribute, Error> {
     )
 }
 
-fn attr_entries_per_fabric_new() -> Result<Attribute, Error> {
+fn attr_entries_per_fabric_new() -> Attribute {
     Attribute::new(
         Attributes::EntriesPerFabric as u16,
         AttrValue::Uint16(acl::ENTRIES_PER_FABRIC as u16),

--- a/matter/src/data_model/system_model/descriptor.rs
+++ b/matter/src/data_model/system_model/descriptor.rs
@@ -54,25 +54,25 @@ impl DescriptorCluster {
                 AttrValue::Custom,
                 Access::RV,
                 Quality::NONE,
-            )?,
+            ),
             Attribute::new(
                 Attributes::ServerList as u16,
                 AttrValue::Custom,
                 Access::RV,
                 Quality::NONE,
-            )?,
+            ),
             Attribute::new(
                 Attributes::PartsList as u16,
                 AttrValue::Custom,
                 Access::RV,
                 Quality::NONE,
-            )?,
+            ),
             Attribute::new(
                 Attributes::ClientList as u16,
                 AttrValue::Custom,
                 Access::RV,
                 Quality::NONE,
-            )?,
+            ),
         ];
         c.base.add_attributes(&attrs[..])?;
         Ok(c)

--- a/matter/tests/common/echo_cluster.rs
+++ b/matter/tests/common/echo_cluster.rs
@@ -176,31 +176,31 @@ impl EchoCluster {
             AttrValue::Uint16(0x1234),
             Access::RV,
             Quality::NONE,
-        )?)?;
+        ))?;
         c.base.add_attribute(Attribute::new(
             Attributes::Att2 as u16,
             AttrValue::Uint16(0x5678),
             Access::RV,
             Quality::NONE,
-        )?)?;
+        ))?;
         c.base.add_attribute(Attribute::new(
             Attributes::AttWrite as u16,
             AttrValue::Uint16(ATTR_WRITE_DEFAULT_VALUE),
             Access::WRITE | Access::NEED_ADMIN,
             Quality::NONE,
-        )?)?;
+        ))?;
         c.base.add_attribute(Attribute::new(
             Attributes::AttCustom as u16,
             AttrValue::Custom,
             Access::READ | Access::NEED_VIEW,
             Quality::NONE,
-        )?)?;
+        ))?;
         c.base.add_attribute(Attribute::new(
             Attributes::AttWriteList as u16,
             AttrValue::Custom,
             Access::WRITE | Access::NEED_ADMIN,
             Quality::NONE,
-        )?)?;
+        ))?;
         Ok(c)
     }
 


### PR DESCRIPTION
Issue is mentioned [here](https://github.com/project-chip/matter-rs/issues/46).
This lets `Attribute::new()` return `Self` instead of `Result<Self,Error>`.