### PR TITLE
Handle out of sessions and out of exchanges

### DIFF
--- a/rs-matter/src/core.rs
+++ b/rs-matter/src/core.rs
@@ -17,6 +17,8 @@
 
 use core::{borrow::Borrow, cell::RefCell};
 
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
+
 use crate::{
     acl::AclMgr,
     data_model::{
@@ -61,6 +63,8 @@ pub struct Matter<'a> {
     dev_att: &'a dyn DevAttDataFetcher,
     pub(crate) port: u16,
     pub(crate) exchanges: RefCell<heapless::Vec<ExchangeCtx, MAX_EXCHANGES>>,
+    pub(crate) ephemeral: RefCell<Option<ExchangeCtx>>,
+    pub(crate) ephemeral_mutex: Mutex<NoopRawMutex, ()>,
     pub session_mgr: RefCell<SessionMgr>, // Public for tests
 }
 
@@ -108,6 +112,8 @@ impl<'a> Matter<'a> {
             dev_att,
             port,
             exchanges: RefCell::new(heapless::Vec::new()),
+            ephemeral: RefCell::new(None),
+            ephemeral_mutex: Mutex::new(()),
             session_mgr: RefCell::new(SessionMgr::new(epoch, rand)),
         }
     }

--- a/rs-matter/src/error.rs
+++ b/rs-matter/src/error.rs
@@ -47,6 +47,8 @@ pub enum ErrorCode {
     NoMemory,
     NoSession,
     NoSpace,
+    NoSpaceExchanges,
+    NoSpaceSessions,
     NoSpaceAckTable,
     NoSpaceRetransTable,
     NoTagFound,

--- a/rs-matter/src/secure_channel/common.rs
+++ b/rs-matter/src/secure_channel/common.rs
@@ -78,8 +78,8 @@ pub fn create_sc_status_report(
             // the session will be closed soon
             GeneralCode::Success
         }
-        SCStatusCodes::Busy
-        | SCStatusCodes::InvalidParameter
+        SCStatusCodes::Busy => GeneralCode::Busy,
+        SCStatusCodes::InvalidParameter
         | SCStatusCodes::NoSharedTrustRoots
         | SCStatusCodes::SessionNotFound => GeneralCode::Failure,
     };


### PR DESCRIPTION
(Still in DRAFT as I want to do some final tests before merging.)

What this PR does:
* When there are too many sessions, it would evict (and send `Close` via an ephemeral exchange) the oldest session
  * Can happen either during Case/Pase session completion (on `clone_session`), or during a brand new exchange establishment
* When there are too many exchanges, and a request for a new exchange pops up, the request is denied by sending `Busy` as a response to the exchange initiation request.
  * Note that I'm not sure sending `Busy` is absolutely correct w.r.t. ^^^, but that's how I interpret the spec. I don't think it is OK to just terminate in emergency old exchanges when a new one pops up, because the spec is clear that each exchange must be properly closed. Moreover, we can't properly close existing exchanges, as these might be async-awaiting something else rather than the network (as in awaiting in their data model handlers the window blinds to cover)

**UPDATE**: The exchange code is currently all over the place. We need `ExchangeMgr` (possibly privately owning the `SessionMgr`). But this is better left for a subsequent PR, or else the changes will become too big and messy to review.