### PR TITLE
Update the types of the arguments for General Commissioning cluster's ArmFailSafe command to match spec

### DIFF
--- a/rs-matter/src/data_model/sdm/failsafe.rs
+++ b/rs-matter/src/data_model/sdm/failsafe.rs
@@ -34,7 +34,7 @@ enum NocState {
 #[derive(PartialEq)]
 pub struct ArmedCtx {
     session_mode: SessionMode,
-    timeout: u8,
+    timeout: u16,
     noc_state: NocState,
 }
 
@@ -54,7 +54,7 @@ impl FailSafe {
         Self { state: State::Idle }
     }
 
-    pub fn arm(&mut self, timeout: u8, session_mode: SessionMode) -> Result<(), Error> {
+    pub fn arm(&mut self, timeout: u16, session_mode: SessionMode) -> Result<(), Error> {
         match &mut self.state {
             State::Idle => {
                 self.state = State::Armed(ArmedCtx {

--- a/rs-matter/src/data_model/sdm/general_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/general_commissioning.rs
@@ -117,8 +117,8 @@ pub const CLUSTER: Cluster<'static> = Cluster {
 
 #[derive(FromTLV, ToTLV)]
 struct FailSafeParams {
-    expiry_len: u8,
-    bread_crumb: u8,
+    expiry_len: u16,
+    bread_crumb: u64,
 }
 
 #[derive(ToTLV)]


### PR DESCRIPTION
The spec calls out the type of `ExpiryLengthSeconds` as a `uint16` and `Breadcrumb` as `uint64`. This PR updates them to match. I stumbled across this as I was seeing an error to parse arguments to the `ArmFailSafe` which was preventing commissioning.