### PR TITLE
Prepare for a breaking change in the Rust compiler.

### DIFF
--- a/rs-matter/src/transport/network.rs
+++ b/rs-matter/src/transport/network.rs
@@ -64,7 +64,7 @@ pub use embassy_net_stack::*;
 
 #[cfg(feature = "std")]
 pub mod std_stack {
-    pub trait NetworkStackDriver {}
+    pub trait NetworkStackDriver: 'static {}
 
     impl NetworkStackDriver for () {}
 


### PR DESCRIPTION
The soundness fix in rust-lang/rust#115008 will cause rs-matter to break, even though it is not unsound. The missing bound is very hard to abuse, but still a soundness hole in our type system.

It will likely take 12 weeks before a stable compiler with the soundness fix is shipped.