### PR TITLE
Fix CI

### DIFF
--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -70,6 +70,7 @@
 //!
 //! Start off exploring by going to the [Matter] object.
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(stable_features)]
 #![cfg_attr(feature = "nightly", feature(async_fn_in_trait))]
 #![cfg_attr(feature = "nightly", feature(impl_trait_projections))]
 #![cfg_attr(feature = "nightly", allow(incomplete_features))]


### PR DESCRIPTION
Subject says it all. One of the nightly features we rely on got stabilized these days, in the recent nightlies. Fingers crossed `async-fn-in-trait` [will be stabilized soon as well](https://github.com/rust-lang/rust/pull/115822#issuecomment-1731161598).