### PR TITLE
Update syn crate from version 1 to 2 and add more error handling

### DIFF
--- a/rs-matter-macros/Cargo.toml
+++ b/rs-matter-macros/Cargo.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", features = ["extra-traits"]}
+syn = { version = "2", features = ["extra-traits"]}
 quote = "1"
 proc-macro2 = "1"
 proc-macro-crate = "1.3"


### PR DESCRIPTION
#89 Proposal to update the version of syn from 1 to 2.
Also improve error return by adding `syn::Result` and `.to_compile_error()`