### PR TITLE
#102, #103

### DIFF
--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -39,7 +39,7 @@ mod dev_att;
 #[cfg(feature = "std")]
 fn main() -> Result<(), Error> {
     let thread = std::thread::Builder::new()
-        .stack_size(160 * 1024)
+        .stack_size(180 * 1024)
         .spawn(run)
         .unwrap();
 
@@ -74,6 +74,7 @@ fn run() -> Result<(), Error> {
         device_name: "OnOff Light",
         product_name: "Light123",
         vendor_name: "Vendor PQR",
+        unique_id: "aabbccdd",
     };
 
     let (ipv4_addr, ipv6_addr, interface) = initialize_network()?;

--- a/rs-matter/src/data_model/cluster_basic_information.rs
+++ b/rs-matter/src/data_model/cluster_basic_information.rs
@@ -41,6 +41,7 @@ pub enum Attributes {
     SwVer(AttrType<u32>) = 9,
     SwVerString(AttrUtfType) = 0xa,
     SerialNo(AttrUtfType) = 0x0f,
+    UniqueId(AttrUtfType) = 0x12,
 }
 
 attribute_enum!(Attributes);
@@ -56,6 +57,7 @@ pub enum AttributesDiscriminants {
     SwVer = 9,
     SwVerString = 0xa,
     SerialNo = 0x0f,
+    UniqueId = 0x12,
 }
 
 #[derive(Default)]
@@ -70,6 +72,7 @@ pub struct BasicInfoConfig<'a> {
     pub device_name: &'a str,
     pub vendor_name: &'a str,
     pub product_name: &'a str,
+    pub unique_id: &'a str,
 }
 
 pub const CLUSTER: Cluster<'static> = Cluster {
@@ -128,6 +131,11 @@ pub const CLUSTER: Cluster<'static> = Cluster {
             Access::RV,
             Quality::FIXED,
         ),
+        Attribute::new(
+            AttributesDiscriminants::UniqueId as u16,
+            Access::RV,
+            Quality::FIXED,
+        ),
     ],
     commands: &[],
 };
@@ -166,6 +174,7 @@ impl<'a> BasicInfoCluster<'a> {
                     Attributes::SwVer(codec) => codec.encode(writer, self.cfg.sw_ver),
                     Attributes::SwVerString(codec) => codec.encode(writer, self.cfg.sw_ver_str),
                     Attributes::SerialNo(codec) => codec.encode(writer, self.cfg.serial_no),
+                    Attributes::UniqueId(codec) => codec.encode(writer, self.cfg.unique_id),
                 }
             }
         } else {

--- a/rs-matter/src/data_model/objects/encoder.rs
+++ b/rs-matter/src/data_model/objects/encoder.rs
@@ -30,7 +30,7 @@ use crate::{
     interaction_model::messages::ib::{AttrDataTag, AttrRespTag},
     tlv::{FromTLV, TLVElement, TLVWriter, TagType, ToTLV},
 };
-use log::error;
+use log::{error, warn};
 
 use super::{AttrDetails, CmdDetails, DataModelHandler};
 
@@ -149,7 +149,10 @@ impl<'a, 'b, 'c> AttrDataEncoder<'a, 'b, 'c> {
         };
 
         if let Some(status) = status {
-            AttrResp::Status(status).to_tlv(tw, TagType::Anonymous)?;
+            let resp = AttrResp::Status(status);
+            warn!("Read status: {:?}", resp);
+
+            resp.to_tlv(tw, TagType::Anonymous)?;
         }
 
         Ok(true)
@@ -172,6 +175,7 @@ impl<'a, 'b, 'c> AttrDataEncoder<'a, 'b, 'c> {
         };
 
         if let Some(status) = status {
+            warn!("Write status: {:?}", status);
             status.to_tlv(tw, TagType::Anonymous)?;
         }
 

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -694,7 +694,6 @@ impl<'a> Matter<'a> {
             };
 
             if send {
-                dest_tx.log("Sending packet");
                 self.notify_changed();
 
                 return Ok(true);

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -263,6 +263,8 @@ impl Session {
     pub(crate) fn send(&mut self, epoch: Epoch, tx: &mut Packet) -> Result<(), Error> {
         self.last_use = epoch();
 
+        tx.log("About to send packet");
+
         tx.proto_encode(
             self.peer_addr,
             self.peer_nodeid,

--- a/rs-matter/tests/common/im_engine.rs
+++ b/rs-matter/tests/common/im_engine.rs
@@ -72,6 +72,7 @@ const BASIC_INFO: BasicInfoConfig<'static> = BasicInfoConfig {
     device_name: "Test Device",
     product_name: "TestProd",
     vendor_name: "TestVendor",
+    unique_id: "aabbccdd",
 };
 
 struct DummyDevAtt;


### PR DESCRIPTION
@kedars 
Really weird - the (latest?) Google Matter Controller fails provisioning if querying attribute `UniqueId` from the Basic Info cluster fails.

It is weird because in the Matter 1.0 spec, the attribute is marked as "optional". Perhaps they made it mandatory in Matter - 1.1? (Need to check this in the latest spec.)

This PR also addresses #103 at least to some extent, by reporting with a `warn` level all cluster reads/writes that return a non-OK status.