### PR TITLE
Expose `rs-matter`'s lib as `matter_rs`

### DIFF
--- a/examples/onoff_light/src/dev_att.rs
+++ b/examples/onoff_light/src/dev_att.rs
@@ -15,8 +15,8 @@
  *    limitations under the License.
  */
 
-use rs_matter::data_model::sdm::dev_att::{DataType, DevAttDataFetcher};
-use rs_matter::error::{Error, ErrorCode};
+use matter_rs::data_model::sdm::dev_att::{DataType, DevAttDataFetcher};
+use matter_rs::error::{Error, ErrorCode};
 
 pub struct HardCodedDevAtt {}
 

--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -20,19 +20,19 @@ use core::pin::pin;
 
 use embassy_futures::select::select3;
 use log::info;
-use rs_matter::core::{CommissioningData, Matter};
-use rs_matter::data_model::cluster_basic_information::BasicInfoConfig;
-use rs_matter::data_model::cluster_on_off;
-use rs_matter::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
-use rs_matter::data_model::objects::*;
-use rs_matter::data_model::root_endpoint;
-use rs_matter::data_model::system_model::descriptor;
-use rs_matter::error::Error;
-use rs_matter::mdns::{MdnsRunBuffers, MdnsService};
-use rs_matter::secure_channel::spake2p::VerifierData;
-use rs_matter::transport::core::RunBuffers;
-use rs_matter::transport::network::{Ipv4Addr, Ipv6Addr, NetworkStack};
-use rs_matter::utils::select::EitherUnwrap;
+use matter_rs::core::{CommissioningData, Matter};
+use matter_rs::data_model::cluster_basic_information::BasicInfoConfig;
+use matter_rs::data_model::cluster_on_off;
+use matter_rs::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
+use matter_rs::data_model::objects::*;
+use matter_rs::data_model::root_endpoint;
+use matter_rs::data_model::system_model::descriptor;
+use matter_rs::error::Error;
+use matter_rs::mdns::{MdnsRunBuffers, MdnsService};
+use matter_rs::secure_channel::spake2p::VerifierData;
+use matter_rs::transport::core::RunBuffers;
+use matter_rs::transport::network::{Ipv4Addr, Ipv6Addr, NetworkStack};
+use matter_rs::utils::select::EitherUnwrap;
 
 mod dev_att;
 
@@ -81,18 +81,18 @@ fn run() -> Result<(), Error> {
     let dev_att = dev_att::HardCodedDevAtt::new();
 
     #[cfg(feature = "std")]
-    let epoch = rs_matter::utils::epoch::sys_epoch;
+    let epoch = matter_rs::utils::epoch::sys_epoch;
 
     #[cfg(feature = "std")]
-    let rand = rs_matter::utils::rand::sys_rand;
+    let rand = matter_rs::utils::rand::sys_rand;
 
     // NOTE (no_std): For no_std, provide your own function here
     #[cfg(not(feature = "std"))]
-    let epoch = rs_matter::utils::epoch::dummy_epoch;
+    let epoch = matter_rs::utils::epoch::dummy_epoch;
 
     // NOTE (no_std): For no_std, provide your own function here
     #[cfg(not(feature = "std"))]
-    let rand = rs_matter::utils::rand::dummy_rand;
+    let rand = matter_rs::utils::rand::dummy_rand;
 
     let mdns = MdnsService::new(
         0,
@@ -100,7 +100,7 @@ fn run() -> Result<(), Error> {
         ipv4_addr.octets(),
         Some((ipv6_addr.octets(), interface)),
         &dev_det,
-        rs_matter::MATTER_PORT,
+        matter_rs::MATTER_PORT,
     );
 
     info!("mDNS initialized");
@@ -112,13 +112,13 @@ fn run() -> Result<(), Error> {
         &mdns,
         epoch,
         rand,
-        rs_matter::MATTER_PORT,
+        matter_rs::MATTER_PORT,
     );
 
     info!("Matter initialized");
 
     #[cfg(all(feature = "std", not(target_os = "espidf")))]
-    let mut psm = rs_matter::persist::Psm::new(&matter, std::env::temp_dir().join("rs-matter"))?;
+    let mut psm = matter_rs::persist::Psm::new(&matter, std::env::temp_dir().join("rs-matter"))?;
 
     let handler = HandlerCompat(handler(&matter));
 
@@ -225,8 +225,8 @@ fn initialize_logger() {
 #[inline(never)]
 fn initialize_network() -> Result<(Ipv4Addr, Ipv6Addr, u32), Error> {
     use log::error;
+    use matter_rs::error::ErrorCode;
     use nix::{net::if_::InterfaceFlags, sys::socket::SockaddrIn6};
-    use rs_matter::error::ErrorCode;
 
     let interfaces = || {
         nix::ifaddrs::getifaddrs().unwrap().filter(|ia| {

--- a/examples/speaker/src/dev_att.rs
+++ b/examples/speaker/src/dev_att.rs
@@ -15,8 +15,8 @@
  *    limitations under the License.
  */
 
-use rs_matter::data_model::sdm::dev_att::{DataType, DevAttDataFetcher};
-use rs_matter::error::Error;
+use matter_rs::data_model::sdm::dev_att::{DataType, DevAttDataFetcher};
+use matter_rs::error::Error;
 
 pub struct HardCodedDevAtt {}
 

--- a/examples/speaker/src/main.rs
+++ b/examples/speaker/src/main.rs
@@ -17,11 +17,11 @@
 
 // TODO
 // mod dev_att;
-// use rs_matter::core::{self, CommissioningData};
-// use rs_matter::data_model::cluster_basic_information::BasicInfoConfig;
-// use rs_matter::data_model::cluster_media_playback::{Commands, MediaPlaybackCluster};
-// use rs_matter::data_model::device_types::DEV_TYPE_ON_SMART_SPEAKER;
-// use rs_matter::secure_channel::spake2p::VerifierData;
+// use matter_rs::core::{self, CommissioningData};
+// use matter_rs::data_model::cluster_basic_information::BasicInfoConfig;
+// use matter_rs::data_model::cluster_media_playback::{Commands, MediaPlaybackCluster};
+// use matter_rs::data_model::device_types::DEV_TYPE_ON_SMART_SPEAKER;
+// use matter_rs::secure_channel::spake2p::VerifierData;
 
 fn main() {
     //     env_logger::init();

--- a/examples/speaker/src/speaker.rs
+++ b/examples/speaker/src/speaker.rs
@@ -15,11 +15,11 @@
  *    limitations under the License.
  */
 
-use rs_matter::core::{self, CommissioningData};
-use rs_matter::data_model::cluster_basic_information::BasicInfoConfig;
-use rs_matter::data_model::cluster_media_playback::{Commands, MediaPlaybackCluster};
-use rs_matter::data_model::device_types::DEV_TYPE_ON_SMART_SPEAKER;
-use rs_matter::secure_channel::spake2p::VerifierData;
+use matter_rs::core::{self, CommissioningData};
+use matter_rs::data_model::cluster_basic_information::BasicInfoConfig;
+use matter_rs::data_model::cluster_media_playback::{Commands, MediaPlaybackCluster};
+use matter_rs::data_model::device_types::DEV_TYPE_ON_SMART_SPEAKER;
+use matter_rs::secure_channel::spake2p::VerifierData;
 
 mod dev_att;
 

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -10,6 +10,10 @@ keywords = ["matter", "smart", "smart-home", "IoT", "ESP32"]
 categories = ["embedded", "network-programming"]
 license = "Apache-2.0"
 
+[lib]
+name = "matter_rs"
+path = "src/lib.rs"
+
 [features]
 default = ["os", "mbedtls"]
 os = ["std", "backtrace", "env_logger", "nix", "critical-section/std", "embassy-sync/std", "embassy-time/std"]

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -25,13 +25,13 @@
 //! # Examples
 //! ```ignore
 //! /// TODO: Fix once new API has stabilized a bit
-//! use rs_matter::{Matter, CommissioningData};
-//! use rs_matter::data_model::device_types::device_type_add_on_off_light;
-//! use rs_matter::data_model::cluster_basic_information::BasicInfoConfig;
-//! use rs_matter::secure_channel::spake2p::VerifierData;
+//! use matter_rs::{Matter, CommissioningData};
+//! use matter_rs::data_model::device_types::device_type_add_on_off_light;
+//! use matter_rs::data_model::cluster_basic_information::BasicInfoConfig;
+//! use matter_rs::secure_channel::spake2p::VerifierData;
 //!
-//! # use rs_matter::data_model::sdm::dev_att::{DataType, DevAttDataFetcher};
-//! # use rs_matter::error::Error;
+//! # use matter_rs::data_model::sdm::dev_att::{DataType, DevAttDataFetcher};
+//! # use matter_rs::error::Error;
 //! # pub struct DevAtt{}
 //! # impl DevAttDataFetcher for DevAtt{
 //! # fn get_devatt_data(&self, data_type: DataType, data: &mut [u8]) -> Result<usize, Error> { Ok(0) }

--- a/rs-matter/tests/common/attributes.rs
+++ b/rs-matter/tests/common/attributes.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use rs_matter::{
+use matter_rs::{
     interaction_model::{messages::ib::AttrResp, messages::msg::ReportDataMsg},
     tlv::{TLVElement, TLVList, TLVWriter, TagType, ToTLV},
     utils::writebuf::WriteBuf,

--- a/rs-matter/tests/common/commands.rs
+++ b/rs-matter/tests/common/commands.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use rs_matter::{
+use matter_rs::{
     data_model::objects::EncodeValue,
     interaction_model::{
         messages::ib::{CmdPath, CmdStatus, InvResp},

--- a/rs-matter/tests/common/echo_cluster.rs
+++ b/rs-matter/tests/common/echo_cluster.rs
@@ -19,8 +19,7 @@ use core::cell::Cell;
 use core::convert::TryInto;
 use std::sync::{Arc, Mutex, Once};
 
-use num_derive::FromPrimitive;
-use rs_matter::{
+use matter_rs::{
     attribute_enum, command_enum,
     data_model::objects::{
         Access, AttrData, AttrDataEncoder, AttrDataWriter, AttrDetails, AttrType, Attribute,
@@ -33,6 +32,7 @@ use rs_matter::{
     transport::exchange::Exchange,
     utils::rand::Rand,
 };
+use num_derive::FromPrimitive;
 use strum::{EnumDiscriminants, FromRepr};
 
 pub const ID: u32 = 0xABCD;

--- a/rs-matter/tests/common/handlers.rs
+++ b/rs-matter/tests/common/handlers.rs
@@ -1,5 +1,5 @@
 use log::{info, warn};
-use rs_matter::{
+use matter_rs::{
     error::ErrorCode,
     interaction_model::{
         core::{IMStatusCode, OpCode},

--- a/rs-matter/tests/common/im_engine.rs
+++ b/rs-matter/tests/common/im_engine.rs
@@ -20,7 +20,7 @@ use core::borrow::Borrow;
 use core::future::pending;
 use core::time::Duration;
 use embassy_futures::select::select3;
-use rs_matter::{
+use matter_rs::{
     acl::{AclEntry, AuthMode},
     data_model::{
         cluster_basic_information::{self, BasicInfoConfig},
@@ -174,10 +174,10 @@ impl<'a> Handler for ImEngineHandler<'a> {
 
     fn invoke(
         &self,
-        exchange: &rs_matter::transport::exchange::Exchange,
-        cmd: &rs_matter::data_model::objects::CmdDetails,
-        data: &rs_matter::tlv::TLVElement,
-        encoder: rs_matter::data_model::objects::CmdDataEncoder,
+        exchange: &matter_rs::transport::exchange::Exchange,
+        cmd: &matter_rs::data_model::objects::CmdDetails,
+        data: &matter_rs::tlv::TLVElement,
+        encoder: matter_rs::data_model::objects::CmdDataEncoder,
     ) -> Result<(), Error> {
         self.handler.invoke(exchange, cmd, data, encoder)
     }
@@ -209,16 +209,16 @@ impl<'a> ImEngine<'a> {
     /// Create the interaction model engine
     pub fn new(cat_ids: NocCatIds) -> Self {
         #[cfg(feature = "std")]
-        use rs_matter::utils::epoch::sys_epoch as epoch;
+        use matter_rs::utils::epoch::sys_epoch as epoch;
 
         #[cfg(not(feature = "std"))]
-        use rs_matter::utils::epoch::dummy_epoch as epoch;
+        use matter_rs::utils::epoch::dummy_epoch as epoch;
 
         #[cfg(feature = "std")]
-        use rs_matter::utils::rand::sys_rand as rand;
+        use matter_rs::utils::rand::sys_rand as rand;
 
         #[cfg(not(feature = "std"))]
-        use rs_matter::utils::rand::dummy_rand as rand;
+        use matter_rs::utils::rand::dummy_rand as rand;
 
         let matter = Matter::new(
             &BASIC_INFO,

--- a/rs-matter/tests/data_model/acl_and_dataver.rs
+++ b/rs-matter/tests/data_model/acl_and_dataver.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use rs_matter::{
+use matter_rs::{
     acl::{gen_noc_cat, AclEntry, AuthMode, Target},
     data_model::{
         objects::{EncodeValue, Privilege},

--- a/rs-matter/tests/data_model/attribute_lists.rs
+++ b/rs-matter/tests/data_model/attribute_lists.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use rs_matter::{
+use matter_rs::{
     data_model::objects::EncodeValue,
     interaction_model::{
         core::IMStatusCode,

--- a/rs-matter/tests/data_model/attributes.rs
+++ b/rs-matter/tests/data_model/attributes.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use rs_matter::{
+use matter_rs::{
     data_model::{
         cluster_on_off,
         objects::{EncodeValue, GlobalElements},

--- a/rs-matter/tests/data_model/commands.rs
+++ b/rs-matter/tests/data_model/commands.rs
@@ -21,7 +21,7 @@ use crate::{
     echo_req, echo_resp,
 };
 
-use rs_matter::{
+use matter_rs::{
     data_model::{cluster_on_off, objects::EncodeValue},
     interaction_model::{
         core::IMStatusCode,

--- a/rs-matter/tests/data_model/long_reads.rs
+++ b/rs-matter/tests/data_model/long_reads.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use rs_matter::{
+use matter_rs::{
     data_model::{
         cluster_basic_information as basic_info, cluster_on_off as onoff,
         objects::{EncodeValue, GlobalElements},

--- a/rs-matter/tests/data_model/timed_requests.rs
+++ b/rs-matter/tests/data_model/timed_requests.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use rs_matter::{
+use matter_rs::{
     data_model::objects::EncodeValue,
     interaction_model::{
         core::IMStatusCode,

--- a/tools/tlv/src/main.rs
+++ b/tools/tlv/src/main.rs
@@ -16,8 +16,8 @@
  */
 
 use clap::{App, Arg};
-use rs_matter::cert;
-use rs_matter::tlv;
+use matter_rs::cert;
+use matter_rs::tlv;
 use simple_logger::SimpleLogger;
 use std::process;
 


### PR DESCRIPTION
Then `s/rs-matter::/matter_rs::/g`.

Whilst we can't have the crates.io name, we can still have the library name if we want.

I'm not that bothered either way, but I thought I'd open it as a suggestion.