### PR TITLE
[mdns] Fix multicast routing error on esp32 (and likely other platforms)

### DIFF
--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -8,8 +8,10 @@ use log::info;
 
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
 use crate::error::{Error, ErrorCode};
+#[cfg(any(feature = "std", feature = "embassy-net"))]
+use crate::transport::network::IpAddr;
 use crate::transport::network::{
-    Address, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6,
+    Address, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6,
 };
 use crate::transport::pipe::{Chunk, Pipe};
 use crate::utils::select::{EitherUnwrap, Notification};

--- a/rs-matter/src/transport/network.rs
+++ b/rs-matter/src/transport/network.rs
@@ -17,9 +17,9 @@
 
 use core::fmt::{Debug, Display};
 #[cfg(not(feature = "std"))]
-pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 #[cfg(feature = "std")]
-pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub enum Address {


### PR DESCRIPTION
According to the RFC
(https://datatracker.ietf.org/doc/html/rfc2553#section-3.3), it is necessary to disambiguate link-local addresses with the interface index (in the scope_id field).  Lacking this field, newer versions of lwip that support proper IPv6 scopes will yield EHOSTUNREACH (Host unreachable). Other implementations like on Linux and OS X will likely be affected by the lack of this field for more complex networking setups.

Fixes #100