### PR TITLE
Fix nightly CI

### DIFF
--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -71,9 +71,10 @@
 //! Start off exploring by going to the [Matter] object.
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(stable_features)]
+#![allow(unknown_lints)]
 #![cfg_attr(feature = "nightly", feature(async_fn_in_trait))]
+#![cfg_attr(feature = "nightly", allow(async_fn_in_trait))]
 #![cfg_attr(feature = "nightly", feature(impl_trait_projections))]
-#![cfg_attr(feature = "nightly", allow(incomplete_features))]
 
 pub mod acl;
 pub mod cert;


### PR DESCRIPTION
There is a [new lint](https://github.com/rust-lang/rust/pull/116184) Clippy complains about (that our async code's futures are not `Send`).

The ^^^ is OK for embedded actually, and given that this lint will be around for (quite) some time even after [AFIT is stabilized](https://github.com/rust-lang/rust/pull/115822) - as it needs [this functionality which in the meantime won't happen this year](https://blog.rust-lang.org/inside-rust/2023/05/03/stabilizing-async-fn-in-trait.html#mvp-part-2-send-bounds-and-associated-return-types) - I suggest we just suppress it, as the `embedded-hal` folks did for their crates.
