### PR TITLE
Switch to stable Rust, remove the `nightly` feature

### DIFF
--- a/.github/workflows/ci-tlv-tool.yml
+++ b/.github/workflows/ci-tlv-tool.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 env:
+  RUST_TOOLCHAIN: stable
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -17,6 +18,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt, clippy, rust-src
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_TOOLCHAIN: nightly
+  RUST_TOOLCHAIN: stable
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CARGO_TERM_COLOR: always
 
@@ -21,11 +21,9 @@ jobs:
       matrix:
         crypto-backend: ['rustcrypto', 'mbedtls', 'openssl']
         features: ['', 'alloc', 'os']
-        toolchain: ['stable', 'nightly']
 
     steps:
       - name: Rust
-        if: matrix.toolchain == 'nightly'
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
@@ -35,14 +33,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Fmt
-        run: cargo +${{ matrix.toolchain == 'nightly' && env.RUST_TOOLCHAIN || 'stable'}} fmt -- --check
+        run: cargo fmt -- --check
 
       - name: Clippy
-        run: cargo +${{ matrix.toolchain == 'nightly' && env.RUST_TOOLCHAIN || 'stable'}} clippy --no-deps --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},${{ matrix.toolchain == 'nightly' && 'nightly' || ''}} -- -Dwarnings
+        run: cargo clippy --no-deps --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}} -- -Dwarnings
 
       - name: Build
-        run: cargo +${{ matrix.toolchain == 'nightly' && env.RUST_TOOLCHAIN || 'stable'}} build --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},${{ matrix.toolchain == 'nightly' && 'nightly' || ''}}
+        run: cargo build --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}}
 
       - name: Test
         if: matrix.features == 'os'
-        run: cargo +${{ matrix.toolchain == 'nightly' && env.RUST_TOOLCHAIN || 'stable'}} test --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},${{ matrix.toolchain == 'nightly' && 'nightly' || ''}} -- --test-threads=1
+        run: cargo test --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}}

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -3,6 +3,7 @@ name: PublishDryRun
 on: workflow_dispatch
 
 env:
+  RUST_TOOLCHAIN: stable
   CRATE_NAME: rs-matter
 
 jobs:
@@ -10,6 +11,12 @@ jobs:
     name: PublishDryRun
     runs-on: ubuntu-latest
     steps:
+      - name: Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt, clippy, rust-src
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/publish-macros-dry-run.yml
+++ b/.github/workflows/publish-macros-dry-run.yml
@@ -2,11 +2,20 @@ name: PublishMacrosDryRun
 
 on: workflow_dispatch
 
+env:
+  RUST_TOOLCHAIN: stable
+
 jobs:
   publish_macros_dry_run:
     name: PublishMacrosDryRun
     runs-on: ubuntu-latest
     steps:
+      - name: Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt, clippy, rust-src
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/publish-macros.yml
+++ b/.github/workflows/publish-macros.yml
@@ -2,11 +2,20 @@ name: PublishMacros
 
 on: workflow_dispatch
 
+env:
+  RUST_TOOLCHAIN: stable
+
 jobs:
   publish_macros:
     name: PublishMacros
     runs-on: ubuntu-latest
     steps:
+      - name: Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt, clippy, rust-src
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish
 on: workflow_dispatch
 
 env:
+  RUST_TOOLCHAIN: stable
   CRATE_NAME: rs-matter
 
 jobs:
@@ -10,6 +11,12 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
+      - name: Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt, clippy, rust-src
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["matter", "smart", "smart-home", "IoT", "ESP32"]
 categories = ["embedded", "network-programming"]
 license = "Apache-2.0"
+rust-version = "1.75"
 
 [features]
 default = ["os", "mbedtls"]
@@ -17,7 +18,6 @@ esp-idf = ["std", "rustcrypto", "esp-idf-sys"]
 std = ["alloc", "rand", "async-io", "esp-idf-sys?/std", "embassy-time/generic-queue-16"]
 backtrace = []
 alloc = []
-nightly = []
 openssl = ["alloc", "dep:openssl", "foreign-types", "hmac", "sha2"]
 mbedtls = ["alloc", "dep:mbedtls"]
 rustcrypto = ["alloc", "sha2", "hmac", "pbkdf2", "hkdf", "aes", "ccm", "p256", "elliptic-curve", "crypto-bigint", "x509-cert", "rand_core"]

--- a/rs-matter/src/data_model/core.rs
+++ b/rs-matter/src/data_model/core.rs
@@ -68,11 +68,7 @@ impl<T> DataModel<T> {
         #[cfg(not(feature = "alloc"))]
         let interaction = &mut interaction;
 
-        #[cfg(feature = "nightly")]
         let metadata = self.0.lock().await;
-
-        #[cfg(not(feature = "nightly"))]
-        let metadata = self.0.lock();
 
         if interaction.start().await? {
             match interaction {

--- a/rs-matter/src/data_model/objects/encoder.rs
+++ b/rs-matter/src/data_model/objects/encoder.rs
@@ -133,18 +133,7 @@ impl<'a, 'b, 'c> AttrDataEncoder<'a, 'b, 'c> {
             Ok(attr) => {
                 let encoder = AttrDataEncoder::new(attr, tw);
 
-                let result = {
-                    #[cfg(not(feature = "nightly"))]
-                    {
-                        handler.read(attr, encoder)
-                    }
-
-                    #[cfg(feature = "nightly")]
-                    {
-                        handler.read(attr, encoder).await
-                    }
-                };
-
+                let result = handler.read(attr, encoder).await;
                 match result {
                     Ok(()) => None,
                     Err(e) => {
@@ -173,18 +162,7 @@ impl<'a, 'b, 'c> AttrDataEncoder<'a, 'b, 'c> {
     ) -> Result<(), Error> {
         let status = match item {
             Ok((attr, data)) => {
-                let result = {
-                    #[cfg(not(feature = "nightly"))]
-                    {
-                        handler.write(attr, AttrData::new(attr.dataver, data))
-                    }
-
-                    #[cfg(feature = "nightly")]
-                    {
-                        handler.write(attr, AttrData::new(attr.dataver, data)).await
-                    }
-                };
-
+                let result = handler.write(attr, AttrData::new(attr.dataver, data)).await;
                 match result {
                     Ok(()) => attr.status(IMStatusCode::Success)?,
                     Err(error) => attr.status(error.into())?,
@@ -347,18 +325,7 @@ impl<'a, 'b, 'c> CmdDataEncoder<'a, 'b, 'c> {
                 let mut tracker = CmdDataTracker::new();
                 let encoder = CmdDataEncoder::new(cmd, &mut tracker, tw);
 
-                let result = {
-                    #[cfg(not(feature = "nightly"))]
-                    {
-                        handler.invoke(exchange, cmd, data, encoder)
-                    }
-
-                    #[cfg(feature = "nightly")]
-                    {
-                        handler.invoke(exchange, cmd, data, encoder).await
-                    }
-                };
-
+                let result = handler.invoke(exchange, cmd, data, encoder).await;
                 match result {
                     Ok(()) => cmd.success(&tracker),
                     Err(error) => {

--- a/rs-matter/src/data_model/objects/handler.rs
+++ b/rs-matter/src/data_model/objects/handler.rs
@@ -23,17 +23,9 @@ use crate::{
 
 use super::{AttrData, AttrDataEncoder, AttrDetails, CmdDataEncoder, CmdDetails};
 
-#[cfg(feature = "nightly")]
 pub use asynch::*;
 
-#[cfg(not(feature = "nightly"))]
-pub trait DataModelHandler: super::Metadata + Handler {}
-#[cfg(not(feature = "nightly"))]
-impl<T> DataModelHandler for T where T: super::Metadata + Handler {}
-
-#[cfg(feature = "nightly")]
 pub trait DataModelHandler: super::asynch::AsyncMetadata + asynch::AsyncHandler {}
-#[cfg(feature = "nightly")]
 impl<T> DataModelHandler for T where T: super::asynch::AsyncMetadata + asynch::AsyncHandler {}
 
 pub trait ChangeNotifier<T> {
@@ -294,7 +286,6 @@ macro_rules! handler_chain_type {
     };
 }
 
-#[cfg(feature = "nightly")]
 mod asynch {
     use crate::{
         data_model::objects::{AttrData, AttrDataEncoder, AttrDetails, CmdDataEncoder, CmdDetails},

--- a/rs-matter/src/data_model/objects/metadata.rs
+++ b/rs-matter/src/data_model/objects/metadata.rs
@@ -17,7 +17,6 @@
 
 use crate::data_model::objects::Node;
 
-#[cfg(feature = "nightly")]
 pub use asynch::*;
 
 use super::HandlerCompat;
@@ -120,7 +119,6 @@ where
     }
 }
 
-#[cfg(feature = "nightly")]
 pub mod asynch {
     use crate::data_model::objects::{HandlerCompat, Node};
 

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -70,11 +70,7 @@
 //!
 //! Start off exploring by going to the [Matter] object.
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(stable_features)]
-#![allow(unknown_lints)]
-#![cfg_attr(feature = "nightly", feature(async_fn_in_trait))]
-#![cfg_attr(feature = "nightly", allow(async_fn_in_trait))]
-#![cfg_attr(feature = "nightly", feature(impl_trait_projections))]
+#![allow(async_fn_in_trait)]
 
 pub mod acl;
 pub mod cert;


### PR DESCRIPTION
On Dec 28, Rust 1.75 was released *which finally allows using async traits with the stable compiler*.

Therefore, this PR removes the `nightly`  feature flag which used to protect all async traits defined in the `rs-matter` crate.

**We no longer need a nightly compiler, yay!**

There is an upcoming bigger, subsequent PR which - besides updating a few dependencies - will also introduce the [`embedded-nal-async`](https://github.com/rust-embedded-community/embedded-nal/tree/master/embedded-nal-async) crate into the codebase, which would - in turn - allow us to get rid of the hard-coded UDP stack implementations based on `async-io` and `embassy-net`, and therefore remove the `async-io` and `embassy-net` as dependencies.

* `embassy-net` does implement the `embedded-nal-async` traits directly
* The Rust STD socket layer is adapted to the `embedded-nal-async` traits by the `std-embedded-nal-async` crate, but we do not have to depend on it directly, of course. Users can pick and choose.

