### PR TITLE
Add rs_matter crate to derive ToTlv for enums.

### DIFF
--- a/rs-matter/src/data_model/objects/mod.rs
+++ b/rs-matter/src/data_model/objects/mod.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 use crate::error::Error;
-use crate::tlv::{TLVWriter, TagType, ToTLV};
+use crate::tlv::ToTLV;
 
 mod attribute;
 pub use attribute::*;

--- a/rs-matter/src/data_model/sdm/general_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/general_commissioning.rs
@@ -20,7 +20,7 @@ use core::convert::TryInto;
 
 use crate::data_model::objects::*;
 use crate::data_model::sdm::failsafe::FailSafe;
-use crate::tlv::{FromTLV, TLVElement, TLVWriter, TagType, ToTLV, UtfStr};
+use crate::tlv::{FromTLV, TLVElement, ToTLV, UtfStr};
 use crate::transport::exchange::Exchange;
 use crate::utils::rand::Rand;
 use crate::{attribute_enum, cmd_enter};

--- a/rs-matter/src/data_model/sdm/nw_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/nw_commissioning.rs
@@ -24,7 +24,7 @@ use crate::{
         Cluster, Dataver, Handler, NonBlockingHandler, Quality, ATTRIBUTE_LIST, FEATURE_MAP,
     },
     error::Error,
-    tlv::{OctetStr, TLVWriter, TagType, ToTLV},
+    tlv::{OctetStr, TagType, ToTLV},
     utils::rand::Rand,
 };
 

--- a/rs-matter/src/group_keys.rs
+++ b/rs-matter/src/group_keys.rs
@@ -18,7 +18,7 @@
 use crate::{
     crypto::{self, SYMM_KEY_LEN_BYTES},
     error::{Error, ErrorCode},
-    tlv::{FromTLV, TLVWriter, TagType, ToTLV},
+    tlv::{FromTLV, ToTLV},
 };
 
 type KeySetKey = [u8; SYMM_KEY_LEN_BYTES];

--- a/rs-matter/src/interaction_model/messages.rs
+++ b/rs-matter/src/interaction_model/messages.rs
@@ -18,7 +18,7 @@
 use crate::{
     data_model::objects::{ClusterId, EndptId},
     error::{Error, ErrorCode},
-    tlv::{FromTLV, TLVWriter, TagType, ToTLV},
+    tlv::{FromTLV, ToTLV},
 };
 
 // A generic path with endpoint, clusters, and a leaf
@@ -69,7 +69,7 @@ pub mod msg {
     use crate::{
         error::Error,
         interaction_model::core::IMStatusCode,
-        tlv::{FromTLV, TLVArray, TLVWriter, TagType, ToTLV},
+        tlv::{FromTLV, TLVArray, ToTLV},
     };
 
     use super::ib::{


### PR DESCRIPTION
Without it, these have to be imported which seems not as clean.