### PR TITLE
Lower the CERT TLV size to the max specified in the spec

### DIFF
--- a/rs-matter/src/cert/mod.rs
+++ b/rs-matter/src/cert/mod.rs
@@ -29,7 +29,8 @@ use num_derive::FromPrimitive;
 pub use self::asn1_writer::ASN1Writer;
 use self::printer::CertPrinter;
 
-pub const MAX_CERT_TLV_LEN: usize = 1024; // TODO
+// As per section 6.1.3 "Certificate Sizes" of the Matter 1.1 spec
+pub const MAX_CERT_TLV_LEN: usize = 400;
 
 // As per https://datatracker.ietf.org/doc/html/rfc5280
 


### PR DESCRIPTION
We have been overly pessimistic in terms of expected certificates TLV size. The spec is clear the certs should be smaller than 400 bytes, so I think this is safe (and Matter provisioning with Google passes fine).

This saves in total ~ 16K, as certs are everywhere (fabrics and sessions' nocs).

=============================

The next change to shortly follow is also a relatively low hanging fruit (stuff in the QR code generation). 

The changes that will follow afterwards though are much more obtrusive (as in making the exchanges to share a single TX/RX buffer whenever possible). But exchange cleanup is due anyway (and a bit necessary so as to address retransmissions and to make sure we are behaving when the user drops an unfinished exchange in the middle of the transmission due to errors).

