### PR TITLE
Allow buffer sharing between mDNS and Matter transport; const-ify constructors

### DIFF
--- a/rs-matter/src/mdns/proto.rs
+++ b/rs-matter/src/mdns/proto.rs
@@ -18,6 +18,8 @@ use octseq::Truncate;
 
 use crate::error::{Error, ErrorCode};
 
+use super::Service;
+
 impl From<ShortBuf> for Error {
     fn from(_: ShortBuf) -> Self {
         Self::new(ErrorCode::NoSpace)
@@ -333,15 +335,6 @@ impl<'a> Host<'a> {
 
         Dname::<heapless07::Vec<u8, 64>>::from_chars(host_fqdn.chars())
     }
-}
-
-pub struct Service<'a> {
-    pub name: &'a str,
-    pub service: &'a str,
-    pub protocol: &'a str,
-    pub port: u16,
-    pub service_subtypes: &'a [&'a str],
-    pub txt_kvs: &'a [(&'a str, &'a str)],
 }
 
 impl<'a> Service<'a> {

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -306,7 +306,7 @@ pub struct SessionMgr {
 
 impl SessionMgr {
     #[inline(always)]
-    pub fn new(epoch: Epoch, rand: Rand) -> Self {
+    pub const fn new(epoch: Epoch, rand: Rand) -> Self {
         Self {
             sessions: heapless::Vec::new(),
             next_sess_id: 1,

--- a/rs-matter/src/utils/buf.rs
+++ b/rs-matter/src/utils/buf.rs
@@ -1,0 +1,81 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use core::ops::{Deref, DerefMut};
+
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::{Mutex, MutexGuard};
+
+/// A trait for concurrently accessing a &mut [u8] buffer from multiple async tasks.
+pub trait BufferAccess {
+    type Buffer<'a>: DerefMut<Target = [u8]>
+    where
+        Self: 'a;
+
+    /// Get a reference to the buffer.
+    /// Await until the buffer is available, as it might be in use by somebody else.
+    async fn get(&self) -> Self::Buffer<'_>;
+}
+
+impl<T> BufferAccess for &T
+where
+    T: BufferAccess,
+{
+    type Buffer<'a> = T::Buffer<'a> where Self: 'a;
+
+    async fn get(&self) -> Self::Buffer<'_> {
+        (*self).get().await
+    }
+}
+
+/// A concrete implementation of `BufferAccess` utilizing a single internal buffer.
+pub struct BufferAccessImpl<const N: usize>(Mutex<NoopRawMutex, heapless::Vec<u8, N>>);
+
+impl<const N: usize> BufferAccessImpl<N> {
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self(Mutex::new(heapless::Vec::new()))
+    }
+}
+
+impl<const N: usize> BufferAccess for BufferAccessImpl<N> {
+    type Buffer<'a> = BufferImpl<'a, N> where Self: 'a;
+
+    async fn get(&self) -> Self::Buffer<'_> {
+        let mut guard = self.0.lock().await;
+
+        guard.resize_default(N).unwrap();
+
+        BufferImpl(guard)
+    }
+}
+
+pub struct BufferImpl<'a, const N: usize>(MutexGuard<'a, NoopRawMutex, heapless::Vec<u8, N>>);
+
+impl<'a, const N: usize> Deref for BufferImpl<'a, N> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a, const N: usize> DerefMut for BufferImpl<'a, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/rs-matter/src/utils/mod.rs
+++ b/rs-matter/src/utils/mod.rs
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+pub mod buf;
 pub mod epoch;
 pub mod parsebuf;
 pub mod rand;


### PR DESCRIPTION
The built-in mDNS implementation is adjusted in such a way, that it can share and re-use the RX/TX pair of buffers which are also used by the exchange/Matter transport layer. While not an enormous memory saving (~ 3K), it paves the way for the upcoming changes to the Exchange layer itself, where the existing `PacketBuffers` structure (~ 25K) is gone and everything works with this single RX/TX pair - at least with regards to the exchange layer (Secure Channel won't need extra RX/TX either, the IM layer is another story but still overall a big win).

Additional gains:
* I was finally able to `const`-ify the `Matter::new` / `Matter::new_default` constructors (thanks to `const`-ifying the mDNS construction itself which required changing a few `HashMap`s to `BTreeMap`s)
  * This is also a win for memory, as now the compiler can generate the layout of the `Matter` object and everything in it _at compile time_, put the result in the `rodata` section (= flash), and for creation of a "real" `Matter` object, just take the raw memory, `memcpy` into it the `Matter` object initial state from `rodata` and be done with it - no extra temporary memory necessary. 
  * In future, the `const` constructors would allow us to offer users to allocate the `Matter` object statically and not put it on stack or in a Box. As in `static MATTER: Matter<'static> = Matter::new(...)`. Still some work here, but we are approaching this status quo.
* `UdpSend` and `UdpReceive` traits are renamed to `NetworkSend` and `NetworkReceive`. They also now take/return our own `Address` enum rather than a `SocketAddr`. Reason: I'm relatively certain we'll be able to re-use them with minor to no changes for modeling the BLE transport and TCP, as from the POV of Matter, these protocols still operate in a packetized manner (i.e. with a 2-bytes len prefix in front of each packet for TCP)
* `NetworkReceive` has an additional method now - `wait_available` which is the key for sharing the RX/TX buffers from above. Basically, I'm only async-locking the RX buffer and giving it to either mDNS or Matter transport when the socket below tells us that there is a packet waiting for us in the OS network stack queue - via `wait_available`. This method is already implemented for STD/async-io, can be implemented for baremetal `embassy-net`/`smoltcp` with a small PR I'll contribute to them, and finally, at the price of... an additional RX buffer can be implemented for exotic OSes, though I doubt there would be any that won't natively support it. :)

Finally, the changes from above no longer force the user to create the mDNS service separately - as long as the user is not providing their own one to the `Matter` object (`MdnsService::Provided(_)`), the `Matter` constructor will just construct our pure-Rust one, or the Bonjour one or the Avahi one, depending on the OS.
