### PR TITLE
Start using idl parsing for basic_info and media clusters

### DIFF
--- a/rs-matter/src/data_model/cluster_basic_information.rs
+++ b/rs-matter/src/data_model/cluster_basic_information.rs
@@ -24,9 +24,12 @@ use crate::{
     utils::rand::Rand,
 };
 use heapless::String;
+use rs_matter_macros::idl_import;
 use strum::FromRepr;
 
-pub const ID: u32 = 0x0028;
+idl_import!(clusters = ["BasicInformation"]);
+
+pub use basic_information::ID;
 
 #[derive(Clone, Copy, Debug, FromRepr)]
 #[repr(u16)]

--- a/rs-matter/src/data_model/cluster_media_playback.rs
+++ b/rs-matter/src/data_model/cluster_media_playback.rs
@@ -27,8 +27,13 @@ use crate::{
 };
 use chrono::{DateTime, NaiveDate};
 use num_derive::FromPrimitive;
+use rs_matter_macros::idl_import;
 
-pub const ID: u32 = 0x0506;
+idl_import!(clusters = ["MediaPlayback"]);
+
+pub use media_playback::Commands;
+pub use media_playback::ID;
+
 #[derive(FromPrimitive)]
 pub enum Attributes {
     CurrentState = 0x0,
@@ -78,23 +83,6 @@ impl CommandStatus {
             CommandStatus::SeekOutOfRange => 5,
         }
     }
-}
-
-#[derive(FromPrimitive, PartialEq)]
-pub enum Commands {
-    Play = 0x0,
-    Pause = 0x1,
-    Stop = 0x2,
-    StartOver = 0x3,
-    Previous = 0x4,
-    Next = 0x5,
-    Rewind = 0x6,
-    FastForward = 0x7,
-    SkipForward = 0x8,
-    SkipBackward = 0x9,
-    // Response is from us to server
-    PlaybackResponse = 0xa,
-    Seek = 0x0b,
 }
 
 struct PlaybackPosition {

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -258,7 +258,7 @@ impl<T: ToTLV> ToTLV for Option<T> {
 /// The value may be null or a valid value
 /// Note: Null is different from Option. If the value is optional, include Option<> too. For
 /// example, Option<Nullable<T>>
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug, Hash, Eq)]
 pub enum Nullable<T> {
     Null,
     NotNull(T),

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -55,25 +55,6 @@ use super::{
     packet::{MAX_RX_BUF_SIZE, MAX_RX_STATUS_BUF_SIZE, MAX_TX_BUF_SIZE},
 };
 
-#[derive(Debug)]
-enum OpCodeDescriptor {
-    SecureChannel(OpCode),
-    InteractionModel(crate::interaction_model::core::OpCode),
-    Unknown(u8),
-}
-
-impl From<u8> for OpCodeDescriptor {
-    fn from(value: u8) -> Self {
-        if let Some(opcode) = num::FromPrimitive::from_u8(value) {
-            Self::SecureChannel(opcode)
-        } else if let Some(opcode) = num::FromPrimitive::from_u8(value) {
-            Self::InteractionModel(opcode)
-        } else {
-            Self::Unknown(value)
-        }
-    }
-}
-
 pub const MATTER_SOCKET_BIND_ADDR: SocketAddr =
     SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, MATTER_PORT, 0, 0));
 

--- a/rs-matter/tests/common/im_engine.rs
+++ b/rs-matter/tests/common/im_engine.rs
@@ -443,7 +443,7 @@ impl<'a> NetworkReceive for NetworkReceiver<'a> {
     async fn recv_from(&mut self, buffer: &mut [u8]) -> Result<(usize, Address), Error> {
         let vec = self.0.receive().await;
 
-        buffer[..vec.len()].copy_from_slice(&vec);
+        buffer[..vec.len()].copy_from_slice(vec);
         let len = vec.len();
 
         self.0.receive_done();


### PR DESCRIPTION
These could not be imported previously because some structs in their definition use optional and nullable. 

## Changes

- pass in the `matter_rs` crate name into the matter IDL macros, so we can reference things like `matter_rs::traits::Nullable`
- Addeed hash and eq to nullable, since that seems required for our derive macros for structs
- add matter IDL parsing into basic_info and media_playback. For now just use the clusterid from there (as a compile test)
- add unit testing for code generation for nullable and optional field support.