### PR TITLE
Make the `Error` type usage in the tlv macros fully specified

### DIFF
--- a/rs-matter-macros-impl/src/tlv.rs
+++ b/rs-matter-macros-impl/src/tlv.rs
@@ -108,7 +108,7 @@ fn gen_totlv_for_struct(
 
     quote! {
         impl #generics #krate::tlv::ToTLV for #struct_name #generics {
-            fn to_tlv(&self, tw: &mut #krate::tlv::TLVWriter, tag_type: #krate::tlv::TagType) -> Result<(), Error> {
+            fn to_tlv(&self, tw: &mut #krate::tlv::TLVWriter, tag_type: #krate::tlv::TagType) -> Result<(), #krate::error::Error> {
                 let anchor = tw.get_tail();
 
                 if let Err(err) = (|| {
@@ -346,7 +346,7 @@ fn gen_fromtlv_for_enum(
            impl #generics #krate::tlv::FromTLV <#lifetime> for #enum_name #generics {
                fn from_tlv(t: &#krate::tlv::TLVElement<#lifetime>) -> Result<Self, #krate::error::Error> {
                    let mut t_iter = t.confirm_struct()?.enter().ok_or_else(|| #krate::error::Error::new(#krate::error::ErrorCode::Invalid))?;
-                   let mut item = t_iter.next().ok_or_else(|| Error::new(#krate::error::ErrorCode::Invalid))?;
+                   let mut item = t_iter.next().ok_or_else(|| #krate::error::Error::new(#krate::error::ErrorCode::Invalid))?;
                    if let TagType::Context(tag) = item.get_tag() {
                        match tag {
                            #(
@@ -488,7 +488,7 @@ mod tests {
                       &self,
                       tw: &mut rs_matter_maybe_renamed::tlv::TLVWriter,
                       tag_type: rs_matter_maybe_renamed::tlv::TagType
-                    ) -> Result<(), Error> {
+                    ) -> Result<(), rs_matter_maybe_renamed::error::Error> {
                       let anchor = tw.get_tail();
                       if let Err(err) = (|| {
                           tw.start_struct(tag_type)?;

--- a/rs-matter/src/data_model/objects/mod.rs
+++ b/rs-matter/src/data_model/objects/mod.rs
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-use crate::error::Error;
 use crate::tlv::ToTLV;
 
 mod attribute;

--- a/rs-matter/src/interaction_model/messages.rs
+++ b/rs-matter/src/interaction_model/messages.rs
@@ -67,7 +67,6 @@ impl GenericPath {
 pub mod msg {
 
     use crate::{
-        error::Error,
         interaction_model::core::IMStatusCode,
         tlv::{FromTLV, TLVArray, ToTLV},
     };

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -55,25 +55,6 @@ use super::{
     packet::{MAX_RX_BUF_SIZE, MAX_RX_STATUS_BUF_SIZE, MAX_TX_BUF_SIZE},
 };
 
-#[derive(Debug)]
-enum OpCodeDescriptor {
-    SecureChannel(OpCode),
-    InteractionModel(crate::interaction_model::core::OpCode),
-    Unknown(u8),
-}
-
-impl From<u8> for OpCodeDescriptor {
-    fn from(value: u8) -> Self {
-        if let Some(opcode) = num::FromPrimitive::from_u8(value) {
-            Self::SecureChannel(opcode)
-        } else if let Some(opcode) = num::FromPrimitive::from_u8(value) {
-            Self::InteractionModel(opcode)
-        } else {
-            Self::Unknown(value)
-        }
-    }
-}
-
 pub const MATTER_SOCKET_BIND_ADDR: SocketAddr =
     SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, MATTER_PORT, 0, 0));
 


### PR DESCRIPTION
Before that, some code generation was referencing `Error` and required error to be imported in the global namespace. Macros should not depend on use statements in underlying code (and we mostly had Error already fully namespaced)