### PR TITLE
Add a macro for to/from TLV support for bitflags

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -23,7 +23,7 @@ rustcrypto = ["alloc", "sha2", "hmac", "pbkdf2", "hkdf", "aes", "ccm", "p256", "
 
 [dependencies]
 rs-matter-macros = { version = "0.1", path = "../rs-matter-macros" }
-bitflags = { version =  "1.3", default-features = false } # TODO: Update to 2.x
+bitflags = { version =  "2.5", default-features = false } # TODO: Update to 2.x
 byteorder = { version = "1.5", default-features = false }
 heapless = "0.8"
 heapless07 = { package = "heapless", version = "0.7" } # Necessary for domain 0.9

--- a/rs-matter/src/data_model/objects/attribute.rs
+++ b/rs-matter/src/data_model/objects/attribute.rs
@@ -23,7 +23,8 @@ use bitflags::bitflags;
 use core::fmt::{self, Debug};
 
 bitflags! {
-    #[derive(Default)]
+    #[repr(transparent)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Access: u16 {
         // These must match the bits in the Privilege object :-|
         const NEED_VIEW = 0x00001;
@@ -37,15 +38,15 @@ bitflags! {
         const FAB_SENSITIVE = 0x0080;
         const TIMED_ONLY = 0x0100;
 
-        const READ_PRIVILEGE_MASK = Self::NEED_VIEW.bits | Self::NEED_MANAGE.bits | Self::NEED_OPERATE.bits | Self::NEED_ADMIN.bits;
-        const WRITE_PRIVILEGE_MASK = Self::NEED_MANAGE.bits | Self::NEED_OPERATE.bits | Self::NEED_ADMIN.bits;
-        const RV = Self::READ.bits | Self::NEED_VIEW.bits;
-        const RF = Self::READ.bits | Self::FAB_SCOPED.bits;
-        const RA = Self::READ.bits | Self::NEED_ADMIN.bits;
-        const RWVA = Self::READ.bits | Self::WRITE.bits | Self::NEED_VIEW.bits | Self::NEED_ADMIN.bits;
-        const RWFA = Self::READ.bits | Self::WRITE.bits | Self::FAB_SCOPED.bits | Self::NEED_ADMIN.bits;
-        const RWVM = Self::READ.bits | Self::WRITE.bits | Self::NEED_VIEW.bits | Self::NEED_MANAGE.bits;
-        const RWFVM = Self::READ.bits | Self::WRITE.bits | Self::FAB_SCOPED.bits |Self::NEED_VIEW.bits | Self::NEED_MANAGE.bits;
+        const READ_PRIVILEGE_MASK = Self::NEED_VIEW.bits() | Self::NEED_MANAGE.bits() | Self::NEED_OPERATE.bits() | Self::NEED_ADMIN.bits();
+        const WRITE_PRIVILEGE_MASK = Self::NEED_MANAGE.bits() | Self::NEED_OPERATE.bits() | Self::NEED_ADMIN.bits();
+        const RV = Self::READ.bits() | Self::NEED_VIEW.bits();
+        const RF = Self::READ.bits() | Self::FAB_SCOPED.bits();
+        const RA = Self::READ.bits() | Self::NEED_ADMIN.bits();
+        const RWVA = Self::READ.bits() | Self::WRITE.bits() | Self::NEED_VIEW.bits() | Self::NEED_ADMIN.bits();
+        const RWFA = Self::READ.bits() | Self::WRITE.bits() | Self::FAB_SCOPED.bits() | Self::NEED_ADMIN.bits();
+        const RWVM = Self::READ.bits() | Self::WRITE.bits() | Self::NEED_VIEW.bits() | Self::NEED_MANAGE.bits();
+        const RWFVM = Self::READ.bits() | Self::WRITE.bits() | Self::FAB_SCOPED.bits() |Self::NEED_VIEW.bits() | Self::NEED_MANAGE.bits();
     }
 }
 
@@ -73,7 +74,8 @@ impl Access {
 }
 
 bitflags! {
-    #[derive(Default)]
+    #[repr(transparent)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Quality: u8 {
         const NONE = 0x00;
         const SCENE = 0x01;      // Short: S
@@ -81,11 +83,11 @@ bitflags! {
         const FIXED = 0x04;      // Short: F
         const NULLABLE = 0x08;   // Short: X
 
-        const SN = Self::SCENE.bits | Self::PERSISTENT.bits;
-        const S = Self::SCENE.bits;
-        const N = Self::PERSISTENT.bits;
-        const F = Self::FIXED.bits;
-        const X = Self::NULLABLE.bits;
+        const SN = Self::SCENE.bits() | Self::PERSISTENT.bits();
+        const S = Self::SCENE.bits();
+        const N = Self::PERSISTENT.bits();
+        const F = Self::FIXED.bits();
+        const X = Self::NULLABLE.bits();
     }
 }
 

--- a/rs-matter/src/data_model/objects/privilege.rs
+++ b/rs-matter/src/data_model/objects/privilege.rs
@@ -24,17 +24,18 @@ use log::error;
 use bitflags::bitflags;
 
 bitflags! {
-    #[derive(Default)]
+    #[repr(transparent)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Privilege: u8 {
         const V = 0x01;
         const O = 0x02;
         const M = 0x04;
         const A = 0x08;
 
-        const VIEW = Self::V.bits;
-        const OPERATE = Self::V.bits | Self::O.bits;
-        const MANAGE = Self::V.bits | Self::O.bits | Self::M.bits;
-        const ADMIN = Self::V.bits | Self::O.bits| Self::M.bits| Self::A.bits;
+        const VIEW = Self::V.bits();
+        const OPERATE = Self::V.bits() | Self::O.bits();
+        const MANAGE = Self::V.bits() | Self::O.bits() | Self::M.bits();
+        const ADMIN = Self::V.bits() | Self::O.bits() | Self::M.bits() | Self::A.bits();
     }
 }
 

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -488,7 +488,7 @@ impl<'a> ToTLV for TLVElement<'a> {
 #[cfg(test)]
 mod tests {
     use super::{FromTLV, OctetStr, TLVWriter, TagType, ToTLV};
-    use crate::{error::Error, tlv::TLVList, utils::writebuf::WriteBuf};
+    use crate::{tlv::TLVList, utils::writebuf::WriteBuf};
     use rs_matter_macros::{FromTLV, ToTLV};
 
     #[derive(ToTLV)]

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -485,6 +485,30 @@ impl<'a> ToTLV for TLVElement<'a> {
     }
 }
 
+/// Implements to/from TLV for the given enumeration that was
+/// created using `bitflags!`
+///
+/// NOTE:
+///   - bitflgs are generally unrestricted. The provided implementations
+///     do NOT attempt to validate flags for validity and the entire
+///     range of flags will be marshalled (including unknown flags)
+#[macro_export]
+macro_rules! bitflags_tlv {
+    ($enum_name:ident, $type:ident) => {
+        impl FromTLV<'_> for $enum_name {
+            fn from_tlv(t: &TLVElement) -> Result<Self, Error> {
+                Ok(Self::from_bits_retain(t.$type()?))
+            }
+        }
+
+        impl ToTLV for $enum_name {
+            fn to_tlv(&self, tw: &mut TLVWriter, tag: TagType) -> Result<(), Error> {
+                tw.$type(tag, self.bits())
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::{FromTLV, OctetStr, TLVWriter, TagType, ToTLV};

--- a/rs-matter/src/transport/plain_hdr.rs
+++ b/rs-matter/src/transport/plain_hdr.rs
@@ -29,7 +29,8 @@ pub enum SessionType {
 }
 
 bitflags! {
-    #[derive(Default)]
+    #[repr(transparent)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct MsgFlags: u8 {
         const DSIZ_UNICAST_NODEID = 0x01;
         const DSIZ_GROUPCAST_NODEID = 0x02;

--- a/rs-matter/src/transport/proto_hdr.rs
+++ b/rs-matter/src/transport/proto_hdr.rs
@@ -26,7 +26,8 @@ use crate::{crypto, error::*};
 use log::{info, trace};
 
 bitflags! {
-    #[derive(Default)]
+    #[repr(transparent)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct ExchFlags: u8 {
         const VENDOR = 0x10;
         const SECEX = 0x08;

--- a/rs-matter/tests/tlv_encoding.rs
+++ b/rs-matter/tests/tlv_encoding.rs
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2024 Project CHIP Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[cfg(test)]
+mod tlv_encoding_tests {
+    use rs_matter::error::Error;
+    use rs_matter::tlv::{get_root_node, FromTLV, TLVWriter, TagType, ToTLV};
+    use rs_matter::utils::writebuf::WriteBuf;
+
+    #[derive(PartialEq, Debug, ToTLV, FromTLV)]
+    struct SimpleStruct {
+        number1: u8,
+        number2: u32,
+    }
+
+    #[derive(PartialEq, Debug, ToTLV, FromTLV)]
+    #[allow(dead_code)]
+    enum SimpleEnum {
+        A,
+        B,
+        C,
+    }
+
+    #[derive(PartialEq, Debug, ToTLV, FromTLV)]
+    struct SimpleStructWithEnum {
+        enum1: SimpleEnum,
+        number2: u32,
+    }
+
+    fn encode_to_tlv(what: &impl ToTLV) -> Result<Vec<u8>, Error> {
+        const MAX_OUTPUT_SIZE: usize = 1024;
+
+        let mut output_buffer = [0u8; MAX_OUTPUT_SIZE];
+        let mut write_buf = WriteBuf::new(&mut output_buffer);
+        let mut writer = TLVWriter::new(&mut write_buf);
+        what.to_tlv(&mut writer, TagType::Anonymous)?;
+
+        Ok(Vec::from(write_buf.as_slice()))
+    }
+
+    fn decode_from_tlv<'a, T: FromTLV<'a>>(data: &'a [u8]) -> Result<T, Error> {
+        let node = get_root_node(data)?;
+        T::from_tlv(&node)
+    }
+
+    macro_rules! asserted_ok {
+        ($a:expr, $message: literal) => {
+            match $a {
+                Ok(value) => value,
+                Err(e) => {
+                    assert!(false, "{} failed with {:?}", $message, e);
+                    return;
+                }
+            }
+        };
+    }
+
+    #[test]
+    fn encode_simple_struct() {
+        let a = SimpleStruct {
+            number1: 123,
+            number2: 0x23456,
+        };
+
+        let encoded = asserted_ok!(encode_to_tlv(&a), "Encoding to TLV");
+        let b = asserted_ok!(decode_from_tlv(&encoded), "Decoding of LTV");
+
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn simple_enum_formats() {
+        let with_enum = SimpleStructWithEnum {
+            enum1: SimpleEnum::C,
+            number2: 0x23456,
+        };
+
+        let without_enum = SimpleStruct {
+            number1: 2,
+            number2: 0x23456,
+        };
+
+        let encoded = asserted_ok!(encode_to_tlv(&with_enum), "Encoding to TLV");
+
+        // check that enums are encoded as a simple u8
+        let b = asserted_ok!(decode_from_tlv::<SimpleStruct>(&encoded), "Decoding of TLV");
+        assert_eq!(b, without_enum);
+
+        // check that enum decoding back works (i.e. encode/decode are idem-potent)
+        let b = asserted_ok!(
+            decode_from_tlv::<SimpleStructWithEnum>(&encoded),
+            "Decoding of TLV"
+        );
+        assert_eq!(b, with_enum);
+    }
+}


### PR DESCRIPTION
This builds on top of #143 

## Changes

- update bitflags crate to latest version. This is in case we manage to implement To/From TLV for bitflags::Flags type (although I am unsure here ... I tried and I get errors because we have defined to/from TLV for slices and references)
- define a macro `bitflags_tlv` that implements ToTLV/FromTLV for the given macro given an underlying data type that is expected
- Make use of this macro in idl codegen
- Added some unit tests