### PR TITLE
Fix from tlv for nullable with full path, add FromTLV generation for structs in idl codegen

### DIFF
--- a/rs-matter-macros-impl/src/idl.rs
+++ b/rs-matter-macros-impl/src/idl.rs
@@ -261,9 +261,10 @@ fn struct_definition(s: &Struct, context: &IdlGenerateContext) -> TokenStream {
     // at least
 
     let fields = s.fields.iter().map(|f| struct_field_definition(f, context));
+    let krate = context.rs_matter_crate.clone();
 
     quote!(
-        #[derive(Debug, PartialEq, Eq, Clone, Hash, ToTLV)]
+        #[derive(Debug, PartialEq, Eq, Clone, Hash, #krate::tlv::FromTLV, #krate::tlv::ToTLV)]
         pub struct #name {
            #(#fields),*
         }
@@ -387,7 +388,15 @@ mod tests {
         assert_tokenstreams_eq!(
             &defs,
             &quote!(
-                #[derive(Debug, PartialEq, Eq, Clone, Hash, ToTLV)]
+                #[derive(
+                    Debug,
+                    PartialEq,
+                    Eq,
+                    Clone,
+                    Hash,
+                    rs_matter_crate::tlv::FromTLV,
+                    rs_matter_crate::tlv::ToTLV,
+                )]
                 pub struct NetworkInfoStruct {
                     connected: bool,
                     test_optional: Option<u8>,
@@ -395,22 +404,54 @@ mod tests {
                     test_both: Option<rs_matter_crate::tlv::Nullable<u32>>,
                 }
 
-                #[derive(Debug, PartialEq, Eq, Clone, Hash, ToTLV)]
+                #[derive(
+                    Debug,
+                    PartialEq,
+                    Eq,
+                    Clone,
+                    Hash,
+                    rs_matter_crate::tlv::FromTLV,
+                    rs_matter_crate::tlv::ToTLV,
+                )]
                 pub struct IdentifyRequest {
                     identify_time: u16,
                 }
 
-                #[derive(Debug, PartialEq, Eq, Clone, Hash, ToTLV)]
+                #[derive(
+                    Debug,
+                    PartialEq,
+                    Eq,
+                    Clone,
+                    Hash,
+                    rs_matter_crate::tlv::FromTLV,
+                    rs_matter_crate::tlv::ToTLV,
+                )]
                 pub struct SomeRequest {
                     group: u16,
                 }
 
-                #[derive(Debug, PartialEq, Eq, Clone, Hash, ToTLV)]
+                #[derive(
+                    Debug,
+                    PartialEq,
+                    Eq,
+                    Clone,
+                    Hash,
+                    rs_matter_crate::tlv::FromTLV,
+                    rs_matter_crate::tlv::ToTLV,
+                )]
                 pub struct TestResponse {
                     capacity: u8,
                 }
 
-                #[derive(Debug, PartialEq, Eq, Clone, Hash, ToTLV)]
+                #[derive(
+                    Debug,
+                    PartialEq,
+                    Eq,
+                    Clone,
+                    Hash,
+                    rs_matter_crate::tlv::FromTLV,
+                    rs_matter_crate::tlv::ToTLV,
+                )]
                 pub struct AnotherResponse {
                     status: u8,
                     group_id: u16,
@@ -601,13 +642,29 @@ mod tests {
                         Toggle = 2,
                     }
 
-                    #[derive(Debug, PartialEq, Eq, Clone, Hash, ToTLV)]
+                    #[derive(
+                        Debug,
+                        PartialEq,
+                        Eq,
+                        Clone,
+                        Hash,
+                        rs_matter_crate::tlv::FromTLV,
+                        rs_matter_crate::tlv::ToTLV,
+                    )]
                     pub struct OffWithEffectRequest {
                         effect_identifier: EffectIdentifierEnum,
                         effect_variant: u8,
                     }
 
-                    #[derive(Debug, PartialEq, Eq, Clone, Hash, ToTLV)]
+                    #[derive(
+                        Debug,
+                        PartialEq,
+                        Eq,
+                        Clone,
+                        Hash,
+                        rs_matter_crate::tlv::FromTLV,
+                        rs_matter_crate::tlv::ToTLV,
+                    )]
                     pub struct OnWithTimedOffRequest {
                         on_off_control: OnOffControlBitmap,
                         on_time: u16,

--- a/rs-matter-macros/src/lib.rs
+++ b/rs-matter-macros/src/lib.rs
@@ -36,13 +36,13 @@ fn get_crate_name() -> String {
     }
 }
 
-#[proc_macro_derive(ToTLV, attributes(tlvargs, tagval))]
+#[proc_macro_derive(ToTLV, attributes(tlvargs, tagval, enumval))]
 pub fn derive_totlv(item: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(item as DeriveInput);
     rs_matter_macros_impl::tlv::derive_totlv(ast, get_crate_name()).into()
 }
 
-#[proc_macro_derive(FromTLV, attributes(tlvargs, tagval))]
+#[proc_macro_derive(FromTLV, attributes(tlvargs, tagval, enumval))]
 pub fn derive_fromtlv(item: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(item as DeriveInput);
     rs_matter_macros_impl::tlv::derive_fromtlv(ast, get_crate_name()).into()

--- a/rs-matter/src/data_model/cluster_basic_information.rs
+++ b/rs-matter/src/data_model/cluster_basic_information.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use core::{cell::RefCell, convert::TryInto};
+use core::cell::RefCell;
 
 use super::objects::*;
 use crate::{

--- a/rs-matter/src/data_model/cluster_on_off.rs
+++ b/rs-matter/src/data_model/cluster_on_off.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use core::{cell::Cell, convert::TryInto};
+use core::cell::Cell;
 
 use super::objects::*;
 use crate::{

--- a/rs-matter/src/data_model/objects/cluster.rs
+++ b/rs-matter/src/data_model/objects/cluster.rs
@@ -33,10 +33,7 @@ use crate::{
     // TODO: This layer shouldn't really depend on the TLV layer, should create an abstraction layer
     tlv::{Nullable, TLVWriter, TagType},
 };
-use core::{
-    convert::TryInto,
-    fmt::{self, Debug},
-};
+use core::fmt::{self, Debug};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, FromRepr)]
 #[repr(u16)]

--- a/rs-matter/src/data_model/sdm/admin_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/admin_commissioning.rs
@@ -16,7 +16,6 @@
  */
 
 use core::cell::RefCell;
-use core::convert::TryInto;
 
 use crate::data_model::objects::*;
 use crate::mdns::Mdns;

--- a/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
@@ -14,12 +14,9 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-use core::convert::TryInto;
-
 use crate::{
-    attribute_enum, cmd_enter, command_enum, data_model::objects::AttrType, data_model::objects::*,
-    error::Error, tlv::TLVElement, transport::exchange::Exchange, utils::rand::Rand,
+    attribute_enum, cmd_enter, command_enum, data_model::objects::*, error::Error, tlv::TLVElement,
+    transport::exchange::Exchange, utils::rand::Rand,
 };
 use log::info;
 use strum::{EnumDiscriminants, FromRepr};

--- a/rs-matter/src/data_model/sdm/general_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/general_commissioning.rs
@@ -16,7 +16,6 @@
  */
 
 use core::cell::RefCell;
-use core::convert::TryInto;
 
 use crate::data_model::objects::*;
 use crate::data_model::sdm::failsafe::FailSafe;

--- a/rs-matter/src/data_model/sdm/general_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/general_diagnostics.rs
@@ -14,12 +14,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-use core::convert::TryInto;
-
 use crate::{
     attribute_enum, cmd_enter, command_enum,
-    data_model::objects::AttrType,
     data_model::objects::*,
     error::{Error, ErrorCode},
     tlv::TLVElement,

--- a/rs-matter/src/data_model/sdm/group_key_management.rs
+++ b/rs-matter/src/data_model/sdm/group_key_management.rs
@@ -14,12 +14,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-use core::convert::TryInto;
-
 use crate::{
     attribute_enum, cmd_enter, command_enum,
-    data_model::objects::AttrType,
     data_model::objects::*,
     error::{Error, ErrorCode},
     tlv::TLVElement,

--- a/rs-matter/src/data_model/sdm/noc.rs
+++ b/rs-matter/src/data_model/sdm/noc.rs
@@ -16,7 +16,6 @@
  */
 
 use core::cell::RefCell;
-use core::convert::TryInto;
 
 use crate::acl::{AclEntry, AclMgr, AuthMode};
 use crate::cert::{Cert, MAX_CERT_TLV_LEN};

--- a/rs-matter/src/data_model/system_model/access_control.rs
+++ b/rs-matter/src/data_model/system_model/access_control.rs
@@ -16,7 +16,6 @@
  */
 
 use core::cell::RefCell;
-use core::convert::TryInto;
 
 use strum::{EnumDiscriminants, FromRepr};
 

--- a/rs-matter/src/data_model/system_model/descriptor.rs
+++ b/rs-matter/src/data_model/system_model/descriptor.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use core::convert::TryInto;
-
 use strum::FromRepr;
 
 use crate::attribute_enum;

--- a/rs-matter/src/interaction_model/core.rs
+++ b/rs-matter/src/interaction_model/core.rs
@@ -25,7 +25,7 @@ use crate::{
     utils::epoch::Epoch,
 };
 use log::error;
-use num::{self, FromPrimitive};
+use num::FromPrimitive;
 use num_derive::FromPrimitive;
 
 use super::messages::msg::{

--- a/rs-matter/tests/common/echo_cluster.rs
+++ b/rs-matter/tests/common/echo_cluster.rs
@@ -16,7 +16,6 @@
  */
 
 use core::cell::Cell;
-use core::convert::TryInto;
 use std::sync::{Arc, Mutex, Once};
 
 use num_derive::FromPrimitive;


### PR DESCRIPTION
This builds upon #145 

FromTLV for BasicInfoCluster was broken because the nullable use was `matter_rs::tlv::Nullable<...>` and because we were using path_segments[0] for the not_found, we were trying to call `matter_rs::tlv_not_found` instead of the proper `matter_rs::tlv::Nullable::tlv_not_found`.

I still find it slightly odd that we do not use the path arguments at all, so we may want to refine this logic at some point, however for now at least IDL gen works for the few clusters we do use it (media, onoff and basicinfo).

Added unit tests for things as well.