### PR TITLE
Use stabilized core::net on no_std

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["matter", "smart", "smart-home", "IoT", "ESP32"]
 categories = ["embedded", "network-programming"]
 license = "Apache-2.0"
-rust-version = "1.75"
+rust-version = "1.77"
 
 [features]
 default = ["os", "mbedtls"]
@@ -32,7 +32,6 @@ num-derive = "0.4"
 num-traits = { version = "0.2", default-features = false }
 strum = { version = "0.26", features = ["derive"], default-features = false }
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_debug"] }
-no-std-net = "0.6" # To be replaced with core::net once Rust 1.77 is out
 subtle = { version = "2.5", default-features = false }
 safemem = { version = "0.3", default-features = false }
 owo-colors = "4"

--- a/rs-matter/src/transport/network.rs
+++ b/rs-matter/src/transport/network.rs
@@ -18,7 +18,7 @@
 use core::fmt::{Debug, Display};
 
 #[cfg(not(feature = "std"))]
-pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+pub use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 #[cfg(feature = "std")]
 pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 


### PR DESCRIPTION
Rust 1.77 release on the March 21st stabilized [core::net](https://doc.rust-lang.org/stable/core/net/index.html)

Use the newly stabilized `core::net` allows remove dependency upon third party create `no-std-net` and use the official types for network addresses in no-std environments

I'll make follow-up PR in `smoltcp` to have types conversion between `rs-matter (core::net)`and `smoltcp`
