### PR TITLE
Update `proc-macro-crate` to `3.1.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,15 @@ debug = true
 opt-level = 3
 
 [workspace.dependencies]
-clap = { version = "4.4.11", features = ["derive"] }
-miette = { version = "5.10.0", features = ["fancy"] }
-nom = "7.1.3"
-nom-greedyerror = "0.5.0"
-nom-supreme = "0.8.0"
-nom_locate = "4.2.0"
-thiserror = "1.0.50"
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["regex", "json"] }
+clap = { version = "4", features = ["derive"] }
+miette = { version = "5", features = ["fancy"] }
+nom = "7"
+nom-greedyerror = "0.5"
+nom-supreme = "0.8"
+nom_locate = "4.2"
+thiserror = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["regex", "json"] }
 
 [profile.flamegraph]
 inherits = "release"

--- a/rs-matter-macros-impl/Cargo.toml
+++ b/rs-matter-macros-impl/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-quote = "1.0.33"
-rs-matter-data-model={path = "../rs-matter-data-model", features = ["idl"]}
-syn = {version="2.0.48", features = ["extra-traits", "parsing", "proc-macro"]}
-proc-macro2 = "1.0.70"
-convert_case = "0.6.0"
+quote = "1"
+rs-matter-data-model = { path = "../rs-matter-data-model", features = ["idl"] }
+syn = { version = "2", features = ["extra-traits", "parsing", "proc-macro"] }
+proc-macro2 = "1"
+convert_case = "0.6"
 
 [dev-dependencies]
 assert-tokenstreams-eq = "0.1.0"

--- a/rs-matter-macros/Cargo.toml
+++ b/rs-matter-macros/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro = true
 syn = { version = "2.0.48", features = ["extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"
-proc-macro-crate = "3.0.0"
+proc-macro-crate = "3.1.0"
 
-rs-matter-data-model = { path = "../rs-matter-data-model", features=["idl"] }
+rs-matter-data-model = { path = "../rs-matter-data-model", features = ["idl"] }
 rs-matter-macros-impl = { path = "../rs-matter-macros-impl" }

--- a/rs-matter-macros/Cargo.toml
+++ b/rs-matter-macros/Cargo.toml
@@ -19,10 +19,10 @@ license = "Apache-2.0"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.48", features = ["extra-traits", "parsing"] }
+syn = { version = "2", features = ["extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"
-proc-macro-crate = "3.1.0"
+proc-macro-crate = "3"
 
 rs-matter-data-model = { path = "../rs-matter-data-model", features = ["idl"] }
 rs-matter-macros-impl = { path = "../rs-matter-macros-impl" }


### PR DESCRIPTION
The old version caused a conflict with another crate that prevented me from compiling the code.

To prevent future conflicts, it would make sense to only define the major version (minor and patch updates should not break code):
```diff
[dependencies]
-syn = { version = "2.0.48", features = ["extra-traits", "parsing"] }
+syn = { version = "2", features = ["extra-traits", "parsing"] }
quote = "1"
proc-macro2 = "1"
-proc-macro-crate = "3.1.0"
+proc-macro-crate = "3"
```