### PR TITLE
fix(rs-matter): undeclare crate

### DIFF
--- a/rs-matter/src/error.rs
+++ b/rs-matter/src/error.rs
@@ -195,14 +195,6 @@ impl From<mbedtls::Error> for Error {
     }
 }
 
-#[cfg(target_os = "espidf")]
-impl From<esp_idf_sys::EspError> for Error {
-    fn from(e: esp_idf_sys::EspError) -> Self {
-        ::log::error!("Error in ESP: {}", e);
-        Self::new(ErrorCode::TLSStack) // TODO: Not a good mapping
-    }
-}
-
 #[cfg(feature = "rustcrypto")]
 impl From<ccm::aead::Error> for Error {
     fn from(_e: ccm::aead::Error) -> Self {


### PR DESCRIPTION
Building for esp fails with

```
failed to resolve: use of undeclared crate or module `esp_idf_sys`
```

I think during previous clean-ups this was forgotten as the crate is not referenced anywhere else. Removing the error as well to unblock development for esp systems.