### PR TITLE
mDNS fix: TXT records must not be empty

### DIFF
--- a/rs-matter/src/mdns.rs
+++ b/rs-matter/src/mdns.rs
@@ -176,7 +176,7 @@ impl ServiceMode {
                 protocol: "_tcp",
                 port: matter_port,
                 service_subtypes: &[],
-                txt_kvs: &[],
+                txt_kvs: &[("", "")],
             }),
             ServiceMode::Commissionable(discriminator) => {
                 let discriminator_str = Self::get_discriminator_str(*discriminator);


### PR DESCRIPTION
According to [RFC 6763](https://datatracker.ietf.org/doc/html/rfc6763#section-6.1), "An empty TXT record containing zero strings is not allowed. DNS-SD implementations MUST NOT emit empty TXT records."

By simply emitting a TXT record with a zero-length key-value pair, commissioning of devices based on the built-in mDNS implementation now succeeds when issued from Apple-based devices like the iPhone.