### PR TITLE
OnOffCluster: add an optional callback to new()

### DIFF
--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -158,7 +158,7 @@ fn handler<'a>(matter: &'a Matter<'a>) -> impl Metadata + NonBlockingHandler + '
             .chain(
                 1,
                 cluster_on_off::ID,
-                cluster_on_off::OnOffCluster::new(*matter.borrow()),
+                cluster_on_off::OnOffCluster::new(*matter.borrow(), None),
             ),
     )
 }

--- a/rs-matter/tests/common/im_engine.rs
+++ b/rs-matter/tests/common/im_engine.rs
@@ -150,7 +150,11 @@ impl<'a> ImEngineHandler<'a> {
             .chain(0, echo_cluster::ID, EchoCluster::new(2, *matter.borrow()))
             .chain(1, descriptor::ID, DescriptorCluster::new(*matter.borrow()))
             .chain(1, echo_cluster::ID, EchoCluster::new(3, *matter.borrow()))
-            .chain(1, cluster_on_off::ID, OnOffCluster::new(*matter.borrow(), None));
+            .chain(
+                1,
+                cluster_on_off::ID,
+                OnOffCluster::new(*matter.borrow(), None),
+            );
 
         Self { handler }
     }

--- a/rs-matter/tests/common/im_engine.rs
+++ b/rs-matter/tests/common/im_engine.rs
@@ -141,7 +141,7 @@ pub struct ImOutput {
 }
 
 pub struct ImEngineHandler<'a> {
-    handler: handler_chain_type!(OnOffCluster, EchoCluster, DescriptorCluster<'static>, EchoCluster | RootEndpointHandler<'a>),
+    handler: handler_chain_type!(OnOffCluster<'a>, EchoCluster, DescriptorCluster<'static>, EchoCluster | RootEndpointHandler<'a>),
 }
 
 impl<'a> ImEngineHandler<'a> {
@@ -150,7 +150,7 @@ impl<'a> ImEngineHandler<'a> {
             .chain(0, echo_cluster::ID, EchoCluster::new(2, *matter.borrow()))
             .chain(1, descriptor::ID, DescriptorCluster::new(*matter.borrow()))
             .chain(1, echo_cluster::ID, EchoCluster::new(3, *matter.borrow()))
-            .chain(1, cluster_on_off::ID, OnOffCluster::new(*matter.borrow()));
+            .chain(1, cluster_on_off::ID, OnOffCluster::new(*matter.borrow(), None));
 
         Self { handler }
     }


### PR DESCRIPTION
Users of rs-matter may want to execute their own logic when a cluster switches state. This commit adds a `callback: Option<&'a dyn Fn(bool)>` parameter to OnOffCluster::new(). If set, that callback executes each time `OnOffCluster::set(value: bool)` is called with a different value than the previous one.