### PR TITLE
Make Clippy happy

### DIFF
--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -416,6 +416,12 @@ pub struct AclMgr {
     changed: bool,
 }
 
+impl Default for AclMgr {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AclMgr {
     #[inline(always)]
     pub const fn new() -> Self {

--- a/rs-matter/src/data_model/subscriptions.rs
+++ b/rs-matter/src/data_model/subscriptions.rs
@@ -56,6 +56,12 @@ pub struct Subscriptions<const N: usize> {
     pub(crate) notification: Notification<NoopRawMutex>,
 }
 
+impl<const N: usize> Default for Subscriptions<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<const N: usize> Subscriptions<N> {
     /// Create the instance.
     #[inline(always)]

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -190,6 +190,12 @@ pub struct FabricMgr {
     changed: bool,
 }
 
+impl Default for FabricMgr {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FabricMgr {
     #[inline(always)]
     pub const fn new() -> Self {

--- a/rs-matter/src/interaction_model/busy.rs
+++ b/rs-matter/src/interaction_model/busy.rs
@@ -41,6 +41,12 @@ use super::{
 /// not accepted in time by the actual Interaction Model responder, due to all its handlers being occupied with work.
 pub struct BusyInteractionModel(());
 
+impl Default for BusyInteractionModel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BusyInteractionModel {
     #[inline(always)]
     pub const fn new() -> Self {

--- a/rs-matter/src/secure_channel/busy.rs
+++ b/rs-matter/src/secure_channel/busy.rs
@@ -40,6 +40,12 @@ use super::common::{sc_write, OpCode, SCStatusCodes, PROTO_ID_SECURE_CHANNEL};
 /// not accepted in time by the actual Secure Channel responder, due to all its handlers being occupied with work.
 pub struct BusySecureChannel(());
 
+impl Default for BusySecureChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BusySecureChannel {
     const BUSY_RETRY_DELAY_MS: u16 = 500;
 

--- a/rs-matter/src/secure_channel/case.rs
+++ b/rs-matter/src/secure_channel/case.rs
@@ -43,6 +43,12 @@ pub struct CaseSession {
     local_fabric_idx: usize,
 }
 
+impl Default for CaseSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CaseSession {
     #[inline(always)]
     pub const fn new() -> Self {

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -589,7 +589,7 @@ pub struct SenderTx<'a, 'b> {
 
 impl<'a, 'b> SenderTx<'a, 'b> {
     pub fn split(&mut self) -> (&Exchange<'_>, &mut [u8]) {
-        (&self.sender.exchange, self.message.payload())
+        (self.sender.exchange, self.message.payload())
     }
 
     pub fn payload(&mut self) -> &mut [u8] {

--- a/rs-matter/src/utils/ifmutex.rs
+++ b/rs-matter/src/utils/ifmutex.rs
@@ -26,7 +26,6 @@ use super::signal::Signal;
 
 /// Error returned by [`Mutex::try_lock`]
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TryLockError;
 
 /// Async mutex with conditional locking based on the data inside the mutex.

--- a/rs-matter/src/utils/notification.rs
+++ b/rs-matter/src/utils/notification.rs
@@ -22,6 +22,15 @@ use super::signal::Signal;
 /// A notification primitive that allows for notifying a single waiter.
 pub struct Notification<M>(Signal<M, Option<()>>);
 
+impl<M> Default for Notification<M>
+where
+    M: RawMutex,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<M> Notification<M>
 where
     M: RawMutex,


### PR DESCRIPTION
Clippy in latest nighties became noisier (as usual), so this PR is fixing the latest round of Clippy complains and thus the CI too.

(99% lack of `Default` impl, and 99% done with just `cargo clippy --allow-dirty --fix`).
