### PR TITLE
Expose concurrent commissioning flow attribute

### DIFF
--- a/rs-matter/src/data_model/root_endpoint.rs
+++ b/rs-matter/src/data_model/root_endpoint.rs
@@ -139,7 +139,7 @@ pub fn wrap<'a>(
         .chain(
             endpoint_id,
             general_commissioning::ID,
-            GenCommCluster::new(failsafe, rand),
+            GenCommCluster::new(failsafe, true, rand),
         )
         .chain(
             endpoint_id,

--- a/rs-matter/tests/data_model/long_reads.rs
+++ b/rs-matter/tests/data_model/long_reads.rs
@@ -149,6 +149,12 @@ fn wildcard_read_resp(part: u8) -> Vec<AttrResp<'static>> {
             gen_comm::AttributesDiscriminants::BasicCommissioningInfo,
             dont_care.clone()
         ),
+        attr_data!(
+            0,
+            48,
+            gen_comm::AttributesDiscriminants::SupportsConcurrentConnection,
+            dont_care.clone()
+        ),
         attr_data!(0, 49, GlobalElements::FeatureMap, dont_care.clone()),
         attr_data!(0, 49, GlobalElements::AttributeList, dont_care.clone()),
         attr_data!(
@@ -201,15 +207,15 @@ fn wildcard_read_resp(part: u8) -> Vec<AttrResp<'static>> {
             adm_comm::AttributesDiscriminants::WindowStatus,
             dont_care.clone()
         ),
+    ];
+
+    let part2 = vec![
         attr_data!(
             0,
             60,
             adm_comm::AttributesDiscriminants::AdminFabricIndex,
             dont_care.clone()
         ),
-    ];
-
-    let part2 = vec![
         attr_data!(
             0,
             60,


### PR DESCRIPTION
This read-only attribute (`true` by default as per spec) needs to be explicitly set to `false` for `rs-matter` deployments where non-concurrent commissioning is used (i.e. what we currently do for ESP IDF Wifi+BLE commissioning).
