### PR TITLE
Pass explicit DiscoveryCapabilities

### DIFF
--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -150,11 +150,14 @@ fn run() -> Result<(), Error> {
     let mut transport = pin!(matter.run(
         &socket,
         &socket,
-        Some(CommissioningData {
-            // TODO: Hard-coded for now
-            verifier: VerifierData::new_with_pw(123456, *matter.borrow()),
-            discriminator: 250,
-        }),
+        Some((
+            CommissioningData {
+                // TODO: Hard-coded for now
+                verifier: VerifierData::new_with_pw(123456, *matter.borrow()),
+                discriminator: 250,
+            },
+            Default::default(),
+        )),
     ));
 
     // NOTE:

--- a/rs-matter/src/pairing/mod.rs
+++ b/rs-matter/src/pairing/mod.rs
@@ -34,6 +34,7 @@ use self::{
     qr::{compute_qr_code_text, print_qr_code},
 };
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct DiscoveryCapabilities {
     on_ip_network: bool,
     ble: bool,
@@ -41,8 +42,8 @@ pub struct DiscoveryCapabilities {
 }
 
 impl DiscoveryCapabilities {
-    pub fn new(on_ip_network: bool, ble: bool, soft_access_point: bool) -> Self {
-        DiscoveryCapabilities {
+    pub const fn new(on_ip_network: bool, ble: bool, soft_access_point: bool) -> Self {
+        Self {
             on_ip_network,
             ble,
             soft_access_point,

--- a/rs-matter/src/secure_channel/spake2p.rs
+++ b/rs-matter/src/secure_channel/spake2p.rs
@@ -86,6 +86,7 @@ impl Default for Spake2P {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct VerifierData {
     pub data: VerifierOption,
     // For the VerifierOption::Verifier, the following fields only serve
@@ -94,6 +95,7 @@ pub struct VerifierData {
     pub count: u32,
 }
 
+#[derive(Debug, Clone)]
 pub enum VerifierOption {
     /// With Password
     Password(u32),

--- a/rs-matter/tests/common/im_engine.rs
+++ b/rs-matter/tests/common/im_engine.rs
@@ -259,7 +259,7 @@ impl<'a> ImEngine<'a> {
     }
 
     fn init_matter(matter: &Matter, local_nodeid: u64, remote_nodeid: u64, cat_ids: &NocCatIds) {
-        matter.transport_mgr.reset();
+        matter.transport_mgr.reset().unwrap();
 
         let mut session = ReservedSession::reserve_now(matter).unwrap();
 


### PR DESCRIPTION
Minor extension to allow the user to pass a custom `DiscoveryCapabilities` instance thru the API.

Currently, a `Default::default()` discovery caps is hard-coded in `rs-matter`, however this is not appropriate because the default instance is set for ethernet commissioning, while the user might want Wifi+BLE.
