### PR TITLE
Make all system clusters cloneable

### DIFF
--- a/rs-matter/src/data_model/cluster_basic_information.rs
+++ b/rs-matter/src/data_model/cluster_basic_information.rs
@@ -135,6 +135,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     commands: &[],
 };
 
+#[derive(Clone)]
 pub struct BasicInfoCluster<'a> {
     data_ver: Dataver,
     cfg: &'a BasicInfoConfig<'a>,

--- a/rs-matter/src/data_model/cluster_on_off.rs
+++ b/rs-matter/src/data_model/cluster_on_off.rs
@@ -61,6 +61,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     ],
 };
 
+#[derive(Clone)]
 pub struct OnOffCluster {
     data_ver: Dataver,
     on: Cell<bool>,

--- a/rs-matter/src/data_model/objects/dataver.rs
+++ b/rs-matter/src/data_model/objects/dataver.rs
@@ -19,6 +19,7 @@ use core::cell::Cell;
 
 use crate::utils::rand::Rand;
 
+#[derive(Clone)]
 pub struct Dataver {
     ver: Cell<u32>,
     changed: Cell<bool>,

--- a/rs-matter/src/data_model/sdm/admin_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/admin_commissioning.rs
@@ -98,6 +98,7 @@ pub struct OpenCommWindowReq<'a> {
     salt: OctetStr<'a>,
 }
 
+#[derive(Clone)]
 pub struct AdminCommCluster<'a> {
     data_ver: Dataver,
     pase_mgr: &'a RefCell<PaseMgr>,

--- a/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
@@ -60,6 +60,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     commands: &[CommandsDiscriminants::ResetCounts as _],
 };
 
+#[derive(Clone)]
 pub struct EthNwDiagCluster {
     data_ver: Dataver,
 }

--- a/rs-matter/src/data_model/sdm/failsafe.rs
+++ b/rs-matter/src/data_model/sdm/failsafe.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use log::error;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 #[allow(dead_code)]
 #[allow(clippy::enum_variant_names)]
 enum NocState {

--- a/rs-matter/src/data_model/sdm/general_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/general_commissioning.rs
@@ -126,12 +126,13 @@ struct FailSafeParams {
     bread_crumb: u64,
 }
 
-#[derive(ToTLV)]
+#[derive(ToTLV, Clone)]
 struct BasicCommissioningInfo {
     expiry_len: u16,
     max_cmltv_failsafe_secs: u16,
 }
 
+#[derive(Clone)]
 pub struct GenCommCluster<'a> {
     data_ver: Dataver,
     basic_comm_info: BasicCommissioningInfo,

--- a/rs-matter/src/data_model/sdm/general_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/general_diagnostics.rs
@@ -70,6 +70,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     commands: &[CommandsDiscriminants::TestEventTrigger as _],
 };
 
+#[derive(Clone)]
 pub struct GenDiagCluster {
     data_ver: Dataver,
 }

--- a/rs-matter/src/data_model/sdm/group_key_management.rs
+++ b/rs-matter/src/data_model/sdm/group_key_management.rs
@@ -76,6 +76,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     commands: &[CommandsDiscriminants::KeySetWrite as _],
 };
 
+#[derive(Clone)]
 pub struct GrpKeyMgmtCluster {
     data_ver: Dataver,
 }

--- a/rs-matter/src/data_model/sdm/noc.rs
+++ b/rs-matter/src/data_model/sdm/noc.rs
@@ -213,6 +213,7 @@ struct RemoveFabricReq {
     fab_idx: u8,
 }
 
+#[derive(Clone)]
 pub struct NocCluster<'a> {
     data_ver: Dataver,
     epoch: Epoch,

--- a/rs-matter/src/data_model/sdm/nw_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/nw_commissioning.rs
@@ -83,6 +83,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     commands: &[],
 };
 
+#[derive(Clone)]
 pub struct NwCommCluster {
     data_ver: Dataver,
 }

--- a/rs-matter/src/data_model/system_model/access_control.rs
+++ b/rs-matter/src/data_model/system_model/access_control.rs
@@ -76,6 +76,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     commands: &[],
 };
 
+#[derive(Clone)]
 pub struct AccessControlCluster<'a> {
     data_ver: Dataver,
     acl_mgr: &'a RefCell<AclMgr>,

--- a/rs-matter/src/data_model/system_model/descriptor.rs
+++ b/rs-matter/src/data_model/system_model/descriptor.rs
@@ -89,6 +89,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub struct DescriptorCluster<'a> {
     matcher: &'a dyn PartsMatcher,
     data_ver: Dataver,


### PR DESCRIPTION
Yeah, I need that for my own selfish purposes :)...

BUT: I think it is a good idea anyway, because all system clusters are very small in size, as they either contain references, or minimal aggregated data. So I think we can ensure their cloneability in the long run without shooting ourselves in the foot.

In fact, we should try to derive more. For example, would be good to have `Debug` on these as well, and then `Debug`, `Clone`, `Eq` on most TLV structures. But... step by step.

