### PR TITLE
Add more TLV nw-comm structs

### DIFF
--- a/rs-matter/src/data_model/root_endpoint.rs
+++ b/rs-matter/src/data_model/root_endpoint.rs
@@ -22,7 +22,7 @@ use super::{
         group_key_management,
         group_key_management::GrpKeyMgmtCluster,
         noc::{self, NocCluster},
-        nw_commissioning::{self, NwCommCluster},
+        nw_commissioning::{self, EthNwCommCluster},
     },
     system_model::{
         access_control::{self, AccessControlCluster},
@@ -34,7 +34,7 @@ pub type RootEndpointHandler<'a> = handler_chain_type!(
     DescriptorCluster<'static>,
     BasicInfoCluster<'a>,
     GenCommCluster<'a>,
-    NwCommCluster,
+    EthNwCommCluster,
     AdminCommCluster<'a>,
     NocCluster<'a>,
     AccessControlCluster<'a>,
@@ -47,7 +47,7 @@ pub const CLUSTERS: [Cluster<'static>; 10] = [
     descriptor::CLUSTER,
     cluster_basic_information::CLUSTER,
     general_commissioning::CLUSTER,
-    nw_commissioning::CLUSTER,
+    nw_commissioning::ETH_CLUSTER,
     admin_commissioning::CLUSTER,
     noc::CLUSTER,
     access_control::CLUSTER,
@@ -135,7 +135,11 @@ pub fn wrap<'a>(
             admin_commissioning::ID,
             AdminCommCluster::new(pase, mdns, rand),
         )
-        .chain(endpoint_id, nw_commissioning::ID, NwCommCluster::new(rand))
+        .chain(
+            endpoint_id,
+            nw_commissioning::ID,
+            EthNwCommCluster::new(rand),
+        )
         .chain(
             endpoint_id,
             general_commissioning::ID,

--- a/rs-matter/tests/common/im_engine.rs
+++ b/rs-matter/tests/common/im_engine.rs
@@ -102,7 +102,7 @@ const NODE: Node<'static> = Node {
                 descriptor::CLUSTER,
                 cluster_basic_information::CLUSTER,
                 general_commissioning::CLUSTER,
-                nw_commissioning::CLUSTER,
+                nw_commissioning::ETH_CLUSTER,
                 admin_commissioning::CLUSTER,
                 noc::CLUSTER,
                 access_control::CLUSTER,


### PR DESCRIPTION
The PR does ~~two~~ three things:
* Defines most of the structs necessary for all the supported NW commissioning attributes and commands to actually be processed; this might be superseded in future by the IDL-to-Rust generator, but until it is fully functional, we'll need these
* Exposes three different cluster metadata structs: `ETH_CLUSTER` (formally `CLUSTER`), `THR_CLUSTER` and `WIFI_CLUSTER` (as the set of commands an attributes differ depending on what is the used operational network)
* Renames the existing `NwCommCluster` handler to `EthNwCommCluster`, as it is really Ethernet specific. Users (like me) who would like to use other networks, like Wifi (or Thread) need a different handler provided by themselves.