### PR TITLE
Root endpoint with Wifi support; Wifi NW diagnostics cluster

### DIFF
--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -181,7 +181,7 @@ fn run() -> Result<(), Error> {
 const NODE: Node<'static> = Node {
     id: 0,
     endpoints: &[
-        root_endpoint::endpoint(0),
+        root_endpoint::endpoint(0, root_endpoint::OperNwType::Ethernet),
         Endpoint {
             id: 1,
             device_type: DEV_TYPE_ON_OFF_LIGHT,
@@ -196,7 +196,7 @@ fn dm_handler<'a>(
 ) -> impl Metadata + NonBlockingHandler + 'a {
     (
         NODE,
-        root_endpoint::handler(0, matter)
+        root_endpoint::eth_handler(0, matter)
             .chain(
                 1,
                 descriptor::ID,

--- a/rs-matter/src/data_model/root_endpoint.rs
+++ b/rs-matter/src/data_model/root_endpoint.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::{
     cluster_basic_information::{self, BasicInfoCluster, BasicInfoConfig},
-    objects::{Cluster, EmptyHandler, Endpoint, EndptId},
+    objects::{Cluster, EmptyHandler, Endpoint, EndptId, HandlerCompat},
     sdm::{
         admin_commissioning::{self, AdminCommCluster},
         dev_att::DevAttDataFetcher,
@@ -19,8 +19,7 @@ use super::{
         failsafe::FailSafe,
         general_commissioning::{self, GenCommCluster},
         general_diagnostics::{self, GenDiagCluster},
-        group_key_management,
-        group_key_management::GrpKeyMgmtCluster,
+        group_key_management::{self, GrpKeyMgmtCluster},
         noc::{self, NocCluster},
         nw_commissioning::{self, EthNwCommCluster},
     },
@@ -30,20 +29,7 @@ use super::{
     },
 };
 
-pub type RootEndpointHandler<'a> = handler_chain_type!(
-    DescriptorCluster<'static>,
-    BasicInfoCluster<'a>,
-    GenCommCluster<'a>,
-    EthNwCommCluster,
-    AdminCommCluster<'a>,
-    NocCluster<'a>,
-    AccessControlCluster<'a>,
-    GenDiagCluster,
-    EthNwDiagCluster,
-    GrpKeyMgmtCluster
-);
-
-pub const CLUSTERS: [Cluster<'static>; 10] = [
+const ETH_NW_CLUSTERS: [Cluster<'static>; 10] = [
     descriptor::CLUSTER,
     cluster_basic_information::CLUSTER,
     general_commissioning::CLUSTER,
@@ -56,15 +42,96 @@ pub const CLUSTERS: [Cluster<'static>; 10] = [
     group_key_management::CLUSTER,
 ];
 
-pub const fn endpoint(id: EndptId) -> Endpoint<'static> {
+const WIFI_NW_CLUSTERS: [Cluster<'static>; 10] = [
+    descriptor::CLUSTER,
+    cluster_basic_information::CLUSTER,
+    general_commissioning::CLUSTER,
+    nw_commissioning::ETH_CLUSTER,
+    admin_commissioning::CLUSTER,
+    noc::CLUSTER,
+    access_control::CLUSTER,
+    general_diagnostics::CLUSTER,
+    ethernet_nw_diagnostics::CLUSTER,
+    group_key_management::CLUSTER,
+];
+
+/// The type of operational network (Ethernet, Wifi or (future) Thread)
+/// for which root endpoint meta-data is being requested
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum OperNwType {
+    Ethernet,
+    Wifi,
+}
+
+/// A utility function to create a root (Endpoint 0) object using the requested operational network type.
+pub const fn endpoint(id: EndptId, op_nw_type: OperNwType) -> Endpoint<'static> {
     Endpoint {
         id,
         device_type: super::device_types::DEV_TYPE_ROOT_NODE,
-        clusters: &CLUSTERS,
+        clusters: clusters(op_nw_type),
     }
 }
 
-pub fn handler<'a, T>(endpoint_id: u16, matter: &'a T) -> RootEndpointHandler<'a>
+/// A utility function to return the clusters for a root (Endpoint 0) object using the requested operational network type.
+pub const fn clusters(op_nw_type: OperNwType) -> &'static [Cluster<'static>] {
+    match op_nw_type {
+        OperNwType::Ethernet => &ETH_NW_CLUSTERS,
+        OperNwType::Wifi => &WIFI_NW_CLUSTERS,
+    }
+}
+
+/// A type alias for a root (Endpoint 0) handler using Ethernet as an operational network
+pub type EthRootEndpointHandler<'a> = RootEndpointHandler<'a, EthNwCommCluster, EthNwDiagCluster>;
+
+/// A type representing the type of the root (Endpoint 0) handler
+/// which is generic over the operational transport clusters (i.e. Ethernet, Wifi or Thread)
+pub type RootEndpointHandler<'a, NWCOMM, NWDIAG> = handler_chain_type!(
+    NWCOMM,
+    NWDIAG,
+    HandlerCompat<descriptor::DescriptorCluster<'a>>,
+    HandlerCompat<cluster_basic_information::BasicInfoCluster<'a>>,
+    HandlerCompat<general_commissioning::GenCommCluster<'a>>,
+    HandlerCompat<admin_commissioning::AdminCommCluster<'a>>,
+    HandlerCompat<noc::NocCluster<'a>>,
+    HandlerCompat<access_control::AccessControlCluster<'a>>,
+    HandlerCompat<general_diagnostics::GenDiagCluster>,
+    HandlerCompat<group_key_management::GrpKeyMgmtCluster>
+);
+
+/// A utility function to instantiate the root (Endpoint 0) handler using Ethernet as the operational network.
+pub fn eth_handler<'a, T>(endpoint_id: u16, matter: &'a T) -> EthRootEndpointHandler<'a>
+where
+    T: Borrow<BasicInfoConfig<'a>>
+        + Borrow<dyn DevAttDataFetcher + 'a>
+        + Borrow<RefCell<PaseMgr>>
+        + Borrow<RefCell<FabricMgr>>
+        + Borrow<RefCell<AclMgr>>
+        + Borrow<RefCell<FailSafe>>
+        + Borrow<dyn Mdns + 'a>
+        + Borrow<Epoch>
+        + Borrow<Rand>
+        + 'a,
+{
+    handler(
+        endpoint_id,
+        matter,
+        EthNwCommCluster::new(*matter.borrow()),
+        ethernet_nw_diagnostics::ID,
+        EthNwDiagCluster::new(*matter.borrow()),
+    )
+}
+
+/// A utility function to instantiate the root (Endpoint 0) handler.
+/// Besides a reference to the main `Matter` object, this function
+/// needs user-supplied implementations of the network commissioning
+/// and network diagnostics clusters.
+pub fn handler<'a, NWCOMM, NWDIAG, T>(
+    endpoint_id: u16,
+    matter: &'a T,
+    nwcomm: NWCOMM,
+    nwdiag_id: u32,
+    nwdiag: NWDIAG,
+) -> RootEndpointHandler<'a, NWCOMM, NWDIAG>
 where
     T: Borrow<BasicInfoConfig<'a>>
         + Borrow<dyn DevAttDataFetcher + 'a>
@@ -88,11 +155,14 @@ where
         matter.borrow(),
         *matter.borrow(),
         *matter.borrow(),
+        nwcomm,
+        nwdiag_id,
+        nwdiag,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn wrap<'a>(
+fn wrap<'a, NWCOMM, NWDIAG>(
     endpoint_id: u16,
     basic_info: &'a BasicInfoConfig<'a>,
     dev_att: &'a dyn DevAttDataFetcher,
@@ -103,52 +173,53 @@ pub fn wrap<'a>(
     mdns: &'a dyn Mdns,
     epoch: Epoch,
     rand: Rand,
-) -> RootEndpointHandler<'a> {
+    nwcomm: NWCOMM,
+    nwdiag_id: u32,
+    nwdiag: NWDIAG,
+) -> RootEndpointHandler<'a, NWCOMM, NWDIAG> {
     EmptyHandler
         .chain(
             endpoint_id,
             group_key_management::ID,
-            GrpKeyMgmtCluster::new(rand),
-        )
-        .chain(
-            endpoint_id,
-            ethernet_nw_diagnostics::ID,
-            EthNwDiagCluster::new(rand),
+            HandlerCompat(GrpKeyMgmtCluster::new(rand)),
         )
         .chain(
             endpoint_id,
             general_diagnostics::ID,
-            GenDiagCluster::new(rand),
+            HandlerCompat(GenDiagCluster::new(rand)),
         )
         .chain(
             endpoint_id,
             access_control::ID,
-            AccessControlCluster::new(acl, rand),
+            HandlerCompat(AccessControlCluster::new(acl, rand)),
         )
         .chain(
             endpoint_id,
             noc::ID,
-            NocCluster::new(dev_att, fabric, acl, failsafe, mdns, epoch, rand),
+            HandlerCompat(NocCluster::new(
+                dev_att, fabric, acl, failsafe, mdns, epoch, rand,
+            )),
         )
         .chain(
             endpoint_id,
             admin_commissioning::ID,
-            AdminCommCluster::new(pase, mdns, rand),
-        )
-        .chain(
-            endpoint_id,
-            nw_commissioning::ID,
-            EthNwCommCluster::new(rand),
+            HandlerCompat(AdminCommCluster::new(pase, mdns, rand)),
         )
         .chain(
             endpoint_id,
             general_commissioning::ID,
-            GenCommCluster::new(failsafe, true, rand),
+            HandlerCompat(GenCommCluster::new(failsafe, false, rand)),
         )
         .chain(
             endpoint_id,
             cluster_basic_information::ID,
-            BasicInfoCluster::new(basic_info, rand),
+            HandlerCompat(BasicInfoCluster::new(basic_info, rand)),
         )
-        .chain(endpoint_id, descriptor::ID, DescriptorCluster::new(rand))
+        .chain(
+            endpoint_id,
+            descriptor::ID,
+            HandlerCompat(DescriptorCluster::new(rand)),
+        )
+        .chain(endpoint_id, nwdiag_id, nwdiag)
+        .chain(endpoint_id, nw_commissioning::ID, nwcomm)
 }

--- a/rs-matter/src/data_model/sdm/mod.rs
+++ b/rs-matter/src/data_model/sdm/mod.rs
@@ -24,3 +24,4 @@ pub mod general_diagnostics;
 pub mod group_key_management;
 pub mod noc;
 pub mod nw_commissioning;
+pub mod wifi_nw_diagnostics;

--- a/rs-matter/src/data_model/sdm/wifi_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/wifi_nw_diagnostics.rs
@@ -1,0 +1,244 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use core::cell::RefCell;
+
+use crate::{
+    attribute_enum, command_enum,
+    data_model::objects::*,
+    error::{Error, ErrorCode},
+    tlv::{TLVElement, TagType},
+    transport::exchange::Exchange,
+    utils::rand::Rand,
+};
+
+use log::info;
+
+use rs_matter_macros::{FromTLV, ToTLV};
+use strum::{EnumDiscriminants, FromRepr};
+
+pub const ID: u32 = 0x0036;
+
+#[derive(FromRepr, EnumDiscriminants)]
+#[repr(u16)]
+pub enum Attributes {
+    Bssid = 0x00,
+    SecurityType(AttrType<WiFiSecurity>) = 0x01,
+    WifiVersion(AttrType<WiFiVersion>) = 0x02,
+    ChannelNumber(AttrType<u16>) = 0x03,
+    Rssi(AttrType<i8>) = 0x04,
+    BeaconLostCount(AttrType<u32>) = 0x05,
+    BeaconRxCount(AttrType<u32>) = 0x06,
+    PacketMulticastRxCount(AttrType<u32>) = 0x07,
+    PacketMulticastTxCount(AttrType<u32>) = 0x08,
+    PacketUnicastRxCount(AttrType<u32>) = 0x09,
+    PacketUnicastTxCount(AttrType<u32>) = 0x0a,
+    CurrentMaxRate(AttrType<u64>) = 0x0b,
+    OverrunCount(AttrType<u64>) = 0x0c,
+}
+
+attribute_enum!(Attributes);
+
+#[derive(FromRepr, EnumDiscriminants)]
+#[repr(u32)]
+pub enum Commands {
+    ResetCounts = 0x0,
+}
+
+command_enum!(Commands);
+
+pub const CLUSTER: Cluster<'static> = Cluster {
+    id: ID as _,
+    feature_map: 0,
+    attributes: &[
+        FEATURE_MAP,
+        ATTRIBUTE_LIST,
+        Attribute::new(
+            AttributesDiscriminants::Bssid as u16,
+            Access::RV,
+            Quality::NONE,
+        ),
+        Attribute::new(
+            AttributesDiscriminants::SecurityType as u16,
+            Access::RV,
+            Quality::FIXED,
+        ),
+        Attribute::new(
+            AttributesDiscriminants::WifiVersion as u16,
+            Access::RV,
+            Quality::FIXED,
+        ),
+        Attribute::new(
+            AttributesDiscriminants::ChannelNumber as u16,
+            Access::RV,
+            Quality::FIXED,
+        ),
+        Attribute::new(
+            AttributesDiscriminants::Rssi as u16,
+            Access::RV,
+            Quality::FIXED,
+        ),
+    ],
+    commands: &[CommandsDiscriminants::ResetCounts as _],
+};
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, FromTLV, ToTLV, FromRepr)]
+#[repr(u8)]
+pub enum WiFiSecurity {
+    Unspecified = 0,
+    Unencrypted = 1,
+    Wep = 2,
+    WpaPersonal = 3,
+    Wpa2Personal = 4,
+    Wpa3Personal = 5,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, FromTLV, ToTLV, FromRepr)]
+#[repr(u8)]
+pub enum WiFiVersion {
+    A = 0,
+    B = 1,
+    G = 2,
+    N = 3,
+    AC = 4,
+    AX = 5,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, FromTLV, ToTLV, FromRepr)]
+#[repr(u8)]
+pub enum AssociationFailure {
+    Unknown = 0,
+    AssociationFailed = 1,
+    AuthenticationFailed = 2,
+    SsidNotFound = 3,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, FromTLV, ToTLV, FromRepr)]
+#[repr(u8)]
+pub enum ConnectionStatus {
+    Connected = 0,
+    NotConnected = 1,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WifiNwDiagData {
+    pub bssid: [u8; 6],
+    pub security_type: WiFiSecurity,
+    pub wifi_version: WiFiVersion,
+    pub channel_number: u16,
+    pub rssi: i8,
+}
+
+/// A cluster implementing the Matter Wifi Diagnostics Cluster.
+#[derive(Clone)]
+pub struct WifiNwDiagCluster {
+    data_ver: Dataver,
+    data: RefCell<WifiNwDiagData>,
+}
+
+impl WifiNwDiagCluster {
+    /// Create a new instance.
+    pub fn new(rand: Rand, data: WifiNwDiagData) -> Self {
+        Self {
+            data_ver: Dataver::new(rand),
+            data: RefCell::new(data),
+        }
+    }
+
+    pub fn set(&self, data: WifiNwDiagData) -> bool {
+        if *self.data.borrow() != data {
+            *self.data.borrow_mut() = data;
+            self.data_ver.changed();
+
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Read the value of an attribute.
+    pub fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
+        if let Some(mut writer) = encoder.with_dataver(self.data_ver.get())? {
+            if attr.is_system() {
+                CLUSTER.read(attr.attr_id, writer)
+            } else {
+                let data = self.data.borrow();
+
+                match attr.attr_id.try_into()? {
+                    Attributes::Bssid => writer.str8(TagType::Anonymous, &data.bssid),
+                    Attributes::SecurityType(codec) => codec.encode(writer, data.security_type),
+                    Attributes::WifiVersion(codec) => codec.encode(writer, data.wifi_version),
+                    Attributes::ChannelNumber(codec) => codec.encode(writer, data.channel_number),
+                    Attributes::Rssi(codec) => codec.encode(writer, data.rssi),
+                    _ => Err(ErrorCode::AttributeNotFound.into()),
+                }
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Write the value of an attribute.
+    pub fn write(&self, _attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
+        let _data = data.with_dataver(self.data_ver.get())?;
+
+        self.data_ver.changed();
+
+        Ok(())
+    }
+
+    /// Invoke a command.
+    pub fn invoke(
+        &self,
+        _exchange: &Exchange,
+        cmd: &CmdDetails,
+        _data: &TLVElement,
+        _encoder: CmdDataEncoder,
+    ) -> Result<(), Error> {
+        match cmd.cmd_id.try_into()? {
+            Commands::ResetCounts => {
+                info!("ResetCounts: Not yet supported");
+            }
+        }
+
+        self.data_ver.changed();
+
+        Ok(())
+    }
+}
+
+impl Handler for WifiNwDiagCluster {
+    fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
+        WifiNwDiagCluster::read(self, attr, encoder)
+    }
+
+    fn write(&self, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
+        WifiNwDiagCluster::write(self, attr, data)
+    }
+
+    fn invoke(
+        &self,
+        exchange: &Exchange,
+        cmd: &CmdDetails,
+        data: &TLVElement,
+        encoder: CmdDataEncoder,
+    ) -> Result<(), Error> {
+        WifiNwDiagCluster::invoke(self, exchange, cmd, data, encoder)
+    }
+}
+
+impl NonBlockingHandler for WifiNwDiagCluster {}

--- a/rs-matter/tests/common/im_engine.rs
+++ b/rs-matter/tests/common/im_engine.rs
@@ -38,7 +38,7 @@ use rs_matter::{
             AttrData, AttrDataEncoder, AttrDetails, Endpoint, Handler, HandlerCompat, Metadata,
             Node, NonBlockingHandler, Privilege,
         },
-        root_endpoint::{self, RootEndpointHandler},
+        root_endpoint::{self, EthRootEndpointHandler},
         sdm::{
             admin_commissioning,
             dev_att::{DataType, DevAttDataFetcher},
@@ -148,12 +148,12 @@ pub struct ImOutput {
 }
 
 pub struct ImEngineHandler<'a> {
-    handler: handler_chain_type!(OnOffCluster, EchoCluster, DescriptorCluster<'static>, EchoCluster | RootEndpointHandler<'a>),
+    handler: handler_chain_type!(OnOffCluster, EchoCluster, DescriptorCluster<'static>, EchoCluster | EthRootEndpointHandler<'a>),
 }
 
 impl<'a> ImEngineHandler<'a> {
     pub fn new(matter: &'a Matter<'a>) -> Self {
-        let handler = root_endpoint::handler(0, matter)
+        let handler = root_endpoint::eth_handler(0, matter)
             .chain(0, echo_cluster::ID, EchoCluster::new(2, *matter.borrow()))
             .chain(1, descriptor::ID, DescriptorCluster::new(*matter.borrow()))
             .chain(1, echo_cluster::ID, EchoCluster::new(3, *matter.borrow()))


### PR DESCRIPTION
(A follow up on https://github.com/project-chip/rs-matter/pull/167 , as promised there.)

* This PR provides extra types for the Root endpoint which are generified by the type of operational network.
* It also provides a simple implementation of the Wifi NW Diagnostics cluster (next to the existing Eth NW diagnostics one)

The existing types/struct which were actually hard-coded for Ethernet are now type-aliased / delegate to the new types and are renamed as follows:
* `root_endpont::CLUSTERS` -> `root_endpoint::ETH_CLUSTERS` (and there's also `WIFI_CLUSTERS` now)
* `root_endpoint::endpoint` takes an extra parameter - `OperNwType`
* `RootEndpointHandler` type -> `EthRootEndpointHandler` type, and there is a newly-introduced `RootEndpointHandler` which is generified by `NWCOMM` and `NWDIAG`
* `root_endpoint::handler` -> `root_endpoint::eth_handler`. Here also, newly introduced more generic `root_endpoint::handler` fn which takes extra parameters

... Looking at the "on off" example actually shows the API-visible changes. Minor breakage to backward compatibility - users just need to prefix a few things with `eth_` now.
