### PR TITLE
Update EthernetNetworkDiagnostics to start using idl imports for some constants.

### DIFF
--- a/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
@@ -20,8 +20,13 @@ use crate::{
 };
 use log::info;
 use strum::{EnumDiscriminants, FromRepr};
+use rs_matter_macros::idl_import;
 
-pub const ID: u32 = 0x0037;
+idl_import!(clusters = ["EthernetNetworkDiagnostics"]);
+
+pub use ethernet_network_diagnostics::ID;
+pub use ethernet_network_diagnostics::Commands;
+pub use ethernet_network_diagnostics::CommandsDiscriminants;
 
 #[derive(FromRepr, EnumDiscriminants)]
 #[repr(u16)]
@@ -31,12 +36,6 @@ pub enum Attributes {
 }
 
 attribute_enum!(Attributes);
-
-#[derive(FromRepr, EnumDiscriminants)]
-#[repr(u32)]
-pub enum Commands {
-    ResetCounts = 0x0,
-}
 
 command_enum!(Commands);
 

--- a/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
@@ -19,14 +19,14 @@ use crate::{
     transport::exchange::Exchange, utils::rand::Rand,
 };
 use log::info;
-use strum::{EnumDiscriminants, FromRepr};
 use rs_matter_macros::idl_import;
+use strum::{EnumDiscriminants, FromRepr};
 
 idl_import!(clusters = ["EthernetNetworkDiagnostics"]);
 
-pub use ethernet_network_diagnostics::ID;
 pub use ethernet_network_diagnostics::Commands;
 pub use ethernet_network_diagnostics::CommandsDiscriminants;
+pub use ethernet_network_diagnostics::ID;
 
 #[derive(FromRepr, EnumDiscriminants)]
 #[repr(u16)]


### PR DESCRIPTION
Plan to start adding some more support to things in macros - many other things fail because we do not yet support char_string, octet_string or list entries in our TLV logic (generally it looks like anything involving lifetimes is not yet available). Will need a bit of iteration to add that as I am not sure if we have any existing patterns for them.