### PR TITLE
Add support for IDL-gen for structures that contain char_string and octet_string

### DIFF
--- a/rs-matter-macros-impl/src/tlv.rs
+++ b/rs-matter-macros-impl/src/tlv.rs
@@ -138,13 +138,7 @@ fn gen_totlv_for_struct(
     let mut tags = Vec::new();
 
     for field in fields.named.iter() {
-        //        let field_name: &syn::Ident = field.ident.as_ref().unwrap();
-        //        let name: String = field_name.to_string();
-        //        let literal_key_str = syn::LitStr::new(&name, field.span());
-        //        let type_name = &field.ty;
-        //        keys.push(quote! { #literal_key_str });
         idents.push(&field.ident);
-        //        types.push(type_name.to_token_stream());
         if let Some(a) = parse_tag_val(&field.attrs) {
             tags.push(a);
         } else {

--- a/rs-matter/src/data_model/sdm/general_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/general_commissioning.rs
@@ -26,18 +26,15 @@ use crate::{attribute_enum, cmd_enter};
 use crate::{command_enum, error::*};
 use log::info;
 use strum::{EnumDiscriminants, FromRepr};
+use rs_matter_macros::idl_import;
 
-#[derive(Clone, Copy)]
-#[allow(dead_code)]
-enum CommissioningError {
-    Ok = 0,
-    ErrValueOutsideRange = 1,
-    ErrInvalidAuth = 2,
-    ErrNotCommissioning = 3,
-    ErrBusyWithOtherAdmin = 4,
-}
+idl_import!(clusters = ["GeneralCommissioning"]);
 
-pub const ID: u32 = 0x0030;
+pub use general_commissioning::ID;
+pub use general_commissioning::Commands;
+pub use general_commissioning::CommissioningErrorEnum;
+pub use general_commissioning::RegulatoryLocationTypeEnum;
+
 
 #[derive(FromRepr, EnumDiscriminants)]
 #[repr(u16)]
@@ -51,13 +48,6 @@ pub enum Attributes {
 
 attribute_enum!(Attributes);
 
-#[derive(FromRepr)]
-#[repr(u32)]
-pub enum Commands {
-    ArmFailsafe = 0x00,
-    SetRegulatoryConfig = 0x02,
-    CommissioningComplete = 0x04,
-}
 
 command_enum!(Commands);
 
@@ -73,12 +63,6 @@ pub enum RespCommands {
 struct CommonResponse<'a> {
     error_code: u8,
     debug_txt: UtfStr<'a>,
-}
-
-pub enum RegLocationType {
-    Indoor = 0,
-    Outdoor = 1,
-    IndoorOutdoor = 2,
 }
 
 pub const CLUSTER: Cluster<'static> = Cluster {
@@ -114,7 +98,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
         ),
     ],
     commands: &[
-        Commands::ArmFailsafe as _,
+        Commands::ArmFailSafe as _,
         Commands::SetRegulatoryConfig as _,
         Commands::CommissioningComplete as _,
     ],
@@ -171,11 +155,11 @@ impl<'a> GenCommCluster<'a> {
                     Attributes::BreadCrumb(codec) => codec.encode(writer, 0),
                     // TODO: Arch-Specific
                     Attributes::RegConfig(codec) => {
-                        codec.encode(writer, RegLocationType::IndoorOutdoor as _)
+                        codec.encode(writer, RegulatoryLocationTypeEnum::IndoorOutdoor as _)
                     }
                     // TODO: Arch-Specific
                     Attributes::LocationCapability(codec) => {
-                        codec.encode(writer, RegLocationType::IndoorOutdoor as _)
+                        codec.encode(writer, RegulatoryLocationTypeEnum::IndoorOutdoor as _)
                     }
                     Attributes::BasicCommissioningInfo(_) => {
                         self.basic_comm_info
@@ -200,7 +184,7 @@ impl<'a> GenCommCluster<'a> {
         encoder: CmdDataEncoder,
     ) -> Result<(), Error> {
         match cmd.cmd_id.try_into()? {
-            Commands::ArmFailsafe => self.handle_command_armfailsafe(exchange, data, encoder)?,
+            Commands::ArmFailSafe => self.handle_command_armfailsafe(exchange, data, encoder)?,
             Commands::SetRegulatoryConfig => {
                 self.handle_command_setregulatoryconfig(exchange, data, encoder)?
             }
@@ -233,9 +217,9 @@ impl<'a> GenCommCluster<'a> {
             )
             .is_err()
         {
-            CommissioningError::ErrBusyWithOtherAdmin as u8
+            CommissioningErrorEnum::BusyWithOtherAdmin as u8
         } else {
-            CommissioningError::Ok as u8
+            CommissioningErrorEnum::OK as u8
         };
 
         let cmd_data = CommonResponse {
@@ -282,14 +266,14 @@ impl<'a> GenCommCluster<'a> {
         encoder: CmdDataEncoder,
     ) -> Result<(), Error> {
         cmd_enter!("Commissioning Complete");
-        let mut status: u8 = CommissioningError::Ok as u8;
+        let mut status: u8 = CommissioningErrorEnum::OK as u8;
 
         // Has to be a Case Session
         if exchange
             .with_session(|sess| Ok(sess.get_local_fabric_idx()))?
             .is_none()
         {
-            status = CommissioningError::ErrInvalidAuth as u8;
+            status = CommissioningErrorEnum::InvalidAuthentication as u8;
         }
 
         // AddNOC or UpdateNOC must have happened, and that too for the same fabric
@@ -300,7 +284,7 @@ impl<'a> GenCommCluster<'a> {
             .disarm(exchange.with_session(|sess| Ok(sess.get_session_mode().clone()))?)
             .is_err()
         {
-            status = CommissioningError::ErrInvalidAuth as u8;
+            status = CommissioningErrorEnum::InvalidAuthentication as u8;
         }
 
         let cmd_data = CommonResponse {

--- a/rs-matter/src/data_model/sdm/general_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/general_commissioning.rs
@@ -25,16 +25,15 @@ use crate::utils::rand::Rand;
 use crate::{attribute_enum, cmd_enter};
 use crate::{command_enum, error::*};
 use log::info;
-use strum::{EnumDiscriminants, FromRepr};
 use rs_matter_macros::idl_import;
+use strum::{EnumDiscriminants, FromRepr};
 
 idl_import!(clusters = ["GeneralCommissioning"]);
 
-pub use general_commissioning::ID;
 pub use general_commissioning::Commands;
 pub use general_commissioning::CommissioningErrorEnum;
 pub use general_commissioning::RegulatoryLocationTypeEnum;
-
+pub use general_commissioning::ID;
 
 #[derive(FromRepr, EnumDiscriminants)]
 #[repr(u16)]
@@ -47,7 +46,6 @@ pub enum Attributes {
 }
 
 attribute_enum!(Attributes);
-
 
 command_enum!(Commands);
 

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -151,7 +151,7 @@ totlv_for!(i8 u8 i16 u16 i32 u32 i64 u64 bool);
 // - TLVArray: Is an array of entries, with reference within the original list
 
 /// Implements UTFString from the spec
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Hash, Eq)]
 pub struct UtfStr<'a>(pub &'a [u8]);
 
 impl<'a> UtfStr<'a> {
@@ -177,7 +177,7 @@ impl<'a> FromTLV<'a> for UtfStr<'a> {
 }
 
 /// Implements OctetString from the spec
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Hash, Eq)]
 pub struct OctetStr<'a>(pub &'a [u8]);
 
 impl<'a> OctetStr<'a> {


### PR DESCRIPTION
### Changes

- Idl support for these (including lifetime logic) and unit tests
- Make use of these in the general commissioning cluster implementation
- Added derive of hash and eq for utfstr/octetstr since we seem to default implementing those for structs