### PR TITLE
Improved logging of exchange IDs

### DIFF
--- a/rs-matter/src/transport/mrp.rs
+++ b/rs-matter/src/transport/mrp.rs
@@ -156,7 +156,7 @@ impl ReliableMessage {
             if let Some(retrans) = &mut self.retrans {
                 if retrans.pre_send(tx_plain.ctr).is_err() {
                     // Too many retransmissions, give up
-                    error!("Too many retransmissions. Giving up");
+                    error!("Packet {tx_plain}{tx_proto}: Too many retransmissions. Giving up");
 
                     self.retrans = None;
                     self.ack = None;


### PR DESCRIPTION
Accidentally, I ended up in a noisy network setup with all the UDP extras: delayed packets, lost packets, all of it.

This uncovered a couple of bugs, fixes for which I'll be PR-ing shortly.

But first, a PR that logs extra identification for each exchange:
- The problem is that we are currently only logging the internal exchange ID and the internal session ID.
- To correlate for _what packet / session_ an exchange is spawned / ended / processing, we also need to log the "external" exchange ID identifiers. Specifically these are what I find useful and what I added with this PR:
- Local session ID ("SID")
- Remote session ID ("RSID")
- Exchange ID (the `u16` Matter one which is shared between the local and remote session)

