### PR TITLE
Fix a couple of packet processing bugs

### DIFF
--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -411,24 +411,27 @@ impl MessageMeta {
 
     /// Utility method to check if the protocol is Secure Channel, and the opcode is a standalone ACK (`MrpStandaloneAck`).
     pub(crate) fn is_standalone_ack(&self) -> bool {
-        !self.reliable
-            && self.proto_id == PROTO_ID_SECURE_CHANNEL
+        self.proto_id == PROTO_ID_SECURE_CHANNEL
             && self.proto_opcode == secure_channel::common::OpCode::MRPStandAloneAck as u8
     }
 
     /// Utility method to check if the protocol is Secure Channel, and the opcode is Status.
     pub(crate) fn is_sc_status(&self) -> bool {
-        !self.reliable
-            && self.proto_id == PROTO_ID_SECURE_CHANNEL
+        self.proto_id == PROTO_ID_SECURE_CHANNEL
             && self.proto_opcode == secure_channel::common::OpCode::StatusReport as u8
     }
 
     /// Utility method to check if the protocol is Secure Channel, and the opcode is a new session request.
     pub(crate) fn is_new_session(&self) -> bool {
-        self.reliable
-            && self.proto_id == PROTO_ID_SECURE_CHANNEL
+        self.proto_id == PROTO_ID_SECURE_CHANNEL
             && (self.proto_opcode == secure_channel::common::OpCode::PBKDFParamRequest as u8
                 || self.proto_opcode == secure_channel::common::OpCode::CASESigma1 as u8)
+    }
+
+    /// Utility method to check if the meta-data indicates a new exchange
+    pub(crate) fn is_new_exchange(&self) -> bool {
+        // Don't create new exchanges for standalone ACKs and for SC status codes
+        !self.is_standalone_ack() && !self.is_sc_status()
     }
 }
 


### PR DESCRIPTION
As mentioned in #177, this is the follow-up PR that addresses the actual two bugs I found:

#### (1) In `mrp.rs` (our message ACK and re-transmission logic):
- The case where we might get an ACK ID which is different (= earlier) than the one we expect was logged as an `error!` **but not handled in any way**. As a result, the logic was assuming that we got ACK for the ID we were waiting for and _stopped re-transmitting the message_, which is wrong!
- How it should be handled:
  - Receiving an ACK for an earlier message than the latest we've sent is completely normal. This often happens when we re-transmit a message more than once: once we receive an ACK for the _first_ transmission of the message we of course stop re-transmitting and proceed the conversation - however - it is completely possible that we receive a late "ACK" for an earlier retransmission we did send. No, this won't necessarily be detected by the msg duplication logic in the session, if this is the **latest** message sent by the other peer.
  - The fix is to simply error out with `ErrorCode::Duplicate` because this message - in fact - is a duplicate. And then send an ACK if the message requires it.
 
#### (2) in `core.rs`, function `decode_packet`:
- **Turns out we were happily creating NEW exchanges for late-arriving ACKs**! This was happening because once we receive an ACK for the last message of an exchange, we of course remove the exchange. _However_, if we have sent the last message more than once, we might receive **multiple** ACKs for it, but all later ones should just be discarded, rather than initiating a new exchange
- The fix was to simply never to open a new exchange for ACK messages. I did it for ACKs _and_ SC status reports, as both cannot initiate an exchange, though the real offender was ACKs
- Note that the function is reorganized a bit even if the fix was simple: this is to improve a bit the readability

#### Finally, the following additional logging adjustments:
- Receiving an ACK for an exchange which is not there (anymore) is now a warning, as it is definitely not an error on noisy channels
- Ditto for the `mrp` "mismatch" logic
- Ditto for receiving an encrypted message for a missing session. This happens during pase/case negotiation once the original unencrypted session is removed and a new encrypted one is created. Just like with the "missing exchange" case, we might receive extra ACKs for a session which is no longer there if the channel is noisy
- Encrypted messages which did not have a session _were previously wrongly displayed as a `MsgSyncCounter` request_, due to the proto header not being decoded (as we don't have a session, and thus proto hdr default state was containing 0s for opcode and proto ID).  This is now fixed.