### PR TITLE
Keep the local fabric idx in subscriptions

### DIFF
--- a/rs-matter/src/data_model/sdm/noc.rs
+++ b/rs-matter/src/data_model/sdm/noc.rs
@@ -453,6 +453,9 @@ impl<'a> NocCluster<'a> {
         data: &TLVElement,
         encoder: CmdDataEncoder,
     ) -> Result<(), Error> {
+        // TODO: Need to remove all sessions for this fabric
+        // TODO: Need to remove all IM subscriptions for this fabric
+
         cmd_enter!("Remove Fabric");
         let req = RemoveFabricReq::from_tlv(data).map_err(Error::map_invalid_data_type)?;
         if self

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -136,13 +136,14 @@ impl<'m> TransportMgr<'m> {
     pub(crate) async fn initiate<'a>(
         &'a self,
         matter: &'a Matter<'a>,
-        node_id: u64,
+        fabric_idx: u8,
+        peer_node_id: u64,
         secure: bool,
     ) -> Result<Exchange<'_>, Error> {
         let mut session_mgr = self.session_mgr.borrow_mut();
 
         session_mgr
-            .get_for_node(node_id, secure)
+            .get_for_node(fabric_idx, peer_node_id, secure)
             .ok_or(ErrorCode::NoSession)?;
 
         let exch_id = session_mgr.get_next_exch_id();
@@ -150,7 +151,9 @@ impl<'m> TransportMgr<'m> {
         // `unwrap` is safe because we know we have a session or else the early return from above would've triggered
         // The reason why we call `get_for_node` twice is to ensure that we don't waste an `exch_id` in case
         // we don't have a session in the first place
-        let session = session_mgr.get_for_node(node_id, secure).unwrap();
+        let session = session_mgr
+            .get_for_node(fabric_idx, peer_node_id, secure)
+            .unwrap();
 
         let exch_index = session
             .add_exch(exch_id, Role::Initiator(Default::default()))

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -764,18 +764,24 @@ impl<'a> Exchange<'a> {
         self.matter
     }
 
-    /// Create a new initiator exchange on the provided Matter stack for the provided Node ID
+    /// Create a new initiator exchange on the provided Matter stack for the provided peer Node ID
     ///
-    /// This method will fail if there is no existing session in the provided Matter satack for the provided Node ID.
+    /// This method will fail if there is no existing session in the provided Matter stack for the provided peer Node ID.
     ///
-    // TODO: This signature will change in future
+    // TODO: This signature will change in future, once we are able to do mDNS lookups and thus create a
+    // new session on our own (currently we can't do it because - in the absence of mDNS lookups - we cannot
+    // find the IP address and port corresponding to the peer Node ID with which we are trying to initiate an exchange).
     #[inline(always)]
     pub async fn initiate(
         matter: &'a Matter<'a>,
-        node_id: u64,
+        fabric_idx: u8,
+        peer_node_id: u64,
         secure: bool,
     ) -> Result<Self, Error> {
-        matter.transport_mgr.initiate(matter, node_id, secure).await
+        matter
+            .transport_mgr
+            .initiate(matter, fabric_idx, peer_node_id, secure)
+            .await
     }
 
     /// Accepts a new responder exchange pending on the provided Matter stack.

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -205,8 +205,11 @@ impl Session {
         &self.att_challenge
     }
 
-    pub(crate) fn is_for_node(&self, node_id: u64, secure: bool) -> bool {
-        self.peer_nodeid == Some(node_id) && self.is_encrypted() == secure && !self.reserved
+    pub(crate) fn is_for_node(&self, fabric_idx: u8, peer_node_id: u64, secure: bool) -> bool {
+        self.get_local_fabric_idx() == Some(fabric_idx)
+            && self.peer_nodeid == Some(peer_node_id)
+            && self.is_encrypted() == secure
+            && !self.reserved
     }
 
     pub(crate) fn is_for_rx(&self, rx_peer: &Address, rx_plain: &PlainHdr) -> bool {
@@ -658,11 +661,16 @@ impl SessionMgr {
         session
     }
 
-    pub(crate) fn get_for_node(&mut self, node_id: u64, secure: bool) -> Option<&mut Session> {
+    pub(crate) fn get_for_node(
+        &mut self,
+        fabric_idx: u8,
+        peer_node_id: u64,
+        secure: bool,
+    ) -> Option<&mut Session> {
         let mut session = self
             .sessions
             .iter_mut()
-            .find(|sess| sess.is_for_node(node_id, secure));
+            .find(|sess| sess.is_for_node(fabric_idx, peer_node_id, secure));
 
         if let Some(session) = session.as_mut() {
             session.update_last_used(self.epoch);

--- a/rs-matter/tests/common/im_engine.rs
+++ b/rs-matter/tests/common/im_engine.rs
@@ -335,8 +335,13 @@ impl<'a> ImEngine<'a> {
                     NetworkReceiveImpl(recv_remote),
                 ),
                 join(responder.respond_once("0"), async move {
-                    let mut exchange =
-                        Exchange::initiate(matter_client, IM_ENGINE_REMOTE_PEER_ID, true).await?;
+                    let mut exchange = Exchange::initiate(
+                        matter_client,
+                        1, /*just one fabric in tests*/
+                        IM_ENGINE_REMOTE_PEER_ID,
+                        true,
+                    )
+                    .await?;
 
                     for ip in input {
                         exchange


### PR DESCRIPTION
Necessary for fixing [this issue](https://github.com/ivmarkov/esp-idf-matter/issues/3) - yet - not enough. Why - read below.

I'm PR-ing this part for now because I think this is uncontroversial and is necessary anyway. 

**Problem**: I forgot that the peer node ID is only unique in the context of a concrete fabric, so if we want to uniquely identify a node, this is done by the pair `(fabric-index/fabric-id, node-id)` and not just `node-id`.

The PR is slightly bigger, as I took the liberty to rename `node_id` to `peer_node_id` in the subscription context, as well as in the called transport methods. I think this is worthwhile, or else `node_id` can be interpreted as _our_ node ID, which is incorrect of course.

=================

Why is this fix not enough? (I'm seeking your advise what could be the problem.)

Apple Matter is a bit weird. Putting aside the fact that we are commissioned into two fabrics, the other weird thing that happens is that once we are commissioned in the second fabric, they are communicating with us on behalf of TWO different IP addresses, which - however - do represent the **same** node+fabric ID?!
- IP Address 1 (in my case): `fe80::8d7:cf23:8b0b:f715%2` - in fact this guy has two different nodes, one on fabric 1, and another on fabric 2 - see our session dump below
- IP Address 2: `fe80::416:93dd:216a:d50a%2` - this guy has the only one node on fabric 1 (or so we know), but its node on Fabric 1 _is the same_ as the node of the previous IP!

And now the real weird part: we receive a subscription request from IP Address 2 and this all goes well. 
But when the time comes to report on that subscription in some seconds / minutes and initiate a new exchange, it just so happens that we select an existing session for "IP Address 1" instead, because we are just looking for a session matching the fabric index (=1) and the node ID. And since the first address _also_ has created sessions to us on behalf of fabric 1, we just happen to pick a session for IP Address 1, even if the subscription came from IP Address 2.

... and get "Invalid Subscription" from the other peer.

Now, if we pick a session based on fabric index + peer node ID **+ remote address**, then we select a session with "IP Address 2" (the address from where the subscription came) and all is well!

So @kedars what do you think is going on? Shall I just also keep the IP address in the subscription data and do a match by that address too? This works (confirmed) but sounds a bit weird. Am I missing something in the spec?

Session dump:
```
Sessions for IP Address 1:
=============================================

(Skip this block, it contains non-CASE sessions, not interesting):
Session: fb_idx: None,    peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(1088638830675445622), local_nodeid: 0, local: 0, remote: 0, msg_ctr: 9017568, mode: PlainText, ts: 1717612457.779132481s
Session: fb_idx: None,    peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(0), local_nodeid: 0, local: 1, remote: 8566, msg_ctr: 44517232, mode: Pase(NotExpected), ts: 1717612462.458154527s
Session: fb_idx: None,    peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(9297024357880017542), local_nodeid: 0, local: 0, remote: 0, msg_ctr: 87475376, mode: PlainText, ts: 1717612462.78951294s
Session: fb_idx: None,    peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(17849542785653146437), local_nodeid: 0, local: 0, remote: 0, msg_ctr: 35224863, mode: PlainText, ts: 1717612493.671745767s
Session: fb_idx: None,    peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(1088638830675445622), local_nodeid: 0, local: 0, remote: 0, msg_ctr: 9017568, mode: PlainText, ts: 1717612457.779132481s
Session: fb_idx: None,    peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(0), local_nodeid: 0, local: 1, remote: 8566, msg_ctr: 44517232, mode: Pase(NotExpected), ts: 1717612462.458154527s
Session: fb_idx: None,    peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(9297024357880017542), local_nodeid: 0, local: 0, remote: 0, msg_ctr: 87475376, mode: PlainText, ts: 1717612462.78951294s
Session: fb_idx: None,    peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(17849542785653146437), local_nodeid: 0, local: 0, remote: 0, msg_ctr: 35224863, mode: PlainText, ts: 1717612493.671745767s

!!! This block is interesting:
Session: fb_idx: Some(1), peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(864992019), local_nodeid: 1121512030, local: 2, remote: 8567, msg_ctr: 198121502, mode: Case(CaseDetails { fab_idx: 1, cat_ids: [0, 0, 0] }), ts: 1717612496.261807843s
Session: fb_idx: Some(2), peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(3725013030), local_nodeid: 4012158658, local: 3, remote: 8568, msg_ctr: 254531801, mode: Case(CaseDetails { fab_idx: 2, cat_ids: [0, 0, 0] }), ts: 1717612494.724025958s
Session: fb_idx: Some(1), peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(864992019), local_nodeid: 1121512030, local: 2, remote: 8567, msg_ctr: 198121502, mode: Case(CaseDetails { fab_idx: 1, cat_ids: [0, 0, 0] }), ts: 1717612500.816538095s
Session: fb_idx: Some(2), peer: [fe80::8d7:cf23:8b0b:f715%2]:51398, peer_nodeid: Some(3725013030), local_nodeid: 4012158658, local: 3, remote: 8568, msg_ctr: 254531801, mode: Case(CaseDetails { fab_idx: 2, cat_ids: [0, 0, 0] }), ts: 1717612494.724025958s


Sessions for IP Address 2:
=============================================
(Skip this block, it contains non-CASE sessions, not interesting):
Session: fb_idx: None,    peer: [fe80::416:93dd:216a:d50a%2]:65218, peer_nodeid: Some(1162526195568380034), local_nodeid: 0, local: 0, remote: 0, msg_ctr: 84020839, mode: PlainText, ts: 1717612496.321803477s
Session: fb_idx: None,    peer: [fe80::416:93dd:216a:d50a%2]:65218, peer_nodeid: Some(1162526195568380034), local_nodeid: 0, local: 0, remote: 0, msg_ctr: 84020839, mode: PlainText, ts: 1717612496.321803477s

!!! This block is interesting: see - fb_idx = 1 and peer_nodeid = 864992019 which is also present for Address 1?!
Session: fb_idx: Some(1), peer: [fe80::416:93dd:216a:d50a%2]:65218, peer_nodeid: Some(864992019), local_nodeid: 1121512030, local: 4, remote: 48265, msg_ctr: 226861159, mode: Case(CaseDetails { fab_idx: 1, cat_ids: [0, 0, 0] }), ts: 1717612500.815073586s
Session: fb_idx: Some(1), peer: [fe80::416:93dd:216a:d50a%2]:65218, peer_nodeid: Some(864992019), local_nodeid: 1121512030, local: 4, remote: 48265, msg_ctr: 226861159, mode: Case(CaseDetails { fab_idx: 1, cat_ids: [0, 0, 0] }), ts: 1717612500.815073586s
```


