### PR TITLE
Remove all sessions and subscriptions on fabric removal

### DIFF
--- a/rs-matter/src/core.rs
+++ b/rs-matter/src/core.rs
@@ -261,6 +261,12 @@ impl<'a> Borrow<RefCell<FailSafe>> for Matter<'a> {
     }
 }
 
+impl<'a> Borrow<TransportMgr<'a>> for Matter<'a> {
+    fn borrow(&self) -> &TransportMgr<'a> {
+        &self.transport_mgr
+    }
+}
+
 impl<'a> Borrow<BasicInfoConfig<'a>> for Matter<'a> {
     fn borrow(&self) -> &BasicInfoConfig<'a> {
         self.dev_det

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -247,7 +247,13 @@ impl FabricMgr {
     }
 
     pub fn add(&mut self, f: Fabric, mdns: &dyn Mdns) -> Result<u8, Error> {
-        let slot = self.fabrics.iter().position(|x| x.is_none());
+        // Do not re-use slots (if possible) because currently we use the
+        // position of the fabric in the array as a `fabric_index` as per the Matter Core spec
+        // TODO: In future introduce a new field in Fabric to store the fabric index, as
+        // we do for session indexes.
+        let slot = (self.fabrics.len() == MAX_SUPPORTED_FABRICS)
+            .then(|| self.fabrics.iter().position(|x| x.is_none()))
+            .flatten();
 
         if slot.is_some() || self.fabrics.len() < MAX_SUPPORTED_FABRICS {
             mdns.add(&f.mdns_service_name, ServiceMode::Commissioned)?;

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -77,6 +77,7 @@ pub struct TransportMgr<'m> {
     pub(crate) rx: IfMutex<NoopRawMutex, Packet<MAX_RX_BUF_SIZE>>,
     pub(crate) tx: IfMutex<NoopRawMutex, Packet<MAX_TX_BUF_SIZE>>,
     pub(crate) dropped: Notification<NoopRawMutex>,
+    pub(crate) session_removed: Notification<NoopRawMutex>,
     pub session_mgr: RefCell<SessionMgr>, // For testing
     pub(crate) mdns: MdnsImpl<'m>,
 }
@@ -88,6 +89,7 @@ impl<'m> TransportMgr<'m> {
             rx: IfMutex::new(Packet::new()),
             tx: IfMutex::new(Packet::new()),
             dropped: Notification::new(),
+            session_removed: Notification::new(),
             session_mgr: RefCell::new(SessionMgr::new(epoch, rand)),
             mdns,
         }
@@ -140,20 +142,38 @@ impl<'m> TransportMgr<'m> {
         peer_node_id: u64,
         secure: bool,
     ) -> Result<Exchange<'_>, Error> {
+        // TODO: Future: once we have mDNS lookups in place
+        // create a new session if no suitable one is found
+
+        let session_id = {
+            // (block necessary, or else we end up re-borrowing `SessionMgr` as mut twice)
+
+            let mut session_mgr = self.session_mgr.borrow_mut();
+
+            session_mgr
+                .get_for_node(fabric_idx, peer_node_id, secure)
+                .ok_or(ErrorCode::NoSession)?
+                .id
+        };
+
+        self.initiate_for_session(matter, session_id)
+    }
+
+    pub(crate) fn initiate_for_session<'a>(
+        &'a self,
+        matter: &'a Matter<'a>,
+        session_id: u32,
+    ) -> Result<Exchange<'_>, Error> {
         let mut session_mgr = self.session_mgr.borrow_mut();
 
-        session_mgr
-            .get_for_node(fabric_idx, peer_node_id, secure)
-            .ok_or(ErrorCode::NoSession)?;
+        session_mgr.get(session_id).ok_or(ErrorCode::NoSession)?;
 
         let exch_id = session_mgr.get_next_exch_id();
 
         // `unwrap` is safe because we know we have a session or else the early return from above would've triggered
         // The reason why we call `get_for_node` twice is to ensure that we don't waste an `exch_id` in case
         // we don't have a session in the first place
-        let session = session_mgr
-            .get_for_node(fabric_idx, peer_node_id, secure)
-            .unwrap();
+        let session = session_mgr.get(session_id).unwrap();
 
         let exch_index = session
             .add_exch(exch_id, Role::Initiator(Default::default()))
@@ -510,6 +530,7 @@ impl<'m> TransportMgr<'m> {
 
                     // See above why `unwrap` is safe
                     let mut session = session_mgr.remove(session_id).unwrap();
+                    self.session_removed.notify();
 
                     self.encode_packet(
                         packet,
@@ -552,6 +573,7 @@ impl<'m> TransportMgr<'m> {
                         .map(|sess| sess.id)
                     {
                         session_mgr.remove(session_id);
+                        self.session_removed.notify();
                     }
                 } else {
                     info!(
@@ -895,6 +917,7 @@ impl<'m> TransportMgr<'m> {
 
         // It is a responsibility of the caller to ensure that this method is called with a valid session ID
         let mut session = session_mgr.remove(id).unwrap();
+        self.session_removed.notify();
 
         info!(
             "Evicting session {} [SID:{:x},RSID:{:x}]",

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -642,12 +642,28 @@ impl SessionMgr {
     }
 
     /// This assumes that the higher layer has taken care of doing anything required
-    /// as per the spec before the session is erased
+    /// as per the spec before the session is removed
     pub fn remove(&mut self, id: u32) -> Option<Session> {
         if let Some(index) = self.sessions.iter().position(|sess| sess.id == id) {
             Some(self.sessions.swap_remove(index))
         } else {
             None
+        }
+    }
+
+    /// This assumes that the higher layer has taken care of doing anything required
+    /// as per the spec before the sessions are removed
+    pub fn remove_for_fabric(&mut self, fabric_idx: u8) {
+        loop {
+            let Some(index) = self
+                .sessions
+                .iter()
+                .position(|sess| sess.get_local_fabric_idx() == Some(fabric_idx))
+            else {
+                break;
+            };
+
+            self.sessions.swap_remove(index);
         }
     }
 


### PR DESCRIPTION
- As the subject says, this PR makes sure that on de-provisioning (fabric removal) we also clean up the transport from all sessions associated with the fabric which is being removed.
- The PR will also remove all subscriptions associated with the removed sessions. 
- (Since it is now possible) the PR implements logic that would cause any exchanges waiting on `recv` or `send` of a session which is being removed to immediately bail out with "NoSession" rather than waiting until the `recv`/`send` timeout expires

This PR _also_ fixes https://github.com/project-chip/rs-matter/issues/182, but that's because the fallback code-path where - in the absence of a valid session ID - we search (and potentially create) a session by fab-idx + peer node ID, is now (temporarily) commented out.

I think we should restore the fallback logic back to life once we know how exactly to find (or create) a session for reporting which is different from the original one.

For now, reporting _only_ thru the original session is seemingly good enough. The peer node would anyway resubscribe if the session is over and it does not receive a subscription response within the provided timeout (which most of the time seems to be one minute).
