### PR TITLE
Do not stop rs-matter on send errors

### DIFF
--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -991,7 +991,10 @@ impl<'m> TransportMgr<'m> {
                     data
                 );
 
-                Err(e)
+                // Do not return an error as that would unroll the main `rs-matter` loop
+                // and sending errors are normal and can happen for various reasons
+                // TODO: Provide the error as a feedback to the packet creator instead, in the mutex data
+                Ok(())
             }
         }
     }


### PR DESCRIPTION
This one-liner makes sure that `rs-matter` continues to operate even if a remote peer is no longer reachable on its known network address.

There's a TODO in there in that we should actually return the failure error to the code that prepared the send packet in the first place (i.e. in the TX mutex), so that it can handle the error however it sees fit (do an mDNS lookup and then re-send, or give up sending etc.)

However, I suggest we address the TODO once we have mDNS lookups in place.