### PR TITLE
Fix two regressions from the new re-arm logic

### DIFF
--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -545,10 +545,7 @@ impl AclMgr {
         //     ],
         //     Extension: []
         // }
-        if req.accessor.auth_mode == AuthMode::Pase
-            && req.accessor.fab_idx == 0
-            && self.entries.iter().all(Option::is_none)
-        {
+        if req.accessor.auth_mode == AuthMode::Pase {
             return true;
         }
 
@@ -676,11 +673,11 @@ pub(crate) mod tests {
 
         let accessor = Accessor::new(0, AccessorSubjects::new(112233), AuthMode::Pase, &am);
         let path = GenericPath::new(Some(1), Some(1234), None);
-        let mut req = AccessReq::new(&accessor, path, Access::READ);
-        req.set_target_perms(Access::RWVA);
+        let mut req_pase = AccessReq::new(&accessor, path, Access::READ);
+        req_pase.set_target_perms(Access::RWVA);
 
-        // Default allow for PASE if no entries yet
-        assert!(req.allow());
+        // Always allow for PASE sessions
+        assert!(req_pase.allow());
 
         let accessor = Accessor::new(2, AccessorSubjects::new(112233), AuthMode::Case, &am);
         let path = GenericPath::new(Some(1), Some(1234), None);
@@ -698,6 +695,9 @@ pub(crate) mod tests {
         let new = AclEntry::new(FAB_1, Privilege::VIEW, AuthMode::Case);
         assert_eq!(am.borrow_mut().add(new).unwrap(), 0);
         assert_eq!(req.allow(), false);
+
+        // Always allow for PASE sessions
+        assert!(req_pase.allow());
 
         // Allow
         let new = AclEntry::new(FAB_2, Privilege::VIEW, AuthMode::Case);


### PR DESCRIPTION
@kedars I'm so sorry - not sure how I've tested it, but I've managed to introduce two regressions addressed here:
- The guards for dropping the new fabric and its single ACL entry of course need a flag

- The second fix restores unconditional "ADMIN" privileges for _any_ PASE session, as it was in your original code
  - ACL unit tests did not catch this because, ahem, I've changed them too to reflect my (wrong) understanding that a PASE session has ADMIN access only until it is upgraded with a valid fabric index. Which is - in retrospective - completely false, because even after the upgrade - given that ACLs only work for CASE sessions (PASE auth mode is "future") - the unconditional ADMIN for any PASE should remain.
  -  It is another topic that on commissioning complete we should kill off all PASE sessions which I'm not yet sure is happening (for which I'll create a separate small PR later if necessary)