### PR TITLE
Re-introduce supports-concurrent-connections

### DIFF
--- a/rs-matter/src/data_model/root_endpoint.rs
+++ b/rs-matter/src/data_model/root_endpoint.rs
@@ -121,6 +121,7 @@ where
         EthNwCommCluster::new(*matter.borrow()),
         ethernet_nw_diagnostics::ID,
         EthNwDiagCluster::new(*matter.borrow()),
+        true,
     )
 }
 
@@ -138,6 +139,7 @@ pub fn handler<'a, NWCOMM, NWDIAG, T>(
     nwcomm: NWCOMM,
     nwdiag_id: u32,
     nwdiag: NWDIAG,
+    supports_concurrent_connection: bool,
 ) -> RootEndpointHandler<'a, NWCOMM, NWDIAG>
 where
     T: Borrow<BasicInfoConfig<'a>>
@@ -167,6 +169,7 @@ where
         nwcomm,
         nwdiag_id,
         nwdiag,
+        supports_concurrent_connection,
     )
 }
 
@@ -186,6 +189,7 @@ fn wrap<'a, NWCOMM, NWDIAG>(
     nwcomm: NWCOMM,
     nwdiag_id: u32,
     nwdiag: NWDIAG,
+    supports_concurrent_connection: bool,
 ) -> RootEndpointHandler<'a, NWCOMM, NWDIAG> {
     EmptyHandler
         .chain(
@@ -225,7 +229,11 @@ fn wrap<'a, NWCOMM, NWDIAG>(
         .chain(
             endpoint_id,
             general_commissioning::ID,
-            HandlerCompat(GenCommCluster::new(failsafe, false, rand)),
+            HandlerCompat(GenCommCluster::new(
+                failsafe,
+                supports_concurrent_connection,
+                rand,
+            )),
         )
         .chain(
             endpoint_id,

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -274,7 +274,7 @@ impl<'m> TransportMgr<'m> {
                 send,
                 recv,
                 &PacketBufferExternalAccess(&self.tx),
-                PacketBufferExternalAccess(&self.rx),
+                &PacketBufferExternalAccess(&self.rx),
                 host,
                 interface,
                 self.rand,


### PR DESCRIPTION
Not sure how exactly, but this change apparently did not land in `main`.

We need it so that folks can create their own root endpoint, which does support the non-concurrent commissioning scenario (as I do, in `rs-matter-stack` and `esp-idf-matter`).