### PR TITLE
Option to replace initial mDNS and DevAtt post-construction

### DIFF
--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -97,6 +97,10 @@ impl<'m> TransportMgr<'m> {
         }
     }
 
+    pub(crate) fn replace_mdns(&mut self, mdns: MdnsImpl<'m>) {
+        self.mdns = mdns;
+    }
+
     #[cfg(all(feature = "large-buffers", feature = "alloc"))]
     pub fn initialize_buffers(&self) -> Result<(), Error> {
         let mut rx = self.rx.try_lock().map_err(|_| ErrorCode::InvalidState)?;


### PR DESCRIPTION
There is a big comment above the newly-introduced `replace_mdns` utility method that explains the issue at hand.

I have this problem in actual real-life code, hence pushing for it. :) Not a fictitious problem.
