### PR TITLE
Update embassy-sync

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -39,7 +39,7 @@ time = { version = "0.3", default-features = false }
 verhoeff = { version = "1", default-features = false }
 embassy-futures = "0.1"
 embassy-time = "0.3"
-embassy-sync = "0.5"
+embassy-sync = "0.6"
 critical-section = "1.1"
 domain = { version = "0.10", default-features = false, features = ["heapless"] }
 portable-atomic = "1"


### PR DESCRIPTION
Update `embassy-sync` to the recently released 0.6 version.

Not strictly necessary, yet not doing so causes issues in downstream crates like `rs-matter-stack` and `esp-idf-matter`. Simply updating `embassy-sync` is the easiest way to avoid these.
