### PR TITLE
Remove duplicate state from system clusters

### DIFF
--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-use core::borrow::Borrow;
 use core::pin::pin;
 use std::net::UdpSocket;
 
@@ -108,7 +107,7 @@ fn run() -> Result<(), Error> {
 
     let mut mdns = pin!(run_mdns(&matter));
 
-    let on_off = cluster_on_off::OnOffCluster::new(*matter.borrow());
+    let on_off = cluster_on_off::OnOffCluster::new(Dataver::new_rand(matter.rand()));
 
     let subscriptions = Subscriptions::<3>::new();
 
@@ -153,7 +152,7 @@ fn run() -> Result<(), Error> {
         Some((
             CommissioningData {
                 // TODO: Hard-coded for now
-                verifier: VerifierData::new_with_pw(123456, *matter.borrow()),
+                verifier: VerifierData::new_with_pw(123456, matter.rand()),
                 discriminator: 250,
             },
             Default::default(),
@@ -196,11 +195,11 @@ fn dm_handler<'a>(
 ) -> impl Metadata + NonBlockingHandler + 'a {
     (
         NODE,
-        root_endpoint::eth_handler(0, matter)
+        root_endpoint::eth_handler(0, matter.rand())
             .chain(
                 1,
                 descriptor::ID,
-                descriptor::DescriptorCluster::new(*matter.borrow()),
+                descriptor::DescriptorCluster::new(Dataver::new_rand(matter.rand())),
             )
             .chain(1, cluster_on_off::ID, on_off),
     )

--- a/rs-matter/src/data_model/cluster_basic_information.rs
+++ b/rs-matter/src/data_model/cluster_basic_information.rs
@@ -17,15 +17,15 @@
 
 use core::cell::RefCell;
 
-use super::objects::*;
-use crate::{
-    attribute_enum,
-    error::{Error, ErrorCode},
-    utils::rand::Rand,
-};
-use heapless::String;
 use rs_matter_macros::idl_import;
+
 use strum::FromRepr;
+
+use crate::attribute_enum;
+use crate::error::{Error, ErrorCode};
+use crate::transport::exchange::Exchange;
+
+use super::objects::*;
 
 idl_import!(clusters = ["BasicInformation"]);
 
@@ -136,40 +136,44 @@ pub const CLUSTER: Cluster<'static> = Cluster {
 };
 
 #[derive(Clone)]
-pub struct BasicInfoCluster<'a> {
+pub struct BasicInfoCluster {
     data_ver: Dataver,
-    cfg: &'a BasicInfoConfig<'a>,
-    node_label: RefCell<String<32>>, // Max node-label as per the spec
+    node_label: RefCell<heapless::String<32>>, // Max node-label as per the spec
 }
 
-impl<'a> BasicInfoCluster<'a> {
-    pub fn new(cfg: &'a BasicInfoConfig<'a>, rand: Rand) -> Self {
-        let node_label = RefCell::new("".try_into().unwrap());
+impl BasicInfoCluster {
+    pub const fn new(data_ver: Dataver) -> Self {
         Self {
-            data_ver: Dataver::new(rand),
-            cfg,
-            node_label,
+            data_ver,
+            node_label: RefCell::new(heapless::String::new()),
         }
     }
 
-    pub fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
+    pub fn read(
+        &self,
+        exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
         if let Some(writer) = encoder.with_dataver(self.data_ver.get())? {
             if attr.is_system() {
                 CLUSTER.read(attr.attr_id, writer)
             } else {
+                let cfg = exchange.matter().dev_det();
+
                 match attr.attr_id.try_into()? {
                     Attributes::DMRevision(codec) => codec.encode(writer, 1),
-                    Attributes::VendorName(codec) => codec.encode(writer, self.cfg.vendor_name),
-                    Attributes::VendorId(codec) => codec.encode(writer, self.cfg.vid),
-                    Attributes::ProductName(codec) => codec.encode(writer, self.cfg.product_name),
-                    Attributes::ProductId(codec) => codec.encode(writer, self.cfg.pid),
+                    Attributes::VendorName(codec) => codec.encode(writer, cfg.vendor_name),
+                    Attributes::VendorId(codec) => codec.encode(writer, cfg.vid),
+                    Attributes::ProductName(codec) => codec.encode(writer, cfg.product_name),
+                    Attributes::ProductId(codec) => codec.encode(writer, cfg.pid),
                     Attributes::NodeLabel(codec) => {
                         codec.encode(writer, self.node_label.borrow().as_str())
                     }
-                    Attributes::HwVer(codec) => codec.encode(writer, self.cfg.hw_ver),
-                    Attributes::SwVer(codec) => codec.encode(writer, self.cfg.sw_ver),
-                    Attributes::SwVerString(codec) => codec.encode(writer, self.cfg.sw_ver_str),
-                    Attributes::SerialNo(codec) => codec.encode(writer, self.cfg.serial_no),
+                    Attributes::HwVer(codec) => codec.encode(writer, cfg.hw_ver),
+                    Attributes::SwVer(codec) => codec.encode(writer, cfg.sw_ver),
+                    Attributes::SwVerString(codec) => codec.encode(writer, cfg.sw_ver_str),
+                    Attributes::SerialNo(codec) => codec.encode(writer, cfg.serial_no),
                 }
             }
         } else {
@@ -177,7 +181,12 @@ impl<'a> BasicInfoCluster<'a> {
         }
     }
 
-    pub fn write(&self, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
+    pub fn write(
+        &self,
+        _exchange: &Exchange,
+        attr: &AttrDetails,
+        data: AttrData,
+    ) -> Result<(), Error> {
         let data = data.with_dataver(self.data_ver.get())?;
 
         match attr.attr_id.try_into()? {
@@ -197,19 +206,24 @@ impl<'a> BasicInfoCluster<'a> {
     }
 }
 
-impl<'a> Handler for BasicInfoCluster<'a> {
-    fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
-        BasicInfoCluster::read(self, attr, encoder)
+impl Handler for BasicInfoCluster {
+    fn read(
+        &self,
+        exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
+        BasicInfoCluster::read(self, exchange, attr, encoder)
     }
 
-    fn write(&self, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
-        BasicInfoCluster::write(self, attr, data)
+    fn write(&self, exchange: &Exchange, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
+        BasicInfoCluster::write(self, exchange, attr, data)
     }
 }
 
-impl<'a> NonBlockingHandler for BasicInfoCluster<'a> {}
+impl NonBlockingHandler for BasicInfoCluster {}
 
-impl<'a> ChangeNotifier<()> for BasicInfoCluster<'a> {
+impl ChangeNotifier<()> for BasicInfoCluster {
     fn consume_change(&mut self) -> Option<()> {
         self.data_ver.consume_change(())
     }

--- a/rs-matter/src/data_model/cluster_template.rs
+++ b/rs-matter/src/data_model/cluster_template.rs
@@ -15,11 +15,9 @@
  *    limitations under the License.
  */
 
-use crate::{
-    data_model::objects::{Cluster, Handler},
-    error::{Error, ErrorCode},
-    utils::rand::Rand,
-};
+use crate::data_model::objects::{Cluster, Handler};
+use crate::error::{Error, ErrorCode};
+use crate::transport::exchange::Exchange;
 
 use super::objects::{
     AttrDataEncoder, AttrDetails, ChangeNotifier, Dataver, NonBlockingHandler, ATTRIBUTE_LIST,
@@ -40,13 +38,16 @@ pub struct TemplateCluster {
 }
 
 impl TemplateCluster {
-    pub fn new(rand: Rand) -> Self {
-        Self {
-            data_ver: Dataver::new(rand),
-        }
+    pub const fn new(data_ver: Dataver) -> Self {
+        Self { data_ver }
     }
 
-    pub fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
+    pub fn read(
+        &self,
+        _exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
         if let Some(writer) = encoder.with_dataver(self.data_ver.get())? {
             if attr.is_system() {
                 CLUSTER.read(attr.attr_id, writer)
@@ -60,8 +61,13 @@ impl TemplateCluster {
 }
 
 impl Handler for TemplateCluster {
-    fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
-        TemplateCluster::read(self, attr, encoder)
+    fn read(
+        &self,
+        exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
+        TemplateCluster::read(self, exchange, attr, encoder)
     }
 }
 

--- a/rs-matter/src/data_model/objects/dataver.rs
+++ b/rs-matter/src/data_model/objects/dataver.rs
@@ -16,32 +16,38 @@
  */
 
 use core::cell::Cell;
+use core::num::Wrapping;
 
 use crate::utils::rand::Rand;
 
-#[derive(Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Dataver {
-    ver: Cell<u32>,
+    ver: Cell<Wrapping<u32>>,
     changed: Cell<bool>,
 }
 
 impl Dataver {
-    pub fn new(rand: Rand) -> Self {
-        let mut buf = [0; 4];
-        rand(&mut buf);
+    pub fn new_rand(rand: Rand) -> Self {
+        let mut bytes = [0; 4];
 
+        rand(&mut bytes);
+
+        Self::new(u32::from_le_bytes(bytes))
+    }
+
+    pub const fn new(initial: u32) -> Self {
         Self {
-            ver: Cell::new(u32::from_be_bytes(buf)),
+            ver: Cell::new(Wrapping(initial)),
             changed: Cell::new(false),
         }
     }
 
     pub fn get(&self) -> u32 {
-        self.ver.get()
+        self.ver.get().0
     }
 
     pub fn changed(&self) -> u32 {
-        self.ver.set(self.ver.get().overflowing_add(1).0);
+        self.ver.set(self.ver.get() + Wrapping(1));
         self.changed.set(true);
 
         self.get()

--- a/rs-matter/src/data_model/root_endpoint.rs
+++ b/rs-matter/src/data_model/root_endpoint.rs
@@ -1,35 +1,18 @@
-use core::{borrow::Borrow, cell::RefCell};
+use crate::handler_chain_type;
+use crate::utils::rand::Rand;
 
-use crate::{
-    acl::AclMgr,
-    fabric::FabricMgr,
-    handler_chain_type,
-    mdns::Mdns,
-    secure_channel::pake::PaseMgr,
-    transport::core::TransportMgr,
-    utils::{epoch::Epoch, rand::Rand},
-};
-
-use super::{
-    cluster_basic_information::{self, BasicInfoCluster, BasicInfoConfig},
-    objects::{Cluster, EmptyHandler, Endpoint, EndptId, HandlerCompat},
-    sdm::{
-        admin_commissioning::{self, AdminCommCluster},
-        dev_att::DevAttDataFetcher,
-        ethernet_nw_diagnostics::{self, EthNwDiagCluster},
-        failsafe::FailSafe,
-        general_commissioning::{self, GenCommCluster},
-        general_diagnostics::{self, GenDiagCluster},
-        group_key_management::{self, GrpKeyMgmtCluster},
-        noc::{self, NocCluster},
-        nw_commissioning::{self, EthNwCommCluster},
-        wifi_nw_diagnostics,
-    },
-    system_model::{
-        access_control::{self, AccessControlCluster},
-        descriptor::{self, DescriptorCluster},
-    },
-};
+use super::cluster_basic_information::{self, BasicInfoCluster};
+use super::objects::{Cluster, Dataver, EmptyHandler, Endpoint, EndptId, HandlerCompat};
+use super::sdm::admin_commissioning::{self, AdminCommCluster};
+use super::sdm::ethernet_nw_diagnostics::{self, EthNwDiagCluster};
+use super::sdm::general_commissioning::{self, BasicCommissioningInfo, GenCommCluster};
+use super::sdm::general_diagnostics::{self, GenDiagCluster};
+use super::sdm::group_key_management::{self, GrpKeyMgmtCluster};
+use super::sdm::noc::{self, NocCluster};
+use super::sdm::nw_commissioning::{self, EthNwCommCluster};
+use super::sdm::wifi_nw_diagnostics;
+use super::system_model::access_control::{self, AccessControlCluster};
+use super::system_model::descriptor::{self, DescriptorCluster};
 
 const ETH_NW_CLUSTERS: [Cluster<'static>; 10] = [
     descriptor::CLUSTER,
@@ -91,159 +74,101 @@ pub type RootEndpointHandler<'a, NWCOMM, NWDIAG> = handler_chain_type!(
     NWCOMM,
     NWDIAG,
     HandlerCompat<descriptor::DescriptorCluster<'a>>,
-    HandlerCompat<cluster_basic_information::BasicInfoCluster<'a>>,
-    HandlerCompat<general_commissioning::GenCommCluster<'a>>,
-    HandlerCompat<admin_commissioning::AdminCommCluster<'a>>,
-    HandlerCompat<noc::NocCluster<'a>>,
-    HandlerCompat<access_control::AccessControlCluster<'a>>,
+    HandlerCompat<cluster_basic_information::BasicInfoCluster>,
+    HandlerCompat<general_commissioning::GenCommCluster>,
+    HandlerCompat<admin_commissioning::AdminCommCluster>,
+    HandlerCompat<noc::NocCluster>,
+    HandlerCompat<access_control::AccessControlCluster>,
     HandlerCompat<general_diagnostics::GenDiagCluster>,
     HandlerCompat<group_key_management::GrpKeyMgmtCluster>
 );
 
 /// A utility function to instantiate the root (Endpoint 0) handler using Ethernet as the operational network.
-pub fn eth_handler<'a, T>(endpoint_id: u16, matter: &'a T) -> EthRootEndpointHandler<'a>
-where
-    T: Borrow<BasicInfoConfig<'a>>
-        + Borrow<dyn DevAttDataFetcher + 'a>
-        + Borrow<RefCell<PaseMgr>>
-        + Borrow<RefCell<FabricMgr>>
-        + Borrow<RefCell<AclMgr>>
-        + Borrow<RefCell<FailSafe>>
-        + Borrow<TransportMgr<'a>>
-        + Borrow<dyn Mdns + 'a>
-        + Borrow<Epoch>
-        + Borrow<Rand>
-        + 'a,
-{
+pub fn eth_handler(endpoint_id: u16, rand: Rand) -> EthRootEndpointHandler<'static> {
     handler(
         endpoint_id,
-        matter,
-        EthNwCommCluster::new(*matter.borrow()),
+        EthNwCommCluster::new(Dataver::new_rand(rand)),
         ethernet_nw_diagnostics::ID,
-        EthNwDiagCluster::new(*matter.borrow()),
+        EthNwDiagCluster::new(Dataver::new_rand(rand)),
         true,
+        rand,
     )
 }
 
 /// A utility function to instantiate the root (Endpoint 0) handler.
-/// Besides a reference to the main `Matter` object, this function
+/// Besides a `Rand` function, this function
 /// needs user-supplied implementations of the network commissioning
 /// and network diagnostics clusters.
-//
-// TODO: The borrow abstraction below is not of much use and only increases
-// the size of the handlers, as they hold on to various managers instead
-// of simply keeping a reference to the `Matter` object. Remove it in future.
-pub fn handler<'a, NWCOMM, NWDIAG, T>(
+pub fn handler<NWCOMM, NWDIAG>(
     endpoint_id: u16,
-    matter: &'a T,
     nwcomm: NWCOMM,
     nwdiag_id: u32,
     nwdiag: NWDIAG,
     supports_concurrent_connection: bool,
-) -> RootEndpointHandler<'a, NWCOMM, NWDIAG>
-where
-    T: Borrow<BasicInfoConfig<'a>>
-        + Borrow<dyn DevAttDataFetcher + 'a>
-        + Borrow<RefCell<PaseMgr>>
-        + Borrow<RefCell<FabricMgr>>
-        + Borrow<RefCell<AclMgr>>
-        + Borrow<RefCell<FailSafe>>
-        + Borrow<TransportMgr<'a>>
-        + Borrow<dyn Mdns + 'a>
-        + Borrow<Epoch>
-        + Borrow<Rand>
-        + 'a,
-{
+    rand: Rand,
+) -> RootEndpointHandler<'static, NWCOMM, NWDIAG> {
     wrap(
         endpoint_id,
-        matter.borrow(),
-        matter.borrow(),
-        matter.borrow(),
-        matter.borrow(),
-        matter.borrow(),
-        matter.borrow(),
-        matter.borrow(),
-        matter.borrow(),
-        *matter.borrow(),
-        *matter.borrow(),
         nwcomm,
         nwdiag_id,
         nwdiag,
         supports_concurrent_connection,
+        rand,
     )
 }
 
-#[allow(clippy::too_many_arguments)]
-fn wrap<'a, NWCOMM, NWDIAG>(
+fn wrap<NWCOMM, NWDIAG>(
     endpoint_id: u16,
-    basic_info: &'a BasicInfoConfig<'a>,
-    dev_att: &'a dyn DevAttDataFetcher,
-    pase: &'a RefCell<PaseMgr>,
-    fabric: &'a RefCell<FabricMgr>,
-    acl: &'a RefCell<AclMgr>,
-    failsafe: &'a RefCell<FailSafe>,
-    transport_mgr: &'a TransportMgr<'a>,
-    mdns: &'a dyn Mdns,
-    epoch: Epoch,
-    rand: Rand,
     nwcomm: NWCOMM,
     nwdiag_id: u32,
     nwdiag: NWDIAG,
     supports_concurrent_connection: bool,
-) -> RootEndpointHandler<'a, NWCOMM, NWDIAG> {
+    rand: Rand,
+) -> RootEndpointHandler<'static, NWCOMM, NWDIAG> {
     EmptyHandler
         .chain(
             endpoint_id,
             group_key_management::ID,
-            HandlerCompat(GrpKeyMgmtCluster::new(rand)),
+            HandlerCompat(GrpKeyMgmtCluster::new(Dataver::new_rand(rand))),
         )
         .chain(
             endpoint_id,
             general_diagnostics::ID,
-            HandlerCompat(GenDiagCluster::new(rand)),
+            HandlerCompat(GenDiagCluster::new(Dataver::new_rand(rand))),
         )
         .chain(
             endpoint_id,
             access_control::ID,
-            HandlerCompat(AccessControlCluster::new(acl, rand)),
+            HandlerCompat(AccessControlCluster::new(Dataver::new_rand(rand))),
         )
         .chain(
             endpoint_id,
             noc::ID,
-            HandlerCompat(NocCluster::new(
-                dev_att,
-                fabric,
-                acl,
-                failsafe,
-                transport_mgr,
-                mdns,
-                epoch,
-                rand,
-            )),
+            HandlerCompat(NocCluster::new(Dataver::new_rand(rand))),
         )
         .chain(
             endpoint_id,
             admin_commissioning::ID,
-            HandlerCompat(AdminCommCluster::new(pase, mdns, rand)),
+            HandlerCompat(AdminCommCluster::new(Dataver::new_rand(rand))),
         )
         .chain(
             endpoint_id,
             general_commissioning::ID,
             HandlerCompat(GenCommCluster::new(
-                failsafe,
+                Dataver::new_rand(rand),
+                BasicCommissioningInfo::new(),
                 supports_concurrent_connection,
-                rand,
             )),
         )
         .chain(
             endpoint_id,
             cluster_basic_information::ID,
-            HandlerCompat(BasicInfoCluster::new(basic_info, rand)),
+            HandlerCompat(BasicInfoCluster::new(Dataver::new_rand(rand))),
         )
         .chain(
             endpoint_id,
             descriptor::ID,
-            HandlerCompat(DescriptorCluster::new(rand)),
+            HandlerCompat(DescriptorCluster::new(Dataver::new_rand(rand))),
         )
         .chain(endpoint_id, nwdiag_id, nwdiag)
         .chain(endpoint_id, nw_commissioning::ID, nwcomm)

--- a/rs-matter/src/data_model/sdm/admin_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/admin_commissioning.rs
@@ -15,20 +15,18 @@
  *    limitations under the License.
  */
 
-use core::cell::RefCell;
+use log::info;
+
+use num_derive::FromPrimitive;
+
+use strum::{EnumDiscriminants, FromRepr};
 
 use crate::data_model::objects::*;
-use crate::mdns::Mdns;
-use crate::secure_channel::pake::PaseMgr;
 use crate::secure_channel::spake2p::VerifierData;
 use crate::tlv::{FromTLV, Nullable, OctetStr, TLVElement};
 use crate::transport::exchange::Exchange;
-use crate::utils::rand::Rand;
 use crate::{attribute_enum, cmd_enter};
 use crate::{command_enum, error::*};
-use log::info;
-use num_derive::FromPrimitive;
-use strum::{EnumDiscriminants, FromRepr};
 
 pub const ID: u32 = 0x003C;
 
@@ -98,23 +96,22 @@ pub struct OpenCommWindowReq<'a> {
     salt: OctetStr<'a>,
 }
 
-#[derive(Clone)]
-pub struct AdminCommCluster<'a> {
+#[derive(Debug, Clone)]
+pub struct AdminCommCluster {
     data_ver: Dataver,
-    pase_mgr: &'a RefCell<PaseMgr>,
-    mdns: &'a dyn Mdns,
 }
 
-impl<'a> AdminCommCluster<'a> {
-    pub fn new(pase_mgr: &'a RefCell<PaseMgr>, mdns: &'a dyn Mdns, rand: Rand) -> Self {
-        Self {
-            data_ver: Dataver::new(rand),
-            pase_mgr,
-            mdns,
-        }
+impl AdminCommCluster {
+    pub const fn new(data_ver: Dataver) -> Self {
+        Self { data_ver }
     }
 
-    pub fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
+    pub fn read(
+        &self,
+        _exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
         if let Some(writer) = encoder.with_dataver(self.data_ver.get())? {
             if attr.is_system() {
                 CLUSTER.read(attr.attr_id, writer)
@@ -134,13 +131,14 @@ impl<'a> AdminCommCluster<'a> {
 
     pub fn invoke(
         &self,
+        exchange: &Exchange,
         cmd: &CmdDetails,
         data: &TLVElement,
         _encoder: CmdDataEncoder,
     ) -> Result<(), Error> {
         match cmd.cmd_id.try_into()? {
-            Commands::OpenCommWindow => self.handle_command_opencomm_win(data)?,
-            Commands::RevokeComm => self.handle_command_revokecomm_win(data)?,
+            Commands::OpenCommWindow => self.handle_command_opencomm_win(exchange, data)?,
+            Commands::RevokeComm => self.handle_command_revokecomm_win(exchange, data)?,
             _ => Err(ErrorCode::CommandNotFound)?,
         }
 
@@ -149,20 +147,38 @@ impl<'a> AdminCommCluster<'a> {
         Ok(())
     }
 
-    fn handle_command_opencomm_win(&self, data: &TLVElement) -> Result<(), Error> {
+    fn handle_command_opencomm_win(
+        &self,
+        exchange: &Exchange,
+        data: &TLVElement,
+    ) -> Result<(), Error> {
         cmd_enter!("Open Commissioning Window");
         let req = OpenCommWindowReq::from_tlv(data)?;
         let verifier = VerifierData::new(req.verifier.0, req.iterations, req.salt.0);
-        self.pase_mgr
+        exchange
+            .matter()
+            .pase_mgr
             .borrow_mut()
-            .enable_pase_session(verifier, req.discriminator, self.mdns)?;
+            .enable_pase_session(
+                verifier,
+                req.discriminator,
+                &exchange.matter().transport_mgr.mdns,
+            )?;
 
         Ok(())
     }
 
-    fn handle_command_revokecomm_win(&self, _data: &TLVElement) -> Result<(), Error> {
+    fn handle_command_revokecomm_win(
+        &self,
+        exchange: &Exchange,
+        _data: &TLVElement,
+    ) -> Result<(), Error> {
         cmd_enter!("Revoke Commissioning Window");
-        self.pase_mgr.borrow_mut().disable_pase_session(self.mdns)?;
+        exchange
+            .matter()
+            .pase_mgr
+            .borrow_mut()
+            .disable_pase_session(&exchange.matter().transport_mgr.mdns)?;
 
         // TODO: Send status code if no commissioning window is open
 
@@ -170,25 +186,30 @@ impl<'a> AdminCommCluster<'a> {
     }
 }
 
-impl<'a> Handler for AdminCommCluster<'a> {
-    fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
-        AdminCommCluster::read(self, attr, encoder)
+impl Handler for AdminCommCluster {
+    fn read(
+        &self,
+        exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
+        AdminCommCluster::read(self, exchange, attr, encoder)
     }
 
     fn invoke(
         &self,
-        _exchange: &Exchange,
+        exchange: &Exchange,
         cmd: &CmdDetails,
         data: &TLVElement,
         encoder: CmdDataEncoder,
     ) -> Result<(), Error> {
-        AdminCommCluster::invoke(self, cmd, data, encoder)
+        AdminCommCluster::invoke(self, exchange, cmd, data, encoder)
     }
 }
 
-impl<'a> NonBlockingHandler for AdminCommCluster<'a> {}
+impl NonBlockingHandler for AdminCommCluster {}
 
-impl<'a> ChangeNotifier<()> for AdminCommCluster<'a> {
+impl ChangeNotifier<()> for AdminCommCluster {
     fn consume_change(&mut self) -> Option<()> {
         self.data_ver.consume_change(())
     }

--- a/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
@@ -14,13 +14,18 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-use crate::{
-    attribute_enum, cmd_enter, command_enum, data_model::objects::*, error::Error, tlv::TLVElement,
-    transport::exchange::Exchange, utils::rand::Rand,
-};
+
 use log::info;
+
 use rs_matter_macros::idl_import;
+
 use strum::{EnumDiscriminants, FromRepr};
+
+use crate::data_model::objects::*;
+use crate::error::Error;
+use crate::tlv::TLVElement;
+use crate::transport::exchange::Exchange;
+use crate::{attribute_enum, cmd_enter, command_enum};
 
 idl_import!(clusters = ["EthernetNetworkDiagnostics"]);
 
@@ -59,19 +64,22 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     commands: &[CommandsDiscriminants::ResetCounts as _],
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct EthNwDiagCluster {
     data_ver: Dataver,
 }
 
 impl EthNwDiagCluster {
-    pub fn new(rand: Rand) -> Self {
-        Self {
-            data_ver: Dataver::new(rand),
-        }
+    pub const fn new(data_ver: Dataver) -> Self {
+        Self { data_ver }
     }
 
-    pub fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
+    pub fn read(
+        &self,
+        _exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
         if let Some(writer) = encoder.with_dataver(self.data_ver.get())? {
             if attr.is_system() {
                 CLUSTER.read(attr.attr_id, writer)
@@ -86,7 +94,12 @@ impl EthNwDiagCluster {
         }
     }
 
-    pub fn write(&self, _attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
+    pub fn write(
+        &self,
+        _exchange: &Exchange,
+        _attr: &AttrDetails,
+        data: AttrData,
+    ) -> Result<(), Error> {
         let _data = data.with_dataver(self.data_ver.get())?;
 
         self.data_ver.changed();
@@ -114,12 +127,17 @@ impl EthNwDiagCluster {
 }
 
 impl Handler for EthNwDiagCluster {
-    fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
-        EthNwDiagCluster::read(self, attr, encoder)
+    fn read(
+        &self,
+        exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
+        EthNwDiagCluster::read(self, exchange, attr, encoder)
     }
 
-    fn write(&self, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
-        EthNwDiagCluster::write(self, attr, data)
+    fn write(&self, exchange: &Exchange, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
+        EthNwDiagCluster::write(self, exchange, attr, data)
     }
 
     fn invoke(

--- a/rs-matter/src/data_model/sdm/general_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/general_diagnostics.rs
@@ -14,16 +14,16 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-use crate::{
-    attribute_enum, cmd_enter, command_enum,
-    data_model::objects::*,
-    error::{Error, ErrorCode},
-    tlv::TLVElement,
-    transport::exchange::Exchange,
-    utils::rand::Rand,
-};
+
 use log::info;
+
 use strum::{EnumDiscriminants, FromRepr};
+
+use crate::data_model::objects::*;
+use crate::error::{Error, ErrorCode};
+use crate::tlv::TLVElement;
+use crate::transport::exchange::Exchange;
+use crate::{attribute_enum, cmd_enter, command_enum};
 
 pub const ID: u32 = 0x0033;
 
@@ -70,19 +70,22 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     commands: &[CommandsDiscriminants::TestEventTrigger as _],
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct GenDiagCluster {
     data_ver: Dataver,
 }
 
 impl GenDiagCluster {
-    pub fn new(rand: Rand) -> Self {
-        Self {
-            data_ver: Dataver::new(rand),
-        }
+    pub const fn new(data_ver: Dataver) -> Self {
+        Self { data_ver }
     }
 
-    pub fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
+    pub fn read(
+        &self,
+        _exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
         if let Some(writer) = encoder.with_dataver(self.data_ver.get())? {
             if attr.is_system() {
                 CLUSTER.read(attr.attr_id, writer)
@@ -97,7 +100,12 @@ impl GenDiagCluster {
         }
     }
 
-    pub fn write(&self, _attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
+    pub fn write(
+        &self,
+        _exchange: &Exchange,
+        _attr: &AttrDetails,
+        data: AttrData,
+    ) -> Result<(), Error> {
         let _data = data.with_dataver(self.data_ver.get())?;
 
         self.data_ver.changed();
@@ -125,12 +133,17 @@ impl GenDiagCluster {
 }
 
 impl Handler for GenDiagCluster {
-    fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
-        GenDiagCluster::read(self, attr, encoder)
+    fn read(
+        &self,
+        exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
+        GenDiagCluster::read(self, exchange, attr, encoder)
     }
 
-    fn write(&self, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
-        GenDiagCluster::write(self, attr, data)
+    fn write(&self, exchange: &Exchange, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
+        GenDiagCluster::write(self, exchange, attr, data)
     }
 
     fn invoke(

--- a/rs-matter/src/data_model/system_model/access_control.rs
+++ b/rs-matter/src/data_model/system_model/access_control.rs
@@ -15,18 +15,18 @@
  *    limitations under the License.
  */
 
-use core::cell::RefCell;
 use core::num::NonZeroU8;
 
 use strum::{EnumDiscriminants, FromRepr};
+
+use log::{error, info};
 
 use crate::acl::{self, AclEntry, AclMgr};
 use crate::data_model::objects::*;
 use crate::interaction_model::messages::ib::{attr_list_write, ListOperation};
 use crate::tlv::{FromTLV, TLVElement, TagType, ToTLV};
-use crate::utils::rand::Rand;
+use crate::transport::exchange::Exchange;
 use crate::{attribute_enum, error::*};
-use log::{error, info};
 
 pub const ID: u32 = 0x001F;
 
@@ -77,21 +77,55 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     commands: &[],
 };
 
-#[derive(Clone)]
-pub struct AccessControlCluster<'a> {
+#[derive(Debug, Clone)]
+pub struct AccessControlCluster {
     data_ver: Dataver,
-    acl_mgr: &'a RefCell<AclMgr>,
 }
 
-impl<'a> AccessControlCluster<'a> {
-    pub fn new(acl_mgr: &'a RefCell<AclMgr>, rand: Rand) -> Self {
-        Self {
-            data_ver: Dataver::new(rand),
-            acl_mgr,
+impl AccessControlCluster {
+    pub const fn new(data_ver: Dataver) -> Self {
+        Self { data_ver }
+    }
+
+    pub fn read(
+        &self,
+        exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
+        self.read_acl_attr(&exchange.matter().acl_mgr.borrow(), attr, encoder)
+    }
+
+    pub fn write(
+        &self,
+        exchange: &Exchange,
+        attr: &AttrDetails,
+        data: AttrData,
+    ) -> Result<(), Error> {
+        match attr.attr_id.try_into()? {
+            Attributes::Acl(_) => {
+                attr_list_write(attr, data.with_dataver(self.data_ver.get())?, |op, data| {
+                    self.write_acl_attr(
+                        &mut exchange.matter().acl_mgr.borrow_mut(),
+                        &op,
+                        data,
+                        NonZeroU8::new(attr.fab_idx).ok_or(ErrorCode::Invalid)?,
+                    )
+                })
+            }
+            _ => {
+                error!("Attribute not yet supported: this shouldn't happen");
+                Err(ErrorCode::AttributeNotFound.into())
+            }
         }
     }
 
-    pub fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
+    fn read_acl_attr(
+        &self,
+        acl_mgr: &AclMgr,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
         if let Some(mut writer) = encoder.with_dataver(self.data_ver.get())? {
             if attr.is_system() {
                 CLUSTER.read(attr.attr_id, writer)
@@ -99,7 +133,7 @@ impl<'a> AccessControlCluster<'a> {
                 match attr.attr_id.try_into()? {
                     Attributes::Acl(_) => {
                         writer.start_array(AttrDataWriter::TAG)?;
-                        self.acl_mgr.borrow().for_each_acl(|entry| {
+                        acl_mgr.for_each_acl(|entry| {
                             if !attr.fab_filter || attr.fab_idx == entry.fab_idx.get() {
                                 entry.to_tlv(&mut writer, TagType::Anonymous)?;
                             }
@@ -133,30 +167,13 @@ impl<'a> AccessControlCluster<'a> {
         }
     }
 
-    pub fn write(&self, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
-        match attr.attr_id.try_into()? {
-            Attributes::Acl(_) => {
-                attr_list_write(attr, data.with_dataver(self.data_ver.get())?, |op, data| {
-                    self.write_acl_attr(
-                        &op,
-                        data,
-                        NonZeroU8::new(attr.fab_idx).ok_or(ErrorCode::Invalid)?,
-                    )
-                })
-            }
-            _ => {
-                error!("Attribute not yet supported: this shouldn't happen");
-                Err(ErrorCode::AttributeNotFound.into())
-            }
-        }
-    }
-
     /// Write the ACL Attribute
     ///
     /// This takes care of 4 things, add item, edit item, delete item, delete list.
     /// Care about fabric-scoped behaviour is taken
     fn write_acl_attr(
         &self,
+        acl_mgr: &mut AclMgr,
         op: &ListOperation,
         data: &TLVElement,
         fab_idx: NonZeroU8,
@@ -170,36 +187,37 @@ impl<'a> AccessControlCluster<'a> {
                 acl_entry.fab_idx = fab_idx;
 
                 if let ListOperation::EditItem(index) = op {
-                    self.acl_mgr
-                        .borrow_mut()
-                        .edit(*index as u8, fab_idx, acl_entry)?;
+                    acl_mgr.edit(*index as u8, fab_idx, acl_entry)?;
                 } else {
-                    self.acl_mgr.borrow_mut().add(acl_entry)?;
+                    acl_mgr.add(acl_entry)?;
                 }
 
                 Ok(())
             }
-            ListOperation::DeleteItem(index) => {
-                self.acl_mgr.borrow_mut().delete(*index as u8, fab_idx)
-            }
-            ListOperation::DeleteList => self.acl_mgr.borrow_mut().delete_for_fabric(fab_idx),
+            ListOperation::DeleteItem(index) => acl_mgr.delete(*index as u8, fab_idx),
+            ListOperation::DeleteList => acl_mgr.delete_for_fabric(fab_idx),
         }
     }
 }
 
-impl<'a> Handler for AccessControlCluster<'a> {
-    fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
-        AccessControlCluster::read(self, attr, encoder)
+impl Handler for AccessControlCluster {
+    fn read(
+        &self,
+        exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
+        AccessControlCluster::read(self, exchange, attr, encoder)
     }
 
-    fn write(&self, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
-        AccessControlCluster::write(self, attr, data)
+    fn write(&self, exchange: &Exchange, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
+        AccessControlCluster::write(self, exchange, attr, data)
     }
 }
 
-impl<'a> NonBlockingHandler for AccessControlCluster<'a> {}
+impl NonBlockingHandler for AccessControlCluster {}
 
-impl<'a> ChangeNotifier<()> for AccessControlCluster<'a> {
+impl ChangeNotifier<()> for AccessControlCluster {
     fn consume_change(&mut self) -> Option<()> {
         self.data_ver.consume_change(())
     }
@@ -207,15 +225,12 @@ impl<'a> ChangeNotifier<()> for AccessControlCluster<'a> {
 
 #[cfg(test)]
 mod tests {
-    use core::cell::RefCell;
-
-    use crate::{
-        acl::{AclEntry, AclMgr, AuthMode},
-        data_model::objects::{AttrDataEncoder, AttrDetails, Node, Privilege},
-        interaction_model::messages::ib::ListOperation,
-        tlv::{get_root_node_struct, ElementType, TLVElement, TLVWriter, TagType, ToTLV},
-        utils::{rand::dummy_rand, writebuf::WriteBuf},
-    };
+    use crate::acl::{AclEntry, AclMgr, AuthMode};
+    use crate::data_model::objects::{AttrDataEncoder, AttrDetails, Node, Privilege};
+    use crate::data_model::system_model::access_control::Dataver;
+    use crate::interaction_model::messages::ib::ListOperation;
+    use crate::tlv::{get_root_node_struct, ElementType, TLVElement, TLVWriter, TagType, ToTLV};
+    use crate::utils::writebuf::WriteBuf;
 
     use super::AccessControlCluster;
 
@@ -228,8 +243,8 @@ mod tests {
         let mut writebuf = WriteBuf::new(&mut buf);
         let mut tw = TLVWriter::new(&mut writebuf);
 
-        let acl_mgr = RefCell::new(AclMgr::new());
-        let acl = AccessControlCluster::new(&acl_mgr, dummy_rand);
+        let mut acl_mgr = AclMgr::new();
+        let acl = AccessControlCluster::new(Dataver::new(0));
 
         let new = AclEntry::new(FAB_2, Privilege::VIEW, AuthMode::Case);
         new.to_tlv(&mut tw, TagType::Anonymous).unwrap();
@@ -237,12 +252,11 @@ mod tests {
 
         // Test, ACL has fabric index 2, but the accessing fabric is 1
         //    the fabric index in the TLV should be ignored and the ACL should be created with entry 1
-        let result = acl.write_acl_attr(&ListOperation::AddItem, &data, FAB_1);
+        let result = acl.write_acl_attr(&mut acl_mgr, &ListOperation::AddItem, &data, FAB_1);
         assert!(result.is_ok());
 
         let verifier = AclEntry::new(FAB_1, Privilege::VIEW, AuthMode::Case);
         acl_mgr
-            .borrow()
             .for_each_acl(|a| {
                 assert_eq!(*a, verifier);
                 Ok(())
@@ -258,23 +272,23 @@ mod tests {
         let mut tw = TLVWriter::new(&mut writebuf);
 
         // Add 3 ACLs, belonging to fabric index 2, 1 and 2, in that order
-        let acl_mgr = RefCell::new(AclMgr::new());
+        let mut acl_mgr = AclMgr::new();
         let mut verifier = [
             AclEntry::new(FAB_2, Privilege::VIEW, AuthMode::Case),
             AclEntry::new(FAB_1, Privilege::VIEW, AuthMode::Case),
             AclEntry::new(FAB_2, Privilege::ADMIN, AuthMode::Case),
         ];
         for i in &verifier {
-            acl_mgr.borrow_mut().add(i.clone()).unwrap();
+            acl_mgr.add(i.clone()).unwrap();
         }
-        let acl = AccessControlCluster::new(&acl_mgr, dummy_rand);
+        let acl = AccessControlCluster::new(Dataver::new(0));
 
         let new = AclEntry::new(FAB_2, Privilege::VIEW, AuthMode::Case);
         new.to_tlv(&mut tw, TagType::Anonymous).unwrap();
         let data = get_root_node_struct(writebuf.as_slice()).unwrap();
 
         // Test, Edit Fabric 2's index 1 - with accessing fabring as 2 - allow
-        let result = acl.write_acl_attr(&ListOperation::EditItem(1), &data, FAB_2);
+        let result = acl.write_acl_attr(&mut acl_mgr, &ListOperation::EditItem(1), &data, FAB_2);
         // Fabric 2's index 1, is actually our index 2, update the verifier
         verifier[2] = new;
         assert!(result.is_ok());
@@ -282,7 +296,6 @@ mod tests {
         // Also validate in the acl_mgr that the entries are in the right order
         let mut index = 0;
         acl_mgr
-            .borrow()
             .for_each_acl(|a| {
                 assert_eq!(*a, verifier[index]);
                 index += 1;
@@ -295,28 +308,27 @@ mod tests {
     /// - The listindex used for delete should be relative to the current fabric
     fn acl_cluster_delete() {
         // Add 3 ACLs, belonging to fabric index 2, 1 and 2, in that order
-        let acl_mgr = RefCell::new(AclMgr::new());
+        let mut acl_mgr = AclMgr::new();
         let input = [
             AclEntry::new(FAB_2, Privilege::VIEW, AuthMode::Case),
             AclEntry::new(FAB_1, Privilege::VIEW, AuthMode::Case),
             AclEntry::new(FAB_2, Privilege::ADMIN, AuthMode::Case),
         ];
         for i in &input {
-            acl_mgr.borrow_mut().add(i.clone()).unwrap();
+            acl_mgr.add(i.clone()).unwrap();
         }
-        let acl = AccessControlCluster::new(&acl_mgr, dummy_rand);
+        let acl = AccessControlCluster::new(Dataver::new(0));
         // data is don't-care actually
         let data = TLVElement::new(TagType::Anonymous, ElementType::True);
 
         // Test , Delete Fabric 1's index 0
-        let result = acl.write_acl_attr(&ListOperation::DeleteItem(0), &data, FAB_1);
+        let result = acl.write_acl_attr(&mut acl_mgr, &ListOperation::DeleteItem(0), &data, FAB_1);
         assert!(result.is_ok());
 
         let verifier = [input[0].clone(), input[2].clone()];
         // Also validate in the acl_mgr that the entries are in the right order
         let mut index = 0;
         acl_mgr
-            .borrow()
             .for_each_acl(|a| {
                 assert_eq!(*a, verifier[index]);
                 index += 1;
@@ -332,16 +344,16 @@ mod tests {
         let mut writebuf = WriteBuf::new(&mut buf);
 
         // Add 3 ACLs, belonging to fabric index 2, 1 and 2, in that order
-        let acl_mgr = RefCell::new(AclMgr::new());
+        let mut acl_mgr = AclMgr::new();
         let input = [
             AclEntry::new(FAB_2, Privilege::VIEW, AuthMode::Case),
             AclEntry::new(FAB_1, Privilege::VIEW, AuthMode::Case),
             AclEntry::new(FAB_2, Privilege::ADMIN, AuthMode::Case),
         ];
         for i in input {
-            acl_mgr.borrow_mut().add(i).unwrap();
+            acl_mgr.add(i).unwrap();
         }
-        let acl = AccessControlCluster::new(&acl_mgr, dummy_rand);
+        let acl = AccessControlCluster::new(Dataver::new(0));
         // Test 1, all 3 entries are read in the response without fabric filtering
         {
             let attr = AttrDetails {
@@ -362,7 +374,7 @@ mod tests {
             let mut tw = TLVWriter::new(&mut writebuf);
             let encoder = AttrDataEncoder::new(&attr, &mut tw);
 
-            acl.read(&attr, encoder).unwrap();
+            acl.read_acl_attr(&acl_mgr, &attr, encoder).unwrap();
             assert_eq!(
                 // &[
                 //     21, 53, 1, 36, 0, 0, 55, 1, 24, 54, 2, 21, 36, 1, 1, 36, 2, 2, 54, 3, 24, 54,
@@ -401,7 +413,7 @@ mod tests {
             let mut tw = TLVWriter::new(&mut writebuf);
             let encoder = AttrDataEncoder::new(&attr, &mut tw);
 
-            acl.read(&attr, encoder).unwrap();
+            acl.read_acl_attr(&acl_mgr, &attr, encoder).unwrap();
             assert_eq!(
                 // &[
                 //     21, 53, 1, 36, 0, 0, 55, 1, 24, 54, 2, 21, 36, 1, 1, 36, 2, 2, 54, 3, 24, 54,
@@ -436,7 +448,7 @@ mod tests {
             let mut tw = TLVWriter::new(&mut writebuf);
             let encoder = AttrDataEncoder::new(&attr, &mut tw);
 
-            acl.read(&attr, encoder).unwrap();
+            acl.read_acl_attr(&acl_mgr, &attr, encoder).unwrap();
             assert_eq!(
                 // &[
                 //     21, 53, 1, 36, 0, 0, 55, 1, 24, 54, 2, 21, 36, 1, 1, 36, 2, 2, 54, 3, 24, 54,

--- a/rs-matter/src/data_model/system_model/descriptor.rs
+++ b/rs-matter/src/data_model/system_model/descriptor.rs
@@ -15,13 +15,15 @@
  *    limitations under the License.
  */
 
+use core::fmt::Debug;
+
 use strum::FromRepr;
 
 use crate::attribute_enum;
 use crate::data_model::objects::*;
 use crate::error::Error;
 use crate::tlv::{TLVWriter, TagType, ToTLV};
-use crate::utils::rand::Rand;
+use crate::transport::exchange::Exchange;
 
 pub const ID: u32 = 0x001D;
 
@@ -51,6 +53,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
     commands: &[],
 };
 
+#[derive(Debug)]
 struct StandardPartsMatcher;
 
 impl PartsMatcher for StandardPartsMatcher {
@@ -59,6 +62,7 @@ impl PartsMatcher for StandardPartsMatcher {
     }
 }
 
+#[derive(Debug)]
 struct AggregatorPartsMatcher;
 
 impl PartsMatcher for AggregatorPartsMatcher {
@@ -67,7 +71,7 @@ impl PartsMatcher for AggregatorPartsMatcher {
     }
 }
 
-pub trait PartsMatcher {
+pub trait PartsMatcher: Debug {
     fn describe(&self, our_endpoint: EndptId, endpoint: EndptId) -> bool;
 }
 
@@ -91,29 +95,34 @@ where
 
 #[derive(Clone)]
 pub struct DescriptorCluster<'a> {
-    matcher: &'a dyn PartsMatcher,
     data_ver: Dataver,
+    matcher: &'a dyn PartsMatcher,
 }
 
 impl DescriptorCluster<'static> {
-    pub fn new(rand: Rand) -> Self {
-        Self::new_matching(&StandardPartsMatcher, rand)
+    pub const fn new(data_ver: Dataver) -> Self {
+        Self::new_matching(data_ver, &StandardPartsMatcher)
     }
 
-    pub fn new_aggregator(rand: Rand) -> Self {
-        Self::new_matching(&AggregatorPartsMatcher, rand)
+    pub const fn new_aggregator(data_ver: Dataver) -> Self {
+        Self::new_matching(data_ver, &AggregatorPartsMatcher)
     }
 }
 
 impl<'a> DescriptorCluster<'a> {
-    pub fn new_matching(matcher: &'a dyn PartsMatcher, rand: Rand) -> DescriptorCluster<'a> {
-        Self {
-            matcher,
-            data_ver: Dataver::new(rand),
-        }
+    pub const fn new_matching(
+        data_ver: Dataver,
+        matcher: &'a dyn PartsMatcher,
+    ) -> DescriptorCluster<'a> {
+        Self { data_ver, matcher }
     }
 
-    pub fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
+    pub fn read(
+        &self,
+        _exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
         if let Some(mut writer) = encoder.with_dataver(self.data_ver.get())? {
             if attr.is_system() {
                 CLUSTER.read(attr.attr_id, writer)
@@ -231,8 +240,13 @@ impl<'a> DescriptorCluster<'a> {
 }
 
 impl<'a> Handler for DescriptorCluster<'a> {
-    fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
-        DescriptorCluster::read(self, attr, encoder)
+    fn read(
+        &self,
+        exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
+        DescriptorCluster::read(self, exchange, attr, encoder)
     }
 }
 

--- a/rs-matter/src/secure_channel/case.rs
+++ b/rs-matter/src/secure_channel/case.rs
@@ -253,7 +253,7 @@ impl Case {
         );
 
         // Create an ephemeral Key Pair
-        let key_pair = KeyPair::new(exchange.matter().rand)?;
+        let key_pair = KeyPair::new(exchange.matter().rand())?;
         let _ = key_pair.get_public_key(&mut case_session.our_pub_key)?;
 
         // Derive the Shared Secret
@@ -265,7 +265,7 @@ impl Case {
         //        println!("Derived secret: {:x?} len: {}", secret, len);
 
         let mut our_random: [u8; 32] = [0; 32];
-        (exchange.matter().rand)(&mut our_random);
+        (exchange.matter().rand())(&mut our_random);
 
         // Derive the Encrypted Part
         const MAX_ENCRYPTED_SIZE: usize = 800;
@@ -301,7 +301,7 @@ impl Case {
 
                 let encrypted_len = Case::get_sigma2_encryption(
                     fabric,
-                    exchange.matter().rand,
+                    exchange.matter().rand(),
                     &our_random,
                     case_session,
                     signature,

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -593,7 +593,7 @@ impl<'a> TxMessage<'a> {
         let (peer, retransmission) = session.pre_send(
             Some(self.exchange_id.exchange_index()),
             &mut self.packet.header,
-            self.matter.epoch,
+            self.matter.epoch(),
         )?;
 
         self.packet.peer = peer;
@@ -839,7 +839,7 @@ impl<'a> Exchange<'a> {
         received_timeout_ms: u32,
     ) -> Result<Self, Error> {
         if received_timeout_ms > 0 {
-            let epoch = matter.epoch;
+            let epoch = matter.epoch();
 
             loop {
                 let mut accept = pin!(matter.transport_mgr.accept_if(matter, |_, exch, _| {

--- a/rs-matter/tests/common/echo_cluster.rs
+++ b/rs-matter/tests/common/echo_cluster.rs
@@ -30,7 +30,6 @@ use rs_matter::{
     interaction_model::messages::ib::{attr_list_write, ListOperation},
     tlv::{TLVElement, TagType},
     transport::exchange::Exchange,
-    utils::rand::Rand,
 };
 use strum::{EnumDiscriminants, FromRepr};
 
@@ -135,9 +134,9 @@ pub struct EchoCluster {
 }
 
 impl EchoCluster {
-    pub fn new(multiplier: u8, rand: Rand) -> Self {
+    pub const fn new(multiplier: u8, data_ver: Dataver) -> Self {
         Self {
-            data_ver: Dataver::new(rand),
+            data_ver,
             multiplier,
             att1: Cell::new(0x1234),
             att2: Cell::new(0x5678),
@@ -264,11 +263,16 @@ pub const ATTR_CUSTOM_VALUE: u32 = 0xcafebeef;
 pub const ATTR_WRITE_DEFAULT_VALUE: u16 = 0xcafe;
 
 impl Handler for EchoCluster {
-    fn read(&self, attr: &AttrDetails, encoder: AttrDataEncoder) -> Result<(), Error> {
+    fn read(
+        &self,
+        _exchange: &Exchange,
+        attr: &AttrDetails,
+        encoder: AttrDataEncoder,
+    ) -> Result<(), Error> {
         EchoCluster::read(self, attr, encoder)
     }
 
-    fn write(&self, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
+    fn write(&self, _exchange: &Exchange, attr: &AttrDetails, data: AttrData) -> Result<(), Error> {
         EchoCluster::write(self, attr, data)
     }
 


### PR DESCRIPTION
(
This is a mechanical change that I had to apply laboriously everywhere, hence the large number of changed files.
But otherwise, no big semantic changes.
)

#### What

Currently, a lot of the system clusters contain state, in the form of various Matter objects that are borrowed upon the system cluster creation. For example:
- Failsafe
- ACL mgr
- Transport mgr
- Pase mgr
- ... and quite a few others

The culprit for me is the NOC cluster, [which contains a ton of data](https://github.com/project-chip/rs-matter/blob/main/rs-matter/src/data_model/sdm/noc.rs#L219).

- The thing is, caching this data **is completely unnecessary**, because every cluster command (read/write/invoke) operates on a provided `Exchange`.
- The `Exchange` object - of course - is bound to a certain `Matter` instance, which is available via `Exchange::matter(&self)`
- The `Matter` instance in turn contains all of that data which is needlessly cached in the cluster and takes space

Moreover, I would argue that caching this data in the cluster is **even incorrect**! What happens if the user has created the cluster on **one** `Matter` instance, but then erroneously uses the cluster for **another** Matter instance? Havoc.

(This problem by the way was fixed in the Pase / Case SC handlers with the transport rework, but I did not touch the DM clusters back then.)

#### Scope of changes

The changes are completely mechanical and should NOT introduce any semantic changes:
- All state from all system clusters (except `Dataver` - see below for that one) is removed
- All previously cached Matter state is now retrieved on-the-fly from the supplied `Matter` object of the supplied `Exchange` reference
- Cluster methods `read`/`write` did not have a reference to `Exchange` (`invoke` did (?)) which was an omission I addressed now
- I also removed the lifetime `'a` which was present in the `read/write/invoke` methods of `AsyncHandler` and which is unnecessary (as I was extending the signatures of the `Handler` / `AsyncHandler` traits' methods anyway)

#### What is NOT part of the changes

- Addressing the header issue (we have #190 for that)
- Commenting old code (we have #191 for that)
- Treatment of `Dataver`. `Dataver` got two very minor changes, but is otherwise unchanged, and is still part of the cluster handler state (in fact, it is the only state of most system clusters now) which I think is **wrong**! BUT:
  - I haven't figured out in my head how to handle `Dataver`. It is also related to #166 which is not solved yet
  - (`Dataver`s for system cluster should probably be part of the `Matter` object _itself_. As these clusters are changing the state of that object, and not state they they themselves own)
- Anything else we feel is pressing but might de-focus the purpose of this PR

#### Why now?

1. Our handling of commissioning completion is currently wrong. We need to register the new Fabric ONLY when we get `CommissioningComplete` and not before that. Currently, we do it on `AddNoc` and that's not OK. The C++ SDK does it [properly](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp#L244)

2. To fix (1) from above, _without introducing even more temporary space on the program stack_ I need to rework a bit how fabrics are handled - in that each fabric needs to have a pending/non-commissioned flag. This would also allow me to get rid of the `NocData` thing which is a looping 400 bytes and is stored in _each session_. If I do this, ideally I need to merge the ACLs which are per-fabric really into the `Fabric` object (tracking them in the `AclMgr` is simply not convenient - for the same reasons why having separate sessions from exchanges was not convenient and now all exchanges for a session are aggregated within its corresponding `Session` struct)

... but then (2) means I had to introduce _even more cached state_ to the NOC and General Commissioning handlers, hence this PR to just stop this.

