### PR TITLE
Fix compilation with latest log version

### DIFF
--- a/tools/tlv/Cargo.toml
+++ b/tools/tlv/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 
 [dependencies]
 rs-matter = { path = "../../rs-matter" }
-log = {version = "0.4.14", features = ["max_level_trace", "release_max_level_warn"]}
+log = "0.4"
 simple_logger = "1.16.0"
 clap = "2.34"
 


### PR DESCRIPTION
The reason why the CI of tlv-tool started failing lately is because there is a new check in latest `log` which checks if there are multiple, incompatible log-max-levels which are specified as features.

And we do have incompatibility:
* In `rs-matter`:
```toml
log = { version = "0.4", features = ["max_level_debug", "release_max_level_debug"] }
```
(This is since forever, i.e. since before I was around.)

* In tlv-tool:
```toml
log = {version = "0.4.14", features = ["max_level_trace", "release_max_level_warn"]}
```

This PR simply removes the custom levels from tlv-tool and tlv-tool will use the ones from `rs-matter` (_which might have been the case anyway before_ - silently).

Open to other suggestions.
