### PR TITLE
Fix no-std build

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -44,7 +44,7 @@ critical-section = "1.1"
 domain = { version = "0.10", default-features = false, features = ["heapless"] }
 portable-atomic = "1"
 qrcodegen-no-heap = "1.8"
-scopeguard = "1"
+scopeguard = { version = "1", default-features = false }
 
 # crypto
 openssl = { version = "0.10", optional = true }
@@ -81,7 +81,7 @@ tokio-stream = { version = "0.1" }
 [dev-dependencies]
 env_logger = "0.11"
 nix = { version = "0.27", features = ["net"] }
-futures-lite = "1"
+futures-lite = "2"
 async-channel = "2"
 
 [[example]]


### PR DESCRIPTION
This PR addresses an omission, where I've accidentally included the `scopeguard` dependency with default features, so it compiles with STD enabled (and fails to compile for pure no-std targets).

(I've also up-ed the "dev" dependency `futures-lite` to "2" as this is the latest version, which is used everywhere else, including in `async-io` which is also a dependency of ours. Not that it matters so much, but to avoid our `cargo tree` depending on two different `futures-lite` versions - 1 and 2 respectively.)