### PR TITLE
Fix ACL modifications

### DIFF
--- a/rs-matter/src/data_model/system_model/access_control.rs
+++ b/rs-matter/src/data_model/system_model/access_control.rs
@@ -134,7 +134,12 @@ impl AccessControlCluster {
                     Attributes::Acl(_) => {
                         writer.start_array(AttrDataWriter::TAG)?;
                         acl_mgr.for_each_acl(|entry| {
-                            if !attr.fab_filter || attr.fab_idx == entry.fab_idx.get() {
+                            if !attr.fab_filter
+                                || entry
+                                    .fab_idx
+                                    .map(|fi| fi.get() == attr.fab_idx)
+                                    .unwrap_or(false)
+                            {
                                 entry.to_tlv(&mut writer, TagType::Anonymous)?;
                             }
 
@@ -184,7 +189,7 @@ impl AccessControlCluster {
                 let mut acl_entry = AclEntry::from_tlv(data)?;
                 info!("ACL  {:?}", acl_entry);
                 // Overwrite the fabric index with our accessing fabric index
-                acl_entry.fab_idx = fab_idx;
+                acl_entry.fab_idx = Some(fab_idx);
 
                 if let ListOperation::EditItem(index) = op {
                     acl_mgr.edit(*index as u8, fab_idx, acl_entry)?;


### PR DESCRIPTION
This is a regression from https://github.com/project-chip/rs-matter/pull/170
I've changed then `AclEntry::fab_idx` from `Option` to mandatory in an effort to make it clear that when persisted in non-volatile storage, the fabric index should always be there. 

What I did not realize back then is that when the `AclEntry` struct is coming from the other peer, this field will **not** be set, as the fabric index is coming from the session access context instead.

For the time being and while we use the `AclEntry` struct for both de-serializing incoming peer TLV, as well as for the on-disk/storage format, we'll have to have this field as optional. This might change once I introduce the long-in-the-works optimizations on fabric and NOC cluster operations.