### PR TITLE
allow endpoints with multiple device types

### DIFF
--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -195,7 +195,7 @@ const NODE: Node<'static> = Node {
         root_endpoint::endpoint(0, root_endpoint::OperNwType::Ethernet),
         Endpoint {
             id: 1,
-            device_type: DEV_TYPE_ON_OFF_LIGHT,
+            device_types: &[DEV_TYPE_ON_OFF_LIGHT],
             clusters: &[descriptor::CLUSTER, cluster_on_off::CLUSTER],
         },
     ],

--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -133,7 +133,7 @@ fn run() -> Result<(), Error> {
         core::mem::size_of_val(&responder.run::<4, 4>())
     );
 
-    // Run the responder with up to 4 handlers (i.e. 4 exchanges can be handled simultenously)
+    // Run the responder with up to 4 handlers (i.e. 4 exchanges can be handled simultaneously)
     // Clients trying to open more exchanges than the ones currently running will get "I'm busy, please try again later"
     let mut respond = pin!(responder.run::<4, 4>());
 

--- a/examples/onoff_light_bt/src/main.rs
+++ b/examples/onoff_light_bt/src/main.rs
@@ -244,7 +244,7 @@ const NODE: Node<'static> = Node {
         root_endpoint::endpoint(0, root_endpoint::OperNwType::Wifi),
         Endpoint {
             id: 1,
-            device_type: DEV_TYPE_ON_OFF_LIGHT,
+            device_types: &[DEV_TYPE_ON_OFF_LIGHT],
             clusters: &[descriptor::CLUSTER, cluster_on_off::CLUSTER],
         },
     ],

--- a/rs-matter/src/data_model/objects/endpoint.rs
+++ b/rs-matter/src/data_model/objects/endpoint.rs
@@ -24,7 +24,7 @@ use super::{AttrId, Attribute, Cluster, ClusterId, CmdId, DeviceType, EndptId};
 #[derive(Debug, Clone)]
 pub struct Endpoint<'a> {
     pub id: EndptId,
-    pub device_type: DeviceType,
+    pub device_types: &'a [DeviceType],
     pub clusters: &'a [Cluster<'a>],
 }
 

--- a/rs-matter/src/data_model/root_endpoint.rs
+++ b/rs-matter/src/data_model/root_endpoint.rs
@@ -52,7 +52,7 @@ pub enum OperNwType {
 pub const fn endpoint(id: EndptId, op_nw_type: OperNwType) -> Endpoint<'static> {
     Endpoint {
         id,
-        device_type: super::device_types::DEV_TYPE_ROOT_NODE,
+        device_types: &[super::device_types::DEV_TYPE_ROOT_NODE],
         clusters: clusters(op_nw_type),
     }
 }

--- a/rs-matter/src/data_model/system_model/descriptor.rs
+++ b/rs-matter/src/data_model/system_model/descriptor.rs
@@ -182,8 +182,9 @@ impl<'a> DescriptorCluster<'a> {
         tw.start_array(tag)?;
         for endpoint in node.endpoints {
             if endpoint.id == endpoint_id {
-                let dev_type = endpoint.device_type;
-                dev_type.to_tlv(&TagType::Anonymous, &mut *tw)?;
+                for dev_type in endpoint.device_types {
+                    dev_type.to_tlv(&TagType::Anonymous, &mut *tw)?;
+                }
             }
         }
 

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -60,7 +60,7 @@ impl<'a> E2eTestHandler<'a> {
                     access_control::CLUSTER,
                     echo_cluster::CLUSTER,
                 ],
-                device_type: DEV_TYPE_ROOT_NODE,
+                device_types: &[DEV_TYPE_ROOT_NODE],
             },
             Endpoint {
                 id: 1,
@@ -69,7 +69,7 @@ impl<'a> E2eTestHandler<'a> {
                     cluster_on_off::CLUSTER,
                     echo_cluster::CLUSTER,
                 ],
-                device_type: DEV_TYPE_ON_OFF_LIGHT,
+                device_types: &[DEV_TYPE_ON_OFF_LIGHT],
             },
         ],
     };

--- a/rs-matter/tests/common/im_engine.rs
+++ b/rs-matter/tests/common/im_engine.rs
@@ -109,7 +109,7 @@ const NODE: Node<'static> = Node {
                 access_control::CLUSTER,
                 echo_cluster::CLUSTER,
             ],
-            device_type: DEV_TYPE_ROOT_NODE,
+            device_types: &[DEV_TYPE_ROOT_NODE],
         },
         Endpoint {
             id: 1,
@@ -118,7 +118,7 @@ const NODE: Node<'static> = Node {
                 cluster_on_off::CLUSTER,
                 echo_cluster::CLUSTER,
             ],
-            device_type: DEV_TYPE_ON_OFF_LIGHT,
+            device_types: &[DEV_TYPE_ON_OFF_LIGHT],
         },
     ],
 };


### PR DESCRIPTION
Bridged devices need to implement multiple device types on an endpoint. Changing the `device_types` field in the `Endpoint` struct to a slice will allow that.