### PR TITLE
Compatibility with C++ SDK E2E Tests

### DIFF
--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -341,9 +341,10 @@ async fn run_mdns(matter: &Matter<'_>) -> Result<(), Error> {
             &Host {
                 id: 0,
                 hostname: "rs-matter-demo",
-                ip: ipv4_addr.octets(),
-                ipv6: Some(ipv6_addr.octets()),
+                ip: ipv4_addr,
+                ipv6: ipv6_addr,
             },
+            Some(ipv4_addr),
             Some(interface),
         )
         .await

--- a/examples/onoff_light_bt/src/main.rs
+++ b/examples/onoff_light_bt/src/main.rs
@@ -375,9 +375,10 @@ async fn run_mdns(matter: &Matter<'_>) -> Result<(), Error> {
             &Host {
                 id: 0,
                 hostname: "rs-matter-demo",
-                ip: ipv4_addr.octets(),
-                ipv6: Some(ipv6_addr.octets()),
+                ip: ipv4_addr,
+                ipv6: ipv6_addr,
             },
+            Some(ipv4_addr),
             Some(interface),
         )
         .await

--- a/rs-matter/src/core.rs
+++ b/rs-matter/src/core.rs
@@ -326,14 +326,15 @@ impl<'a> Matter<'a> {
         send: S,
         recv: R,
         host: &crate::mdns::Host<'_>,
-        interface: Option<u32>,
+        ipv4_interface: Option<core::net::Ipv4Addr>,
+        ipv6_interface: Option<u32>,
     ) -> Result<(), Error>
     where
         S: NetworkSend,
         R: NetworkReceive,
     {
         self.transport_mgr
-            .run_builtin_mdns(send, recv, host, interface)
+            .run_builtin_mdns(send, recv, host, ipv4_interface, ipv6_interface)
             .await
     }
 

--- a/rs-matter/src/data_model/sdm/group_key_management.rs
+++ b/rs-matter/src/data_model/sdm/group_key_management.rs
@@ -59,17 +59,17 @@ pub const CLUSTER: Cluster<'static> = Cluster {
         ),
         Attribute::new(
             AttributesDiscriminants::GroupTable as u16,
-            Access::RF,
+            Access::RF.union(Access::NEED_VIEW),
             Quality::NONE,
         ),
         Attribute::new(
             AttributesDiscriminants::MaxGroupsPerFabric as u16,
-            Access::READ,
+            Access::RV,
             Quality::FIXED,
         ),
         Attribute::new(
             AttributesDiscriminants::MaxGroupKeysPerFabric as u16,
-            Access::READ,
+            Access::RV,
             Quality::FIXED,
         ),
     ],

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -314,7 +314,9 @@ pub enum CommissionningFlowType {
 }
 
 pub fn print_qr_code(qr_code_text: &str, buf: &mut [u8]) -> Result<(), Error> {
-    info!("QR Code Text: {}", qr_code_text);
+    // Do not remove this logging line or change its formatting.
+    // C++ E2E tests rely on this log line to grep the QR code
+    info!("SetupQRCode: [{}]", qr_code_text);
 
     let (tmp_buf, out_buf) = buf.split_at_mut(buf.len() / 2);
 

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -288,7 +288,8 @@ impl<'m> TransportMgr<'m> {
         send: S,
         recv: R,
         host: &crate::mdns::Host<'_>,
-        interface: Option<u32>,
+        ipv4_interface: Option<core::net::Ipv4Addr>,
+        ipv6_interface: Option<u32>,
     ) -> Result<(), Error>
     where
         S: NetworkSend,
@@ -303,7 +304,8 @@ impl<'m> TransportMgr<'m> {
                 &PacketBufferExternalAccess(&self.tx),
                 &PacketBufferExternalAccess(&self.rx),
                 host,
-                interface,
+                ipv4_interface,
+                ipv6_interface,
                 self.rand,
             )
             .await


### PR DESCRIPTION
This PR contains three separate commits which are not related to each other - other than the fact that they make us compatible(*) with the C++ SDK E2E Tests framework. 

**Yay!**

Specifically:
* The E2E tests do log-grepping of a couple of items, so these items need to be named in a special way:
  * The QR code textual representation
  * The mDNS service publishment
* The E2E tests [setup a virtual network](https://github.com/project-chip/connectedhomeip/blob/e9d7b2fffc59f191c2d71f5da4653801bc9e17ca/scripts/tests/chiptest/linux.py#L65) which I - for the life of me - couldn't get to broadcast mDNS via IPv4. :-) Therefore, I made the IPv4 broadcasting in our built-in mDNS responder optional. It is fully supported of course, but can now be switched off programatically
* Weirdly I decided to try the E2E tests first with one of the few clusters we only _pretend_ to support - `group_key_management.rs`. While there is still work to be done there in future, I've at least fixed the permissions on the attributes, as they did not have any (as the Core Spec BTW is also wrongly documenting these)

(*) To start the tests, we also need support for Matter Basic Commissioning. The support for this is ready, I'm just waiting for this PR to make it through first.

After that, we need two sample applications corresponding to the all-clusters example in Matter as well as another one whose name I don't recall right now.
And of course some hard work to enable more and more tests after that (we need to establish a nightly E2E test CI) and fix all bugs that are coming through.
