### PR TITLE
Compatibility with C++ E2E tests continued: Implement the Open Basic Commissioning Window CMD

### DIFF
--- a/rs-matter/src/pairing/mod.rs
+++ b/rs-matter/src/pairing/mod.rs
@@ -17,15 +17,17 @@
 
 //! This module contains the logic for generating the pairing code and the QR code for easy pairing.
 
+use bitflags::bitflags;
+
 use log::info;
 
 use qr::no_optional_data;
+
 use verhoeff::Verhoeff;
 
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
 use crate::error::Error;
-use crate::secure_channel::spake2p::VerifierOption;
-use crate::CommissioningData;
+use crate::BasicCommData;
 
 use self::code::{compute_pairing_code, pretty_print_pairing_code};
 use self::qr::{compute_qr_code_text, print_qr_code};
@@ -34,58 +36,26 @@ pub mod code;
 pub mod qr;
 pub mod vendor_identifiers;
 
-// TODO: Rework as a `bitflags!` enum
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct DiscoveryCapabilities {
-    on_ip_network: bool,
-    ble: bool,
-    soft_access_point: bool,
-}
-
-impl DiscoveryCapabilities {
-    pub const fn new(on_ip_network: bool, ble: bool, soft_access_point: bool) -> Self {
-        Self {
-            on_ip_network,
-            ble,
-            soft_access_point,
-        }
-    }
-
-    pub fn has_value(&self) -> bool {
-        self.on_ip_network || self.ble || self.soft_access_point
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct DiscoveryCapabilities: u8 {
+        const SOFT_AP = 0x01;
+        const BLE = 0x02;
+        const IP = 0x04;
     }
 }
 
 impl Default for DiscoveryCapabilities {
     fn default() -> Self {
-        DiscoveryCapabilities {
-            on_ip_network: true,
-            ble: false,
-            soft_access_point: false,
-        }
-    }
-}
-
-impl DiscoveryCapabilities {
-    fn as_bits(&self) -> u8 {
-        let mut bits = 0;
-        if self.soft_access_point {
-            bits |= 1 << 0;
-        }
-        if self.ble {
-            bits |= 1 << 1;
-        }
-        if self.on_ip_network {
-            bits |= 1 << 2;
-        }
-        bits
+        Self::IP
     }
 }
 
 /// Prepares and prints the pairing code and the QR code for easy pairing.
 pub fn print_pairing_code_and_qr(
     dev_det: &BasicInfoConfig,
-    comm_data: &CommissioningData,
+    comm_data: &BasicCommData,
     discovery_capabilities: DiscoveryCapabilities,
     buf: &mut [u8],
 ) -> Result<(), Error> {
@@ -104,12 +74,4 @@ pub fn print_pairing_code_and_qr(
     print_qr_code(qr_code, remaining_buf)?;
 
     Ok(())
-}
-
-fn passwd_from_comm_data(comm_data: &CommissioningData) -> u32 {
-    // todo: should this be part of the comm_data implementation?
-    match comm_data.verifier.data {
-        VerifierOption::Password(pwd) => pwd,
-        VerifierOption::Verifier(_) => 0,
-    }
 }

--- a/rs-matter/src/transport/network/btp.rs
+++ b/rs-matter/src/transport/network/btp.rs
@@ -36,7 +36,6 @@ use crate::transport::network::{Address, BtAddr, NetworkReceive, NetworkSend};
 use crate::utils::init::{init, Init};
 use crate::utils::select::Coalesce;
 use crate::utils::sync::IfMutex;
-use crate::CommissioningData;
 
 pub use context::{BtpContext, MAX_BTP_SESSIONS};
 pub use gatt::*;
@@ -149,9 +148,9 @@ where
         &'a self,
         service_name: &'a str,
         dev_det: &BasicInfoConfig<'_>,
-        dev_comm: &CommissioningData,
+        discriminator: u16,
     ) -> impl Future<Output = Result<(), Error>> + 'a {
-        let adv_data = AdvData::new(dev_det, dev_comm);
+        let adv_data = AdvData::new(dev_det, discriminator);
 
         let context = self.context.clone();
 

--- a/rs-matter/src/transport/network/btp/gatt.rs
+++ b/rs-matter/src/transport/network/btp/gatt.rs
@@ -20,7 +20,6 @@ use core::iter::{empty, once};
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
 use crate::error::Error;
 use crate::transport::network::BtAddr;
-use crate::CommissioningData;
 
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub use builtin::BluerGattPeripheral as BuiltinGattPeripheral;
@@ -62,11 +61,11 @@ pub struct AdvData {
 
 impl AdvData {
     /// Create a new instance by using the provided `BasicInfoConfig` and `CommissioningData`.
-    pub const fn new(dev_det: &BasicInfoConfig, comm_data: &CommissioningData) -> Self {
+    pub const fn new(dev_det: &BasicInfoConfig, discriminator: u16) -> Self {
         Self {
             vid: dev_det.vid,
             pid: dev_det.pid,
-            discriminator: comm_data.discriminator,
+            discriminator,
         }
     }
 

--- a/rs-matter/src/transport/network/btp/test.rs
+++ b/rs-matter/src/transport/network/btp/test.rs
@@ -25,8 +25,6 @@ use alloc::{vec, vec::Vec};
 
 use embassy_futures::block_on;
 
-use crate::secure_channel::spake2p::VerifierData;
-use crate::utils::rand::sys_rand;
 use crate::utils::sync::blocking::raw::StdRawMutex;
 
 use super::*;
@@ -215,15 +213,7 @@ impl GattPeriheralMock {
 
         block_on(
             select4(
-                btp.run(
-                    "test",
-                    &BASIC_INFO,
-                    &CommissioningData {
-                        // TODO: Hard-coded for now
-                        verifier: VerifierData::new_with_pw(123456, sys_rand),
-                        discriminator: 250,
-                    },
-                ),
+                btp.run("test", &BASIC_INFO, 250),
                 async {
                     loop {
                         let mut buf = vec![0; 1500];

--- a/rs-matter/src/utils/maybe.rs
+++ b/rs-matter/src/utils/maybe.rs
@@ -75,8 +75,14 @@ impl<T, G> Maybe<T, G> {
     }
 
     /// Create an in-place initializer for a `Maybe` value that is empty.
-    pub fn init_none<I: init::Init<T, E>, E>() -> impl init::Init<Self, E> {
-        Self::init::<I, E>(None)
+    pub fn init_none() -> impl init::Init<Self> {
+        unsafe {
+            init::init_from_closure(move |slot: *mut Self| {
+                addr_of_mut!((*slot).some).write(false);
+
+                Ok(())
+            })
+        }
     }
 
     /// Create an in-place initializer for a `Maybe` value that is not empty

--- a/rs-matter/tests/common/e2e.rs
+++ b/rs-matter/tests/common/e2e.rs
@@ -41,7 +41,7 @@ use rs_matter::transport::network::{
 use rs_matter::transport::session::{NocCatIds, ReservedSession, SessionMode};
 use rs_matter::utils::select::Coalesce;
 use rs_matter::utils::storage::pooled::PooledBuffers;
-use rs_matter::{Matter, MATTER_PORT};
+use rs_matter::{BasicCommData, Matter, MATTER_PORT};
 
 pub mod im;
 pub mod test;
@@ -83,6 +83,11 @@ impl E2eRunner {
         device_name: "E2E",
         product_name: "E2E",
         vendor_name: "E2E",
+    };
+
+    const BASIC_COMM: BasicCommData = BasicCommData {
+        password: 0,
+        discriminator: 0,
     };
 
     /// The ID of the local Matter instance
@@ -213,6 +218,7 @@ impl E2eRunner {
 
         let matter = Matter::new(
             &Self::BASIC_INFO,
+            Self::BASIC_COMM,
             &E2eDummyDevAtt,
             MdnsService::Disabled,
             epoch,


### PR DESCRIPTION
Turns out the support for the Basic Commissioning Window CMD is orthogonal and non-conflicting with the the earlier #209 PR, so I'm opening it here.

As mentioned in the other PR, we need this support, because the E2E tests do call us with this command once the initial commissioning is over.

Also: the existing 2 examples are updated with precisely the PIN (20202021), discriminator (3840) and PID (0x8001) that the E2E tests expect.

BUT - we actually need a dedicated "for-e2e-tests" example app. To be coming later.