### PR TITLE
Mini-fix: mDNS: Mark the node as commissionable with a _CM subtype

### DIFF
--- a/rs-matter/src/mdns.rs
+++ b/rs-matter/src/mdns.rs
@@ -221,6 +221,7 @@ impl ServiceMode {
                     service_subtypes: &[
                         &Self::get_long_service_subtype(*discriminator),
                         &Self::get_short_service_type(*discriminator),
+                        "_CM",
                     ],
                     txt_kvs,
                 })


### PR DESCRIPTION
... Commissioning works even without that, but a user on the Matrix channel was correct that - according to the Core Spec - we need to publish it.
