### PR TITLE
Explicit path expansion iterator

### DIFF
--- a/rs-matter/src/data_model/objects/cluster.rs
+++ b/rs-matter/src/data_model/objects/cluster.rs
@@ -193,6 +193,7 @@ pub struct Cluster<'a> {
 }
 
 impl<'a> Cluster<'a> {
+    /// Create a new cluster with the provided parameters.
     pub const fn new(
         id: ClusterId,
         feature_map: u32,
@@ -207,60 +208,10 @@ impl<'a> Cluster<'a> {
         }
     }
 
-    pub fn match_attributes(
-        &self,
-        attr: Option<AttrId>,
-    ) -> impl Iterator<Item = &'_ Attribute> + '_ {
-        self.attributes
-            .iter()
-            .filter(move |attribute| attr.map(|attr| attr == attribute.id).unwrap_or(true))
-    }
-
-    pub fn match_commands(&self, cmd: Option<CmdId>) -> impl Iterator<Item = CmdId> + '_ {
-        self.commands
-            .iter()
-            .filter(move |id| cmd.map(|cmd| **id == cmd).unwrap_or(true))
-            .copied()
-    }
-
-    pub fn check_attribute(
-        &self,
-        accessor: &Accessor,
-        ep: EndptId,
-        attr: AttrId,
-        write: bool,
-    ) -> Result<(), IMStatusCode> {
-        let attribute = self
-            .attributes
-            .iter()
-            .find(|attribute| attribute.id == attr)
-            .ok_or(IMStatusCode::UnsupportedAttribute)?;
-
-        Self::check_attr_access(
-            accessor,
-            GenericPath::new(Some(ep), Some(self.id), Some(attr as _)),
-            write,
-            attribute.access,
-        )
-    }
-
-    pub fn check_command(
-        &self,
-        accessor: &Accessor,
-        ep: EndptId,
-        cmd: CmdId,
-    ) -> Result<(), IMStatusCode> {
-        self.commands
-            .iter()
-            .find(|id| **id == cmd)
-            .ok_or(IMStatusCode::UnsupportedCommand)?;
-
-        Self::check_cmd_access(
-            accessor,
-            GenericPath::new(Some(ep), Some(self.id), Some(cmd)),
-        )
-    }
-
+    /// Check if the accessor has the required permissions to access the attribute
+    /// designated by the provided path.
+    ///
+    /// if `write` is true, the operation is a write operation, otherwise it is a read operation.
     pub(crate) fn check_attr_access(
         accessor: &Accessor,
         path: GenericPath,
@@ -289,6 +240,8 @@ impl<'a> Cluster<'a> {
         }
     }
 
+    /// Check if the accessor has the required permissions to access the command
+    /// designated by the provided path.
     pub(crate) fn check_cmd_access(
         accessor: &Accessor,
         path: GenericPath,

--- a/rs-matter/src/data_model/objects/endpoint.rs
+++ b/rs-matter/src/data_model/objects/endpoint.rs
@@ -15,11 +15,9 @@
  *    limitations under the License.
  */
 
-use crate::{acl::Accessor, interaction_model::core::IMStatusCode};
-
 use core::fmt;
 
-use super::{AttrId, Attribute, Cluster, ClusterId, CmdId, DeviceType, EndptId};
+use super::{Cluster, DeviceType, EndptId};
 
 #[derive(Debug, Clone)]
 pub struct Endpoint<'a> {
@@ -29,59 +27,16 @@ pub struct Endpoint<'a> {
 }
 
 impl<'a> Endpoint<'a> {
-    pub fn match_attributes(
-        &self,
-        cl: Option<ClusterId>,
-        attr: Option<AttrId>,
-    ) -> impl Iterator<Item = (&'_ Cluster, &'_ Attribute)> + '_ {
-        self.match_clusters(cl).flat_map(move |cluster| {
-            cluster
-                .match_attributes(attr)
-                .map(move |attr| (cluster, attr))
-        })
-    }
-
-    pub fn match_commands(
-        &self,
-        cl: Option<ClusterId>,
-        cmd: Option<CmdId>,
-    ) -> impl Iterator<Item = (&'_ Cluster, CmdId)> + '_ {
-        self.match_clusters(cl)
-            .flat_map(move |cluster| cluster.match_commands(cmd).map(move |cmd| (cluster, cmd)))
-    }
-
-    pub fn check_attribute(
-        &self,
-        accessor: &Accessor,
-        cl: ClusterId,
-        attr: AttrId,
-        write: bool,
-    ) -> Result<(), IMStatusCode> {
-        self.check_cluster(cl)
-            .and_then(|cluster| cluster.check_attribute(accessor, self.id, attr, write))
-    }
-
-    pub fn check_command(
-        &self,
-        accessor: &Accessor,
-        cl: ClusterId,
-        cmd: CmdId,
-    ) -> Result<(), IMStatusCode> {
-        self.check_cluster(cl)
-            .and_then(|cluster| cluster.check_command(accessor, self.id, cmd))
-    }
-
-    pub fn match_clusters(&self, cl: Option<ClusterId>) -> impl Iterator<Item = &'_ Cluster> + '_ {
-        self.clusters
-            .iter()
-            .filter(move |cluster| cl.map(|id| id == cluster.id).unwrap_or(true))
-    }
-
-    pub fn check_cluster(&self, cl: ClusterId) -> Result<&Cluster, IMStatusCode> {
-        self.clusters
-            .iter()
-            .find(|cluster| cluster.id == cl)
-            .ok_or(IMStatusCode::UnsupportedCluster)
+    pub const fn new(
+        id: EndptId,
+        device_types: &'a [DeviceType],
+        clusters: &'a [Cluster<'a>],
+    ) -> Self {
+        Self {
+            id,
+            device_types,
+            clusters,
+        }
     }
 }
 

--- a/rs-matter/src/interaction_model/core.rs
+++ b/rs-matter/src/interaction_model/core.rs
@@ -153,13 +153,14 @@ pub const PROTO_ID_INTERACTION_MODEL: u16 = 0x01;
 pub enum ReportDataReq<'a> {
     Read(&'a ReadReqRef<'a>),
     Subscribe(&'a SubscribeReqRef<'a>),
+    SubscribeReport(&'a SubscribeReqRef<'a>),
 }
 
 impl<'a> ReportDataReq<'a> {
     pub fn attr_requests(&self) -> Result<Option<TLVArray<'a, AttrPath>>, Error> {
         match self {
             Self::Read(req) => req.attr_requests(),
-            Self::Subscribe(req) => req.attr_requests(),
+            Self::Subscribe(req) | Self::SubscribeReport(req) => req.attr_requests(),
         }
     }
 
@@ -167,13 +168,14 @@ impl<'a> ReportDataReq<'a> {
         match self {
             Self::Read(req) => req.dataver_filters(),
             Self::Subscribe(req) => req.dataver_filters(),
+            Self::SubscribeReport(_) => Ok(None),
         }
     }
 
     pub fn fabric_filtered(&self) -> Result<bool, Error> {
         match self {
             Self::Read(req) => req.fabric_filtered(),
-            Self::Subscribe(req) => req.fabric_filtered(),
+            Self::Subscribe(req) | Self::SubscribeReport(req) => req.fabric_filtered(),
         }
     }
 }


### PR DESCRIPTION
As much as I love `Iterator` monadic comprehensions (`flat_map` and friends), the IM path expansion logic in `node.rs` - which was using those - was resulting in huge iterators w.r.t. memory.

The rewrite of the path expansion logic in `node.rs` to use an explicit `PathExpander` iterator with mutable state saves ~ 5K RAM.
While more risky, the mutable logic is covered with unit tests.

Net-net I don't think this change would increase the codebase size, because while `PathExpander` is more verbose - methods from `endpoint.rs` and `cluster.rs` got retired, as these are no longer necessary with the explicit `PathExpander`.

