### PR TITLE
In-place update

### DIFF
--- a/rs-matter/src/tlv/traits/octets.rs
+++ b/rs-matter/src/tlv/traits/octets.rs
@@ -154,6 +154,16 @@ impl<'a, const N: usize> FromTLV<'a> for OctetsOwned<N> {
             Ok(())
         })
     }
+
+    fn check_from_tlv(element: &TLVElement<'a>) -> Result<(), Error> {
+        let octets = element.str()?;
+
+        if octets.len() > N {
+            Err(ErrorCode::NoSpace)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<const N: usize> ToTLV for OctetsOwned<N> {

--- a/rs-matter/src/tlv/traits/vec.rs
+++ b/rs-matter/src/tlv/traits/vec.rs
@@ -60,6 +60,21 @@ where
             Ok(())
         })
     }
+
+    fn check_from_tlv(element: &TLVElement<'a>) -> Result<(), Error> {
+        let mut count = 0;
+
+        while let Some(e) = element.clone().array()?.iter().next() {
+            T::check_from_tlv(&e?)?;
+            count += 1;
+        }
+
+        if count > N {
+            Err(ErrorCode::NoSpace)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<T, const N: usize> ToTLV for Vec<T, N>

--- a/rs-matter/src/utils/init.rs
+++ b/rs-matter/src/utils/init.rs
@@ -91,7 +91,10 @@ pub trait ApplyInit<T>: Init<T> {
                 // the only safe way to handle this situation.
 
                 // Unwrapping should not panic because the initializer is an infallible one
-                Self::__init(self, to).unwrap();
+                match Self::__init(self, to) {
+                    Ok(()) => {}
+                    Err(i) => match i {}
+                }
             }
         };
 

--- a/rs-matter/src/utils/init.rs
+++ b/rs-matter/src/utils/init.rs
@@ -93,7 +93,7 @@ pub trait ApplyInit<T>: Init<T> {
                 // Unwrapping should not panic because the initializer is an infallible one
                 match Self::__init(self, to) {
                     Ok(()) => {}
-                    Err(i) => match i {}
+                    Err(i) => match i {},
                 }
             }
         };


### PR DESCRIPTION
This PR introduces an efficient `FromTLV::update_from_tlv` method with a default implementation that:
- Turns `FromTLV::init_from_tlv` into an infallible initialiser
- Does a check - using the also newly introduced `FromTLV::check_tlv` (which also has a default implementation) _before attempting the update_, so as to make sure, that the initializer can indeed be safely turned into an infallible one (i.e. it will not fail in the middle due to a malformed TLV stream)

Note that `FromTLV::update_from_tlv` assumes that `FromTLV::check_tlv` would be *idempotent* - i.e. calling it multiple times on the same `TLVElement` would yield identical results. However, that should be indeed the case anyway.

The benefit of having `FromTLV::update_from_tlv` is that it gives us **cheap**, **transactional** in-place updates, where either a value is in-place updated with the initializer completely, or the value is not updated at all. Basically, an "in-place" equivalent of:
```rust
fn update(&mut self, element: &TLVElement) -> Result<(), Error> {
    let new = Self::from_tlv(element)?;
    *self = new;

    Ok(())
}
```

The problem with the above `update` method, and the reason why we need `FromTLV::update_from_tlv` is - as usual - stack memory; i.e. it is transactional w.r.t. updating the value, but not cheap. The problem is, the `new` value is first materialized _on-stack_, and only after that it is moved to its final location (`*self`) - a behavior, which rustc might or might not optimize.

While we now have `FromTLV::init_from_tlv` which avoids the on-stack materialization of `FromTLV::from_tlv`, we don't have any "update" equivalent to `FromTLV::init_from_tlv`, which this PR introduces.

**NOTE:** This PR is deliberately in Draft and will stay in such, until I can discuss with @y86-dev (the author of the `pinned-init` crate and a RfL contributor) that the `crate::utils::init::ApplyInit` extension trait introduced with this PR is sound.
