### PR TITLE
Automatic Clippy fixes

### DIFF
--- a/rs-matter-data-model/src/idl.rs
+++ b/rs-matter-data-model/src/idl.rs
@@ -49,7 +49,7 @@ where
     }
 }
 
-impl<'a> DeepestIndex for GreedyError<Span<'a>, ErrorKind> {
+impl DeepestIndex for GreedyError<Span<'_>, ErrorKind> {
     fn depest_index(&self) -> Option<usize> {
         self.errors.iter().map(|(p, _k)| p.location_offset()).max()
     }

--- a/rs-matter/src/cert/asn1_writer.rs
+++ b/rs-matter/src/cert/asn1_writer.rs
@@ -171,7 +171,7 @@ impl<'a> ASN1Writer<'a> {
     }
 }
 
-impl<'a> CertConsumer for ASN1Writer<'a> {
+impl CertConsumer for ASN1Writer<'_> {
     fn start_seq(&mut self, _tag: &str) -> Result<(), Error> {
         self.add_compound(0x30)
     }

--- a/rs-matter/src/cert/mod.rs
+++ b/rs-matter/src/cert/mod.rs
@@ -731,7 +731,7 @@ impl<'a> CertRef<'a> {
     }
 }
 
-impl<'a> fmt::Display for CertRef<'a> {
+impl fmt::Display for CertRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut printer = CertPrinter::new(f);
 

--- a/rs-matter/src/cert/printer.rs
+++ b/rs-matter/src/cert/printer.rs
@@ -45,7 +45,7 @@ const SPACE: [&str; MAX_DEPTH] = [
     "                                ",
 ];
 
-impl<'a, 'b> CertConsumer for CertPrinter<'a, 'b> {
+impl CertConsumer for CertPrinter<'_, '_> {
     fn start_seq(&mut self, tag: &str) -> Result<(), Error> {
         if !tag.is_empty() {
             let _ = writeln!(self.f, "{} {}", SPACE[self.level], tag);

--- a/rs-matter/src/crypto/crypto_rustcrypto.rs
+++ b/rs-matter/src/crypto/crypto_rustcrypto.rs
@@ -354,19 +354,19 @@ impl<'a> SliceBuffer<'a> {
     }
 }
 
-impl<'a> AsMut<[u8]> for SliceBuffer<'a> {
+impl AsMut<[u8]> for SliceBuffer<'_> {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.slice[..self.len]
     }
 }
 
-impl<'a> AsRef<[u8]> for SliceBuffer<'a> {
+impl AsRef<[u8]> for SliceBuffer<'_> {
     fn as_ref(&self) -> &[u8] {
         &self.slice[..self.len]
     }
 }
 
-impl<'a> ccm::aead::Buffer for SliceBuffer<'a> {
+impl ccm::aead::Buffer for SliceBuffer<'_> {
     fn extend_from_slice(&mut self, other: &[u8]) -> ccm::aead::Result<()> {
         self.slice[self.len..][..other.len()].copy_from_slice(other);
         self.len += other.len();
@@ -380,7 +380,7 @@ impl<'a> ccm::aead::Buffer for SliceBuffer<'a> {
 
 struct VecWriter<'a>(&'a mut alloc::vec::Vec<u8>);
 
-impl<'a> Writer for VecWriter<'a> {
+impl Writer for VecWriter<'_> {
     fn write(&mut self, slice: &[u8]) -> x509_cert::der::Result<()> {
         self.0.extend_from_slice(slice);
 

--- a/rs-matter/src/data_model/core.rs
+++ b/rs-matter/src/data_model/core.rs
@@ -745,7 +745,7 @@ where
     }
 }
 
-impl<'a, const N: usize, B, T> ExchangeHandler for DataModel<'a, N, B, T>
+impl<const N: usize, B, T> ExchangeHandler for DataModel<'_, N, B, T>
 where
     T: DataModelHandler,
     B: BufferAccess<IMBuffer>,
@@ -837,7 +837,7 @@ impl<'a> ReportDataReq<'a> {
     }
 }
 
-impl<'a> WriteReqRef<'a> {
+impl WriteReqRef<'_> {
     async fn respond<T>(
         &self,
         handler: T,
@@ -881,7 +881,7 @@ impl<'a> WriteReqRef<'a> {
     }
 }
 
-impl<'a> InvReqRef<'a> {
+impl InvReqRef<'_> {
     async fn respond<T>(
         &self,
         handler: T,

--- a/rs-matter/src/data_model/objects/cluster.rs
+++ b/rs-matter/src/data_model/objects/cluster.rs
@@ -80,7 +80,7 @@ pub struct AttrDetails<'a> {
     pub wildcard: bool,
 }
 
-impl<'a> AttrDetails<'a> {
+impl AttrDetails<'_> {
     pub fn is_system(&self) -> bool {
         Attribute::is_system_attr(self.attr_id)
     }
@@ -136,7 +136,7 @@ pub struct CmdDetails<'a> {
     pub wildcard: bool,
 }
 
-impl<'a> CmdDetails<'a> {
+impl CmdDetails<'_> {
     pub fn path(&self) -> CmdPath {
         CmdPath::new(
             Some(self.endpoint_id),
@@ -285,7 +285,7 @@ impl<'a> Cluster<'a> {
     }
 }
 
-impl<'a> core::fmt::Display for Cluster<'a> {
+impl core::fmt::Display for Cluster<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "id:{}, ", self.id)?;
         write!(f, "attrs[")?;

--- a/rs-matter/src/data_model/objects/encoder.rs
+++ b/rs-matter/src/data_model/objects/encoder.rs
@@ -166,7 +166,7 @@ impl<'a, 'b, 'c> AttrDataWriter<'a, 'b, 'c> {
     }
 }
 
-impl<'a, 'b, 'c> Drop for AttrDataWriter<'a, 'b, 'c> {
+impl Drop for AttrDataWriter<'_, '_, '_> {
     fn drop(&mut self) {
         if !self.completed {
             self.reset();
@@ -174,7 +174,7 @@ impl<'a, 'b, 'c> Drop for AttrDataWriter<'a, 'b, 'c> {
     }
 }
 
-impl<'a, 'b, 'c> Deref for AttrDataWriter<'a, 'b, 'c> {
+impl<'b, 'c> Deref for AttrDataWriter<'_, 'b, 'c> {
     type Target = TLVWriter<'b, 'c>;
 
     fn deref(&self) -> &Self::Target {
@@ -182,7 +182,7 @@ impl<'a, 'b, 'c> Deref for AttrDataWriter<'a, 'b, 'c> {
     }
 }
 
-impl<'a, 'b, 'c> DerefMut for AttrDataWriter<'a, 'b, 'c> {
+impl DerefMut for AttrDataWriter<'_, '_, '_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.tw
     }
@@ -335,7 +335,7 @@ impl<'a, 'b, 'c> CmdDataWriter<'a, 'b, 'c> {
     }
 }
 
-impl<'a, 'b, 'c> Drop for CmdDataWriter<'a, 'b, 'c> {
+impl Drop for CmdDataWriter<'_, '_, '_> {
     fn drop(&mut self) {
         if !self.completed {
             self.reset();
@@ -343,7 +343,7 @@ impl<'a, 'b, 'c> Drop for CmdDataWriter<'a, 'b, 'c> {
     }
 }
 
-impl<'a, 'b, 'c> Deref for CmdDataWriter<'a, 'b, 'c> {
+impl<'b, 'c> Deref for CmdDataWriter<'_, 'b, 'c> {
     type Target = TLVWriter<'b, 'c>;
 
     fn deref(&self) -> &Self::Target {
@@ -351,7 +351,7 @@ impl<'a, 'b, 'c> Deref for CmdDataWriter<'a, 'b, 'c> {
     }
 }
 
-impl<'a, 'b, 'c> DerefMut for CmdDataWriter<'a, 'b, 'c> {
+impl DerefMut for CmdDataWriter<'_, '_, '_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.tw
     }

--- a/rs-matter/src/data_model/objects/endpoint.rs
+++ b/rs-matter/src/data_model/objects/endpoint.rs
@@ -40,7 +40,7 @@ impl<'a> Endpoint<'a> {
     }
 }
 
-impl<'a> core::fmt::Display for Endpoint<'a> {
+impl core::fmt::Display for Endpoint<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "clusters:[")?;
         let mut comma = "";

--- a/rs-matter/src/data_model/objects/metadata.rs
+++ b/rs-matter/src/data_model/objects/metadata.rs
@@ -55,7 +55,10 @@ impl<T> Metadata for &T
 where
     T: Metadata,
 {
-    type MetadataGuard<'a> = T::MetadataGuard<'a> where Self: 'a;
+    type MetadataGuard<'a>
+        = T::MetadataGuard<'a>
+    where
+        Self: 'a;
 
     fn lock(&self) -> Self::MetadataGuard<'_> {
         (**self).lock()
@@ -66,14 +69,17 @@ impl<T> Metadata for &mut T
 where
     T: Metadata,
 {
-    type MetadataGuard<'a> = T::MetadataGuard<'a> where Self: 'a;
+    type MetadataGuard<'a>
+        = T::MetadataGuard<'a>
+    where
+        Self: 'a;
 
     fn lock(&self) -> Self::MetadataGuard<'_> {
         (**self).lock()
     }
 }
 
-impl<'a> MetadataGuard for Node<'a> {
+impl MetadataGuard for Node<'_> {
     fn node(&self) -> Node<'_> {
         Node {
             id: self.id,
@@ -82,8 +88,11 @@ impl<'a> MetadataGuard for Node<'a> {
     }
 }
 
-impl<'a> Metadata for Node<'a> {
-    type MetadataGuard<'g> = Node<'g> where Self: 'g;
+impl Metadata for Node<'_> {
+    type MetadataGuard<'g>
+        = Node<'g>
+    where
+        Self: 'g;
 
     fn lock(&self) -> Self::MetadataGuard<'_> {
         Node {
@@ -97,7 +106,8 @@ impl<M, H> Metadata for (M, H)
 where
     M: Metadata,
 {
-    type MetadataGuard<'a> = M::MetadataGuard<'a>
+    type MetadataGuard<'a>
+        = M::MetadataGuard<'a>
     where
         Self: 'a;
 
@@ -110,7 +120,8 @@ impl<T> Metadata for HandlerCompat<T>
 where
     T: Metadata,
 {
-    type MetadataGuard<'a> = T::MetadataGuard<'a>
+    type MetadataGuard<'a>
+        = T::MetadataGuard<'a>
     where
         Self: 'a;
 
@@ -136,7 +147,10 @@ pub mod asynch {
     where
         T: AsyncMetadata,
     {
-        type MetadataGuard<'a> = T::MetadataGuard<'a> where Self: 'a;
+        type MetadataGuard<'a>
+            = T::MetadataGuard<'a>
+        where
+            Self: 'a;
 
         async fn lock(&self) -> Self::MetadataGuard<'_> {
             (**self).lock().await
@@ -147,15 +161,21 @@ pub mod asynch {
     where
         T: AsyncMetadata,
     {
-        type MetadataGuard<'a> = T::MetadataGuard<'a> where Self: 'a;
+        type MetadataGuard<'a>
+            = T::MetadataGuard<'a>
+        where
+            Self: 'a;
 
         async fn lock(&self) -> Self::MetadataGuard<'_> {
             (**self).lock().await
         }
     }
 
-    impl<'a> AsyncMetadata for Node<'a> {
-        type MetadataGuard<'g> = Node<'g> where Self: 'g;
+    impl AsyncMetadata for Node<'_> {
+        type MetadataGuard<'g>
+            = Node<'g>
+        where
+            Self: 'g;
 
         async fn lock(&self) -> Self::MetadataGuard<'_> {
             Node {
@@ -169,7 +189,8 @@ pub mod asynch {
     where
         M: AsyncMetadata,
     {
-        type MetadataGuard<'a> = M::MetadataGuard<'a>
+        type MetadataGuard<'a>
+            = M::MetadataGuard<'a>
         where
             Self: 'a;
 
@@ -182,7 +203,8 @@ pub mod asynch {
     where
         T: Metadata,
     {
-        type MetadataGuard<'a> = T::MetadataGuard<'a>
+        type MetadataGuard<'a>
+            = T::MetadataGuard<'a>
         where
             Self: 'a;
 

--- a/rs-matter/src/data_model/sdm/thread_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/thread_nw_diagnostics.rs
@@ -459,7 +459,7 @@ impl<'a> ThreadNwDiagCluster<'a> {
     }
 }
 
-impl<'a> Handler for ThreadNwDiagCluster<'a> {
+impl Handler for ThreadNwDiagCluster<'_> {
     fn read(
         &self,
         exchange: &Exchange,
@@ -484,4 +484,4 @@ impl<'a> Handler for ThreadNwDiagCluster<'a> {
     }
 }
 
-impl<'a> NonBlockingHandler for ThreadNwDiagCluster<'a> {}
+impl NonBlockingHandler for ThreadNwDiagCluster<'_> {}

--- a/rs-matter/src/data_model/system_model/access_control.rs
+++ b/rs-matter/src/data_model/system_model/access_control.rs
@@ -327,13 +327,7 @@ mod tests {
             &verifier[0]
         );
         assert_eq!(
-            fab_mgr
-                .get(FAB_2)
-                .unwrap()
-                .acl_iter()
-                .skip(1)
-                .next()
-                .unwrap(),
+            fab_mgr.get(FAB_2).unwrap().acl_iter().nth(1).unwrap(),
             &verifier[2]
         );
     }

--- a/rs-matter/src/data_model/system_model/descriptor.rs
+++ b/rs-matter/src/data_model/system_model/descriptor.rs
@@ -241,7 +241,7 @@ impl<'a> DescriptorCluster<'a> {
     }
 }
 
-impl<'a> Handler for DescriptorCluster<'a> {
+impl Handler for DescriptorCluster<'_> {
     fn read(
         &self,
         exchange: &Exchange,
@@ -252,9 +252,9 @@ impl<'a> Handler for DescriptorCluster<'a> {
     }
 }
 
-impl<'a> NonBlockingHandler for DescriptorCluster<'a> {}
+impl NonBlockingHandler for DescriptorCluster<'_> {}
 
-impl<'a> ChangeNotifier<()> for DescriptorCluster<'a> {
+impl ChangeNotifier<()> for DescriptorCluster<'_> {
     fn consume_change(&mut self) -> Option<()> {
         self.data_ver.consume_change(())
     }

--- a/rs-matter/src/interaction_model/messages.rs
+++ b/rs-matter/src/interaction_model/messages.rs
@@ -444,7 +444,7 @@ pub mod ib {
         Status(CmdStatus),
     }
 
-    impl<'a> CmdResp<'a> {
+    impl CmdResp<'_> {
         pub fn status_new(cmd_path: CmdPath, status: IMStatusCode, cluster_status: u16) -> Self {
             Self::Status(CmdStatus {
                 path: cmd_path,
@@ -464,7 +464,7 @@ pub mod ib {
         Status = 1,
     }
 
-    impl<'a> From<CmdStatus> for CmdResp<'a> {
+    impl From<CmdStatus> for CmdResp<'_> {
         fn from(value: CmdStatus) -> Self {
             Self::Status(value)
         }
@@ -547,7 +547,7 @@ pub mod ib {
         }
     }
 
-    impl<'a> From<AttrStatus> for AttrResp<'a> {
+    impl From<AttrStatus> for AttrResp<'_> {
         fn from(value: AttrStatus) -> Self {
             Self::Status(value)
         }

--- a/rs-matter/src/mdns.rs
+++ b/rs-matter/src/mdns.rs
@@ -140,7 +140,7 @@ impl<'a> MdnsImpl<'a> {
     }
 }
 
-impl<'a> Mdns for MdnsImpl<'a> {
+impl Mdns for MdnsImpl<'_> {
     fn reset(&self) {
         match self.service {
             MdnsService::Disabled => {}

--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -270,7 +270,7 @@ impl<'a> MdnsImpl<'a> {
     }
 }
 
-impl<'a> Services for MdnsImpl<'a> {
+impl Services for MdnsImpl<'_> {
     fn for_each<F>(&self, callback: F) -> Result<(), Error>
     where
         F: FnMut(&Service) -> Result<(), Error>,

--- a/rs-matter/src/mdns/proto.rs
+++ b/rs-matter/src/mdns/proto.rs
@@ -105,7 +105,7 @@ pub struct Host<'a> {
     pub ipv6: Ipv6Addr,
 }
 
-impl<'a> Host<'a> {
+impl Host<'_> {
     /// Broadcast an mDNS packet with the host and its services
     ///
     /// Should be done pro-actively every time there is a change in the host
@@ -464,7 +464,7 @@ impl<'a> Host<'a> {
     }
 }
 
-impl<'a> Service<'a> {
+impl Service<'_> {
     fn add_service<R, T>(
         &self,
         answer: &mut R,
@@ -668,9 +668,9 @@ impl<'a> Service<'a> {
 
 struct Buf<'a>(pub &'a mut [u8], pub usize);
 
-impl<'a> Composer for Buf<'a> {}
+impl Composer for Buf<'_> {}
 
-impl<'a> OctetsBuilder for Buf<'a> {
+impl OctetsBuilder for Buf<'_> {
     type AppendError = ShortBuf;
 
     fn append_slice(&mut self, slice: &[u8]) -> Result<(), Self::AppendError> {
@@ -686,19 +686,19 @@ impl<'a> OctetsBuilder for Buf<'a> {
     }
 }
 
-impl<'a> Truncate for Buf<'a> {
+impl Truncate for Buf<'_> {
     fn truncate(&mut self, len: usize) {
         self.1 = len;
     }
 }
 
-impl<'a> AsMut<[u8]> for Buf<'a> {
+impl AsMut<[u8]> for Buf<'_> {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0[..self.1]
     }
 }
 
-impl<'a> AsRef<[u8]> for Buf<'a> {
+impl AsRef<[u8]> for Buf<'_> {
     fn as_ref(&self) -> &[u8] {
         &self.0[..self.1]
     }
@@ -903,7 +903,7 @@ mod tests {
         tests: &'a [(&'a [Question<'a>], &'a [Answer<'a>], &'a [Answer<'a>])],
     }
 
-    impl<'a> TestRun<'a> {
+    impl TestRun<'_> {
         fn run(&self) {
             let mut buf1 = [0; 1500];
             let mut buf2 = [0; 1500];
@@ -937,7 +937,7 @@ mod tests {
         qtype: Rtype,
     }
 
-    impl<'a> Question<'a> {
+    impl Question<'_> {
         fn prep<'b>(buf: &'b mut [u8], id: u16, questions: &[Question]) -> &'b [u8] {
             let message = MessageBuilder::from_target(Buf(buf, 0)).unwrap();
 
@@ -981,7 +981,7 @@ mod tests {
         details: AnswerDetails<'a>,
     }
 
-    impl<'a> Answer<'a> {
+    impl Answer<'_> {
         fn validate(
             data: &[u8],
             expected_id: u16,

--- a/rs-matter/src/secure_channel/crypto_mbedtls.rs
+++ b/rs-matter/src/secure_channel/crypto_mbedtls.rs
@@ -51,7 +51,6 @@ const MATTER_N_BIN: [u8; 65] = [
 ];
 
 #[allow(non_snake_case)]
-
 pub struct CryptoSpake2 {
     group: EcGroup,
     order: Mpi,

--- a/rs-matter/src/secure_channel/crypto_openssl.rs
+++ b/rs-matter/src/secure_channel/crypto_openssl.rs
@@ -45,7 +45,6 @@ const MATTER_N_BIN: [u8; 65] = [
 ];
 
 #[allow(non_snake_case)]
-
 pub struct CryptoSpake2 {
     group: EcGroup,
     bn_ctx: BigNumContext,

--- a/rs-matter/src/secure_channel/crypto_rustcrypto.rs
+++ b/rs-matter/src/secure_channel/crypto_rustcrypto.rs
@@ -45,7 +45,6 @@ const MATTER_N_BIN: [u8; 65] = [
 ];
 
 #[allow(non_snake_case)]
-
 pub struct CryptoSpake2 {
     xy: p256::Scalar,
     w0: p256::Scalar,

--- a/rs-matter/src/tlv.rs
+++ b/rs-matter/src/tlv.rs
@@ -646,7 +646,7 @@ impl IntoIterator for TLVTag {
     }
 }
 
-impl<'a> IntoIterator for &'a TLVTag {
+impl IntoIterator for &TLVTag {
     type Item = u8;
     type IntoIter = TLVTagIter<Self>;
 
@@ -1021,7 +1021,7 @@ impl<'a> IntoIterator for TLVValue<'a> {
     }
 }
 
-impl<'s, 'a> IntoIterator for &'s TLVValue<'a> {
+impl<'a> IntoIterator for &TLVValue<'a> {
     type Item = u8;
     type IntoIter = TLVValueIter<'a, Self>;
 
@@ -1110,7 +1110,7 @@ where
     }
 }
 
-impl<'a> fmt::Display for TLVValue<'a> {
+impl fmt::Display for TLVValue<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt(f)
     }

--- a/rs-matter/src/tlv/read.rs
+++ b/rs-matter/src/tlv/read.rs
@@ -705,13 +705,13 @@ impl<'a> TLVElement<'a> {
     }
 }
 
-impl<'a> fmt::Debug for TLVElement<'a> {
+impl fmt::Debug for TLVElement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(0, f)
     }
 }
 
-impl<'a> fmt::Display for TLVElement<'a> {
+impl fmt::Display for TLVElement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(0, f)
     }
@@ -930,7 +930,7 @@ impl<'a> TLVSequence<'a> {
             return Ok(TLVElement(Self::EMPTY));
         }
 
-        return Ok(TLVElement::new(self.0));
+        Ok(TLVElement::new(self.0))
     }
 
     /// Return the TLV control byte of the first TLV in the sequence.
@@ -1128,13 +1128,13 @@ impl<'a> TLVSequence<'a> {
     }
 }
 
-impl<'a> fmt::Debug for TLVSequence<'a> {
+impl fmt::Debug for TLVSequence<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(0, f)
     }
 }
 
-impl<'a> fmt::Display for TLVSequence<'a> {
+impl fmt::Display for TLVSequence<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(0, f)
     }
@@ -1219,13 +1219,13 @@ impl<'a> Iterator for TLVSequenceIter<'a> {
     }
 }
 
-impl<'a> fmt::Debug for TLVSequenceIter<'a> {
+impl fmt::Debug for TLVSequenceIter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(0, f)
     }
 }
 
-impl<'a> fmt::Display for TLVSequenceIter<'a> {
+impl fmt::Display for TLVSequenceIter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(0, f)
     }

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -88,7 +88,7 @@ impl<'a> FromTLV<'a> for TLVElement<'a> {
     }
 }
 
-impl<'a> ToTLV for TLVElement<'a> {
+impl ToTLV for TLVElement<'_> {
     fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, mut tw: W) -> Result<(), Error> {
         if self.is_empty() {
             // Special-case serializing empty TLV elements to nothing
@@ -151,7 +151,7 @@ impl<'a> FromTLV<'a> for TLVValue<'a> {
     }
 }
 
-impl<'a> ToTLV for TLVValue<'a> {
+impl ToTLV for TLVValue<'_> {
     fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, mut tw: W) -> Result<(), Error> {
         tw.tlv(tag, self)
     }

--- a/rs-matter/src/tlv/traits/container.rs
+++ b/rs-matter/src/tlv/traits/container.rs
@@ -205,7 +205,7 @@ where
     }
 }
 
-impl<'a, T, C> ToTLV for TLVContainer<'a, T, C> {
+impl<T, C> ToTLV for TLVContainer<'_, T, C> {
     fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, tw: W) -> Result<(), Error> {
         self.element.to_tlv(tag, tw)
     }

--- a/rs-matter/src/tlv/traits/octets.rs
+++ b/rs-matter/src/tlv/traits/octets.rs
@@ -57,7 +57,7 @@ impl<'a> Octets<'a> {
     }
 }
 
-impl<'a> Deref for Octets<'a> {
+impl Deref for Octets<'_> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -71,7 +71,7 @@ impl<'a> FromTLV<'a> for Octets<'a> {
     }
 }
 
-impl<'a> ToTLV for Octets<'a> {
+impl ToTLV for Octets<'_> {
     fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, mut tw: W) -> Result<(), Error> {
         tw.str(tag, self.0)
     }

--- a/rs-matter/src/tlv/traits/slice.rs
+++ b/rs-matter/src/tlv/traits/slice.rs
@@ -37,7 +37,7 @@ use super::{TLVTag, TLVValue, TLVWrite, ToTLV, TLV};
 /// Therefore, use `Slice<'a, T>` instead of `&'a [T]` as a syntax in your structs.
 pub type Slice<'a, T> = &'a [T];
 
-impl<'a, T: ToTLV> ToTLV for &'a [T]
+impl<T: ToTLV> ToTLV for &[T]
 where
     T: ToTLV,
 {

--- a/rs-matter/src/tlv/write.rs
+++ b/rs-matter/src/tlv/write.rs
@@ -67,7 +67,7 @@ impl<'a, 'b> TLVWriter<'a, 'b> {
     }
 }
 
-impl<'a, 'b> TLVWrite for TLVWriter<'a, 'b> {
+impl TLVWrite for TLVWriter<'_, '_> {
     type Position = usize;
 
     fn write(&mut self, byte: u8) -> Result<(), Error> {
@@ -424,7 +424,7 @@ where
     }
 }
 
-impl<'a> TLVWrite for WriteBuf<'a> {
+impl TLVWrite for WriteBuf<'_> {
     type Position = usize;
 
     fn write(&mut self, byte: u8) -> Result<(), Error> {
@@ -440,7 +440,7 @@ impl<'a> TLVWrite for WriteBuf<'a> {
     }
 }
 
-impl<'a> WriteBuf<'a> {
+impl WriteBuf<'_> {
     /// Write a tag and a TLV Octet String to the TLV stream, where the Octet String is a slice of u8 bytes.
     ///
     /// The writing is done via a user-supplied callback `cb`, that is expected to fill the provided buffer with the data

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -299,7 +299,7 @@ pub struct ExchangeIdDisplay<'a> {
     session: &'a Session,
 }
 
-impl<'a> Display for ExchangeIdDisplay<'a> {
+impl Display for ExchangeIdDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let state = self.session.exchanges[self.id.exchange_index()].as_ref();
 
@@ -530,7 +530,7 @@ impl Display for MessageMeta {
 /// An RX message pending on an `Exchange` instance.
 pub struct RxMessage<'a>(PacketAccess<'a, MAX_RX_BUF_SIZE>);
 
-impl<'a> RxMessage<'a> {
+impl RxMessage<'_> {
     /// Get the meta-data of the pending message
     pub fn meta(&self) -> MessageMeta {
         MessageMeta::from(&self.0.header.proto)
@@ -555,7 +555,7 @@ pub struct TxMessage<'a> {
     packet: PacketAccess<'a, MAX_TX_BUF_SIZE>,
 }
 
-impl<'a> TxMessage<'a> {
+impl TxMessage<'_> {
     /// Get a reference to the payload buffer of the TX message being built
     pub fn payload(&mut self) -> &mut [u8] {
         &mut self.packet.buf[PacketHdr::HDR_RESERVE..MAX_TX_BUF_SIZE - PacketHdr::TAIL_RESERVE]
@@ -660,7 +660,7 @@ pub struct SenderTx<'a, 'b> {
     message: TxMessage<'a>,
 }
 
-impl<'a, 'b> SenderTx<'a, 'b> {
+impl SenderTx<'_, '_> {
     pub fn split(&mut self) -> (&Exchange<'_>, &mut [u8]) {
         (self.sender.exchange, self.message.payload())
     }
@@ -1114,7 +1114,7 @@ impl<'a> Exchange<'a> {
     }
 }
 
-impl<'a> Drop for Exchange<'a> {
+impl Drop for Exchange<'_> {
     fn drop(&mut self) {
         let closed = self.with_ctx(|sess, exch_index| Ok(sess.remove_exch(exch_index)));
 
@@ -1124,7 +1124,7 @@ impl<'a> Drop for Exchange<'a> {
     }
 }
 
-impl<'a> Display for Exchange<'a> {
+impl Display for Exchange<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.id)
     }

--- a/rs-matter/src/transport/network/btp/context.rs
+++ b/rs-matter/src/transport/network/btp/context.rs
@@ -137,7 +137,7 @@ where
     }
 }
 
-impl<'a, M> Drop for SessionSendLock<'a, M>
+impl<M> Drop for SessionSendLock<'_, M>
 where
     M: RawMutex,
 {

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -467,7 +467,7 @@ impl<'a> ReservedSession<'a> {
         })
     }
 
-    pub async fn reserve(matter: &'a Matter<'a>) -> Result<ReservedSession<'_>, Error> {
+    pub async fn reserve(matter: &'a Matter<'a>) -> Result<ReservedSession<'a>, Error> {
         let session = Self::reserve_now(matter);
 
         if let Ok(session) = session {
@@ -522,7 +522,7 @@ impl<'a> ReservedSession<'a> {
     }
 }
 
-impl<'a> Drop for ReservedSession<'a> {
+impl Drop for ReservedSession<'_> {
     fn drop(&mut self) {
         if self.complete {
             let mut session_mgr = self.session_mgr.borrow_mut();

--- a/rs-matter/src/utils/storage/pooled.rs
+++ b/rs-matter/src/utils/storage/pooled.rs
@@ -49,7 +49,10 @@ where
     B: BufferAccess<T>,
     T: ?Sized,
 {
-    type Buffer<'a> = B::Buffer<'a> where Self: 'a;
+    type Buffer<'a>
+        = B::Buffer<'a>
+    where
+        Self: 'a;
 
     async fn get(&self) -> Option<Self::Buffer<'_>> {
         (*self).get().await
@@ -99,7 +102,10 @@ where
     M: RawMutex,
     T: Default + Clone,
 {
-    type Buffer<'b> = PooledBuffer<'b, N, M, T> where Self: 'b;
+    type Buffer<'b>
+        = PooledBuffer<'b, N, M, T>
+    where
+        Self: 'b;
 
     async fn get(&self) -> Option<Self::Buffer<'_>> {
         if self.wait_timeout_ms > 0 {
@@ -165,7 +171,7 @@ where
     access: &'a PooledBuffers<N, M, T>,
 }
 
-impl<'a, const N: usize, M, T> Drop for PooledBuffer<'a, N, M, T>
+impl<const N: usize, M, T> Drop for PooledBuffer<'_, N, M, T>
 where
     M: RawMutex,
 {
@@ -177,7 +183,7 @@ where
     }
 }
 
-impl<'a, const N: usize, M, T> Deref for PooledBuffer<'a, N, M, T>
+impl<const N: usize, M, T> Deref for PooledBuffer<'_, N, M, T>
 where
     M: RawMutex,
 {
@@ -188,7 +194,7 @@ where
     }
 }
 
-impl<'a, const N: usize, M, T> DerefMut for PooledBuffer<'a, N, M, T>
+impl<const N: usize, M, T> DerefMut for PooledBuffer<'_, N, M, T>
 where
     M: RawMutex,
 {

--- a/rs-matter/src/utils/sync/mutex.rs
+++ b/rs-matter/src/utils/sync/mutex.rs
@@ -195,7 +195,7 @@ where
     mutex: &'a IfMutex<M, T>,
 }
 
-impl<'a, M, T> Drop for IfMutexGuard<'a, M, T>
+impl<M, T> Drop for IfMutexGuard<'_, M, T>
 where
     M: RawMutex,
     T: ?Sized,
@@ -211,7 +211,7 @@ where
     }
 }
 
-impl<'a, M, T> Deref for IfMutexGuard<'a, M, T>
+impl<M, T> Deref for IfMutexGuard<'_, M, T>
 where
     M: RawMutex,
     T: ?Sized,
@@ -225,7 +225,7 @@ where
     }
 }
 
-impl<'a, M, T> DerefMut for IfMutexGuard<'a, M, T>
+impl<M, T> DerefMut for IfMutexGuard<'_, M, T>
 where
     M: RawMutex,
     T: ?Sized,

--- a/rs-matter/tests/common/e2e.rs
+++ b/rs-matter/tests/common/e2e.rs
@@ -281,7 +281,7 @@ type NetworkPipe<'a, const N: usize> = Channel<'a, NoopRawMutex, heapless::Vec<u
 
 struct NetworkReceiveImpl<'a, const N: usize>(Receiver<'a, NoopRawMutex, heapless::Vec<u8, N>>);
 
-impl<'a, const N: usize> NetworkSend for NetworkSendImpl<'a, N> {
+impl<const N: usize> NetworkSend for NetworkSendImpl<'_, N> {
     async fn send_to(&mut self, data: &[u8], _addr: Address) -> Result<(), Error> {
         let vec = self.0.send().await;
 
@@ -296,7 +296,7 @@ impl<'a, const N: usize> NetworkSend for NetworkSendImpl<'a, N> {
 
 struct NetworkSendImpl<'a, const N: usize>(Sender<'a, NoopRawMutex, heapless::Vec<u8, N>>);
 
-impl<'a, const N: usize> NetworkReceive for NetworkReceiveImpl<'a, N> {
+impl<const N: usize> NetworkReceive for NetworkReceiveImpl<'_, N> {
     async fn wait_available(&mut self) -> Result<(), Error> {
         self.0.receive().await;
 

--- a/rs-matter/tests/common/e2e/im.rs
+++ b/rs-matter/tests/common/e2e/im.rs
@@ -239,7 +239,7 @@ impl<'a> TestReportDataMsg<'a> {
     }
 }
 
-impl<'a> TestToTLV for TestReportDataMsg<'a> {
+impl TestToTLV for TestReportDataMsg<'_> {
     fn test_to_tlv(&self, tag: &TLVTag, tw: &mut TLVWriter) -> Result<(), Error> {
         tw.start_struct(tag)?;
 
@@ -304,7 +304,7 @@ impl<'a> TestInvReq<'a> {
     }
 }
 
-impl<'a> TestToTLV for TestInvReq<'a> {
+impl TestToTLV for TestInvReq<'_> {
     fn test_to_tlv(&self, tag: &TLVTag, tw: &mut TLVWriter) -> Result<(), Error> {
         tw.start_struct(tag)?;
 
@@ -351,7 +351,7 @@ impl<'a> TestInvResp<'a> {
     }
 }
 
-impl<'a> TestToTLV for TestInvResp<'a> {
+impl TestToTLV for TestInvResp<'_> {
     fn test_to_tlv(&self, tag: &TLVTag, tw: &mut TLVWriter) -> Result<(), Error> {
         tw.start_struct(tag)?;
 

--- a/rs-matter/tests/common/e2e/im/attributes.rs
+++ b/rs-matter/tests/common/e2e/im/attributes.rs
@@ -90,7 +90,7 @@ impl<'a> TestAttrData<'a> {
     }
 }
 
-impl<'a> TestToTLV for TestAttrData<'a> {
+impl TestToTLV for TestAttrData<'_> {
     fn test_to_tlv(&self, tag: &TLVTag, tw: &mut TLVWriter) -> Result<(), Error> {
         tw.start_struct(tag)?;
 
@@ -125,7 +125,7 @@ impl<'a> TestAttrResp<'a> {
     }
 }
 
-impl<'a> TestToTLV for TestAttrResp<'a> {
+impl TestToTLV for TestAttrResp<'_> {
     fn test_to_tlv(&self, tag: &TLVTag, tw: &mut TLVWriter) -> Result<(), Error> {
         tw.start_struct(tag)?;
 

--- a/rs-matter/tests/common/e2e/im/commands.rs
+++ b/rs-matter/tests/common/e2e/im/commands.rs
@@ -78,7 +78,7 @@ impl<'a> TestCmdData<'a> {
     }
 }
 
-impl<'a> TestToTLV for TestCmdData<'a> {
+impl TestToTLV for TestCmdData<'_> {
     fn test_to_tlv(&self, tag: &TLVTag, tw: &mut TLVWriter) -> Result<(), Error> {
         tw.start_struct(tag)?;
 
@@ -102,7 +102,7 @@ pub enum TestCmdResp<'a> {
     Status(CmdStatus),
 }
 
-impl<'a> TestToTLV for TestCmdResp<'a> {
+impl TestToTLV for TestCmdResp<'_> {
     fn test_to_tlv(&self, tag: &TLVTag, tw: &mut TLVWriter) -> Result<(), Error> {
         tw.start_struct(tag)?;
 

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -109,7 +109,7 @@ impl<'a> E2eTestHandler<'a> {
     }
 }
 
-impl<'a> Handler for E2eTestHandler<'a> {
+impl Handler for E2eTestHandler<'_> {
     fn read(
         &self,
         exchange: &Exchange,
@@ -139,9 +139,9 @@ impl<'a> Handler for E2eTestHandler<'a> {
     }
 }
 
-impl<'a> NonBlockingHandler for E2eTestHandler<'a> {}
+impl NonBlockingHandler for E2eTestHandler<'_> {}
 
-impl<'a> AsyncHandler for E2eTestHandler<'a> {
+impl AsyncHandler for E2eTestHandler<'_> {
     async fn read(
         &self,
         exchange: &Exchange<'_>,
@@ -183,16 +183,22 @@ impl<'a> AsyncHandler for E2eTestHandler<'a> {
     }
 }
 
-impl<'a> Metadata for E2eTestHandler<'a> {
-    type MetadataGuard<'g> = Node<'g> where Self: 'g;
+impl Metadata for E2eTestHandler<'_> {
+    type MetadataGuard<'g>
+        = Node<'g>
+    where
+        Self: 'g;
 
     fn lock(&self) -> Self::MetadataGuard<'_> {
         Self::NODE
     }
 }
 
-impl<'a> AsyncMetadata for E2eTestHandler<'a> {
-    type MetadataGuard<'g> = Node<'g> where Self: 'g;
+impl AsyncMetadata for E2eTestHandler<'_> {
+    type MetadataGuard<'g>
+        = Node<'g>
+    where
+        Self: 'g;
 
     async fn lock(&self) -> Self::MetadataGuard<'_> {
         Self::NODE


### PR DESCRIPTION
@kedars 

Rust Stable 1.83 is out, and with it we have a bunch of formatting and Clippy issues that this PR is addressing.
_Those break the CI so we probably want this merged ASAP._

The PR surface is large, _but it was created by simply doing_
```sh
cargo clippy --features os,rustcrypto --examples --allow-dirty --fix
```