### PR TITLE
Update embassy-time 0.3 -> 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ $ cargo build
 ### Building and running the example (Linux, MacOS X)
 
 ```
-$ cargo run --example onoff_light --features async-io
+$ cargo run --example onoff_light --features examples
+```
+
+### Building and running the BLE example (Linux, MacOS X)
+
+```
+$ cargo run --example onoff_light_bt --features examples
 ```
 
 ## Test

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -89,6 +89,7 @@ futures-lite = "2"
 async-channel = "2"
 static_cell = "2"
 similar = "2.6"
+embassy-time-queue-utils = { version = "0.1", features = ["generic-queue-64"] }
 
 [[example]]
 name = "onoff_light"

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -39,7 +39,7 @@ owo-colors = "4"
 time = { version = "0.3", default-features = false }
 verhoeff = { version = "1", default-features = false }
 embassy-futures = "0.1"
-embassy-time = "0.3"
+embassy-time = "0.4"
 embassy-sync = "0.6"
 critical-section = "1.1"
 domain = { version = "0.10", default-features = false, features = ["heapless"] }

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -9,12 +9,13 @@ readme = "README.md"
 keywords = ["matter", "smart", "smart-home", "IoT", "ESP32"]
 categories = ["embedded", "network-programming"]
 license = "Apache-2.0"
-rust-version = "1.78"
+rust-version = "1.83"
 
 [features]
 default = ["os", "rustcrypto"]
 #default = ["os", "mbedtls"] mbedtls is broken since several months - check the root cause
-os = ["std", "backtrace", "critical-section/std", "embassy-sync/std", "embassy-time/std", "embassy-time/generic-queue"]
+examples = ["std", "async-io", "async-compat", "embassy-time-queue-utils/generic-queue-64"]
+os = ["std", "backtrace", "critical-section/std", "embassy-sync/std", "embassy-time/std"]
 std = ["alloc", "rand"]
 backtrace = []
 alloc = []
@@ -40,6 +41,7 @@ time = { version = "0.3", default-features = false }
 verhoeff = { version = "1", default-features = false }
 embassy-futures = "0.1"
 embassy-time = "0.4"
+embassy-time-queue-utils = "0.1"
 embassy-sync = "0.6"
 critical-section = "1.1"
 domain = { version = "0.10", default-features = false, features = ["heapless"] }
@@ -91,14 +93,14 @@ similar = "2.6"
 [[example]]
 name = "onoff_light"
 path = "../examples/onoff_light/src/main.rs"
-required-features = ["std", "async-io"]
+required-features = ["examples"]
 
 [[example]]
 name = "onoff_light_bt"
 path = "../examples/onoff_light_bt/src/main.rs"
-required-features = ["std", "async-io", "async-compat"]
+required-features = ["examples"]
 
 # [[example]]
 # name = "speaker"
 # path = "../examples/speaker/src/main.rs"
-# required-features = ["std", "async-io"]
+# required-features = ["examples"]

--- a/rs-matter/tests/common/e2e/im/echo_cluster.rs
+++ b/rs-matter/tests/common/e2e/im/echo_cluster.rs
@@ -119,6 +119,7 @@ impl TestChecker {
     }
 
     /// Get a handle to the globally unique mDNS instance
+    #[allow(static_mut_refs)]
     pub fn get() -> Result<Arc<Mutex<Self>>, Error> {
         unsafe {
             INIT.call_once(|| {


### PR DESCRIPTION
@kedars 

Minimal change that does only what the subject says.

However, **very important** because the change in `embassy-time` was of such a nature, that in your whole `cargo tree` you do need to have **either** `embassy-time <= 0.3` or `embassy-time >= 0.4` (but **cannot** have both). 
(Basically, they changed their "time driver" API, which should not happen again any time soon.)

Since `embassy-time` is popular, and all crates depending on it are mass-updating to 0.4, we need to do it too, or else `rs-matter` cannot be used in one and the same project with these updated crates.
