### PR TITLE
Address warnings reported from latest Clippy

### DIFF
--- a/rs-matter-macros-impl/src/tlv.rs
+++ b/rs-matter-macros-impl/src/tlv.rs
@@ -710,17 +710,17 @@ fn gen_fromtlv_for_enum(
             }
         }
 
-        let enter = (tlvargs.datatype != "naked")
-            .then(|| {
-                quote! {
-                    let element = element
-                        .r#struct()?
-                        .iter()
-                        .next()
-                        .ok_or(#krate::error::ErrorCode::TLVTypeMismatch)??;
-                }
-            })
-            .unwrap_or(TokenStream::new());
+        let enter = if tlvargs.datatype != "naked" {
+            quote! {
+                let element = element
+                    .r#struct()?
+                    .iter()
+                    .next()
+                    .ok_or(#krate::error::ErrorCode::TLVTypeMismatch)??;
+            }
+        } else {
+            TokenStream::new()
+        };
 
         quote! {
             impl #generics #krate::tlv::FromTLV<#lifetime> for #enum_name #generics {

--- a/rs-matter/src/tlv/traits/maybe.rs
+++ b/rs-matter/src/tlv/traits/maybe.rs
@@ -18,7 +18,7 @@
 //! TLV support for TLV optional values and TLV nullable types via `Maybe` and `Option`.
 //! - `Option<T>` and `Optional<T>` both represent an optional value in a TLV struct
 //! - `Nullable<T>` represents a nullable TLV type, where `T` is the non-nullable subdomain of the type.
-//!    i.e. `Nullable<u8>` represents the nullable variation of the TLV `U8` type.
+//!   i.e. `Nullable<u8>` represents the nullable variation of the TLV `U8` type.
 //!
 //! To elaborate, `null` and optional are two different notions in the TLV spec:
 //! - Optional values apply only to TLV structs, and have the semantics

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -62,7 +62,7 @@ impl ExchangeId {
             panic!("Exchange index out of range");
         }
 
-        Self((exchange_index as u32) << 28 | session_id)
+        Self(((exchange_index as u32) << 28) | session_id)
     }
 
     pub(crate) fn session_id(&self) -> u32 {

--- a/rs-matter/src/transport/network/btp/context.rs
+++ b/rs-matter/src/transport/network/btp/context.rs
@@ -168,11 +168,11 @@ where
 ///
 /// The BTP protocol implementation is split into two structures:
 /// - `Btp` - the main BTP protocol implementation, which is responsible for handling the BTP protocol itself. This structure is not `Send` and `Sync`
-///    and is overall a typical future-based protocol implementation, like the others in the `rs-matter` stack.
+///   and is overall a typical future-based protocol implementation, like the others in the `rs-matter` stack.
 /// - `BtpContext` - a structure that holds the state of the BTP protocol shared between itself and the Gatt peripheral implementation.
-///    In terms of ownership, The `Btp` instance holds a `'static` reference to the context, i.e. a `&'static BtpContext<M>` reference,
-///    or an `Arc<BtpContext<M>>` instance for platforms where the Rust `alloc::sync` module is available.
-///    Furthermore, the state kept in `BtpContext` is safe to share amongst multiple threads.
+///   In terms of ownership, The `Btp` instance holds a `'static` reference to the context, i.e. a `&'static BtpContext<M>` reference,
+///   or an `Arc<BtpContext<M>>` instance for platforms where the Rust `alloc::sync` module is available.
+///   Furthermore, the state kept in `BtpContext` is safe to share amongst multiple threads.
 ///
 /// The need to split the BTP implementation into two structures is due to the fact that the `GattPeripheral` trait uses a
 /// `'static + Send + Sync` callback closure so as to report subscribe, unsubscribe and write events back to the BTP protocol implementation.

--- a/rs-matter/src/transport/network/btp/session/packet.rs
+++ b/rs-matter/src/transport/network/btp/session/packet.rs
@@ -377,7 +377,7 @@ impl HandshakeReq {
     /// Return an iterator over the versions supported by the BTP handshake request.
     pub fn versions(&self) -> impl Iterator<Item = u8> + '_ {
         (0..7u8)
-            .map(|index| (self.versions >> (index * 4) & 0xff) as u8)
+            .map(|index| ((self.versions >> (index * 4)) & 0xff) as u8)
             .filter(|version| *version > 0)
     }
 

--- a/rs-matter/tests/common/e2e/im.rs
+++ b/rs-matter/tests/common/e2e/im.rs
@@ -459,7 +459,7 @@ impl ReplyProcessor {
     }
 
     /// Process the supplied element with removing the data value from the `AttrData` payload
-    pub fn remove_attr_data<'a>(element: &TLVElement, buf: &mut [u8]) -> Result<usize, Error> {
+    pub fn remove_attr_data(element: &TLVElement, buf: &mut [u8]) -> Result<usize, Error> {
         (Self::REMOVE_ATTRDATA_VALUE | Self::REMOVE_ATTRDATA_DATAVER).process(element, buf)
     }
 }

--- a/rs-matter/tests/common/e2e/tlv.rs
+++ b/rs-matter/tests/common/e2e/tlv.rs
@@ -108,7 +108,7 @@ where
                 write!(diff_str, "{}{}", sign, change).unwrap();
             }
 
-            assert!(false, "Expected does not match actual:\n== Diff:\n{diff_str}\n== Expected:\n{expected_str}\n== Actual:\n{actual_str}");
+            panic!("Expected does not match actual:\n== Diff:\n{diff_str}\n== Expected:\n{expected_str}\n== Actual:\n{actual_str}");
         }
 
         Ok(())


### PR DESCRIPTION
@kedars This PR is addressing the failing CI pipeline.

It fails because the latest Rust stable brought new Clippy (of course) which now finds some extra warnings.