### PR TITLE
Small formatting improvement and a bugfix: Sending ACKs for ACKs

### DIFF
--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -1032,11 +1032,10 @@ impl<'m> TransportMgr<'m> {
             }
             Err(e) => {
                 error!(
-                    "\n<<SND {} {}B{} !FAILED!: {e:?}: {:02x?}",
+                    "\n<<SND {} {}B{} !FAILED!: {e:?}",
                     peer,
                     data.len(),
                     if system { " (system)" } else { "" },
-                    data
                 );
 
                 // Do not return an error as that would unroll the main `rs-matter` loop

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -484,7 +484,9 @@ impl<'m> TransportMgr<'m> {
         let result = self.decode_packet(packet);
         match result {
             Err(e) if matches!(e.code(), ErrorCode::Duplicate) => {
-                if !packet.peer.is_reliable() {
+                if !packet.peer.is_reliable()
+                    && !MessageMeta::from(&packet.header.proto).is_standalone_ack()
+                {
                     info!("\n>>RCV {packet}\n      => Duplicate, sending ACK");
 
                     {

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -600,7 +600,7 @@ impl TxMessage<'_> {
         self.packet.peer = peer;
 
         info!(
-            "\n<<<<< {}\n => {}",
+            "\n<<SND {}\n      => {}",
             Packet::<0>::display(&self.packet.peer, &self.packet.header),
             if retransmission {
                 "Re-sending"

--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -535,7 +535,7 @@ impl Session {
             min(MAX_MESSAGE_SIZE as u16 / mtu / 2, 255) as u8,
         );
 
-        info!("\n>>RCV (BTP IO) {address} [{hdr}]\n     HANDSHAKE REQ {req:?}\nSelected version: {version}, MTU: {mtu}, window size: {window_size}");
+        info!("\n>>RCV (BTP IO) {address} [{hdr}]\n      HANDSHAKE REQ {req:?}\nSelected version: {version}, MTU: {mtu}, window size: {window_size}");
 
         Ok(Self::init(address, version, mtu, window_size))
     }
@@ -548,7 +548,7 @@ impl Session {
         let payload = iter.as_slice();
 
         info!(
-            "\n>>RCV (BTP IO) {} [{hdr}]\n     READ {}B",
+            "\n>>RCV (BTP IO) {} [{hdr}]\n      READ {}B",
             self.address,
             payload.len()
         );
@@ -574,7 +574,7 @@ impl Session {
         hdr.set_opcode(Some(0x6c));
 
         info!(
-            "\n<<SND (BTP IO) {} [{hdr}]\n     HANDSHAKE RESP {resp:?}",
+            "\n<<SND (BTP IO) {} [{hdr}]\n      HANDSHAKE RESP {resp:?}",
             self.address
         );
 
@@ -644,7 +644,7 @@ impl Session {
         wb.append(segment_data)?;
 
         info!(
-            "\n<<SND (BTP IO) {} [{hdr}]\n     WRITE {}B",
+            "\n<<SND (BTP IO) {} [{hdr}]\n      WRITE {}B",
             self.address,
             segment_data.len()
         );

--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -535,7 +535,7 @@ impl Session {
             min(MAX_MESSAGE_SIZE as u16 / mtu / 2, 255) as u8,
         );
 
-        info!("\n>>>>> (BTP IO) {address} [{hdr}]\nHANDSHAKE REQ {req:?}\nSelected version: {version}, MTU: {mtu}, window size: {window_size}");
+        info!("\n>>RCV (BTP IO) {address} [{hdr}]\n     HANDSHAKE REQ {req:?}\nSelected version: {version}, MTU: {mtu}, window size: {window_size}");
 
         Ok(Self::init(address, version, mtu, window_size))
     }
@@ -548,7 +548,7 @@ impl Session {
         let payload = iter.as_slice();
 
         info!(
-            "\n>>>>> (BTP IO) {} [{hdr}]\nREAD {}B",
+            "\n>>RCV (BTP IO) {} [{hdr}]\n     READ {}B",
             self.address,
             payload.len()
         );
@@ -574,7 +574,7 @@ impl Session {
         hdr.set_opcode(Some(0x6c));
 
         info!(
-            "\n<<<<< (BTP IO) {} [{hdr}]\nHANDSHAKE RESP {resp:?}",
+            "\n<<SND (BTP IO) {} [{hdr}]\n     HANDSHAKE RESP {resp:?}",
             self.address
         );
 
@@ -644,7 +644,7 @@ impl Session {
         wb.append(segment_data)?;
 
         info!(
-            "\n<<<<< (BTP IO) {} [{hdr}]\nWRITE {}B",
+            "\n<<SND (BTP IO) {} [{hdr}]\n     WRITE {}B",
             self.address,
             segment_data.len()
         );


### PR DESCRIPTION
This PR contains two small commits:
* First commit is a small formatting improvement, so that it is clearer which packets are received, and which -transmitted
* Second commit contains a bugfix for a gross issue I'm surprised I have not noticed before: in some cases we are sending a standalone ACK for a received standalone ACK. A simple `if` handles that. (Noticed while testing over a very "noisy" Thread network - basically with a 802.11.5 radio impl whose timeouts are not tuned well yet.)