### PR TITLE
move log max level features to dev-dependencies

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -33,7 +33,7 @@ num = { version = "0.4", default-features = false }
 num-derive = "0.4"
 num-traits = { version = "0.2", default-features = false }
 strum = { version = "0.26", features = ["derive"], default-features = false }
-log = { version = "0.4", features = ["max_level_debug", "release_max_level_debug"] }
+log = "0.4"
 subtle = { version = "2.5", default-features = false }
 safemem = { version = "0.3", default-features = false }
 owo-colors = "4"
@@ -83,6 +83,7 @@ tokio = { version = "1" }
 tokio-stream = { version = "0.1" }
 
 [dev-dependencies]
+log = { version = "0.4", features = ["max_level_debug", "release_max_level_debug"] }
 env_logger = "0.11"
 nix = { version = "0.27", features = ["net"] }
 futures-lite = "2"


### PR DESCRIPTION
Libraries should avoid using the max_level_x features of the log crate, because library users cannot override them. In the dev-dependencies they are only used for the examples.