### PR TITLE
Include examples in CI; fix the examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,7 @@ jobs:
       - name: Test
         if: matrix.features == 'os'
         run: cargo test --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}}
+
+      - name: Examples
+        if: matrix.features == 'os'
+        run: cargo build --examples --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},examples

--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -58,6 +58,8 @@ static DEV_DET: BasicInfoConfig = BasicInfoConfig {
     device_name: "OnOff Light",
     product_name: "Light123",
     vendor_name: "Vendor PQR",
+    sai: None,
+    sii: None,
 };
 
 static DEV_COMM: BasicCommData = BasicCommData {

--- a/examples/onoff_light_bt/src/main.rs
+++ b/examples/onoff_light_bt/src/main.rs
@@ -110,6 +110,8 @@ fn run() -> Result<(), Error> {
         device_name: "OnOff Light",
         product_name: "Light123",
         vendor_name: "Vendor PQR",
+        sai: None,
+        sii: None,
     };
 
     let dev_comm = BasicCommData {


### PR DESCRIPTION
Turns out we don't build examples in CI, and I had forgotten to update these with the new `sai` / `sii` parameters from a couple of days ago.

Examples updated, and CI should build them now.