### PR TITLE
Support for `defmt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,18 +39,21 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Clippy
-        run: cargo clippy --no-deps --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}} -- -Dwarnings
+        run: cargo clippy --no-deps --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},log -- -Dwarnings
+
+      - name: Clippy | defmt
+        run: cargo clippy --no-deps --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},defmt -- -Dwarnings
 
       - name: Build
-        run: cargo build --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}}
+        run: cargo build --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},log
 
       - name: Benchmark
-        run: cargo bench --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}}
+        run: cargo bench --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},log
 
       - name: Test
         if: matrix.features == 'os'
-        run: cargo test --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}}
+        run: cargo test --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},log
 
       - name: Examples
         if: matrix.features == 'os'
-        run: cargo build --examples --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},examples
+        run: cargo build --examples --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},examples,log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo clippy --no-deps --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},log -- -Dwarnings
 
       - name: Clippy | defmt
-        run: cargo clippy --no-deps --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},defmt -- -Dwarnings
+        run: export DEFMT_LOG=trace;cargo clippy --no-deps --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},defmt -- -Dwarnings
 
       - name: Build
         run: cargo build --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},log

--- a/examples/onoff_light_bt/src/main.rs
+++ b/examples/onoff_light_bt/src/main.rs
@@ -279,7 +279,7 @@ fn dm_handler<'a>(
                     rssi: 0,
                 },
             )),
-            false,
+            &false,
             matter.rand(),
         )
         .chain(

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -12,7 +12,8 @@ license = "Apache-2.0"
 rust-version = "1.83"
 
 [features]
-default = ["os", "rustcrypto"]
+#default = ["os", "rustcrypto"]
+default = ["os", "rustcrypto", "defmt"]
 #default = ["os", "mbedtls"] mbedtls is broken since several months - check the root cause
 examples = ["std", "async-io", "async-compat", "embassy-time-queue-utils/generic-queue-64"]
 os = ["std", "backtrace", "critical-section/std", "embassy-sync/std", "embassy-time/std"]
@@ -22,6 +23,7 @@ alloc = []
 openssl = ["alloc", "dep:openssl", "foreign-types", "hmac", "sha2"]
 mbedtls = ["alloc", "dep:mbedtls"]
 rustcrypto = ["alloc", "sha2", "hmac", "pbkdf2", "hkdf", "aes", "ccm", "p256", "elliptic-curve", "crypto-bigint", "x509-cert", "rand_core"]
+defmt = ["dep:defmt", "heapless/defmt-03", "embassy-time/defmt"]
 large-buffers = [] # TCP support
 
 [dependencies]
@@ -34,6 +36,7 @@ num-derive = "0.4"
 num-traits = { version = "0.2", default-features = false }
 strum = { version = "0.26", features = ["derive"], default-features = false }
 log = "0.4"
+defmt = { version = "0.3", optional = true }
 subtle = { version = "2.5", default-features = false }
 safemem = { version = "0.3", default-features = false }
 owo-colors = "4"

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -18,7 +18,7 @@ examples = ["std", "async-io", "async-compat", "embassy-time-queue-utils/generic
 os = ["std", "backtrace", "critical-section/std", "embassy-sync/std", "embassy-time/std"]
 std = ["alloc", "rand"]
 backtrace = []
-alloc = []
+alloc = ["defmt?/alloc"]
 openssl = ["alloc", "dep:openssl", "foreign-types", "hmac", "sha2"]
 mbedtls = ["alloc", "dep:mbedtls"]
 rustcrypto = ["alloc", "sha2", "hmac", "pbkdf2", "hkdf", "aes", "ccm", "p256", "sec1", "elliptic-curve", "crypto-bigint", "x509-cert", "rand_core"]
@@ -36,7 +36,7 @@ num-derive = "0.4"
 num-traits = { version = "0.2", default-features = false }
 strum = { version = "0.26", features = ["derive"], default-features = false }
 log = { version = "0.4", optional = true }
-defmt = { version = "0.3", optional = true }
+defmt = { version = "0.3", optional = true, features = ["ip_in_core"] }
 subtle = { version = "2.5", default-features = false }
 safemem = { version = "0.3", default-features = false }
 owo-colors = "4"

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -12,8 +12,7 @@ license = "Apache-2.0"
 rust-version = "1.83"
 
 [features]
-#default = ["os", "rustcrypto"]
-default = ["os", "rustcrypto", "defmt"]
+default = ["os", "rustcrypto", "log"]
 #default = ["os", "mbedtls"] mbedtls is broken since several months - check the root cause
 examples = ["std", "async-io", "async-compat", "embassy-time-queue-utils/generic-queue-64"]
 os = ["std", "backtrace", "critical-section/std", "embassy-sync/std", "embassy-time/std"]
@@ -24,6 +23,7 @@ openssl = ["alloc", "dep:openssl", "foreign-types", "hmac", "sha2"]
 mbedtls = ["alloc", "dep:mbedtls"]
 rustcrypto = ["alloc", "sha2", "hmac", "pbkdf2", "hkdf", "aes", "ccm", "p256", "elliptic-curve", "crypto-bigint", "x509-cert", "rand_core"]
 defmt = ["dep:defmt", "heapless/defmt-03", "embassy-time/defmt"]
+log = ["dep:log", "embassy-time/log"]
 large-buffers = [] # TCP support
 
 [dependencies]
@@ -35,7 +35,7 @@ num = { version = "0.4", default-features = false }
 num-derive = "0.4"
 num-traits = { version = "0.2", default-features = false }
 strum = { version = "0.26", features = ["derive"], default-features = false }
-log = "0.4"
+log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true }
 subtle = { version = "2.5", default-features = false }
 safemem = { version = "0.3", default-features = false }

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.83"
 
 [features]
 default = ["os", "rustcrypto", "log"]
-#default = ["os", "mbedtls"] mbedtls is broken since several months - check the root cause
+#default = ["os", "mbedtls", "log"] mbedtls is broken since several months - check the root cause
 examples = ["std", "async-io", "async-compat", "embassy-time-queue-utils/generic-queue-64"]
 os = ["std", "backtrace", "critical-section/std", "embassy-sync/std", "embassy-time/std"]
 std = ["alloc", "rand"]
@@ -21,7 +21,7 @@ backtrace = []
 alloc = []
 openssl = ["alloc", "dep:openssl", "foreign-types", "hmac", "sha2"]
 mbedtls = ["alloc", "dep:mbedtls"]
-rustcrypto = ["alloc", "sha2", "hmac", "pbkdf2", "hkdf", "aes", "ccm", "p256", "elliptic-curve", "crypto-bigint", "x509-cert", "rand_core"]
+rustcrypto = ["alloc", "sha2", "hmac", "pbkdf2", "hkdf", "aes", "ccm", "p256", "sec1", "elliptic-curve", "crypto-bigint", "x509-cert", "rand_core"]
 defmt = ["dep:defmt", "heapless/defmt-03", "embassy-time/defmt"]
 log = ["dep:log", "embassy-time/log"]
 large-buffers = [] # TCP support
@@ -66,6 +66,7 @@ hkdf = { version = "0.12", optional = true }
 aes = { version = "0.8", optional = true }
 ccm = { version = "0.5", default-features = false, features = ["alloc"], optional = true }
 p256 = { version = "0.13", default-features = false, features = ["arithmetic", "ecdh", "ecdsa"], optional = true }
+sec1 = { version = "0.7", default-features = false, optional = true }
 elliptic-curve = { version = "0.13", optional = true }
 crypto-bigint = { version = "0.5", default-features = false, optional = true }
 rand_core = { version = "0.6", default-features = false, optional = true }

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -383,9 +383,7 @@ impl AclEntry {
             self.targets.reinit(Nullable::init_some(Vec::init()));
         }
 
-        self.targets
-            .as_mut()
-            .unwrap()
+        unwrap!(self.targets.as_mut())
             .push(target)
             .map_err(|_| ErrorCode::NoSpace.into())
     }

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -168,6 +168,21 @@ impl Display for AccessorSubjects {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for AccessorSubjects {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "[");
+        for i in self.0 {
+            if is_noc_cat(i) {
+                defmt::write!(f, "CAT({} - {})", get_noc_cat_id(i), get_noc_cat_version(i));
+            } else if i != 0 {
+                defmt::write!(f, "{}, ", i);
+            }
+        }
+        defmt::write!(f, "]")
+    }
+}
+
 /// The Accessor Object
 pub struct Accessor<'a> {
     /// The fabric index of the accessor
@@ -460,12 +475,12 @@ pub(crate) mod tests {
 
     pub(crate) const FAB_1: NonZeroU8 = match NonZeroU8::new(1) {
         Some(f) => f,
-        None => unreachable!(),
+        None => ::core::unreachable!(),
     };
 
     pub(crate) const FAB_2: NonZeroU8 = match NonZeroU8::new(2) {
         Some(f) => f,
-        None => unreachable!(),
+        None => ::core::unreachable!(),
     };
 
     #[test]

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -43,6 +43,7 @@ pub const ENTRIES_PER_FABRIC: usize = 3;
 
 // TODO: Check if this and the SessionMode can be combined into some generic data structure
 #[derive(FromPrimitive, Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AuthMode {
     Pase = 1,
     Case = 2,
@@ -231,6 +232,7 @@ impl<'a> Accessor<'a> {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AccessDesc {
     /// The object to be acted upon
     path: GenericPath,
@@ -290,6 +292,7 @@ impl<'a> AccessReq<'a> {
 }
 
 #[derive(FromTLV, ToTLV, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Target {
     cluster: Option<ClusterId>,
     endpoint: Option<EndptId>,
@@ -311,6 +314,7 @@ impl Target {
 }
 
 #[derive(ToTLV, FromTLV, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(start = 1)]
 pub struct AclEntry {
     privilege: Privilege,

--- a/rs-matter/src/cert/asn1_writer.rs
+++ b/rs-matter/src/cert/asn1_writer.rs
@@ -25,6 +25,7 @@ use crate::{
 use core::fmt::Write;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ASN1Writer<'a> {
     buf: &'a mut [u8],
     // The current write offset in the buffer

--- a/rs-matter/src/cert/asn1_writer.rs
+++ b/rs-matter/src/cert/asn1_writer.rs
@@ -268,13 +268,16 @@ impl CertConsumer for ASN1Writer<'_> {
     fn utctime(&mut self, _tag: &str, epoch: u64) -> Result<(), Error> {
         let matter_epoch = MATTER_EPOCH_SECS + epoch;
 
-        let dt = OffsetDateTime::from_unix_timestamp(matter_epoch as _).unwrap();
+        let dt = unwrap!(
+            OffsetDateTime::from_unix_timestamp(matter_epoch as _),
+            "DateTimeError"
+        );
 
         let mut time_str: heapless::String<32> = heapless::String::<32>::new();
 
         if dt.year() >= 2050 {
             // If year is >= 2050, ASN.1 requires it to be Generalised Time
-            write!(
+            write_unwrap!(
                 &mut time_str,
                 "{:04}{:02}{:02}{:02}{:02}{:02}Z",
                 dt.year(),
@@ -283,11 +286,10 @@ impl CertConsumer for ASN1Writer<'_> {
                 dt.hour(),
                 dt.minute(),
                 dt.second()
-            )
-            .unwrap();
+            );
             self.write_str(0x18, time_str.as_bytes())
         } else {
-            write!(
+            write_unwrap!(
                 &mut time_str,
                 "{:02}{:02}{:02}{:02}{:02}{:02}Z",
                 dt.year() % 100,
@@ -296,8 +298,7 @@ impl CertConsumer for ASN1Writer<'_> {
                 dt.hour(),
                 dt.minute(),
                 dt.second()
-            )
-            .unwrap();
+            );
             self.write_str(0x17, time_str.as_bytes())
         }
     }

--- a/rs-matter/src/cert/mod.rs
+++ b/rs-matter/src/cert/mod.rs
@@ -17,13 +17,12 @@
 
 use core::fmt::{self, Write};
 
-use log::error;
-
 use num::FromPrimitive;
 use num_derive::FromPrimitive;
 
 use crate::crypto::KeyPair;
 use crate::error::{Error, ErrorCode};
+use crate::fmt::Bytes;
 use crate::tlv::{FromTLV, Octets, TLVArray, TLVElement, TLVList, ToTLV};
 use crate::utils::epoch::MATTER_CERT_DOESNT_EXPIRE;
 use crate::utils::iter::TryFindIterator;
@@ -201,7 +200,7 @@ impl<'a> Extension<'a> {
                 Self::encode_extension_end(w)?;
             }
             Extension::FutureExtensions(t) => {
-                error!("Future Extensions Not Yet Supported: {:x?}", t.0)
+                error!("Future Extensions Not Yet Supported: {}", Bytes(t.0))
             }
         }
 
@@ -776,9 +775,10 @@ impl<'a> CertVerifier<'a> {
         k.verify_msg(asn1, self.cert.signature()?)
             .inspect_err(|e| {
                 error!(
-                    "Error {e} in signature verification of certificate: {:x?} by {:x?}",
-                    self.cert.get_subject_key_id(),
-                    parent.get_subject_key_id()
+                    "Error {} in signature verification of certificate: {:?} by {:?}",
+                    e,
+                    self.cert.get_subject_key_id().map(Bytes),
+                    parent.get_subject_key_id().map(Bytes)
                 );
             })?;
 
@@ -816,8 +816,6 @@ pub trait CertConsumer {
 
 #[cfg(test)]
 mod tests {
-    use log::info;
-
     use crate::tlv::{FromTLV, TLVElement, TLVWriter, TagType, ToTLV};
     use crate::utils::storage::WriteBuf;
 

--- a/rs-matter/src/cert/mod.rs
+++ b/rs-matter/src/cert/mod.rs
@@ -62,6 +62,7 @@ pub enum CertTag {
 }
 
 #[derive(FromPrimitive, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum EcCurveIdValue {
     Prime256V1 = 1,
 }
@@ -71,6 +72,7 @@ pub fn get_ec_curve_id(algo: u8) -> Option<EcCurveIdValue> {
 }
 
 #[derive(FromPrimitive, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PubKeyAlgoValue {
     EcPubKey = 1,
 }
@@ -80,6 +82,7 @@ pub fn get_pubkey_algo(algo: u8) -> Option<PubKeyAlgoValue> {
 }
 
 #[derive(FromPrimitive, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SignAlgoValue {
     ECDSAWithSHA256 = 1,
 }
@@ -89,6 +92,7 @@ pub fn get_sign_algo(algo: u8) -> Option<SignAlgoValue> {
 }
 
 #[derive(Default, Debug, Clone, FromTLV, ToTLV, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(start = 1)]
 struct BasicConstraints {
     is_ca: bool,
@@ -110,6 +114,7 @@ impl BasicConstraints {
 }
 
 // #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 // #[repr(u8)]
 // enum ExtTag {
 //     BasicConstraints = 1,
@@ -121,6 +126,7 @@ impl BasicConstraints {
 // }
 
 #[derive(Debug, Clone, FromTLV, ToTLV, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(start = 1, lifetime = "'a", datatype = "naked", unordered)]
 enum Extension<'a> {
     BasicConstraints(BasicConstraints),
@@ -319,6 +325,7 @@ impl<'a> Extension<'a> {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, FromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 enum DNTag {
     CommonName = 1,
@@ -346,6 +353,7 @@ enum DNTag {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum DNValue<'a> {
     Uint(u64),
     Utf8(&'a str),
@@ -353,6 +361,7 @@ enum DNValue<'a> {
 }
 
 #[derive(FromTLV, ToTLV, Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 struct DN<'a>(TLVElement<'a>);
 
@@ -547,6 +556,7 @@ enum IntToStringLen {
 }
 
 #[derive(FromTLV, ToTLV, Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct CertRef<'a>(TLVElement<'a>);
 

--- a/rs-matter/src/cert/printer.rs
+++ b/rs-matter/src/cert/printer.rs
@@ -125,7 +125,10 @@ impl CertConsumer for CertPrinter<'_, '_> {
     fn utctime(&mut self, tag: &str, epoch: u64) -> Result<(), Error> {
         let matter_epoch = MATTER_EPOCH_SECS + epoch;
 
-        let dt = OffsetDateTime::from_unix_timestamp(matter_epoch as _).unwrap();
+        let dt = unwrap!(
+            OffsetDateTime::from_unix_timestamp(matter_epoch as _),
+            "Invalid time value"
+        );
 
         let _ = writeln!(self.f, "{} {} {:?}", SPACE[self.level], tag, dt);
         Ok(())

--- a/rs-matter/src/codec/base38.rs
+++ b/rs-matter/src/codec/base38.rs
@@ -240,7 +240,7 @@ mod tests {
     #[test]
     fn can_base38_encode() {
         assert_eq!(
-            encode_string::<{ ENCODED.len() }>(&DECODED).unwrap(),
+            unwrap!(encode_string::<{ ENCODED.len() }>(&DECODED)),
             ENCODED
         );
     }
@@ -248,7 +248,10 @@ mod tests {
     #[test]
     fn can_base38_decode() {
         assert_eq!(
-            decode_vec::<{ DECODED.len() }>(ENCODED).expect("Cannot decode base38"),
+            unwrap!(
+                decode_vec::<{ DECODED.len() }>(ENCODED),
+                "Cannot decode base38"
+            ),
             DECODED
         );
     }

--- a/rs-matter/src/core.rs
+++ b/rs-matter/src/core.rs
@@ -40,6 +40,7 @@ pub const MATTER_PORT: u16 = 5540;
 
 /// Device basic commissioning data
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BasicCommData {
     /// The password which is necessary to authenticate the device in either
     /// initial commissioning, or when the basic commissioning window is opened

--- a/rs-matter/src/crypto/crypto_dummy.rs
+++ b/rs-matter/src/crypto/crypto_dummy.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use log::error;
-
 use crate::{
     error::{Error, ErrorCode},
     utils::rand::Rand,

--- a/rs-matter/src/crypto/crypto_dummy.rs
+++ b/rs-matter/src/crypto/crypto_dummy.rs
@@ -28,6 +28,7 @@ pub fn hkdf_sha256(_salt: &[u8], _ikm: &[u8], _info: &[u8], _key: &mut [u8]) -> 
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Sha256 {}
 
 impl Sha256 {
@@ -64,6 +65,7 @@ impl HmacSha256 {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct KeyPair;
 
 impl KeyPair {

--- a/rs-matter/src/crypto/crypto_esp_mbedtls.rs
+++ b/rs-matter/src/crypto/crypto_esp_mbedtls.rs
@@ -62,6 +62,7 @@ impl HmacSha256 {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct KeyPair {}
 
 impl KeyPair {

--- a/rs-matter/src/crypto/crypto_esp_mbedtls.rs
+++ b/rs-matter/src/crypto/crypto_esp_mbedtls.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use log::error;
+use crate::error;
 
 use crate::error::{Error, ErrorCode};
 use crate::utils::rand::Rand;

--- a/rs-matter/src/crypto/crypto_mbedtls.rs
+++ b/rs-matter/src/crypto/crypto_mbedtls.rs
@@ -21,7 +21,6 @@ use core::fmt::{self, Debug};
 
 use alloc::sync::Arc;
 
-use log::{error, info};
 use mbedtls::{
     bignum::Mpi,
     cipher::{Authenticated, Cipher},
@@ -222,7 +221,6 @@ impl KeyPair {
 }
 
 impl core::fmt::Debug for KeyPair {
-    // TODO: defmt
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("KeyPair").finish()
     }
@@ -377,7 +375,6 @@ impl Sha256 {
 }
 
 impl Debug for Sha256 {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Sha256")
     }

--- a/rs-matter/src/crypto/crypto_mbedtls.rs
+++ b/rs-matter/src/crypto/crypto_mbedtls.rs
@@ -222,6 +222,7 @@ impl KeyPair {
 }
 
 impl core::fmt::Debug for KeyPair {
+    // TODO: defmt
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("KeyPair").finish()
     }
@@ -376,6 +377,7 @@ impl Sha256 {
 }
 
 impl Debug for Sha256 {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Sha256")
     }

--- a/rs-matter/src/crypto/crypto_mbedtls.rs
+++ b/rs-matter/src/crypto/crypto_mbedtls.rs
@@ -208,7 +208,7 @@ impl KeyPair {
         let mbedtls_sign = &mbedtls_sign[..len];
 
         if let Err(e) = tmp_key.verify(hash::Type::Sha256, &msg_hash, mbedtls_sign) {
-            info!("The error is {}", e);
+            info!("The error is {}", display2format!(e));
             Err(ErrorCode::InvalidSignature.into())
         } else {
             Ok(())

--- a/rs-matter/src/crypto/crypto_openssl.rs
+++ b/rs-matter/src/crypto/crypto_openssl.rs
@@ -72,8 +72,8 @@ impl HmacSha256 {
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum KeyType {
-    Public(EcKey<pkey::Public>),
-    Private(EcKey<pkey::Private>),
+    Public(#[cfg_attr(feature = "defmt", defmt(Debug2Format))] EcKey<pkey::Public>),
+    Private(#[cfg_attr(feature = "defmt", defmt(Debug2Format))] EcKey<pkey::Private>),
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -399,5 +399,12 @@ impl Sha256 {
 impl Debug for Sha256 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Sha256")
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Sha256 {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(f, "Sha256")
     }
 }

--- a/rs-matter/src/crypto/crypto_openssl.rs
+++ b/rs-matter/src/crypto/crypto_openssl.rs
@@ -22,7 +22,6 @@ use crate::utils::rand::Rand;
 
 use alloc::vec;
 use foreign_types::ForeignTypeRef;
-use log::error;
 use openssl::asn1::Asn1Type;
 use openssl::bn::{BigNum, BigNumContext};
 use openssl::cipher::CipherRef;
@@ -398,7 +397,6 @@ impl Sha256 {
 }
 
 impl Debug for Sha256 {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Sha256")
     }

--- a/rs-matter/src/crypto/crypto_openssl.rs
+++ b/rs-matter/src/crypto/crypto_openssl.rs
@@ -71,11 +71,13 @@ impl HmacSha256 {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum KeyType {
     Public(EcKey<pkey::Public>),
     Private(EcKey<pkey::Private>),
 }
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct KeyPair {
     key: KeyType,
 }
@@ -396,6 +398,7 @@ impl Sha256 {
 }
 
 impl Debug for Sha256 {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Sha256")
     }

--- a/rs-matter/src/crypto/crypto_rustcrypto.rs
+++ b/rs-matter/src/crypto/crypto_rustcrypto.rs
@@ -53,7 +53,9 @@ type AesCcm = Ccm<Aes128, U16, U13>;
 extern crate alloc;
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Sha256 {
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     hasher: sha2::Sha256,
 }
 
@@ -103,13 +105,16 @@ impl HmacSha256 {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum KeyType {
-    Private(SecretKey),
-    Public(PublicKey),
+    Private(#[cfg_attr(feature = "defmt", defmt(Debug2Format))] SecretKey),
+    Public(#[cfg_attr(feature = "defmt", defmt(Debug2Format))] PublicKey),
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct KeyPair {
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     key: KeyType,
 }
 
@@ -339,6 +344,7 @@ pub fn decrypt_in_place(
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct SliceBuffer<'a> {
     slice: &'a mut [u8],
     len: usize,

--- a/rs-matter/src/crypto/mod.rs
+++ b/rs-matter/src/crypto/mod.rs
@@ -116,13 +116,12 @@ mod tests {
 
     #[test]
     fn test_verify_msg_success() {
-        let key = KeyPair::new_from_public(&test_vectors::PUB_KEY1).unwrap();
-        key.verify_msg(&test_vectors::MSG1_SUCCESS, &test_vectors::SIGNATURE1)
-            .unwrap();
+        let key = unwrap!(KeyPair::new_from_public(&test_vectors::PUB_KEY1));
+        unwrap!(key.verify_msg(&test_vectors::MSG1_SUCCESS, &test_vectors::SIGNATURE1));
     }
     #[test]
     fn test_verify_msg_fail() {
-        let key = KeyPair::new_from_public(&test_vectors::PUB_KEY1).unwrap();
+        let key = unwrap!(KeyPair::new_from_public(&test_vectors::PUB_KEY1));
         assert_eq!(
             key.verify_msg(&test_vectors::MSG1_FAIL, &test_vectors::SIGNATURE1)
                 .map_err(|e| e.code()),

--- a/rs-matter/src/data_model/cluster_basic_information.rs
+++ b/rs-matter/src/data_model/cluster_basic_information.rs
@@ -32,6 +32,7 @@ idl_import!(clusters = ["BasicInformation"]);
 pub use basic_information::ID;
 
 #[derive(Clone, Copy, Debug, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 pub enum Attributes {
     DMRevision(AttrType<u8>) = 0,

--- a/rs-matter/src/data_model/cluster_basic_information.rs
+++ b/rs-matter/src/data_model/cluster_basic_information.rs
@@ -198,11 +198,10 @@ impl BasicInfoCluster {
 
         match attr.attr_id.try_into()? {
             Attributes::NodeLabel(codec) => {
-                *self.node_label.borrow_mut() = codec
+                *self.node_label.borrow_mut() = unwrap!(codec
                     .decode(data)
                     .map_err(|_| Error::new(ErrorCode::InvalidAction))?
-                    .try_into()
-                    .unwrap();
+                    .try_into());
             }
             _ => return Err(Error::new(ErrorCode::InvalidAction)),
         }

--- a/rs-matter/src/data_model/cluster_media_playback.rs
+++ b/rs-matter/src/data_model/cluster_media_playback.rs
@@ -91,12 +91,9 @@ struct PlaybackPosition {
 }
 // Get microseconds since 2000, Jan 1, 00:00:00
 pub fn get_epoch_us() -> u64 {
-    let epoch_start = NaiveDate::from_ymd_opt(2000, 1, 1)
-        .unwrap()
-        .and_hms_micro_opt(0, 0, 0, 0)
-        .unwrap()
-        .and_local_timezone(chrono::Utc)
-        .unwrap();
+    let epoch_start = unwrap!(unwrap!(unwrap!(NaiveDate::from_ymd_opt(2000, 1, 1))
+        .and_hms_micro_opt(0, 0, 0, 0))
+        .and_local_timezone(chrono::Utc));
     DateTime::timestamp_micros(&epoch_start) as u64
 }
 

--- a/rs-matter/src/data_model/cluster_on_off.rs
+++ b/rs-matter/src/data_model/cluster_on_off.rs
@@ -17,8 +17,6 @@
 
 use core::cell::Cell;
 
-use log::info;
-
 use rs_matter_macros::idl_import;
 
 use strum::{EnumDiscriminants, FromRepr};

--- a/rs-matter/src/data_model/core.rs
+++ b/rs-matter/src/data_model/core.rs
@@ -524,12 +524,11 @@ where
 
                     // TODO: Do a more sophisticated check whether something had actually changed w.r.t. this subscription
 
-                    let index = self
+                    let index = unwrap!(self
                         .subscriptions_buffers
                         .borrow()
                         .iter()
-                        .position(|sb| sb.subscription_id == id)
-                        .unwrap();
+                        .position(|sb| sb.subscription_id == id));
                     let rx = self.subscriptions_buffers.borrow_mut().remove(index).buffer;
 
                     let result = self
@@ -714,7 +713,7 @@ where
 
             // Safe to unwrap, as `IMBuffer` is defined to be `MAX_EXCHANGE_RX_BUF_SIZE`, i.e. it cannot be overflown
             // by the payload of the received exchange.
-            buffer.extend_from_slice(rx.payload()).unwrap();
+            unwrap!(buffer.extend_from_slice(rx.payload()));
 
             exchange.rx_done()?;
 
@@ -727,7 +726,7 @@ where
     async fn tx_buffer(&self, exchange: &mut Exchange<'_>) -> Result<Option<B::Buffer<'a>>, Error> {
         if let Some(mut buffer) = self.buffer(exchange).await? {
             // Always safe as `IMBuffer` is defined to be `MAX_EXCHANGE_RX_BUF_SIZE`, which is bigger than `MAX_EXCHANGE_TX_BUF_SIZE`
-            buffer.resize_default(MAX_EXCHANGE_TX_BUF_SIZE).unwrap();
+            unwrap!(buffer.resize_default(MAX_EXCHANGE_TX_BUF_SIZE));
 
             Ok(Some(buffer))
         } else {

--- a/rs-matter/src/data_model/core.rs
+++ b/rs-matter/src/data_model/core.rs
@@ -23,7 +23,6 @@ use core::time::Duration;
 
 use embassy_futures::select::select3;
 use embassy_time::{Instant, Timer};
-use log::{debug, error, info, warn};
 
 use crate::interaction_model::messages::ib::AttrStatus;
 use crate::utils::storage::pooled::BufferAccess;
@@ -388,7 +387,10 @@ where
                 .borrow_mut()
                 .retain(|sb| sb.fabric_idx != fabric_idx || sb.peer_node_id != peer_node_id);
 
-            info!("All subscriptions for [F:{fabric_idx:x},P:{peer_node_id:x}] removed");
+            info!(
+                "All subscriptions for [F:{:x},P:{:x}] removed",
+                fabric_idx, peer_node_id
+            );
         }
 
         let max_int_secs = core::cmp::max(req.max_int_ceil()?, 40); // Say we need at least 4 secs for potential latencies
@@ -432,7 +434,10 @@ where
                 })
                 .await?;
 
-            info!("Subscription [F:{fabric_idx:x},P:{peer_node_id:x}]::{id} created");
+            info!(
+                "Subscription [F:{:x},P:{:x}]::{} created",
+                fabric_idx, peer_node_id, id
+            );
 
             if self.subscriptions.mark_reported(id) {
                 let _ = self
@@ -477,7 +482,11 @@ where
                     .retain(|sb| sb.subscription_id != id);
 
                 info!(
-                    "Subscription [F:{fabric_idx:x},P:{peer_node_id:x}]::{id} removed since its session ({session_id}) had been removed too"
+                    "Subscription [F:{:x},P:{:x}]::{} removed since its session ({}) had been removed too",
+                    fabric_idx,
+                    peer_node_id,
+                    id,
+                    session_id
                 );
             }
 
@@ -491,7 +500,8 @@ where
                     .retain(|sb| sb.subscription_id != id);
 
                 info!(
-                    "Subscription [F:{fabric_idx:x},P:{peer_node_id:x}]::{id} removed due to inactivity"
+                    "Subscription [F:{:x},P:{:x}]::{} removed due to inactivity",
+                    fabric_idx, peer_node_id, id
                 );
             }
 
@@ -500,7 +510,8 @@ where
 
                 if let Some((fabric_idx, peer_node_id, session_id, id)) = sub {
                     info!(
-                        "About to report data for subscription [F:{fabric_idx:x},P:{peer_node_id:x}]::{id}"
+                        "About to report data for subscription [F:{:x},P:{:x}]::{}",
+                        fabric_idx, peer_node_id, id
                     );
 
                     let subscribed = Cell::new(false);
@@ -585,7 +596,10 @@ where
 
             Ok(primed)
         } else {
-            error!("No TX buffer available for processing subscription [F:{fabric_idx:x},P:{peer_node_id:x}]::{id}");
+            error!(
+                "No TX buffer available for processing subscription [F:{:x},P:{:x}]::{}",
+                fabric_idx, peer_node_id, id
+            );
 
             Ok(false)
         }
@@ -676,7 +690,10 @@ where
                 exchange.send(OpCode::ReportData, wb.as_slice()).await?;
 
                 if !Self::recv_status_success(exchange).await? {
-                    info!("Subscription [F:{fabric_idx:x},P:{peer_node_id:x}]::{id} removed during reporting");
+                    info!(
+                        "Subscription [F:{:x},P:{:x}]::{} removed during reporting",
+                        fabric_idx, peer_node_id, id
+                    );
                     return Ok(false);
                 }
 
@@ -736,7 +753,8 @@ where
 
         if opcode != OpCode::StatusResponse as u8 {
             warn!(
-                "Got opcode {opcode:02x}, while expecting status code {:02x}",
+                "Got opcode {:02x}, while expecting status code {:02x}",
+                opcode,
                 OpCode::StatusResponse as u8
             );
 

--- a/rs-matter/src/data_model/objects/attribute.rs
+++ b/rs-matter/src/data_model/objects/attribute.rs
@@ -27,6 +27,7 @@ use crate::utils::bitflags::bitflags;
 bitflags! {
     #[repr(transparent)]
     #[derive(Default)]
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
     pub struct Access: u16 {
         // These must match the bits in the Privilege object :-|
         const NEED_VIEW = 0x00001;
@@ -78,6 +79,7 @@ impl Access {
 bitflags! {
     #[repr(transparent)]
     #[derive(Default)]
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
     pub struct Quality: u8 {
         const NONE = 0x00;
         const SCENE = 0x01;      // Short: S

--- a/rs-matter/src/data_model/objects/attribute.rs
+++ b/rs-matter/src/data_model/objects/attribute.rs
@@ -16,15 +16,17 @@
  */
 #![allow(clippy::bad_bit_mask)]
 
+use core::fmt::{self, Debug};
+
 use crate::data_model::objects::GlobalElements;
 
 use super::{AttrId, Privilege};
-use bitflags::bitflags;
-use core::fmt::{self, Debug};
+
+use crate::utils::bitflags::bitflags;
 
 bitflags! {
     #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Default)]
     pub struct Access: u16 {
         // These must match the bits in the Privilege object :-|
         const NEED_VIEW = 0x00001;
@@ -75,7 +77,7 @@ impl Access {
 
 bitflags! {
     #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Default)]
     pub struct Quality: u8 {
         const NONE = 0x00;
         const SCENE = 0x01;      // Short: S
@@ -92,6 +94,7 @@ bitflags! {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Attribute {
     pub id: AttrId,
     pub quality: Quality,

--- a/rs-matter/src/data_model/objects/cluster.rs
+++ b/rs-matter/src/data_model/objects/cluster.rs
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-use log::error;
 use strum::FromRepr;
 
 use crate::{

--- a/rs-matter/src/data_model/objects/cluster.rs
+++ b/rs-matter/src/data_model/objects/cluster.rs
@@ -36,6 +36,7 @@ use crate::{
 use core::fmt::{self, Debug};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 pub enum GlobalElements {
     _ClusterRevision = 0xFFFD,
@@ -62,6 +63,7 @@ pub const ATTRIBUTE_LIST: Attribute = Attribute::new(
 // methods?
 /// The Attribute Details structure records the details about the attribute under consideration.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AttrDetails<'a> {
     pub node: &'a Node<'a>,
     /// The actual endpoint ID
@@ -128,6 +130,7 @@ impl AttrDetails<'_> {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CmdDetails<'a> {
     pub node: &'a Node<'a>,
     pub endpoint_id: EndptId,
@@ -185,6 +188,7 @@ impl CmdDetails<'_> {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Cluster<'a> {
     pub id: ClusterId,
     pub feature_map: u32,

--- a/rs-matter/src/data_model/objects/dataver.rs
+++ b/rs-matter/src/data_model/objects/dataver.rs
@@ -21,7 +21,9 @@ use core::num::Wrapping;
 use crate::utils::rand::Rand;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Dataver {
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     ver: Cell<Wrapping<u32>>,
     changed: Cell<bool>,
 }

--- a/rs-matter/src/data_model/objects/encoder.rs
+++ b/rs-matter/src/data_model/objects/encoder.rs
@@ -30,7 +30,6 @@ use crate::{
     interaction_model::messages::ib::{AttrDataTag, AttrRespTag},
     tlv::{FromTLV, TLVElement, TLVWrite, TLVWriter, TagType, ToTLV},
 };
-use log::error;
 
 use super::{AttrDetails, CmdDetails, DataModelHandler};
 

--- a/rs-matter/src/data_model/objects/encoder.rs
+++ b/rs-matter/src/data_model/objects/encoder.rs
@@ -358,6 +358,7 @@ impl DerefMut for CmdDataWriter<'_, '_, '_> {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AttrType<T>(PhantomData<fn() -> T>);
 
 impl<T> AttrType<T> {
@@ -387,6 +388,7 @@ impl<T> Default for AttrType<T> {
 }
 
 #[derive(Copy, Clone, Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AttrUtfType;
 
 impl AttrUtfType {

--- a/rs-matter/src/data_model/objects/endpoint.rs
+++ b/rs-matter/src/data_model/objects/endpoint.rs
@@ -20,6 +20,7 @@ use core::fmt;
 use super::{Cluster, DeviceType, EndptId};
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Endpoint<'a> {
     pub id: EndptId,
     pub device_types: &'a [DeviceType],

--- a/rs-matter/src/data_model/objects/mod.rs
+++ b/rs-matter/src/data_model/objects/mod.rs
@@ -49,6 +49,7 @@ pub type AttrId = u16;
 pub type CmdId = u32;
 
 #[derive(Debug, ToTLV, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DeviceType {
     pub dtype: u16,
     pub drev: u16,

--- a/rs-matter/src/data_model/objects/node.rs
+++ b/rs-matter/src/data_model/objects/node.rs
@@ -32,6 +32,7 @@ use super::{AttrDetails, Cluster, ClusterId, CmdDetails, EndptId};
 
 /// The main Matter metadata type describing a Matter Node.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Node<'a> {
     /// The ID of the node.
     pub id: u16,
@@ -193,6 +194,7 @@ impl<const N: usize> core::fmt::Display for DynamicNode<'_, N> {
 /// as well as with information which attributes should only be served if their
 /// dataver had changed.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct AttrReadPath<'a> {
     path: AttrPath,
     dataver_filters: Option<TLVArray<'a, DataVersionFilter>>,
@@ -202,6 +204,7 @@ struct AttrReadPath<'a> {
 /// A helper type for `PathExpander` that captures what type of expansion is being done:
 /// Read requests, write requests, or invoke requests.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum Operation {
     Read,
     Write,

--- a/rs-matter/src/data_model/objects/node.rs
+++ b/rs-matter/src/data_model/objects/node.rs
@@ -412,7 +412,7 @@ where
     ///
     /// This method should only be called when `self.item` is `Some` or else it will panic.
     fn next_for_path(&mut self) -> Result<Option<(EndptId, ClusterId, u32)>, IMStatusCode> {
-        let path = self.item.as_ref().map(PathExpansionItem::path).unwrap();
+        let path = unwrap!(self.item.as_ref().map(PathExpansionItem::path));
 
         let command = matches!(T::OPERATION, Operation::Invoke);
 
@@ -556,7 +556,7 @@ where
                 Ok(Some((endpoint_id, cluster_id, leaf_id))) => {
                     // Next expansion of the path
 
-                    let expanded = self.item.as_ref().unwrap().expand(
+                    let expanded = unwrap!(self.item.as_ref()).expand(
                         self.node,
                         self.accessor,
                         endpoint_id,
@@ -564,7 +564,7 @@ where
                         leaf_id,
                     );
 
-                    if !self.item.as_ref().unwrap().path().is_wildcard() {
+                    if !unwrap!(self.item.as_ref()).path().is_wildcard() {
                         // Non-wildcard path, remove the current item
                         self.item = None;
                     }
@@ -577,7 +577,7 @@ where
                 }
                 Err(status) => {
                     // Report an error status and remove the current item
-                    break Some(Ok(Err(self.item.take().unwrap().into_status(status))));
+                    break Some(Ok(Err(unwrap!(self.item.take()).into_status(status))));
                 }
             }
         }

--- a/rs-matter/src/data_model/objects/privilege.rs
+++ b/rs-matter/src/data_model/objects/privilege.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use log::error;
-
 use crate::error::{Error, ErrorCode};
 use crate::tlv::{FromTLV, TLVElement, TLVTag, TLVWrite, ToTLV, TLV};
 use crate::utils::bitflags::bitflags;
@@ -24,6 +22,7 @@ use crate::utils::bitflags::bitflags;
 bitflags! {
     #[repr(transparent)]
     #[derive(Default)]
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
     pub struct Privilege: u8 {
         const V = 0x01;
         const O = 0x02;

--- a/rs-matter/src/data_model/objects/privilege.rs
+++ b/rs-matter/src/data_model/objects/privilege.rs
@@ -15,17 +15,15 @@
  *    limitations under the License.
  */
 
-use crate::{
-    error::{Error, ErrorCode},
-    tlv::{FromTLV, TLVElement, TLVTag, TLVWrite, ToTLV, TLV},
-};
 use log::error;
 
-use bitflags::bitflags;
+use crate::error::{Error, ErrorCode};
+use crate::tlv::{FromTLV, TLVElement, TLVTag, TLVWrite, ToTLV, TLV};
+use crate::utils::bitflags::bitflags;
 
 bitflags! {
     #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Default)]
     pub struct Privilege: u8 {
         const V = 0x01;
         const O = 0x02;

--- a/rs-matter/src/data_model/root_endpoint.rs
+++ b/rs-matter/src/data_model/root_endpoint.rs
@@ -58,6 +58,7 @@ const THREAD_NW_CLUSTERS: [Cluster<'static>; 10] = [
 /// The type of operational network (Ethernet, Wifi or Thread)
 /// for which root endpoint meta-data is being requested
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum OperNwType {
     Ethernet,
     Wifi,

--- a/rs-matter/src/data_model/sdm/admin_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/admin_commissioning.rs
@@ -30,6 +30,7 @@ use crate::{command_enum, error::*};
 pub const ID: u32 = 0x003C;
 
 #[derive(FromPrimitive, Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WindowStatus {
     WindowNotOpen = 0,
     EnhancedWindowOpen = 1,
@@ -37,6 +38,7 @@ pub enum WindowStatus {
 }
 
 #[derive(Clone, Debug, FromRepr, EnumDiscriminants)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 pub enum Attributes {
     WindowStatus(AttrType<u8>) = 0,
@@ -101,6 +103,7 @@ pub struct OpenBasicCommWindowReq {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdminCommCluster {
     data_ver: Dataver,
 }

--- a/rs-matter/src/data_model/sdm/admin_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/admin_commissioning.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use log::info;
-
 use num_derive::FromPrimitive;
 
 use strum::{EnumDiscriminants, FromRepr};

--- a/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use log::info;
-
 use rs_matter_macros::idl_import;
 
 use strum::{EnumDiscriminants, FromRepr};

--- a/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/ethernet_nw_diagnostics.rs
@@ -65,6 +65,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
 };
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct EthNwDiagCluster {
     data_ver: Dataver,
 }

--- a/rs-matter/src/data_model/sdm/failsafe.rs
+++ b/rs-matter/src/data_model/sdm/failsafe.rs
@@ -18,8 +18,6 @@
 use core::num::NonZeroU8;
 use core::time::Duration;
 
-use log::error;
-
 use crate::cert::{CertRef, MAX_CERT_TLV_LEN};
 use crate::crypto::KeyPair;
 use crate::error::{Error, ErrorCode};
@@ -38,6 +36,7 @@ use crate::utils::storage::Vec;
 bitflags! {
     #[repr(transparent)]
     #[derive(Default)]
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
     pub struct NocFlags: u8 {
         const ADD_CSR_REQ_RECVD = 0x01;
         const UPDATE_CSR_REQ_RECVD = 0x02;

--- a/rs-matter/src/data_model/sdm/failsafe.rs
+++ b/rs-matter/src/data_model/sdm/failsafe.rs
@@ -18,8 +18,6 @@
 use core::num::NonZeroU8;
 use core::time::Duration;
 
-use bitflags::bitflags;
-
 use log::error;
 
 use crate::cert::{CertRef, MAX_CERT_TLV_LEN};
@@ -30,6 +28,7 @@ use crate::interaction_model::core::IMStatusCode;
 use crate::mdns::Mdns;
 use crate::tlv::TLVElement;
 use crate::transport::session::SessionMode;
+use crate::utils::bitflags::bitflags;
 use crate::utils::cell::RefCell;
 use crate::utils::epoch::Epoch;
 use crate::utils::init::{init, Init};
@@ -38,7 +37,7 @@ use crate::utils::storage::Vec;
 
 bitflags! {
     #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Default)]
     pub struct NocFlags: u8 {
         const ADD_CSR_REQ_RECVD = 0x01;
         const UPDATE_CSR_REQ_RECVD = 0x02;

--- a/rs-matter/src/data_model/sdm/failsafe.rs
+++ b/rs-matter/src/data_model/sdm/failsafe.rs
@@ -206,7 +206,7 @@ impl FailSafe {
 
         self.add_flags(NocFlags::ADD_CSR_REQ_RECVD);
 
-        Ok(self.key_pair.as_ref().unwrap())
+        Ok(unwrap!(self.key_pair.as_ref()))
     }
 
     pub fn update_csr_req(&mut self, session_mode: &SessionMode) -> Result<&KeyPair, Error> {
@@ -226,7 +226,7 @@ impl FailSafe {
 
         self.add_flags(NocFlags::UPDATE_CSR_REQ_RECVD);
 
-        Ok(self.key_pair.as_ref().unwrap())
+        Ok(unwrap!(self.key_pair.as_ref()))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -262,7 +262,7 @@ impl FailSafe {
 
         fabric_mgr.borrow_mut().update(
             fab_idx,
-            self.key_pair.take().unwrap(),
+            unwrap!(self.key_pair.take()),
             &self.root_ca,
             noc,
             icac.unwrap_or(&[]),
@@ -309,7 +309,7 @@ impl FailSafe {
         let fab_idx = fabric_mgr
             .borrow_mut()
             .add(
-                self.key_pair.take().unwrap(),
+                unwrap!(self.key_pair.take()),
                 &self.root_ca,
                 noc,
                 icac.unwrap_or(&[]),

--- a/rs-matter/src/data_model/sdm/general_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/general_commissioning.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use log::info;
-
 use rs_matter_macros::idl_import;
 
 use strum::{EnumDiscriminants, FromRepr};

--- a/rs-matter/src/data_model/sdm/general_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/general_commissioning.rs
@@ -56,6 +56,7 @@ pub enum RespCommands {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 struct CommonResponse<'a> {
     error_code: u8,
@@ -81,12 +82,14 @@ impl CommissioningErrorEnum {
 }
 
 #[derive(Debug, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct FailSafeParams {
     expiry_len: u16,
     bread_crumb: u64,
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BasicCommissioningInfo {
     pub expiry_len: u16,
     pub max_cmltv_failsafe_secs: u16,
@@ -109,6 +112,7 @@ impl Default for BasicCommissioningInfo {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 struct RegulatoryConfig<'a> {
     #[tagval(1)]

--- a/rs-matter/src/data_model/sdm/general_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/general_diagnostics.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use log::info;
-
 use strum::{EnumDiscriminants, FromRepr};
 
 use crate::data_model::objects::*;

--- a/rs-matter/src/data_model/sdm/general_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/general_diagnostics.rs
@@ -71,6 +71,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
 };
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GenDiagCluster {
     data_ver: Dataver,
 }

--- a/rs-matter/src/data_model/sdm/group_key_management.rs
+++ b/rs-matter/src/data_model/sdm/group_key_management.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use log::info;
-
 use strum::{EnumDiscriminants, FromRepr};
 
 use crate::data_model::objects::*;

--- a/rs-matter/src/data_model/sdm/group_key_management.rs
+++ b/rs-matter/src/data_model/sdm/group_key_management.rs
@@ -77,6 +77,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
 };
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GrpKeyMgmtCluster {
     data_ver: Dataver,
 }

--- a/rs-matter/src/data_model/sdm/noc.rs
+++ b/rs-matter/src/data_model/sdm/noc.rs
@@ -19,8 +19,6 @@ use core::cell::Cell;
 use core::mem::MaybeUninit;
 use core::num::NonZeroU8;
 
-use log::{error, info, warn};
-
 use strum::{EnumDiscriminants, FromRepr};
 
 use crate::cert::CertRef;
@@ -28,6 +26,7 @@ use crate::crypto::{self, KeyPair};
 use crate::data_model::objects::*;
 use crate::data_model::sdm::dev_att;
 use crate::fabric::MAX_SUPPORTED_FABRICS;
+use crate::fmt::Bytes;
 use crate::tlv::{FromTLV, OctetStr, TLVElement, TLVTag, TLVWrite, ToTLV, UtfStr};
 use crate::transport::exchange::Exchange;
 use crate::transport::session::SessionMode;
@@ -577,7 +576,7 @@ impl NocCluster {
         cmd_enter!("AddTrustedRootCert");
 
         let req = CommonReq::from_tlv(data).map_err(Error::map_invalid_command)?;
-        info!("Received Trusted Cert: {:x?}", req.str);
+        info!("Received Trusted Cert: {}", Bytes(&req.str));
 
         exchange.with_session(|sess| {
             exchange

--- a/rs-matter/src/data_model/sdm/noc.rs
+++ b/rs-matter/src/data_model/sdm/noc.rs
@@ -94,6 +94,7 @@ pub enum Attributes {
 attribute_enum!(Attributes);
 
 #[derive(Debug, Clone, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 struct NocResp<'a> {
     status_code: u8,
@@ -102,6 +103,7 @@ struct NocResp<'a> {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 struct AddNocReq<'a> {
     noc_value: OctetStr<'a>,
@@ -112,6 +114,7 @@ struct AddNocReq<'a> {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 struct CsrReq<'a> {
     nonce: OctetStr<'a>,
@@ -119,23 +122,27 @@ struct CsrReq<'a> {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 struct CommonReq<'a> {
     str: OctetStr<'a>,
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 struct UpdateFabricLabelReq<'a> {
     label: UtfStr<'a>,
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct CertChainReq {
     cert_type: u8,
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct RemoveFabricReq {
     fab_idx: NonZeroU8,
 }
@@ -193,6 +200,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
 };
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NocCluster {
     data_ver: Dataver,
 }

--- a/rs-matter/src/data_model/sdm/noc.rs
+++ b/rs-matter/src/data_model/sdm/noc.rs
@@ -410,12 +410,11 @@ impl NocCluster {
                     // Remove the fabric if we fail further down this function
                     warn!("Removing fabric {} due to failure", fab_idx.get());
 
-                    exchange
+                    unwrap!(exchange
                         .matter()
                         .fabric_mgr
                         .borrow_mut()
-                        .remove(fab_idx, &exchange.matter().transport_mgr.mdns)
-                        .unwrap();
+                        .remove(fab_idx, &exchange.matter().transport_mgr.mdns));
                 }
             });
 

--- a/rs-matter/src/data_model/sdm/nw_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/nw_commissioning.rs
@@ -158,6 +158,7 @@ pub const THR_CLUSTER: Cluster<'static> = cluster(FeatureMap::Thread);
 bitflags! {
     #[repr(transparent)]
     #[derive(Default)]
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
     pub struct WiFiSecurity: u8 {
         const UNENCRYPTED = 0x01;
         const WEP = 0x02;

--- a/rs-matter/src/data_model/sdm/nw_commissioning.rs
+++ b/rs-matter/src/data_model/sdm/nw_commissioning.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use bitflags::bitflags;
-
 use strum::FromRepr;
 
 use crate::data_model::objects::{
@@ -26,6 +24,7 @@ use crate::data_model::objects::{
 use crate::error::{Error, ErrorCode};
 use crate::tlv::{FromTLV, OctetStr, TLVArray, TLVTag, TLVWrite, ToTLV};
 use crate::transport::exchange::Exchange;
+use crate::utils::bitflags::bitflags;
 use crate::{attribute_enum, bitflags_tlv, command_enum};
 
 pub const ID: u32 = 0x0031;
@@ -46,6 +45,7 @@ pub enum Attributes {
 attribute_enum!(Attributes);
 
 #[derive(Debug, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u32)]
 pub enum Commands {
     ScanNetworks = 0x00,
@@ -157,7 +157,7 @@ pub const THR_CLUSTER: Cluster<'static> = cluster(FeatureMap::Thread);
 
 bitflags! {
     #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Default)]
     pub struct WiFiSecurity: u8 {
         const UNENCRYPTED = 0x01;
         const WEP = 0x02;
@@ -170,6 +170,7 @@ bitflags! {
 bitflags_tlv!(WiFiSecurity, u8);
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, FromTLV, ToTLV, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WifiBand {
     B2G4 = 0,
     B3G65 = 1,
@@ -180,6 +181,7 @@ pub enum WifiBand {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct ScanNetworksRequest<'a> {
     pub ssid: Option<OctetStr<'a>>,
@@ -187,6 +189,7 @@ pub struct ScanNetworksRequest<'a> {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct ScanNetworksResponse<'a> {
     pub status: NetworkCommissioningStatus,
@@ -196,6 +199,7 @@ pub struct ScanNetworksResponse<'a> {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ScanNetworksResponseTag {
     Status = 0,
     DebugText = 1,
@@ -204,6 +208,7 @@ pub enum ScanNetworksResponseTag {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct AddWifiNetworkRequest<'a> {
     pub ssid: OctetStr<'a>,
@@ -212,6 +217,7 @@ pub struct AddWifiNetworkRequest<'a> {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct AddThreadNetworkRequest<'a> {
     pub op_dataset: OctetStr<'a>,
@@ -219,6 +225,7 @@ pub struct AddThreadNetworkRequest<'a> {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct RemoveNetworkRequest<'a> {
     pub network_id: OctetStr<'a>,
@@ -226,6 +233,7 @@ pub struct RemoveNetworkRequest<'a> {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct NetworkConfigResponse<'a> {
     pub status: NetworkCommissioningStatus,
@@ -236,6 +244,7 @@ pub struct NetworkConfigResponse<'a> {
 pub type ConnectNetworkRequest<'a> = RemoveNetworkRequest<'a>;
 
 #[derive(Debug, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct ReorderNetworkRequest<'a> {
     pub network_id: OctetStr<'a>,
@@ -244,6 +253,7 @@ pub struct ReorderNetworkRequest<'a> {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct ConnectNetworkResponse<'a> {
     pub status: NetworkCommissioningStatus,
@@ -252,6 +262,7 @@ pub struct ConnectNetworkResponse<'a> {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct WiFiInterfaceScanResult<'a> {
     pub security: WiFiSecurity,
@@ -263,6 +274,7 @@ pub struct WiFiInterfaceScanResult<'a> {
 }
 
 #[derive(Debug, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct ThreadInterfaceScanResult<'a> {
     pub pan_id: u16,
@@ -276,6 +288,7 @@ pub struct ThreadInterfaceScanResult<'a> {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct EthNwCommCluster {
     data_ver: Dataver,
 }
@@ -347,6 +360,7 @@ impl EthNwCommCluster {
 }
 
 #[derive(Debug, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a")]
 pub struct NwInfo<'a> {
     pub network_id: OctetStr<'a>,
@@ -361,6 +375,7 @@ struct NwMetaInfo<'a> {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, FromRepr, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum NetworkCommissioningStatus {
     Success = 0,

--- a/rs-matter/src/data_model/sdm/thread_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/thread_nw_diagnostics.rs
@@ -203,6 +203,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
 };
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, FromTLV, ToTLV, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum RoutingRole {
     Unspecified = 0,
@@ -215,6 +216,7 @@ pub enum RoutingRole {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, FromTLV, ToTLV, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum NetworkFault {
     Unspecified = 0,
@@ -224,6 +226,7 @@ pub enum NetworkFault {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, FromTLV, ToTLV, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum ConnectionStatus {
     Connected = 0,
@@ -231,6 +234,7 @@ pub enum ConnectionStatus {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NeightborTable {
     pub ext_address: u64,
     pub age: u32,
@@ -249,6 +253,7 @@ pub struct NeightborTable {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RouteTable {
     pub ext_address: u64,
     pub rloc16: u16,
@@ -263,12 +268,14 @@ pub struct RouteTable {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SecurityPolicy {
     pub rotation_time: u16,
     pub flags: u16,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OperationalDatasetComponents {
     pub active_timestamp_present: bool,
     pub pending_timestamp_present: bool,

--- a/rs-matter/src/data_model/sdm/thread_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/thread_nw_diagnostics.rs
@@ -17,8 +17,6 @@
 
 use core::net::Ipv6Addr;
 
-use log::info;
-
 use strum::{EnumDiscriminants, FromRepr};
 
 use crate::data_model::objects::*;

--- a/rs-matter/src/data_model/sdm/wifi_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/wifi_nw_diagnostics.rs
@@ -95,6 +95,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
 };
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, FromTLV, ToTLV, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum WiFiSecurity {
     Unspecified = 0,
@@ -106,6 +107,7 @@ pub enum WiFiSecurity {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, FromTLV, ToTLV, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum WiFiVersion {
     A = 0,
@@ -117,6 +119,7 @@ pub enum WiFiVersion {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, FromTLV, ToTLV, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum AssociationFailure {
     Unknown = 0,
@@ -126,6 +129,7 @@ pub enum AssociationFailure {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, FromTLV, ToTLV, FromRepr)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum ConnectionStatus {
     Connected = 0,
@@ -133,6 +137,7 @@ pub enum ConnectionStatus {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WifiNwDiagData {
     pub bssid: [u8; 6],
     pub security_type: WiFiSecurity,
@@ -143,6 +148,7 @@ pub struct WifiNwDiagData {
 
 /// A cluster implementing the Matter Wifi Diagnostics Cluster.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WifiNwDiagCluster {
     data_ver: Dataver,
     data: RefCell<WifiNwDiagData>,

--- a/rs-matter/src/data_model/sdm/wifi_nw_diagnostics.rs
+++ b/rs-matter/src/data_model/sdm/wifi_nw_diagnostics.rs
@@ -17,8 +17,6 @@
 
 use core::cell::RefCell;
 
-use log::info;
-
 use rs_matter_macros::{FromTLV, ToTLV};
 
 use strum::{EnumDiscriminants, FromRepr};

--- a/rs-matter/src/data_model/subscriptions.rs
+++ b/rs-matter/src/data_model/subscriptions.rs
@@ -178,7 +178,7 @@ impl<const N: usize> Subscriptions<N> {
                 .then_some((
                     sub.fabric_idx,
                     sub.peer_node_id,
-                    sub.session_id.unwrap(),
+                    unwrap!(sub.session_id),
                     sub.id,
                 ))
         })

--- a/rs-matter/src/data_model/system_model/access_control.rs
+++ b/rs-matter/src/data_model/system_model/access_control.rs
@@ -79,6 +79,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
 };
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AccessControlCluster {
     data_ver: Dataver,
 }

--- a/rs-matter/src/data_model/system_model/access_control.rs
+++ b/rs-matter/src/data_model/system_model/access_control.rs
@@ -19,8 +19,6 @@ use core::num::NonZeroU8;
 
 use strum::{EnumDiscriminants, FromRepr};
 
-use log::{error, info};
-
 use crate::acl::{self, AclEntry};
 use crate::data_model::objects::*;
 use crate::fabric::FabricMgr;

--- a/rs-matter/src/data_model/system_model/access_control.rs
+++ b/rs-matter/src/data_model/system_model/access_control.rs
@@ -250,16 +250,14 @@ mod tests {
         let mut fab_mgr = FabricMgr::new();
 
         // Add fabric with ID 1
-        fab_mgr
-            .add_with_post_init(KeyPair::new(dummy_rand).unwrap(), |_| Ok(()))
-            .unwrap();
+        unwrap!(fab_mgr.add_with_post_init(unwrap!(KeyPair::new(dummy_rand)), |_| Ok(())));
 
         let acl = AccessControlCluster::new(Dataver::new(0));
 
         let new = AclEntry::new(Some(FAB_2), Privilege::VIEW, AuthMode::Case);
 
-        new.to_tlv(&TLVTag::Anonymous, &mut tw).unwrap();
-        let data = get_root_node_struct(writebuf.as_slice()).unwrap();
+        unwrap!(new.to_tlv(&TLVTag::Anonymous, &mut tw));
+        let data = unwrap!(get_root_node_struct(writebuf.as_slice()));
 
         // Test, ACL has fabric index 2, but the accessing fabric is 1
         //    the fabric index in the TLV should be ignored and the ACL should be created with entry 1

--- a/rs-matter/src/data_model/system_model/descriptor.rs
+++ b/rs-matter/src/data_model/system_model/descriptor.rs
@@ -75,7 +75,6 @@ impl PartsMatcher for AggregatorPartsMatcher {
 }
 
 pub trait PartsMatcher: Debug {
-    // TODO: defmt
     fn describe(&self, our_endpoint: EndptId, endpoint: EndptId) -> bool;
 }
 

--- a/rs-matter/src/data_model/system_model/descriptor.rs
+++ b/rs-matter/src/data_model/system_model/descriptor.rs
@@ -55,6 +55,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
 };
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct StandardPartsMatcher;
 
 impl PartsMatcher for StandardPartsMatcher {
@@ -64,6 +65,7 @@ impl PartsMatcher for StandardPartsMatcher {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct AggregatorPartsMatcher;
 
 impl PartsMatcher for AggregatorPartsMatcher {
@@ -73,6 +75,7 @@ impl PartsMatcher for AggregatorPartsMatcher {
 }
 
 pub trait PartsMatcher: Debug {
+    // TODO: defmt
     fn describe(&self, our_endpoint: EndptId, endpoint: EndptId) -> bool;
 }
 

--- a/rs-matter/src/error.rs
+++ b/rs-matter/src/error.rs
@@ -202,7 +202,7 @@ impl<T> From<std::sync::PoisonError<T>> for Error {
 #[cfg(feature = "openssl")]
 impl From<openssl::error::ErrorStack> for Error {
     fn from(e: openssl::error::ErrorStack) -> Self {
-        error!("Error in TLS: {}", e);
+        error!("Error in OpenSSL: {}", display2format!(e));
         Self::new(ErrorCode::TLSStack)
     }
 }
@@ -210,14 +210,61 @@ impl From<openssl::error::ErrorStack> for Error {
 #[cfg(all(feature = "mbedtls", not(target_os = "espidf")))]
 impl From<mbedtls::Error> for Error {
     fn from(e: mbedtls::Error) -> Self {
-        error!("Error in TLS: {}", e);
+        error!("Error in MbedTLS: {}", debug2format!(e));
         Self::new(ErrorCode::TLSStack)
     }
 }
 
 #[cfg(feature = "rustcrypto")]
 impl From<ccm::aead::Error> for Error {
-    fn from(_e: ccm::aead::Error) -> Self {
+    fn from(e: ccm::aead::Error) -> Self {
+        error!("Error in Crypto (AEAD): {}", display2format!(e));
+        Self::new(ErrorCode::Crypto)
+    }
+}
+
+#[cfg(feature = "rustcrypto")]
+impl From<elliptic_curve::Error> for Error {
+    fn from(e: elliptic_curve::Error) -> Self {
+        error!("Error in Crypto (EC): {}", display2format!(e));
+        Self::new(ErrorCode::Crypto)
+    }
+}
+
+#[cfg(feature = "rustcrypto")]
+impl From<x509_cert::der::Error> for Error {
+    fn from(e: x509_cert::der::Error) -> Self {
+        error!("Error in Crypto (x509_DER): {}", display2format!(e));
+        Self::new(ErrorCode::Crypto)
+    }
+}
+
+#[cfg(feature = "rustcrypto")]
+impl From<p256::ecdsa::Error> for Error {
+    fn from(e: p256::ecdsa::Error) -> Self {
+        error!("Error in Crypto (p256_ECDSA): {}", display2format!(e));
+        Self::new(ErrorCode::Crypto)
+    }
+}
+
+#[cfg(feature = "rustcrypto")]
+impl From<aes::cipher::InvalidLength> for Error {
+    fn from(e: aes::cipher::InvalidLength) -> Self {
+        error!(
+            "Error in Crypto (AES_Cpipher_InvalidLength): {}",
+            display2format!(e)
+        );
+        Self::new(ErrorCode::Crypto)
+    }
+}
+
+#[cfg(feature = "rustcrypto")]
+impl From<sec1::Error> for Error {
+    fn from(e: sec1::Error) -> Self {
+        error!(
+            "Error in Crypto (AES_Cpipher_InvalidLength): {}",
+            display2format!(e)
+        );
         Self::new(ErrorCode::Crypto)
     }
 }
@@ -227,7 +274,7 @@ impl From<bluer::Error> for Error {
     fn from(e: bluer::Error) -> Self {
         // Log the error given that we lose all context from the
         // original error here
-        crate::error!("Error in BTP: {e}");
+        crate::error!("Error in BTP: {}", display2format!(e));
         Self::new(ErrorCode::BtpError)
     }
 }

--- a/rs-matter/src/error.rs
+++ b/rs-matter/src/error.rs
@@ -202,7 +202,7 @@ impl<T> From<std::sync::PoisonError<T>> for Error {
 #[cfg(feature = "openssl")]
 impl From<openssl::error::ErrorStack> for Error {
     fn from(e: openssl::error::ErrorStack) -> Self {
-        ::log::error!("Error in TLS: {}", e);
+        error!("Error in TLS: {}", e);
         Self::new(ErrorCode::TLSStack)
     }
 }
@@ -210,7 +210,7 @@ impl From<openssl::error::ErrorStack> for Error {
 #[cfg(all(feature = "mbedtls", not(target_os = "espidf")))]
 impl From<mbedtls::Error> for Error {
     fn from(e: mbedtls::Error) -> Self {
-        ::log::error!("Error in TLS: {}", e);
+        error!("Error in TLS: {}", e);
         Self::new(ErrorCode::TLSStack)
     }
 }
@@ -227,7 +227,7 @@ impl From<bluer::Error> for Error {
     fn from(e: bluer::Error) -> Self {
         // Log the error given that we lose all context from the
         // original error here
-        ::log::error!("Error in BTP: {e}");
+        crate::error!("Error in BTP: {e}");
         Self::new(ErrorCode::BtpError)
     }
 }
@@ -259,7 +259,6 @@ impl From<Utf8Error> for Error {
 }
 
 impl fmt::Debug for Error {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         #[cfg(not(all(feature = "std", feature = "backtrace")))]
         {
@@ -294,6 +293,13 @@ impl fmt::Display for Error {
         {
             write!(f, "{:?}", self.code())
         }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Error {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(f, "{:?}", self.code())
     }
 }
 

--- a/rs-matter/src/error.rs
+++ b/rs-matter/src/error.rs
@@ -274,7 +274,7 @@ impl From<bluer::Error> for Error {
     fn from(e: bluer::Error) -> Self {
         // Log the error given that we lose all context from the
         // original error here
-        crate::error!("Error in BTP: {}", display2format!(e));
+        error!("Error in BTP: {}", display2format!(e));
         Self::new(ErrorCode::BtpError)
     }
 }

--- a/rs-matter/src/error.rs
+++ b/rs-matter/src/error.rs
@@ -26,6 +26,7 @@ use core::{array::TryFromSliceError, fmt, str::Utf8Error};
 // the returned error type of all APIs that take callbacks that return errors
 // (i.e., `Exchange::with_*`, `WriteBuf::append_with_buf` etc.)
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ErrorCode {
     AttributeNotFound,
     AttributeIsCustom,
@@ -258,6 +259,7 @@ impl From<Utf8Error> for Error {
 }
 
 impl fmt::Debug for Error {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         #[cfg(not(all(feature = "std", feature = "backtrace")))]
         {

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -156,14 +156,14 @@ impl Fabric {
         self.mdns_service_name.clear();
         for c in compressed_id {
             let mut hex = heapless::String::<4>::new();
-            write!(&mut hex, "{:02X}", c).unwrap();
-            self.mdns_service_name.push_str(&hex).unwrap();
+            write_unwrap!(&mut hex, "{:02X}", c);
+            unwrap!(self.mdns_service_name.push_str(&hex));
         }
-        self.mdns_service_name.push('-').unwrap();
+        unwrap!(self.mdns_service_name.push('-'));
         for c in self.node_id.to_be_bytes() {
             let mut hex = heapless::String::<4>::new();
-            write!(&mut hex, "{:02X}", c).unwrap();
-            self.mdns_service_name.push_str(&hex).unwrap();
+            write_unwrap!(&mut hex, "{:02X}", c);
+            unwrap!(self.mdns_service_name.push_str(&hex));
         }
 
         info!("mDNS Service name: {}", self.mdns_service_name);
@@ -483,7 +483,7 @@ impl FabricMgr {
             .map(|fabric| fabric.fab_idx().get())
             .max()
             .unwrap_or(0);
-        let fab_idx = NonZeroU8::new(if max_fab_idx < u8::MAX - 1 {
+        let fab_idx = unwrap!(NonZeroU8::new(if max_fab_idx < u8::MAX - 1 {
             // First try with the next available fabric index larger than all currently used
             max_fab_idx + 1
         } else {
@@ -495,8 +495,7 @@ impl FabricMgr {
             };
 
             fab_idx
-        })
-        .unwrap(); // We never use 0 as a fabric index, nor u8::MAX
+        })); // We never use 0 as a fabric index, nor u8::MAX
 
         self.fabrics.push_init(
             Fabric::init(fab_idx, key_pair)
@@ -505,7 +504,7 @@ impl FabricMgr {
             || ErrorCode::NoSpace.into(),
         )?;
 
-        let fabric = self.fabrics.last_mut().unwrap();
+        let fabric = unwrap!(self.fabrics.last_mut());
         self.changed = true;
 
         Ok(fabric)

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -37,6 +37,7 @@ use crate::utils::storage::{Vec, WriteBuf};
 const COMPRESSED_FABRIC_ID_LEN: usize = 8;
 
 #[derive(Debug, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(lifetime = "'a", start = 1)]
 pub struct FabricDescriptor<'a> {
     root_public_key: OctetStr<'a>,
@@ -51,6 +52,7 @@ pub struct FabricDescriptor<'a> {
 
 /// Fabric type
 #[derive(Debug, ToTLV, FromTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Fabric {
     /// Fabric local index
     fab_idx: NonZeroU8,

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -21,8 +21,6 @@ use core::num::NonZeroU8;
 
 use heapless::String;
 
-use log::{error, info};
-
 use crate::acl::{self, AccessReq, AclEntry, AuthMode};
 use crate::cert::{CertRef, MAX_CERT_TLV_LEN};
 use crate::crypto::{self, hkdf_sha256, HmacSha256, KeyPair};

--- a/rs-matter/src/fmt.rs
+++ b/rs-matter/src/fmt.rs
@@ -1,0 +1,291 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! A module that re-exports the `log` macros if `defmt` is not enabled, or `defmt` macros if `defmt` is enabled.
+//!
+//! The module also defines:
+//! - Custom versions of the core assert macros (`assert!`, `assert_eq!`, etc.) that use the `defmt` macros if the `defmt` feature is enabled.
+//! - Custom versions of the `panic!`, `todo!`, and `unreachable!` macros that use the `defmt` macros if the `defmt` feature is enabled.
+//! - A custom `unwrap!` macro that uses the `defmt` macros if the `defmt` feature is enabled, otherwise it uses the standard library's `unwrap` method.
+//! - A custom `Bytes` struct that formats byte slices as hex in a way compatible with `defmt`.
+#![macro_use]
+#![allow(unused)]
+
+use core::fmt::{Debug, Display, LowerHex};
+
+#[collapse_debuginfo(yes)]
+macro_rules! assert {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::assert!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::assert!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! assert_eq {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::assert_eq!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::assert_eq!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! assert_ne {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::assert_ne!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::assert_ne!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! debug_assert {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::debug_assert!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::debug_assert!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! debug_assert_eq {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::debug_assert_eq!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::debug_assert_eq!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! debug_assert_ne {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::debug_assert_ne!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::debug_assert_ne!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! todo {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::todo!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::todo!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! unreachable {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::unreachable!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::unreachable!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! panic {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::panic!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::panic!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! trace {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "log")]
+            ::log::trace!($s $(, $x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::trace!($s $(, $x)*);
+            #[cfg(not(any(feature = "log", feature="defmt")))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! debug {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "log")]
+            ::log::debug!($s $(, $x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::debug!($s $(, $x)*);
+            #[cfg(not(any(feature = "log", feature="defmt")))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! info {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "log")]
+            ::log::info!($s $(, $x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::info!($s $(, $x)*);
+            #[cfg(not(any(feature = "log", feature="defmt")))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! warn {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "log")]
+            ::log::warn!($s $(, $x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::warn!($s $(, $x)*);
+            #[cfg(not(any(feature = "log", feature="defmt")))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! error {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "log")]
+            ::log::error!($s $(, $x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::error!($s $(, $x)*);
+            #[cfg(not(any(feature = "log", feature="defmt")))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+#[cfg(feature = "defmt")]
+#[collapse_debuginfo(yes)]
+macro_rules! unwrap {
+    ($($x:tt)*) => {
+        ::defmt::unwrap!($($x)*)
+    };
+}
+
+#[cfg(not(feature = "defmt"))]
+#[collapse_debuginfo(yes)]
+macro_rules! unwrap {
+    ($arg:expr) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(e) => {
+                ::core::panic!("unwrap of `{}` failed: {:?}", ::core::stringify!($arg), e);
+            }
+        }
+    };
+    ($arg:expr, $($msg:expr),+ $(,)? ) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(e) => {
+                ::core::panic!("unwrap of `{}` failed: {}: {:?}", ::core::stringify!($arg), ::core::format_args!($($msg,)*), e);
+            }
+        }
+    }
+}
+
+#[cfg(feature = "defmt")]
+macro_rules! display2format {
+    ($arg:expr) => {
+        ::defmt::Display2Format(&$arg)
+    };
+}
+
+#[cfg(not(feature = "defmt"))]
+macro_rules! display2format {
+    ($arg:expr) => {
+        $arg
+    };
+}
+
+#[cfg(feature = "defmt")]
+macro_rules! debug2format {
+    ($arg:expr) => {
+        ::defmt::Debug2Format(&$arg)
+    };
+}
+
+#[cfg(not(feature = "defmt"))]
+macro_rules! debug2format {
+    ($arg:expr) => {
+        $arg
+    };
+}
+
+/// A way to `{:x?}` format a byte slice which is compatible with `defmt`
+pub(crate) struct Bytes<'a>(pub &'a [u8]);
+
+impl Debug for Bytes<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#02x?}", self.0)
+    }
+}
+
+impl Display for Bytes<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#02x?}", self.0)
+    }
+}
+
+impl LowerHex for Bytes<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#02x?}", self.0)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Bytes<'_> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{:02x}", self.0)
+    }
+}

--- a/rs-matter/src/group_keys.rs
+++ b/rs-matter/src/group_keys.rs
@@ -25,6 +25,7 @@ use crate::{
 type KeySetKey = [u8; SYMM_KEY_LEN_BYTES];
 
 #[derive(Debug, Default, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct KeySet {
     pub epoch_key: KeySetKey,
     pub op_key: KeySetKey,

--- a/rs-matter/src/interaction_model/core.rs
+++ b/rs-matter/src/interaction_model/core.rs
@@ -38,6 +38,7 @@ macro_rules! cmd_enter {
 }
 
 #[derive(FromPrimitive, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum IMStatusCode {
     Success = 0,
     Failure = 1,
@@ -110,6 +111,7 @@ impl ToTLV for IMStatusCode {
 }
 
 #[derive(FromPrimitive, Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum OpCode {
     Reserved = 0,
     StatusResponse = 1,
@@ -150,6 +152,7 @@ pub const PROTO_ID_INTERACTION_MODEL: u16 = 0x01;
 /// A wrapper enum for `ReadReq` and `SubscribeReq` that allows downstream code to
 /// treat the two in a unified manner with regards to `OpCode::ReportDataResp` type responses.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ReportDataReq<'a> {
     Read(&'a ReadReqRef<'a>),
     Subscribe(&'a SubscribeReqRef<'a>),

--- a/rs-matter/src/interaction_model/core.rs
+++ b/rs-matter/src/interaction_model/core.rs
@@ -192,9 +192,7 @@ impl StatusResp {
 
 impl TimedReq {
     pub fn timeout_instant(&self, epoch: Epoch) -> Duration {
-        epoch()
-            .checked_add(Duration::from_millis(self.timeout as _))
-            .unwrap()
+        unwrap!(epoch().checked_add(Duration::from_millis(self.timeout as _)))
     }
 }
 

--- a/rs-matter/src/interaction_model/core.rs
+++ b/rs-matter/src/interaction_model/core.rs
@@ -30,10 +30,19 @@ use super::messages::ib::{AttrPath, DataVersionFilter};
 use super::messages::msg::{ReadReqRef, StatusResp, SubscribeReqRef, SubscribeResp, TimedReq};
 
 #[macro_export]
+#[cfg(not(feature = "defmt"))]
 macro_rules! cmd_enter {
     ($e:expr) => {{
         use owo_colors::OwoColorize;
-        info! {"{} {}", "Handling command".cyan(), $e.cyan()}
+        info! {"Got CMD {}", $e.cyan()}
+    }};
+}
+
+#[macro_export]
+#[cfg(feature = "defmt")]
+macro_rules! cmd_enter {
+    ($e:expr) => {{
+        info!("Got CMD {}", $e);
     }};
 }
 

--- a/rs-matter/src/interaction_model/messages.rs
+++ b/rs-matter/src/interaction_model/messages.rs
@@ -143,7 +143,6 @@ pub mod msg {
     }
 
     impl fmt::Debug for SubscribeReqRef<'_> {
-        // TODO: defmt
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("SubscribeReqRef")
                 .field("keep_subs", &self.keep_subs())
@@ -155,6 +154,23 @@ pub mod msg {
                 .field("fabric_filtered", &self.fabric_filtered())
                 .field("dataver_filters", &self.dataver_filters())
                 .finish()
+        }
+    }
+
+    #[cfg(feature = "defmt")]
+    impl defmt::Format for SubscribeReqRef<'_> {
+        fn format(&self, f: defmt::Formatter<'_>) {
+            defmt::write!(f,
+                "SubscribeReqRef {{\n  keep_subs: {:?},\n  min_int_floor: {:?},\n  max_int_ceil: {:?},\n  attr_requests: {:?},\n  event_requests: {:?},\n  event_filters: {:?},\n  fabric_filtered: {:?},\n  dataver_filters: {:?},\n}}",
+                self.keep_subs(),
+                self.min_int_floor(),
+                self.max_int_ceil(),
+                self.attr_requests(),
+                self.event_requests(),
+                self.event_filters(),
+                self.fabric_filtered(),
+                self.dataver_filters(),
+            )
         }
     }
 
@@ -237,13 +253,24 @@ pub mod msg {
     }
 
     impl fmt::Debug for InvReqRef<'_> {
-        // TODO: defmt
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("InvReqRef")
                 .field("suppress_response", &self.suppress_response())
                 .field("timed_request", &self.timed_request())
                 .field("inv_requests", &self.inv_requests())
                 .finish()
+        }
+    }
+
+    #[cfg(feature = "defmt")]
+    impl defmt::Format for InvReqRef<'_> {
+        fn format(&self, f: defmt::Formatter<'_>) {
+            defmt::write!(f,
+                "InvReqRef {{\n  suppress_response: {:?},\n  timed_request: {:?},\n  inv_requests: {:?},\n}}",
+                self.suppress_response(),
+                self.timed_request(),
+                self.inv_requests(),
+            )
         }
     }
 
@@ -307,7 +334,6 @@ pub mod msg {
     }
 
     impl fmt::Debug for ReadReqRef<'_> {
-        // TODO: defmt
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("ReadReqRef")
                 .field("attr_requests", &self.attr_requests())
@@ -316,6 +342,20 @@ pub mod msg {
                 .field("fabric_filtered", &self.fabric_filtered())
                 .field("dataver_filters", &self.dataver_filters())
                 .finish()
+        }
+    }
+
+    #[cfg(feature = "defmt")]
+    impl defmt::Format for ReadReqRef<'_> {
+        fn format(&self, f: defmt::Formatter<'_>) {
+            defmt::write!(f,
+                "ReadReqRef {{\n  attr_requests: {:?},\n  event_requests: {:?},\n  event_filters: {:?},\n  fabric_filtered: {:?},\n  dataver_filters: {:?},\n}}",
+                self.attr_requests(),
+                self.event_requests(),
+                self.event_filters(),
+                self.fabric_filtered(),
+                self.dataver_filters(),
+            )
         }
     }
 
@@ -396,7 +436,6 @@ pub mod msg {
     }
 
     impl fmt::Debug for WriteReqRef<'_> {
-        // TODO: defmt
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("WriteReqRef")
                 .field("supress_response", &self.supress_response())
@@ -404,6 +443,19 @@ pub mod msg {
                 .field("write_requests", &self.write_requests())
                 .field("more_chunked", &self.more_chunked())
                 .finish()
+        }
+    }
+
+    #[cfg(feature = "defmt")]
+    impl defmt::Format for WriteReqRef<'_> {
+        fn format(&self, f: defmt::Formatter<'_>) {
+            defmt::write!(f,
+                "WriteReqRef {{\n  supress_response: {:?},\n  timed_request: {:?},\n  write_requests: {:?},\n  more_chunked: {:?},\n}}",
+                self.supress_response(),
+                self.timed_request(),
+                self.write_requests(),
+                self.more_chunked(),
+            )
         }
     }
 

--- a/rs-matter/src/interaction_model/messages.rs
+++ b/rs-matter/src/interaction_model/messages.rs
@@ -24,6 +24,7 @@ use crate::{
 // A generic path with endpoint, clusters, and a leaf
 // The leaf could be command, attribute, event
 #[derive(Default, Clone, Debug, PartialEq, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(datatype = "list")]
 pub struct GenericPath {
     pub endpoint: Option<EndptId>,
@@ -84,6 +85,7 @@ pub mod msg {
     };
 
     #[derive(Debug, Default, Clone, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub struct SubscribeReq<'a> {
         pub keep_subs: bool,
@@ -141,6 +143,7 @@ pub mod msg {
     }
 
     impl fmt::Debug for SubscribeReqRef<'_> {
+        // TODO: defmt
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("SubscribeReqRef")
                 .field("keep_subs", &self.keep_subs())
@@ -156,6 +159,7 @@ pub mod msg {
     }
 
     #[derive(Debug, Default, Clone, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct SubscribeResp {
         pub subs_id: u32,
         // The Context Tags are discontiguous for some reason
@@ -174,11 +178,13 @@ pub mod msg {
     }
 
     #[derive(Debug, Clone, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct TimedReq {
         pub timeout: u16,
     }
 
     #[derive(Debug, Clone, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct StatusResp {
         pub status: IMStatusCode,
     }
@@ -190,6 +196,7 @@ pub mod msg {
     }
 
     #[derive(Debug, Default, Clone, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub struct InvReq<'a> {
         pub suppress_response: Option<bool>,
@@ -230,6 +237,7 @@ pub mod msg {
     }
 
     impl fmt::Debug for InvReqRef<'_> {
+        // TODO: defmt
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("InvReqRef")
                 .field("suppress_response", &self.suppress_response())
@@ -240,6 +248,7 @@ pub mod msg {
     }
 
     #[derive(FromTLV, ToTLV, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub struct InvResp<'a> {
         pub suppress_response: Option<bool>,
@@ -249,6 +258,7 @@ pub mod msg {
     // This enum is helpful when we are constructing the response
     // step by step in incremental manner
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[repr(u8)]
     pub enum InvRespTag {
         SupressResponse = 0,
@@ -256,6 +266,7 @@ pub mod msg {
     }
 
     #[derive(Debug, Default, Clone, ToTLV, FromTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub struct ReadReq<'a> {
         pub attr_requests: Option<TLVArray<'a, AttrPath>>,
@@ -296,6 +307,7 @@ pub mod msg {
     }
 
     impl fmt::Debug for ReadReqRef<'_> {
+        // TODO: defmt
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("ReadReqRef")
                 .field("attr_requests", &self.attr_requests())
@@ -310,6 +322,7 @@ pub mod msg {
     // This enum is helpful when we are constructing the request
     // step by step in incremental manner
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[repr(u8)]
     pub enum ReadReqTag {
         AttrRequests = 0,
@@ -320,6 +333,7 @@ pub mod msg {
     }
 
     #[derive(Debug, Clone, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub struct WriteReq<'a> {
         pub supress_response: Option<bool>,
@@ -331,6 +345,7 @@ pub mod msg {
     // This enum is helpful when we are constructing the request
     // step by step in incremental manner
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[repr(u8)]
     pub enum WriteReqTag {
         SuppressResponse = 0,
@@ -381,6 +396,7 @@ pub mod msg {
     }
 
     impl fmt::Debug for WriteReqRef<'_> {
+        // TODO: defmt
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("WriteReqRef")
                 .field("supress_response", &self.supress_response())
@@ -393,6 +409,7 @@ pub mod msg {
 
     // Report Data
     #[derive(FromTLV, ToTLV, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub struct ReportDataMsg<'a> {
         pub subscription_id: Option<u32>,
@@ -413,6 +430,7 @@ pub mod msg {
 
     // Write Response
     #[derive(ToTLV, FromTLV, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub struct WriteResp<'a> {
         pub write_responses: TLVArray<'a, AttrStatus>,
@@ -438,6 +456,7 @@ pub mod ib {
 
     // Command Response
     #[derive(Clone, FromTLV, ToTLV, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub enum CmdResp<'a> {
         Cmd(CmdData<'a>),
@@ -471,6 +490,7 @@ pub mod ib {
     }
 
     #[derive(FromTLV, ToTLV, Clone, PartialEq, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct CmdStatus {
         path: CmdPath,
         status: Status,
@@ -489,6 +509,7 @@ pub mod ib {
     }
 
     #[derive(Debug, Clone, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub struct CmdData<'a> {
         pub path: CmdPath,
@@ -508,6 +529,7 @@ pub mod ib {
 
     // Status
     #[derive(Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct Status {
         pub status: IMStatusCode,
         pub cluster_status: u16,
@@ -524,6 +546,7 @@ pub mod ib {
 
     // Attribute Response
     #[derive(Clone, FromTLV, ToTLV, PartialEq, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub enum AttrResp<'a> {
         Status(AttrStatus),
@@ -560,6 +583,7 @@ pub mod ib {
 
     // Attribute Data
     #[derive(Debug, Clone, PartialEq, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     pub struct AttrData<'a> {
         pub data_ver: Option<u32>,
@@ -584,6 +608,7 @@ pub mod ib {
     }
 
     #[derive(Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     /// Operations on an Interaction Model List
     pub enum ListOperation {
         /// Add (append) an item to the list
@@ -627,6 +652,7 @@ pub mod ib {
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct AttrStatus {
         path: AttrPath,
         status: Status,
@@ -643,6 +669,7 @@ pub mod ib {
 
     // Attribute Path
     #[derive(Default, Clone, Debug, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(datatype = "list")]
     pub struct AttrPath {
         pub tag_compression: Option<bool>,
@@ -676,6 +703,7 @@ pub mod ib {
 
     // Command Path
     #[derive(Default, Debug, Clone, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct CmdPath {
         pub path: GenericPath,
     }
@@ -736,6 +764,7 @@ pub mod ib {
     }
 
     #[derive(FromTLV, ToTLV, Clone, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct ClusterPath {
         pub node: Option<u64>,
         pub endpoint: EndptId,
@@ -743,12 +772,14 @@ pub mod ib {
     }
 
     #[derive(FromTLV, ToTLV, Clone, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct DataVersionFilter {
         pub path: ClusterPath,
         pub data_ver: u32,
     }
 
     #[derive(FromTLV, ToTLV, Clone, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(datatype = "list")]
     pub struct EventPath {
         pub node: Option<u64>,
@@ -759,6 +790,7 @@ pub mod ib {
     }
 
     #[derive(FromTLV, ToTLV, Clone, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct EventFilter {
         pub node: Option<u64>,
         pub event_min: Option<u64>,

--- a/rs-matter/src/interaction_model/messages.rs
+++ b/rs-matter/src/interaction_model/messages.rs
@@ -450,7 +450,6 @@ pub mod ib {
         interaction_model::core::IMStatusCode,
         tlv::{FromTLV, Nullable, TLVElement, TLVTag, TLVWrite, ToTLV, TLV},
     };
-    use log::error;
 
     use super::GenericPath;
 

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -73,6 +73,9 @@
 #![allow(async_fn_in_trait)]
 #![recursion_limit = "256"]
 
+// This mod MUST go first, so that the others see its macros.
+pub(crate) mod fmt;
+
 pub mod acl;
 pub mod cert;
 pub mod codec;

--- a/rs-matter/src/mdns.rs
+++ b/rs-matter/src/mdns.rs
@@ -17,8 +17,6 @@
 
 use core::fmt::Write;
 
-use log::info;
-
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
 use crate::error::Error;
 use crate::utils::init::{init, Init};
@@ -158,7 +156,7 @@ impl Mdns for MdnsImpl<'_> {
 
         // Do not remove this logging line or change its formatting.
         // C++ E2E tests rely on this log line to determine when the mDNS service is published
-        info!("mDNS service published: {service}::{mode:?}");
+        info!("mDNS service published: {}::{:?}", service, mode);
 
         Ok(())
     }
@@ -170,7 +168,7 @@ impl Mdns for MdnsImpl<'_> {
             MdnsService::Provided(mdns) => mdns.remove(service),
         }?;
 
-        info!("mDNS service removed: {service}");
+        info!("mDNS service removed: {}", service);
 
         Ok(())
     }

--- a/rs-matter/src/mdns.rs
+++ b/rs-matter/src/mdns.rs
@@ -186,6 +186,7 @@ pub struct Service<'a> {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ServiceMode {
     /// The commissioned state
     Commissioned,

--- a/rs-matter/src/mdns.rs
+++ b/rs-matter/src/mdns.rs
@@ -214,10 +214,10 @@ impl ServiceMode {
                 let vp = Self::get_vp(dev_att.vid, dev_att.pid);
 
                 let mut sai_str = heapless::String::<5>::new();
-                write!(sai_str, "{}", dev_att.sai.unwrap_or(300)).unwrap();
+                write_unwrap!(sai_str, "{}", dev_att.sai.unwrap_or(300));
 
                 let mut sii_str = heapless::String::<5>::new();
-                write!(sii_str, "{}", dev_att.sii.unwrap_or(5000)).unwrap();
+                write_unwrap!(sii_str, "{}", dev_att.sii.unwrap_or(5000));
 
                 let txt_kvs = &[
                     ("D", discriminator_str.as_str()),
@@ -248,7 +248,7 @@ impl ServiceMode {
 
     fn get_long_service_subtype(discriminator: u16) -> heapless::String<32> {
         let mut serv_type = heapless::String::new();
-        write!(&mut serv_type, "_L{}", discriminator).unwrap();
+        write_unwrap!(&mut serv_type, "_L{}", discriminator);
 
         serv_type
     }
@@ -257,19 +257,19 @@ impl ServiceMode {
         let short = Self::compute_short_discriminator(discriminator);
 
         let mut serv_type = heapless::String::new();
-        write!(&mut serv_type, "_S{}", short).unwrap();
+        write_unwrap!(&mut serv_type, "_S{}", short);
 
         serv_type
     }
 
     fn get_discriminator_str(discriminator: u16) -> heapless::String<5> {
-        discriminator.try_into().unwrap()
+        unwrap!(discriminator.try_into())
     }
 
     fn get_vp(vid: u16, pid: u16) -> heapless::String<11> {
         let mut vp = heapless::String::new();
 
-        write!(&mut vp, "{}+{}", vid, pid).unwrap();
+        write_unwrap!(&mut vp, "{}+{}", vid, pid);
 
         vp
     }

--- a/rs-matter/src/mdns/astro.rs
+++ b/rs-matter/src/mdns/astro.rs
@@ -2,8 +2,6 @@ use std::collections::BTreeMap;
 
 use astro_dnssd::{DNSServiceBuilder, RegisteredDnsService};
 
-use crate::info;
-
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
 use crate::error::{Error, ErrorCode};
 use crate::utils::cell::RefCell;

--- a/rs-matter/src/mdns/astro.rs
+++ b/rs-matter/src/mdns/astro.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use astro_dnssd::{DNSServiceBuilder, RegisteredDnsService};
 
-use log::info;
+use crate::info;
 
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
 use crate::error::{Error, ErrorCode};

--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -72,7 +72,7 @@ impl<'a> MdnsImpl<'a> {
 
         services.retain(|(name, _)| name != service);
         services
-            .push((service.try_into().unwrap(), mode))
+            .push((unwrap!(service.try_into()), mode))
             .map_err(|_| ErrorCode::NoSpace)?;
 
         self.notification.notify();

--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -180,7 +180,7 @@ impl<'a> MdnsImpl<'a> {
                 let len = host.broadcast(self, &mut buf, 60)?;
 
                 if len > 0 {
-                    info!("Broadcasting mDNS entry to {}", display2format!(addr));
+                    info!("Broadcasting mDNS entry to {}", addr);
                     send.send_to(&buf[..len], Address::Udp(addr)).await?;
                 }
             }
@@ -254,22 +254,16 @@ impl<'a> MdnsImpl<'a> {
 
                             info!(
                                 "Replying to mDNS query from {} on {}, delay {}ms",
-                                display2format!(addr),
-                                display2format!(reply_addr),
-                                delay_ms
+                                addr, reply_addr, delay_ms
                             );
                             Timer::after(Duration::from_millis(delay_ms as _)).await;
                         } else {
-                            info!(
-                                "Replying to mDNS query from {} on {}",
-                                display2format!(addr),
-                                display2format!(reply_addr)
-                            );
+                            info!("Replying to mDNS query from {} on {}", addr, reply_addr);
                         }
 
                         send.send_to(&tx[..len], Address::Udp(reply_addr)).await?;
                     } else {
-                        info!("Cannot reply to mDNS query from {}: no suitable broadcast address found", display2format!(addr));
+                        info!("Cannot reply to mDNS query from {}: no suitable broadcast address found", addr);
                     }
                 }
             }

--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -180,7 +180,7 @@ impl<'a> MdnsImpl<'a> {
                 let len = host.broadcast(self, &mut buf, 60)?;
 
                 if len > 0 {
-                    info!("Broadcasting mDNS entry to {}", addr);
+                    info!("Broadcasting mDNS entry to {}", display2format!(addr));
                     send.send_to(&buf[..len], Address::Udp(addr)).await?;
                 }
             }
@@ -254,16 +254,22 @@ impl<'a> MdnsImpl<'a> {
 
                             info!(
                                 "Replying to mDNS query from {} on {}, delay {}ms",
-                                addr, reply_addr, delay_ms
+                                display2format!(addr),
+                                display2format!(reply_addr),
+                                delay_ms
                             );
                             Timer::after(Duration::from_millis(delay_ms as _)).await;
                         } else {
-                            info!("Replying to mDNS query from {} on {}", addr, reply_addr);
+                            info!(
+                                "Replying to mDNS query from {} on {}",
+                                display2format!(addr),
+                                display2format!(reply_addr)
+                            );
                         }
 
                         send.send_to(&tx[..len], Address::Udp(reply_addr)).await?;
                     } else {
-                        info!("Cannot reply to mDNS query from {}: no suitable broadcast address found", addr);
+                        info!("Cannot reply to mDNS query from {}: no suitable broadcast address found", display2format!(addr));
                     }
                 }
             }

--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -6,8 +6,6 @@ use embassy_sync::blocking_mutex::raw::{NoopRawMutex, RawMutex};
 use embassy_sync::mutex::Mutex;
 use embassy_time::{Duration, Timer};
 
-use log::{info, warn};
-
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
 use crate::error::{Error, ErrorCode};
 use crate::transport::network::{
@@ -182,7 +180,7 @@ impl<'a> MdnsImpl<'a> {
                 let len = host.broadcast(self, &mut buf, 60)?;
 
                 if len > 0 {
-                    info!("Broadcasting mDNS entry to {addr}");
+                    info!("Broadcasting mDNS entry to {}", addr);
                     send.send_to(&buf[..len], Address::Udp(addr)).await?;
                 }
             }
@@ -220,7 +218,7 @@ impl<'a> MdnsImpl<'a> {
                 let (len, delay) = match host.respond(self, &rx[..len], &mut tx, 60) {
                     Ok((len, delay)) => (len, delay),
                     Err(err) => {
-                        warn!("mDNS protocol error {err} while replying to {addr}");
+                        warn!("mDNS protocol error {} while replying to {}", err, addr);
                         continue;
                     }
                 };
@@ -254,15 +252,18 @@ impl<'a> MdnsImpl<'a> {
                             // Generate a delay between 20 and 120 ms, as per spec
                             let delay_ms = 20 + (b[0] as u32 * 100 / 256);
 
-                            info!("Replying to mDNS query from {addr} on {reply_addr}, delay {delay_ms}ms");
+                            info!(
+                                "Replying to mDNS query from {} on {}, delay {}ms",
+                                addr, reply_addr, delay_ms
+                            );
                             Timer::after(Duration::from_millis(delay_ms as _)).await;
                         } else {
-                            info!("Replying to mDNS query from {addr} on {reply_addr}");
+                            info!("Replying to mDNS query from {} on {}", addr, reply_addr);
                         }
 
                         send.send_to(&tx[..len], Address::Udp(reply_addr)).await?;
                     } else {
-                        info!("Cannot reply to mDNS query from {addr}: no suitable broadcast address found");
+                        info!("Cannot reply to mDNS query from {}: no suitable broadcast address found", addr);
                     }
                 }
             }

--- a/rs-matter/src/mdns/proto.rs
+++ b/rs-matter/src/mdns/proto.rs
@@ -1,8 +1,6 @@
 use core::fmt::Write;
 use core::net::{Ipv4Addr, Ipv6Addr};
 
-use bitflags::bitflags;
-
 use domain::base::header::Flags;
 use domain::base::iana::{Class, Opcode, Rcode};
 use domain::base::message::ShortMessage;
@@ -17,6 +15,7 @@ use domain::rdata::{Aaaa, Ptr, Srv, Txt, A};
 use log::trace;
 
 use crate::error::{Error, ErrorCode};
+use crate::utils::bitflags::bitflags;
 
 use super::Service;
 
@@ -90,7 +89,7 @@ where
 // What additional data to be set in the mDNS reply
 bitflags! {
     #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Default)]
     pub struct AdditionalData: u8 {
         const IPS = 0x01;
         const SRV = 0x02;
@@ -938,8 +937,10 @@ mod tests {
     }
 
     #[derive(Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     struct Question<'a> {
         name: &'a str,
+        #[cfg_attr(feature = "defmt", defmt(Display2Format))]
         qtype: Rtype,
     }
 
@@ -973,15 +974,17 @@ mod tests {
     }
 
     #[derive(Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     enum AnswerDetails<'a> {
-        A(Ipv4Addr),
-        Aaaa(Ipv6Addr),
+        A(#[cfg_attr(feature = "defmt", defmt(Display2Format))] Ipv4Addr),
+        Aaaa(#[cfg_attr(feature = "defmt", defmt(Display2Format))] Ipv6Addr),
         Srv { port: u16, target: &'a str },
         Ptr(&'a str),
         Txt(&'a [(&'a str, &'a str)]),
     }
 
     #[derive(Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     struct Answer<'a> {
         owner: &'a str,
         details: AnswerDetails<'a>,

--- a/rs-matter/src/mdns/proto.rs
+++ b/rs-matter/src/mdns/proto.rs
@@ -1010,8 +1010,8 @@ mod tests {
     #[derive(Debug)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     enum AnswerDetails<'a> {
-        A(#[cfg_attr(feature = "defmt", defmt(Display2Format))] Ipv4Addr),
-        Aaaa(#[cfg_attr(feature = "defmt", defmt(Display2Format))] Ipv6Addr),
+        A(Ipv4Addr),
+        Aaaa(Ipv6Addr),
         Srv { port: u16, target: &'a str },
         Ptr(&'a str),
         Txt(&'a [(&'a str, &'a str)]),

--- a/rs-matter/src/mdns/proto.rs
+++ b/rs-matter/src/mdns/proto.rs
@@ -211,7 +211,7 @@ impl Host<'_> {
         let mut replied = false;
 
         for question in message.question() {
-            trace!("Handling question {:?}", question);
+            trace!("Handling question {:?}", debug2format!(question));
 
             let question = question?;
 

--- a/rs-matter/src/mdns/zeroconf.rs
+++ b/rs-matter/src/mdns/zeroconf.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeMap;
 use std::sync::mpsc::{sync_channel, SyncSender};
 
-use crate::error;
-
 use zeroconf::{prelude::TEventLoop, service::TMdnsService, txt_record::TTxtRecord, ServiceType};
 
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
@@ -17,7 +15,7 @@ struct MdnsEntry(SyncSender<()>);
 impl Drop for MdnsEntry {
     fn drop(&mut self) {
         if let Err(e) = self.0.send(()) {
-            error!("Deregistering mDNS entry failed: {e}");
+            error!("Deregistering mDNS entry failed: {}", debug2format!(e));
         }
     }
 }
@@ -52,7 +50,7 @@ impl<'a> MdnsImpl<'a> {
     pub fn add(&self, name: &str, mode: ServiceMode) -> Result<(), Error> {
         let _ = self.remove(name);
 
-        log::info!("Registering mDNS service {}/{:?}", name, mode);
+        info!("Registering mDNS service {}/{:?}", name, mode);
 
         mode.service(self.dev_det, self.matter_port, name, |service| {
             let service_name = service.service.strip_prefix('_').unwrap_or(service.service);
@@ -73,7 +71,7 @@ impl<'a> MdnsImpl<'a> {
                 ServiceType::new(service_name, protocol)
             }
             .map_err(|err| {
-                log::error!(
+                error!(
                     "Encountered error building service type: {}",
                     err.to_string()
                 );
@@ -95,9 +93,9 @@ impl<'a> MdnsImpl<'a> {
 
                 let mut txt_record = zeroconf::TxtRecord::new();
                 for (k, v) in txt_kvs {
-                    log::info!("mDNS TXT key {k} val {v}");
+                    info!("mDNS TXT key {} val {}", k, v);
                     if let Err(err) = txt_record.insert(&k, &v) {
-                        log::error!(
+                        error!(
                             "Encountered error inserting kv-pair into txt record {}",
                             err.to_string()
                         );
@@ -113,14 +111,14 @@ impl<'a> MdnsImpl<'a> {
                             break;
                         }
                         if let Err(err) = event_loop.poll(std::time::Duration::from_secs(1)) {
-                            log::error!(
+                            error!(
                                 "Failed to poll mDNS service event loop: {}",
                                 err.to_string()
                             );
                             break;
                         }
                     },
-                    Err(err) => log::error!(
+                    Err(err) => error!(
                         "Encountered error registering mDNS service: {}",
                         err.to_string()
                     ),
@@ -137,7 +135,7 @@ impl<'a> MdnsImpl<'a> {
 
     pub fn remove(&self, name: &str) -> Result<(), Error> {
         if self.services.borrow_mut().remove(name).is_some() {
-            log::info!("Deregistering mDNS service {}", name);
+            info!("Deregistering mDNS service {}", name);
         }
 
         Ok(())

--- a/rs-matter/src/mdns/zeroconf.rs
+++ b/rs-matter/src/mdns/zeroconf.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::mpsc::{sync_channel, SyncSender};
 
-use log::error;
+use crate::error;
 
 use zeroconf::{prelude::TEventLoop, service::TMdnsService, txt_record::TTxtRecord, ServiceType};
 

--- a/rs-matter/src/pairing/code.rs
+++ b/rs-matter/src/pairing/code.rs
@@ -32,23 +32,21 @@ pub fn compute_pairing_code(comm_data: &BasicCommData) -> heapless::String<32> {
     } = comm_data;
 
     let mut digits = heapless::String::<32>::new();
-    write!(
+    write_unwrap!(
         &mut digits,
         "{}{:0>5}{:0>4}",
         (VID_PID_PRESENT << 2) | (discriminator >> 10) as u8,
         ((discriminator & 0x300) << 6) | (*password & 0x3FFF) as u16,
         *password >> 14
-    )
-    .unwrap();
+    );
 
     let mut final_digits = heapless::String::<32>::new();
-    write!(
+    write_unwrap!(
         &mut final_digits,
         "{}{}",
         digits,
         digits.calculate_verhoeff_check_digit()
-    )
-    .unwrap();
+    );
 
     final_digits
 }
@@ -56,11 +54,11 @@ pub fn compute_pairing_code(comm_data: &BasicCommData) -> heapless::String<32> {
 pub(super) fn pretty_print_pairing_code(pairing_code: &str) {
     assert!(pairing_code.len() == 11);
     let mut pretty = heapless::String::<32>::new();
-    pretty.push_str(&pairing_code[..4]).unwrap();
-    pretty.push('-').unwrap();
-    pretty.push_str(&pairing_code[4..8]).unwrap();
-    pretty.push('-').unwrap();
-    pretty.push_str(&pairing_code[8..]).unwrap();
+    unwrap!(pretty.push_str(&pairing_code[..4]));
+    unwrap!(pretty.push('-'));
+    unwrap!(pretty.push_str(&pairing_code[4..8]));
+    unwrap!(pretty.push('-'));
+    unwrap!(pretty.push_str(&pairing_code[8..]));
     info!("Pairing Code: {}", pretty);
 }
 

--- a/rs-matter/src/pairing/code.rs
+++ b/rs-matter/src/pairing/code.rs
@@ -17,7 +17,9 @@
 
 use core::fmt::Write;
 
-use super::*;
+use verhoeff::Verhoeff;
+
+use crate::BasicCommData;
 
 pub fn compute_pairing_code(comm_data: &BasicCommData) -> heapless::String<32> {
     // 0: no Vendor ID and Product ID present in Manual Pairing Code

--- a/rs-matter/src/pairing/mod.rs
+++ b/rs-matter/src/pairing/mod.rs
@@ -17,8 +17,6 @@
 
 //! This module contains the logic for generating the pairing code and the QR code for easy pairing.
 
-use bitflags::bitflags;
-
 use log::info;
 
 use qr::no_optional_data;
@@ -27,6 +25,7 @@ use verhoeff::Verhoeff;
 
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
 use crate::error::Error;
+use crate::utils::bitflags::bitflags;
 use crate::BasicCommData;
 
 use self::code::{compute_pairing_code, pretty_print_pairing_code};
@@ -38,7 +37,6 @@ pub mod vendor_identifiers;
 
 bitflags! {
     #[repr(transparent)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct DiscoveryCapabilities: u8 {
         const SOFT_AP = 0x01;
         const BLE = 0x02;

--- a/rs-matter/src/pairing/mod.rs
+++ b/rs-matter/src/pairing/mod.rs
@@ -17,11 +17,7 @@
 
 //! This module contains the logic for generating the pairing code and the QR code for easy pairing.
 
-use log::info;
-
 use qr::no_optional_data;
-
-use verhoeff::Verhoeff;
 
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
 use crate::error::Error;
@@ -37,6 +33,7 @@ pub mod vendor_identifiers;
 
 bitflags! {
     #[repr(transparent)]
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
     pub struct DiscoveryCapabilities: u8 {
         const SOFT_AP = 0x01;
         const BLE = 0x02;

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -329,6 +329,7 @@ pub fn print_qr_code(qr_code_text: &str, buf: &mut [u8]) -> Result<(), Error> {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TextImage {
     Ascii,
     Ansi,

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -561,10 +561,7 @@ mod tests {
         let qr_code_data =
             QrSetupPayload::<NoOptionalData>::new(&dev_det, &comm_data, disc_cap, no_optional_data);
         let mut buf = [0; 1024];
-        let data_str = qr_code_data
-            .try_as_str(&mut buf)
-            .expect("Failed to encode")
-            .0;
+        let data_str = unwrap!(qr_code_data.try_as_str(&mut buf), "Failed to encode").0;
         assert_eq!(data_str, QR_CODE)
     }
 
@@ -587,10 +584,7 @@ mod tests {
         let qr_code_data =
             QrSetupPayload::<NoOptionalData>::new(&dev_det, &comm_data, disc_cap, no_optional_data);
         let mut buf = [0; 1024];
-        let data_str = qr_code_data
-            .try_as_str(&mut buf)
-            .expect("Failed to encode")
-            .0;
+        let data_str = unwrap!(qr_code_data.try_as_str(&mut buf), "Failed to encode").0;
         assert_eq!(data_str, QR_CODE)
     }
 
@@ -635,10 +629,7 @@ mod tests {
         let qr_code_data = QrSetupPayload::new(&dev_det, &comm_data, disc_cap, optional_data);
 
         let mut buf = [0; 1024];
-        let data_str = qr_code_data
-            .try_as_str(&mut buf)
-            .expect("Failed to encode")
-            .0;
+        let data_str = unwrap!(qr_code_data.try_as_str(&mut buf), "Failed to encode").0;
         assert_eq!(data_str, QR_CODE)
     }
 }

--- a/rs-matter/src/persist.rs
+++ b/rs-matter/src/persist.rs
@@ -25,8 +25,6 @@ pub mod fileio {
     use std::io::{Read, Write};
     use std::path::Path;
 
-    use log::info;
-
     use crate::error::{Error, ErrorCode};
     use crate::utils::init::{init, Init};
     use crate::Matter;

--- a/rs-matter/src/respond.rs
+++ b/rs-matter/src/respond.rs
@@ -156,10 +156,7 @@ where
         );
 
         for handler_id in 0..N {
-            handlers
-                .push(self.handle(handler_id))
-                .map_err(|_| ())
-                .unwrap(); // Cannot fail because the vector has size N
+            unwrap!(handlers.push(self.handle(handler_id)).map_err(|_| ())); // Cannot fail because the vector has size N
         }
 
         select_slice(&mut handlers).await.0

--- a/rs-matter/src/respond.rs
+++ b/rs-matter/src/respond.rs
@@ -20,8 +20,6 @@ use core::pin::pin;
 
 use embassy_futures::select::{select3, select_slice};
 
-use log::{error, info};
-
 use crate::data_model::core::{DataModel, IMBuffer};
 use crate::data_model::objects::DataModelHandler;
 use crate::data_model::subscriptions::Subscriptions;
@@ -148,7 +146,7 @@ where
 
     /// Run the responder with a given number of handlers.
     pub async fn run<const N: usize>(&self) -> Result<(), Error> {
-        info!("{}: Creating {N} handlers", self.name);
+        info!("{}: Creating {} handlers", self.name, N);
 
         let mut handlers = heapless::Vec::<_, N>::new();
         info!(
@@ -181,26 +179,44 @@ where
     pub async fn respond_once(&self, handler_id: impl Display) -> Result<(), Error> {
         let mut exchange = Exchange::accept_after(self.matter, self.respond_after_ms).await?;
 
-        ::log::log!(
-            self.log_level(),
-            "{}: Handler {handler_id} / exchange {}: Starting",
-            self.name,
-            exchange.id()
-        );
+        if self.log_warn() {
+            warn!(
+                "{}: Handler {} / exchange {}: Starting",
+                self.name,
+                display2format!(&handler_id),
+                exchange.id()
+            );
+        } else {
+            info!(
+                "{}: Handler {} / exchange {}: Starting",
+                self.name,
+                display2format!(&handler_id),
+                exchange.id()
+            );
+        }
 
         let result = self.handler.handle(&mut exchange).await;
 
         if let Err(err) = &result {
             error!(
-                "{}: Handler {handler_id} / exchange {}: Abandoned because of error {err:?}",
+                "{}: Handler {} / exchange {}: Abandoned because of error {:?}",
                 self.name,
+                display2format!(&handler_id),
+                exchange.id(),
+                err
+            );
+        } else if self.log_warn() {
+            warn!(
+                "{}: Handler {} / exchange {}: Completed",
+                self.name,
+                display2format!(&handler_id),
                 exchange.id()
             );
         } else {
-            ::log::log!(
-                self.log_level(),
-                "{}: Handler {handler_id} / exchange {}: Completed",
+            info!(
+                "{}: Handler {} / exchange {}: Completed",
                 self.name,
+                display2format!(&handler_id),
                 exchange.id()
             );
         }
@@ -208,12 +224,8 @@ where
         result
     }
 
-    fn log_level(&self) -> log::Level {
-        if self.respond_after_ms > 0 {
-            log::Level::Warn
-        } else {
-            log::Level::Info
-        }
+    fn log_warn(&self) -> bool {
+        self.respond_after_ms > 0
     }
 }
 

--- a/rs-matter/src/secure_channel/busy.rs
+++ b/rs-matter/src/secure_channel/busy.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use log::error;
-
 use crate::error::*;
 use crate::respond::ExchangeHandler;
 use crate::transport::exchange::Exchange;

--- a/rs-matter/src/secure_channel/case.rs
+++ b/rs-matter/src/secure_channel/case.rs
@@ -167,18 +167,14 @@ impl Case {
                     // Only now do we add this message to the TT Hash
                     let mut peer_catids: NocCatIds = Default::default();
                     initiator_noc.get_cat_ids(&mut peer_catids)?;
-                    case_session
-                        .tt_hash
-                        .as_mut()
-                        .unwrap()
-                        .update(exchange.rx()?.payload())?;
+                    unwrap!(case_session.tt_hash.as_mut()).update(exchange.rx()?.payload())?;
 
                     let mut session_keys =
                         MaybeUninit::<[u8; 3 * crypto::SYMM_KEY_LEN_BYTES]>::uninit(); // TODO MEDIM BUFFER
                     let session_keys = session_keys.init_zeroed();
                     Case::get_session_keys(
                         fabric.ipk().op_key(),
-                        case_session.tt_hash.as_ref().unwrap(),
+                        unwrap!(case_session.tt_hash.as_ref()),
                         &case_session.shared_secret,
                         session_keys,
                     )?;
@@ -193,7 +189,7 @@ impl Case {
                         peer_addr,
                         SessionMode::Case {
                             // Unwrapping is safe, because if the fabric index was 0, we would not be in here
-                            fab_idx: NonZeroU8::new(case_session.local_fabric_idx).unwrap(),
+                            fab_idx: unwrap!(NonZeroU8::new(case_session.local_fabric_idx)),
                             cat_ids: peer_catids,
                         },
                         Some(&session_keys[0..16]),
@@ -252,12 +248,8 @@ impl Case {
         case_session.peer_sessid = r.initiator_sessid;
         case_session.local_sessid = local_sessid;
         case_session.tt_hash = Some(Sha256::new()?);
-        case_session
-            .tt_hash
-            .as_mut()
-            .unwrap()
-            .update(exchange.rx()?.payload())?;
-        case_session.local_fabric_idx = local_fabric_idx.unwrap().get();
+        unwrap!(case_session.tt_hash.as_mut()).update(exchange.rx()?.payload())?;
+        case_session.local_fabric_idx = unwrap!(local_fabric_idx).get();
         if r.peer_pub_key.0.len() != crypto::EC_POINT_LEN_BYTES {
             error!("Invalid public key length");
             Err(ErrorCode::Invalid)?;
@@ -330,11 +322,7 @@ impl Case {
                 tw.end_container()?;
 
                 if !hash_updated {
-                    case_session
-                        .tt_hash
-                        .as_mut()
-                        .unwrap()
-                        .update(tw.as_slice())?;
+                    unwrap!(case_session.tt_hash.as_mut()).update(tw.as_slice())?;
                     hash_updated = true;
                 }
 
@@ -408,11 +396,11 @@ impl Case {
             Err(ErrorCode::NoSpace)?;
         }
         let mut salt = heapless::Vec::<u8, 256>::new();
-        salt.extend_from_slice(ipk).unwrap();
+        unwrap!(salt.extend_from_slice(ipk));
         let tt = tt.clone();
         let mut tt_hash = [0u8; crypto::SHA256_HASH_LEN_BYTES];
         tt.finish(&mut tt_hash)?;
-        salt.extend_from_slice(&tt_hash).unwrap();
+        unwrap!(salt.extend_from_slice(&tt_hash));
         //        println!("Session Key: salt: {:x?}, len: {}", salt, salt.len());
 
         crypto::hkdf_sha256(salt.as_slice(), shared_secret, &SEKEYS_INFO, key)
@@ -430,7 +418,7 @@ impl Case {
         let mut sigma3_key = [0_u8; crypto::SYMM_KEY_LEN_BYTES];
         Case::get_sigma3_key(
             ipk,
-            case_session.tt_hash.as_ref().unwrap(),
+            unwrap!(case_session.tt_hash.as_ref()),
             &case_session.shared_secret,
             &mut sigma3_key,
         )?;
@@ -456,13 +444,13 @@ impl Case {
             Err(ErrorCode::NoSpace)?;
         }
         let mut salt = heapless::Vec::<u8, 256>::new();
-        salt.extend_from_slice(ipk).unwrap();
+        unwrap!(salt.extend_from_slice(ipk));
 
         let tt = tt.clone();
 
         let mut tt_hash = [0u8; crypto::SHA256_HASH_LEN_BYTES];
         tt.finish(&mut tt_hash)?;
-        salt.extend_from_slice(&tt_hash).unwrap();
+        unwrap!(salt.extend_from_slice(&tt_hash));
         //        println!("Sigma3Key: salt: {:x?}, len: {}", salt, salt.len());
 
         crypto::hkdf_sha256(salt.as_slice(), shared_secret, &S3K_INFO, key)
@@ -483,15 +471,15 @@ impl Case {
             Err(ErrorCode::NoSpace)?;
         }
         let mut salt = heapless::Vec::<u8, 256>::new();
-        salt.extend_from_slice(ipk).unwrap();
-        salt.extend_from_slice(our_random).unwrap();
-        salt.extend_from_slice(&case_session.our_pub_key).unwrap();
+        unwrap!(salt.extend_from_slice(ipk));
+        unwrap!(salt.extend_from_slice(our_random));
+        unwrap!(salt.extend_from_slice(&case_session.our_pub_key));
 
-        let tt = case_session.tt_hash.as_ref().unwrap().clone();
+        let tt = unwrap!(case_session.tt_hash.as_ref()).clone();
 
         let mut tt_hash = [0u8; crypto::SHA256_HASH_LEN_BYTES];
         tt.finish(&mut tt_hash)?;
-        salt.extend_from_slice(&tt_hash).unwrap();
+        unwrap!(salt.extend_from_slice(&tt_hash));
         //        println!("Sigma2Key: salt: {:x?}, len: {}", salt, salt.len());
 
         crypto::hkdf_sha256(salt.as_slice(), &case_session.shared_secret, &S2K_INFO, key)

--- a/rs-matter/src/secure_channel/case.rs
+++ b/rs-matter/src/secure_channel/case.rs
@@ -17,8 +17,6 @@
 
 use core::{mem::MaybeUninit, num::NonZeroU8};
 
-use log::{error, trace};
-
 use crate::{
     alloc,
     cert::CertRef,

--- a/rs-matter/src/secure_channel/case.rs
+++ b/rs-matter/src/secure_channel/case.rs
@@ -39,6 +39,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CaseSession {
     peer_sessid: u16,
     local_sessid: u16,

--- a/rs-matter/src/secure_channel/common.rs
+++ b/rs-matter/src/secure_channel/common.rs
@@ -27,6 +27,7 @@ use super::status_report::{GeneralCode, StatusReport};
 pub const PROTO_ID_SECURE_CHANNEL: u16 = 0x00;
 
 #[derive(FromPrimitive, Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum OpCode {
     MsgCounterSyncReq = 0x00,
     MsgCounterSyncResp = 0x01,
@@ -70,6 +71,7 @@ impl From<OpCode> for MessageMeta {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SCStatusCodes {
     SessionEstablishmentSuccess = 0,
     NoSharedTrustRoots = 1,

--- a/rs-matter/src/secure_channel/core.rs
+++ b/rs-matter/src/secure_channel/core.rs
@@ -17,8 +17,6 @@
 
 use core::mem::MaybeUninit;
 
-use log::error;
-
 use crate::{
     error::*,
     respond::ExchangeHandler,

--- a/rs-matter/src/secure_channel/crypto_mbedtls.rs
+++ b/rs-matter/src/secure_channel/crypto_mbedtls.rs
@@ -24,7 +24,6 @@ use crate::{
 };
 
 use byteorder::{ByteOrder, LittleEndian};
-use log::error;
 use mbedtls::{
     bignum::Mpi,
     ecp::EcPoint,

--- a/rs-matter/src/secure_channel/crypto_openssl.rs
+++ b/rs-matter/src/secure_channel/crypto_openssl.rs
@@ -21,7 +21,6 @@ use crate::{
 };
 
 use byteorder::{ByteOrder, LittleEndian};
-use log::error;
 use openssl::{
     bn::{BigNum, BigNumContext},
     ec::{EcGroup, EcPoint, EcPointRef, PointConversionForm},

--- a/rs-matter/src/secure_channel/pake.rs
+++ b/rs-matter/src/secure_channel/pake.rs
@@ -17,8 +17,6 @@
 
 use core::{fmt::Write, time::Duration};
 
-use log::{error, info};
-
 use crate::crypto;
 use crate::error::{Error, ErrorCode};
 use crate::mdns::{Mdns, ServiceMode};

--- a/rs-matter/src/secure_channel/pake.rs
+++ b/rs-matter/src/secure_channel/pake.rs
@@ -58,7 +58,7 @@ impl PaseSession {
         let num = u64::from_be_bytes(buf);
 
         self.mdns_service_name.clear();
-        write!(&mut self.mdns_service_name, "{:016X}", num).unwrap();
+        write_unwrap!(&mut self.mdns_service_name, "{:016X}", num);
 
         mdns.add(
             &self.mdns_service_name,
@@ -117,7 +117,7 @@ impl PaseMgr {
             )));
 
         // Can't fail as we just initialized the session
-        let session = self.session.as_mut().unwrap();
+        let session = unwrap!(self.session.as_mut());
 
         session.add_mdns(discriminator, self.rand, mdns)
     }
@@ -139,7 +139,7 @@ impl PaseMgr {
             .try_reinit(Maybe::init_some(PaseSession::init(verifier, salt, count)))?;
 
         // Can't fail as we just initialized the session
-        let session = self.session.as_mut().unwrap();
+        let session = unwrap!(self.session.as_mut());
 
         session.add_mdns(discriminator, self.rand, mdns)
     }

--- a/rs-matter/src/secure_channel/spake2p.rs
+++ b/rs-matter/src/secure_channel/spake2p.rs
@@ -44,6 +44,7 @@ const CRYPTO_PUBLIC_KEY_SIZE_BYTES: usize = (2 * CRYPTO_GROUP_SIZE_BYTES) + 1;
 const VERIFIER_SIZE_BYTES: usize = CRYPTO_GROUP_SIZE_BYTES + CRYPTO_PUBLIC_KEY_SIZE_BYTES;
 
 #[derive(PartialEq, Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Spake2VerifierState {
     // Initialised - w0, L are set
     Init,
@@ -54,6 +55,7 @@ pub enum Spake2VerifierState {
 }
 
 #[derive(PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Spake2Mode {
     Unknown,
     Prover,
@@ -239,6 +241,7 @@ impl Default for Spake2P {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct VerifierData {
     /// When `password` is `None`, `verifier` is expected to be set
     pub password: Option<u32>,

--- a/rs-matter/src/secure_channel/spake2p.rs
+++ b/rs-matter/src/secure_channel/spake2p.rs
@@ -112,7 +112,7 @@ impl Spake2P {
     }
 
     pub fn update_context(&mut self, buf: &[u8]) -> Result<(), Error> {
-        self.context.as_mut().unwrap().update(buf)
+        unwrap!(self.context.as_mut()).update(buf)
     }
 
     #[inline(always)]
@@ -339,10 +339,12 @@ mod tests {
             let mut cA: [u8; 32] = [0; 32];
             let mut cB: [u8; 32] = [0; 32];
             let mut TT_hash = [0u8; crypto::SHA256_HASH_LEN_BYTES];
-            let mut h = crypto::Sha256::new().unwrap();
-            h.update(&t.TT[0..t.TT_len]).unwrap();
-            h.finish(&mut TT_hash).unwrap();
-            Spake2P::get_Ke_and_cAcB(&TT_hash, &t.X, &t.Y, &mut Ke, &mut cA, &mut cB).unwrap();
+            let mut h = unwrap!(crypto::Sha256::new());
+            unwrap!(h.update(&t.TT[0..t.TT_len]));
+            unwrap!(h.finish(&mut TT_hash));
+            unwrap!(Spake2P::get_Ke_and_cAcB(
+                &TT_hash, &t.X, &t.Y, &mut Ke, &mut cA, &mut cB
+            ));
             assert_eq!(Ke, t.Ke);
             assert_eq!(cA, t.cA);
             assert_eq!(cB, t.cB);

--- a/rs-matter/src/secure_channel/status_report.rs
+++ b/rs-matter/src/secure_channel/status_report.rs
@@ -24,6 +24,7 @@ use crate::{
 
 #[allow(dead_code)]
 #[derive(FromPrimitive, PartialEq, Eq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GeneralCode {
     Success = 0,
     Failure = 1,
@@ -46,6 +47,7 @@ pub enum GeneralCode {
 
 /// Represents a Status Report message, as per "Appendix D: Status Report Messages" of the Matter Spec.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StatusReport<'a> {
     pub general_code: GeneralCode,
     pub proto_id: u32,

--- a/rs-matter/src/tlv.rs
+++ b/rs-matter/src/tlv.rs
@@ -39,6 +39,7 @@ mod write;
 
 /// Represents the TLV tag type encoded in the control byte of each TLV element.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, num_derive::FromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum TLVTagType {
     Anonymous = 0,
@@ -85,6 +86,7 @@ impl fmt::Display for TLVTagType {
 
 /// Represents the TLV value type encoded in the control byte of each TLV element.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, num_derive::FromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum TLVValueType {
     S8 = 0,
@@ -233,6 +235,7 @@ impl fmt::Display for TLVValueType {
 
 /// Represents the control byte of a TLV element (i.e. the tag type and the value type).
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TLVControl {
     pub tag_type: TLVTagType,
     pub value_type: TLVValueType,
@@ -326,6 +329,7 @@ impl fmt::Display for TLVControl {
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TLV<'a> {
     pub tag: TLVTag,
     pub value: TLVValue<'a>,
@@ -565,6 +569,7 @@ pub type TagType = TLVTag;
 ///
 /// A `TLVTag` can be constructed programmatically, or returned from a `TLVElement`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TLVTag {
     Anonymous,
     Context(u8),
@@ -752,6 +757,7 @@ pub type ElementType<'a> = TLVValue<'a>;
 /// Unlike a `TLVElement` however, a `TLVValue` does not represent a complete container,
 /// but rather, its beginning or end.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TLVValue<'a> {
     S8(i8),
     S16(i16),

--- a/rs-matter/src/tlv/read.rs
+++ b/rs-matter/src/tlv/read.rs
@@ -153,16 +153,16 @@ impl<'a> TLVElement<'a> {
             TLVTagType::Anonymous => TLVTag::Anonymous,
             TLVTagType::Context => TLVTag::Context(slice[0]),
             TLVTagType::CommonPrf16 => {
-                TLVTag::CommonPrf16(u16::from_le_bytes(slice.try_into().unwrap()))
+                TLVTag::CommonPrf16(u16::from_le_bytes(unwrap!(slice.try_into())))
             }
             TLVTagType::CommonPrf32 => {
-                TLVTag::CommonPrf32(u32::from_le_bytes(slice.try_into().unwrap()))
+                TLVTag::CommonPrf32(u32::from_le_bytes(unwrap!(slice.try_into())))
             }
             TLVTagType::ImplPrf16 => {
-                TLVTag::ImplPrf16(u16::from_le_bytes(slice.try_into().unwrap()))
+                TLVTag::ImplPrf16(u16::from_le_bytes(unwrap!(slice.try_into())))
             }
             TLVTagType::ImplPrf32 => {
-                TLVTag::ImplPrf32(u32::from_le_bytes(slice.try_into().unwrap()))
+                TLVTag::ImplPrf32(u32::from_le_bytes(unwrap!(slice.try_into())))
             }
             TLVTagType::FullQual48 => TLVTag::FullQual48 {
                 vendor_id: u16::from_le_bytes([slice[0], slice[1]]),
@@ -189,18 +189,18 @@ impl<'a> TLVElement<'a> {
         let slice = self.0.container_value(control)?;
 
         let value = match control.value_type {
-            TLVValueType::S8 => TLVValue::S8(i8::from_le_bytes(slice.try_into().unwrap())),
-            TLVValueType::S16 => TLVValue::S16(i16::from_le_bytes(slice.try_into().unwrap())),
-            TLVValueType::S32 => TLVValue::S32(i32::from_le_bytes(slice.try_into().unwrap())),
-            TLVValueType::S64 => TLVValue::S64(i64::from_le_bytes(slice.try_into().unwrap())),
-            TLVValueType::U8 => TLVValue::U8(u8::from_le_bytes(slice.try_into().unwrap())),
-            TLVValueType::U16 => TLVValue::U16(u16::from_le_bytes(slice.try_into().unwrap())),
-            TLVValueType::U32 => TLVValue::U32(u32::from_le_bytes(slice.try_into().unwrap())),
-            TLVValueType::U64 => TLVValue::U64(u64::from_le_bytes(slice.try_into().unwrap())),
+            TLVValueType::S8 => TLVValue::S8(i8::from_le_bytes(unwrap!(slice.try_into()))),
+            TLVValueType::S16 => TLVValue::S16(i16::from_le_bytes(unwrap!(slice.try_into()))),
+            TLVValueType::S32 => TLVValue::S32(i32::from_le_bytes(unwrap!(slice.try_into()))),
+            TLVValueType::S64 => TLVValue::S64(i64::from_le_bytes(unwrap!(slice.try_into()))),
+            TLVValueType::U8 => TLVValue::U8(u8::from_le_bytes(unwrap!(slice.try_into()))),
+            TLVValueType::U16 => TLVValue::U16(u16::from_le_bytes(unwrap!(slice.try_into()))),
+            TLVValueType::U32 => TLVValue::U32(u32::from_le_bytes(unwrap!(slice.try_into()))),
+            TLVValueType::U64 => TLVValue::U64(u64::from_le_bytes(unwrap!(slice.try_into()))),
             TLVValueType::False => TLVValue::False,
             TLVValueType::True => TLVValue::True,
-            TLVValueType::F32 => TLVValue::F32(f32::from_le_bytes(slice.try_into().unwrap())),
-            TLVValueType::F64 => TLVValue::F64(f64::from_le_bytes(slice.try_into().unwrap())),
+            TLVValueType::F32 => TLVValue::F32(f32::from_le_bytes(unwrap!(slice.try_into()))),
+            TLVValueType::F64 => TLVValue::F64(f64::from_le_bytes(unwrap!(slice.try_into()))),
             TLVValueType::Utf8l => TLVValue::Utf8l(
                 core::str::from_utf8(slice).map_err(|_| ErrorCode::TLVTypeMismatch)?,
             ),
@@ -978,9 +978,7 @@ impl<'a> TLVSequence<'a> {
     /// the returned sub-slice will designate the start of the value field.
     #[inline(always)]
     fn value_len_start(&self, tag_type: TLVTagType) -> Result<&'a [u8], Error> {
-        Ok(self
-            .tag_start()
-            .unwrap()
+        Ok(unwrap!(self.tag_start())
             .get(tag_type.size()..)
             .ok_or(ErrorCode::TLVTypeMismatch)?)
     }
@@ -1044,10 +1042,10 @@ impl<'a> TLVSequence<'a> {
             .ok_or(ErrorCode::TLVTypeMismatch)?;
 
         let len = match size_len {
-            1 => u8::from_be_bytes(value_len_slice.try_into().unwrap()) as usize,
-            2 => u16::from_le_bytes(value_len_slice.try_into().unwrap()) as usize,
-            4 => u32::from_le_bytes(value_len_slice.try_into().unwrap()) as usize,
-            8 => u64::from_le_bytes(value_len_slice.try_into().unwrap()) as usize,
+            1 => u8::from_be_bytes(unwrap!(value_len_slice.try_into())) as usize,
+            2 => u16::from_le_bytes(unwrap!(value_len_slice.try_into())) as usize,
+            4 => u32::from_le_bytes(unwrap!(value_len_slice.try_into())) as usize,
+            8 => u64::from_le_bytes(unwrap!(value_len_slice.try_into())) as usize,
             _ => unreachable!(),
         };
 

--- a/rs-matter/src/tlv/read.rs
+++ b/rs-matter/src/tlv/read.rs
@@ -706,6 +706,7 @@ impl<'a> TLVElement<'a> {
 }
 
 impl fmt::Debug for TLVElement<'_> {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(0, f)
     }
@@ -1129,6 +1130,7 @@ impl<'a> TLVSequence<'a> {
 }
 
 impl fmt::Debug for TLVSequence<'_> {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(0, f)
     }
@@ -1220,6 +1222,7 @@ impl<'a> Iterator for TLVSequenceIter<'a> {
 }
 
 impl fmt::Debug for TLVSequenceIter<'_> {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(0, f)
     }

--- a/rs-matter/src/tlv/read.rs
+++ b/rs-matter/src/tlv/read.rs
@@ -706,7 +706,6 @@ impl<'a> TLVElement<'a> {
 }
 
 impl fmt::Debug for TLVElement<'_> {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(0, f)
     }
@@ -715,6 +714,13 @@ impl fmt::Debug for TLVElement<'_> {
 impl fmt::Display for TLVElement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(0, f)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for TLVElement<'_> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::Display2Format(self).format(f)
     }
 }
 
@@ -1130,7 +1136,6 @@ impl<'a> TLVSequence<'a> {
 }
 
 impl fmt::Debug for TLVSequence<'_> {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(0, f)
     }
@@ -1139,6 +1144,13 @@ impl fmt::Debug for TLVSequence<'_> {
 impl fmt::Display for TLVSequence<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(0, f)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for TLVSequence<'_> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::Display2Format(self).format(f)
     }
 }
 
@@ -1222,7 +1234,6 @@ impl<'a> Iterator for TLVSequenceIter<'a> {
 }
 
 impl fmt::Debug for TLVSequenceIter<'_> {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(0, f)
     }
@@ -1231,6 +1242,13 @@ impl fmt::Debug for TLVSequenceIter<'_> {
 impl fmt::Display for TLVSequenceIter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(0, f)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for TLVSequenceIter<'_> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::Display2Format(self).format(f)
     }
 }
 

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -175,6 +175,7 @@ mod tests {
     use super::{FromTLV, OctetStr, TLVTag, ToTLV};
 
     fn test_from_tlv<'a, T: FromTLV<'a> + PartialEq + Debug>(data: &'a [u8], expected: T) {
+        // TODO: defmt
         let root = TLVElement::new(data);
         let test = T::from_tlv(&root).unwrap();
         assert_eq!(test, expected);
@@ -231,6 +232,7 @@ mod tests {
     }
 
     #[derive(FromTLV, Debug, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     struct TestDeriveSimple {
         a: u16,
         b: u32,
@@ -245,6 +247,7 @@ mod tests {
     }
 
     #[derive(FromTLV, Debug, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[tlvargs(lifetime = "'a")]
     struct TestDeriveStr<'a> {
         a: u16,
@@ -263,6 +266,7 @@ mod tests {
     }
 
     #[derive(FromTLV, Debug, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     struct TestDeriveOption {
         a: u16,
         b: Option<u16>,
@@ -282,6 +286,7 @@ mod tests {
     }
 
     #[derive(FromTLV, ToTLV, Debug, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     struct TestDeriveFabScoped {
         a: u16,
         #[tagval(0xFE)]
@@ -305,6 +310,7 @@ mod tests {
     }
 
     #[derive(ToTLV, FromTLV, PartialEq, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     enum TestDeriveEnum {
         ValueA(u32),
         ValueB(u32),

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -175,10 +175,9 @@ mod tests {
     use super::{FromTLV, OctetStr, TLVTag, ToTLV};
 
     fn test_from_tlv<'a, T: FromTLV<'a> + PartialEq + Debug>(data: &'a [u8], expected: T) {
-        // TODO: defmt
         let root = TLVElement::new(data);
         let test = T::from_tlv(&root).unwrap();
-        assert_eq!(test, expected);
+        ::core::assert_eq!(test, expected);
 
         let test_init = T::init_from_tlv(root);
 
@@ -186,7 +185,7 @@ mod tests {
 
         let test = test.try_init_with(test_init).unwrap();
 
-        assert_eq!(*test, expected);
+        ::core::assert_eq!(*test, expected);
     }
 
     fn test_to_tlv<T: ToTLV>(t: T, expected: &[u8]) {
@@ -211,7 +210,7 @@ mod tests {
             }
         }
 
-        assert_eq!(writebuf.as_slice(), expected);
+        ::core::assert_eq!(writebuf.as_slice(), expected);
     }
 
     #[derive(ToTLV)]

--- a/rs-matter/src/tlv/traits/array.rs
+++ b/rs-matter/src/tlv/traits/array.rs
@@ -52,7 +52,7 @@ where
                 .map_err(|_| ErrorCode::NoSpace)?;
         }
 
-        Ok(vec.into_array().map_err(|_| ErrorCode::NoSpace).unwrap())
+        Ok(unwrap!(vec.into_array().map_err(|_| ErrorCode::NoSpace)))
     }
 }
 

--- a/rs-matter/src/tlv/traits/bitflags.rs
+++ b/rs-matter/src/tlv/traits/bitflags.rs
@@ -30,10 +30,6 @@ macro_rules! bitflags_tlv {
     ($enum_name:ident, $type:ident) => {
         impl<'a> $crate::tlv::FromTLV<'a> for $enum_name {
             fn from_tlv(element: &$crate::tlv::TLVElement<'a>) -> Result<Self, Error> {
-                // Ok(Self::from_bits_retain($crate::tlv::TLVElement::$type(
-                //     element,
-                // )?))
-                // TODO: defmt
                 Self::from_bits($crate::tlv::TLVElement::$type(element)?).ok_or_else(|| {
                     $crate::error::Error::from($crate::error::ErrorCode::InvalidData)
                 })

--- a/rs-matter/src/tlv/traits/bitflags.rs
+++ b/rs-matter/src/tlv/traits/bitflags.rs
@@ -30,9 +30,13 @@ macro_rules! bitflags_tlv {
     ($enum_name:ident, $type:ident) => {
         impl<'a> $crate::tlv::FromTLV<'a> for $enum_name {
             fn from_tlv(element: &$crate::tlv::TLVElement<'a>) -> Result<Self, Error> {
-                Ok(Self::from_bits_retain($crate::tlv::TLVElement::$type(
-                    element,
-                )?))
+                // Ok(Self::from_bits_retain($crate::tlv::TLVElement::$type(
+                //     element,
+                // )?))
+                // TODO: defmt
+                Self::from_bits($crate::tlv::TLVElement::$type(element)?).ok_or_else(|| {
+                    $crate::error::Error::from($crate::error::ErrorCode::InvalidData)
+                })
             }
         }
 

--- a/rs-matter/src/tlv/traits/container.rs
+++ b/rs-matter/src/tlv/traits/container.rs
@@ -187,11 +187,10 @@ where
         for elem in self.iter() {
             if first {
                 first = false;
+                write!(f, "{elem:?}")?;
             } else {
-                write!(f, ", ")?;
+                write!(f, ", {elem:?}")?;
             }
-
-            write!(f, "{elem:?}")?;
         }
 
         write!(f, "]")
@@ -201,10 +200,23 @@ where
 #[cfg(feature = "defmt")]
 impl<'a, T, C> defmt::Format for TLVContainer<'a, T, C>
 where
-    T: FromTLV<'a> + fmt::Debug,
+    T: FromTLV<'a> + defmt::Format,
 {
     fn format(&self, f: defmt::Formatter<'_>) {
-        defmt::Debug2Format(self).format(f)
+        defmt::write!(f, "[");
+
+        let mut first = true;
+
+        for elem in self.iter() {
+            if first {
+                first = false;
+                defmt::write!(f, "{:?}", elem);
+            } else {
+                defmt::write!(f, ", {:?}", elem);
+            }
+        }
+
+        defmt::write!(f, "]")
     }
 }
 

--- a/rs-matter/src/tlv/traits/container.rs
+++ b/rs-matter/src/tlv/traits/container.rs
@@ -39,14 +39,17 @@ pub type AnyContainer = ();
 
 /// A type-state that indicates that the container should be an array.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ArrayContainer;
 
 /// A type-state that indicates that the container should be a list.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ListContainer;
 
 /// A type-state that indicates that the container should be a struct.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StructContainer;
 
 /// A type alias for an array TLV container.
@@ -173,6 +176,7 @@ where
 }
 
 impl<'a, T, C> fmt::Debug for TLVContainer<'a, T, C>
+// TODO: defmt
 where
     T: FromTLV<'a> + fmt::Debug,
 {
@@ -263,6 +267,7 @@ where
 /// Necessary for the few cases in the code where deserialized TLV structures are mutated -
 /// post deserialization - with custom array data.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TLVArrayOrSlice<'a, T>
 where
     T: FromTLV<'a>,
@@ -437,7 +442,7 @@ where
 //     }
 // }
 
-// impl<'a, T: Debug + ToTLV + FromTLV<'a> + Clone> Debug for TLVArray<'a, T> {
+// impl<'a, T: Debug + ToTLV + FromTLV<'a> + Clone> Debug for TLVArray<'a, T> { // TODO: defmt
 //     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
 //         write!(f, "TLVArray [")?;
 //         let mut first = true;

--- a/rs-matter/src/tlv/traits/container.rs
+++ b/rs-matter/src/tlv/traits/container.rs
@@ -91,7 +91,7 @@ where
 
     /// Returns an iterator over the elements of the container.
     pub fn iter(&self) -> TLVContainerIter<'a, T> {
-        TLVContainerIter::new(self.element.container().unwrap().iter())
+        TLVContainerIter::new(unwrap!(self.element.container()).iter())
     }
 }
 

--- a/rs-matter/src/tlv/traits/container.rs
+++ b/rs-matter/src/tlv/traits/container.rs
@@ -176,7 +176,6 @@ where
 }
 
 impl<'a, T, C> fmt::Debug for TLVContainer<'a, T, C>
-// TODO: defmt
 where
     T: FromTLV<'a> + fmt::Debug,
 {
@@ -196,6 +195,16 @@ where
         }
 
         write!(f, "]")
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<'a, T, C> defmt::Format for TLVContainer<'a, T, C>
+where
+    T: FromTLV<'a> + fmt::Debug,
+{
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::Debug2Format(self).format(f)
     }
 }
 

--- a/rs-matter/src/tlv/traits/maybe.rs
+++ b/rs-matter/src/tlv/traits/maybe.rs
@@ -54,6 +54,7 @@ pub type AsOptional = ();
 
 /// A tag for `Maybe` that makes it behave as a nullable type per the TLV spec.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AsNullable;
 
 /// Represents optional values as per the TLV spec.

--- a/rs-matter/src/tlv/traits/octets.rs
+++ b/rs-matter/src/tlv/traits/octets.rs
@@ -48,6 +48,7 @@ pub type OctetStrOwned<const N: usize> = OctetsOwned<N>;
 ///
 /// When deserializing, this type grabs the octet slice directly from the `TLVElement`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(transparent)]
 pub struct Octets<'a>(pub &'a [u8]);
 
@@ -84,6 +85,7 @@ impl ToTLV for Octets<'_> {
 /// Newtype for owned byte arrays with a fixed maximum length
 /// (represented by a `Vec<u8, N>`)
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(transparent)]
 pub struct OctetsOwned<const N: usize> {
     pub vec: Vec<u8, N>,

--- a/rs-matter/src/transport/dedup.rs
+++ b/rs-matter/src/transport/dedup.rs
@@ -18,6 +18,7 @@
 const MSG_RX_STATE_BITMAP_LEN: u32 = 16;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RxCtrState {
     max_ctr: u32,
     ctr_bitmap: u16,

--- a/rs-matter/src/transport/dedup.rs
+++ b/rs-matter/src/transport/dedup.rs
@@ -88,9 +88,6 @@ impl RxCtrState {
 
 #[cfg(test)]
 mod tests {
-
-    use log::info;
-
     use super::RxCtrState;
 
     const ENCRYPTED: bool = true;

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -50,6 +50,7 @@ pub const MAX_EXCHANGE_TX_BUF_SIZE: usize =
 
 /// An exchange identifier, uniquely identifying a session and an exchange within that session for a given Matter stack.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ExchangeId(u32);
 
 impl ExchangeId {
@@ -324,6 +325,7 @@ impl Display for ExchangeIdDisplay<'_> {
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) enum InitiatorState {
     #[default]
     Owned,
@@ -331,6 +333,7 @@ pub(crate) enum InitiatorState {
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) enum ResponderState {
     #[default]
     AcceptPending,
@@ -339,6 +342,7 @@ pub(crate) enum ResponderState {
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) enum Role {
     Initiator(InitiatorState),
     Responder(ResponderState),
@@ -361,6 +365,7 @@ impl Role {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ExchangeState {
     pub(crate) exch_id: u16,
     pub(crate) role: Role,
@@ -418,6 +423,7 @@ impl ExchangeState {
 /// Meta-data when sending/receving messages via an Exchange.
 /// Basically, the protocol ID, the protocol opcode and whether the message should be set in a reliable manner.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MessageMeta {
     pub proto_id: u16,
     pub proto_opcode: u8,
@@ -659,6 +665,7 @@ impl TxMessage<'_> {
 
 /// Outcome from calling `Exchange::wait_tx`
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TxOutcome {
     /// The other side has acknowledged the last message or the last message was not using the MRP protocol
     /// Stop re-sending.

--- a/rs-matter/src/transport/mrp.rs
+++ b/rs-matter/src/transport/mrp.rs
@@ -32,6 +32,7 @@ const MRP_BACKOFF_MARGIN: (u64, u64) = (11, 10); // 1.1
 const MRP_JITTER_RAND_MAX: u8 = u8::MAX;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RetransEntry {
     /// The retransmission delay interval in milliseconds
     base_delay_interval_ms: u16,
@@ -96,6 +97,7 @@ impl RetransEntry {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AckEntry {
     // The msg counter that we should acknowledge
     pub(crate) msg_ctr: u32,
@@ -117,6 +119,7 @@ impl AckEntry {
 }
 
 #[derive(Default, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ReliableMessage {
     pub(crate) retrans: Option<RetransEntry>,
     pub(crate) ack: Option<AckEntry>,

--- a/rs-matter/src/transport/mrp.rs
+++ b/rs-matter/src/transport/mrp.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use log::{error, warn};
-
 use crate::error::*;
 use crate::utils::epoch::Epoch;
 
@@ -172,7 +170,10 @@ impl ReliableMessage {
             if let Some(retrans) = &mut self.retrans {
                 if retrans.pre_send(tx_plain.ctr).is_err() {
                     // Too many retransmissions, give up
-                    error!("Packet {tx_plain}{tx_proto}: Too many retransmissions. Giving up");
+                    error!(
+                        "Packet {}{}: Too many retransmissions. Giving up",
+                        tx_plain, tx_proto
+                    );
 
                     self.retrans = None;
                     self.ack = None;

--- a/rs-matter/src/transport/network.rs
+++ b/rs-matter/src/transport/network.rs
@@ -124,12 +124,22 @@ impl Display for Address {
 }
 
 impl Debug for Address {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Address::Udp(addr) => writeln!(f, "{}", addr),
             Address::Tcp(addr) => writeln!(f, "{}", addr),
             Address::Btp(addr) => writeln!(f, "{:?}", addr),
+        }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Address {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        match self {
+            Address::Udp(addr) => defmt::write!(f, "UDP {}", defmt::Display2Format(addr)),
+            Address::Tcp(addr) => defmt::write!(f, "TCP {}", defmt::Display2Format(addr)),
+            Address::Btp(addr) => defmt::write!(f, "BTP {}", defmt::Display2Format(addr)),
         }
     }
 }

--- a/rs-matter/src/transport/network.rs
+++ b/rs-matter/src/transport/network.rs
@@ -152,9 +152,9 @@ impl Debug for Address {
 impl defmt::Format for Address {
     fn format(&self, f: defmt::Formatter<'_>) {
         match self {
-            Address::Udp(addr) => defmt::write!(f, "UDP {}", defmt::Display2Format(addr)),
-            Address::Tcp(addr) => defmt::write!(f, "TCP {}", defmt::Display2Format(addr)),
-            Address::Btp(addr) => defmt::write!(f, "BTP {}", defmt::Display2Format(addr)),
+            Address::Udp(addr) => defmt::write!(f, "UDP {}", addr),
+            Address::Tcp(addr) => defmt::write!(f, "TCP {}", addr),
+            Address::Btp(addr) => defmt::write!(f, "BTP {}", addr),
         }
     }
 }

--- a/rs-matter/src/transport/network.rs
+++ b/rs-matter/src/transport/network.rs
@@ -43,7 +43,6 @@ pub const MAX_TX_LARGE_PACKET_SIZE: usize = MAX_RX_LARGE_PACKET_SIZE;
 
 /// A Bluetooth address.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BtAddr(pub [u8; 6]);
 
 impl Display for BtAddr {
@@ -52,6 +51,22 @@ impl Display for BtAddr {
             f,
             "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
             self.0[0], self.0[1], self.0[2], self.0[3], self.0[4], self.0[5]
+        )
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for BtAddr {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(
+            f,
+            "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+            self.0[0],
+            self.0[1],
+            self.0[2],
+            self.0[3],
+            self.0[4],
+            self.0[5]
         )
     }
 }

--- a/rs-matter/src/transport/network.rs
+++ b/rs-matter/src/transport/network.rs
@@ -43,6 +43,7 @@ pub const MAX_TX_LARGE_PACKET_SIZE: usize = MAX_RX_LARGE_PACKET_SIZE;
 
 /// A Bluetooth address.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BtAddr(pub [u8; 6]);
 
 impl Display for BtAddr {
@@ -123,6 +124,7 @@ impl Display for Address {
 }
 
 impl Debug for Address {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Address::Udp(addr) => writeln!(f, "{}", addr),

--- a/rs-matter/src/transport/network/btp.rs
+++ b/rs-matter/src/transport/network/btp.rs
@@ -24,14 +24,13 @@ use embassy_futures::select::select4;
 use embassy_sync::blocking_mutex::raw::{NoopRawMutex, RawMutex};
 use embassy_time::{Duration, Instant, Timer};
 
-use log::trace;
-
 use context::LockError;
 
 use session::{BTP_ACK_TIMEOUT_SECS, BTP_CONN_IDLE_TIMEOUT_SECS};
 
 use crate::data_model::cluster_basic_information::BasicInfoConfig;
 use crate::error::{Error, ErrorCode};
+use crate::fmt::Bytes;
 use crate::transport::network::{Address, BtAddr, NetworkReceive, NetworkSend};
 use crate::utils::init::{init, Init};
 use crate::utils::select::Coalesce;
@@ -228,7 +227,8 @@ where
                 offset = new_offset;
 
                 trace!(
-                    "Sent {slice:02x?} bytes to address {}",
+                    "Sent {} bytes to address {}",
+                    Bytes(slice),
                     session_lock.address()
                 );
 
@@ -297,7 +297,8 @@ where
                 self.gatt.indicate(slice, session_lock.address()).await?;
 
                 trace!(
-                    "Sent {slice:02x?} bytes to address {}",
+                    "Sent {} bytes to address {}",
+                    Bytes(slice),
                     session_lock.address()
                 );
             }

--- a/rs-matter/src/transport/network/btp.rs
+++ b/rs-matter/src/transport/network/btp.rs
@@ -315,7 +315,7 @@ where
         let mut buf = self.send_buf.lock().await;
 
         // Unwrap is safe because the max size of the buffer is MAX_PDU_SIZE
-        buf.resize_default(MAX_BTP_SEGMENT_SIZE).unwrap();
+        unwrap!(buf.resize_default(MAX_BTP_SEGMENT_SIZE));
 
         buf
     }

--- a/rs-matter/src/transport/network/btp/context.rs
+++ b/rs-matter/src/transport/network/btp/context.rs
@@ -268,13 +268,11 @@ where
                     );
                 } else {
                     // Unwrap is safe because we checked the length above
-                    sessions
-                        .push_init(
-                            Session::process_rx_handshake(address, data, gatt_mtu)?
-                                .into_fallible::<Error>(),
-                            || ErrorCode::NoSpace.into(),
-                        )
-                        .unwrap();
+                    unwrap!(sessions.push_init(
+                        Session::process_rx_handshake(address, data, gatt_mtu)?
+                            .into_fallible::<Error>(),
+                        || ErrorCode::NoSpace.into(),
+                    ));
                 }
 
                 Ok(())

--- a/rs-matter/src/transport/network/btp/context.rs
+++ b/rs-matter/src/transport/network/btp/context.rs
@@ -37,6 +37,7 @@ pub const MAX_BTP_SESSIONS: usize = 2;
 
 /// Represents an error that occurred while trying to lock a session for sending.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) enum LockError {
     /// Session for the specified condition was not found.
     NoMatch,

--- a/rs-matter/src/transport/network/btp/gatt.rs
+++ b/rs-matter/src/transport/network/btp/gatt.rs
@@ -135,6 +135,7 @@ impl AdvData {
 /// the Matter BTP protocol, but is otherwise not really having the ambition to model all
 /// possible events of a generic GATT peripheral, which would result in a much larger API surface.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GattPeripheralEvent<'a> {
     /// A GATT central has subscribed for notifications from characteristic `C2`.
     /// In other words, the GATT central is now ready to receive BTP packets.

--- a/rs-matter/src/transport/network/btp/gatt/bluer.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluer.rs
@@ -288,7 +288,7 @@ impl BluerGattPeripheral {
 
         if notifiers.len() < MAX_CONNECTIONS {
             // Unwraping is safe because we just checked the length
-            notifiers.push(notifier).map_err(|_| ()).unwrap();
+            unwrap!(notifiers.push(notifier).map_err(|_| ()));
             trace!("Notify connection from address {} started", address);
         } else {
             warn!(

--- a/rs-matter/src/transport/network/btp/gatt/bluer.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluer.rs
@@ -32,12 +32,11 @@ use bluer::Uuid;
 
 use embassy_futures::select::{select, select_slice, Either};
 
-use log::{info, trace, warn};
-
 use tokio::io::AsyncWriteExt;
 use tokio_stream::StreamExt;
 
 use crate::error::{Error, ErrorCode};
+use crate::fmt::Bytes;
 use crate::transport::network::btp::MIN_MTU;
 use crate::transport::network::{btp::context::MAX_BTP_SESSIONS, BtAddr};
 use crate::utils::init::{init_from_closure, Init};
@@ -182,7 +181,7 @@ impl BluerGattPeripheral {
                                     let address = BtAddr(req.device_address.0);
                                     let data = &new_value;
 
-                                    trace!("Got write request from {address}: {data:02x?}");
+                                    trace!("Got write request from {}: {}", address, Bytes(data));
 
                                     // Notify the BTP protocol implementation for the write
                                     callback_w(GattPeripheralEvent::Write {
@@ -268,7 +267,7 @@ impl BluerGattPeripheral {
 
         result?;
 
-        trace!("Indicated {data:02x?} bytes to address {address}");
+        trace!("Indicated {} bytes to address {}", Bytes(data), address);
 
         Ok(())
     }
@@ -290,9 +289,12 @@ impl BluerGattPeripheral {
         if notifiers.len() < MAX_CONNECTIONS {
             // Unwraping is safe because we just checked the length
             notifiers.push(notifier).map_err(|_| ()).unwrap();
-            trace!("Notify connection from address {address} started");
+            trace!("Notify connection from address {} started", address);
         } else {
-            warn!("Notifiers limit reached; ignoring notifier from address {address}");
+            warn!(
+                "Notifiers limit reached; ignoring notifier from address {}",
+                address
+            );
         }
 
         drop(notifiers);
@@ -376,7 +378,7 @@ impl BluerGattPeripheral {
                         // Notify the BTP protocol implementation
                         callback(GattPeripheralEvent::NotifyUnsubscribed(address));
 
-                        trace!("Notify connection from address {address} stopped");
+                        trace!("Notify connection from address {} stopped", address);
                     }
                 }
             }

--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -43,6 +43,7 @@ pub(crate) const BTP_CONN_IDLE_TIMEOUT_SECS: u16 = 30;
 
 /// Represents the three possible states of each BTP session
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum SessionState {
     /// The session was just created as a result of a remote peer writing a BTP Handshake Request SDU
     /// to characteristic `C1`.
@@ -56,6 +57,7 @@ enum SessionState {
 
 /// Represents the sending window of a BTP session, as per the Matter Core spec.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct SendWindow {
     /// The negotiated window size
     window_size: u8,
@@ -155,6 +157,7 @@ const MAX_MESSAGE_SIZE: usize = MAX_RX_PACKET_SIZE * 2;
 
 /// Represents the receiving window of a BTP session, as per the Matter Core spec.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct RecvWindow {
     /// A ring-buffer holding all received BTP segment' payloads, including not been fully processed yet
     buf: RingBuf<MAX_MESSAGE_SIZE>,
@@ -364,6 +367,7 @@ impl RecvWindow {
 
 /// Represents a BTP Session, as per the MAtter Core spec.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Session {
     address: BtAddr,
     state: SessionState,

--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -232,7 +232,7 @@ impl RecvWindow {
         self.buf.push(payload);
         self.level -= 1;
         // Unwrap is safe because we are only processing BTP data segments here and they always have a sequence number
-        self.ack_seq = hdr.get_seq().unwrap();
+        self.ack_seq = unwrap!(hdr.get_seq());
         self.ack_level += 1;
         self.received_at = Instant::now();
 

--- a/rs-matter/src/transport/network/btp/session/packet.rs
+++ b/rs-matter/src/transport/network/btp/session/packet.rs
@@ -17,8 +17,6 @@
 
 use core::fmt;
 
-use log::trace;
-
 use crate::error::{Error, ErrorCode};
 use crate::utils::bitflags::bitflags;
 use crate::utils::storage::WriteBuf;
@@ -29,7 +27,8 @@ bitflags! {
     /// Consult the Matter Core Specification for more information.
     #[repr(transparent)]
     #[derive(Default)]
-    pub struct BtpFlags: u8 { // TODO: defmt
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
+    pub struct BtpFlags: u8 {
         const HANDSHAKE = 0x40;
         const MANAGEMENT = 0x20;
         const ACK = 0x08;
@@ -42,6 +41,7 @@ bitflags! {
 }
 
 impl fmt::Display for BtpFlags {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut sep = false;
         for flag in [

--- a/rs-matter/src/transport/network/btp/session/packet.rs
+++ b/rs-matter/src/transport/network/btp/session/packet.rs
@@ -18,16 +18,14 @@
 use core::fmt;
 
 use crate::error::{Error, ErrorCode};
-use crate::utils::bitflags::bitflags;
 use crate::utils::storage::WriteBuf;
 
-bitflags! {
+bitflags::bitflags! {
     /// Models the flags in the BTP header.
     ///
     /// Consult the Matter Core Specification for more information.
     #[repr(transparent)]
-    #[derive(Default)]
-    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
+    #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Hash)]
     pub struct BtpFlags: u8 {
         const HANDSHAKE = 0x40;
         const MANAGEMENT = 0x20;
@@ -41,7 +39,6 @@ bitflags! {
 }
 
 impl fmt::Display for BtpFlags {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut sep = false;
         for flag in [
@@ -76,9 +73,42 @@ impl fmt::Display for BtpFlags {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for BtpFlags {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        let mut sep = false;
+        for flag in [
+            Self::HANDSHAKE,
+            Self::MANAGEMENT,
+            Self::ACK,
+            Self::BEGINNING_SEGMENT,
+            Self::CONTINUE,
+            Self::ENDING_SEGMENT,
+        ] {
+            if self.contains(flag) {
+                if sep {
+                    defmt::write!(f, "|");
+                }
+
+                let str = match flag {
+                    Self::HANDSHAKE => "H",
+                    Self::MANAGEMENT => "M",
+                    Self::ACK => "A",
+                    Self::BEGINNING_SEGMENT => "B",
+                    Self::CONTINUE => "C",
+                    Self::ENDING_SEGMENT => "E",
+                    _ => "?",
+                };
+
+                defmt::write!(f, "{}", str);
+                sep = true;
+            }
+        }
+    }
+}
+
 /// Models the BTP header.
 #[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BtpHdr {
     flags: BtpFlags,
     opcode: u8,
@@ -347,6 +377,31 @@ impl fmt::Display for BtpHdr {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for BtpHdr {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        if !self.flags.is_empty() {
+            defmt::write!(f, "{}", self.flags);
+        }
+
+        if let Some(opcode) = self.get_opcode() {
+            defmt::write!(f, ",OP:{:x}", opcode);
+        }
+
+        if let Some(ack_num) = self.get_ack() {
+            defmt::write!(f, ",ACTR:{:x}", ack_num);
+        }
+
+        if let Some(seq_num) = self.get_seq() {
+            defmt::write!(f, ",CTR:{:x}", seq_num);
+        }
+
+        if let Some(msg_len) = self.get_msg_len() {
+            defmt::write!(f, ",LEN:{:x}", msg_len);
+        }
     }
 }
 

--- a/rs-matter/src/transport/network/btp/session/packet.rs
+++ b/rs-matter/src/transport/network/btp/session/packet.rs
@@ -17,11 +17,10 @@
 
 use core::fmt;
 
-use bitflags::bitflags;
-
 use log::trace;
 
 use crate::error::{Error, ErrorCode};
+use crate::utils::bitflags::bitflags;
 use crate::utils::storage::WriteBuf;
 
 bitflags! {
@@ -29,8 +28,8 @@ bitflags! {
     ///
     /// Consult the Matter Core Specification for more information.
     #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct BtpFlags: u8 {
+    #[derive(Default)]
+    pub struct BtpFlags: u8 { // TODO: defmt
         const HANDSHAKE = 0x40;
         const MANAGEMENT = 0x20;
         const ACK = 0x08;
@@ -79,6 +78,7 @@ impl fmt::Display for BtpFlags {
 
 /// Models the BTP header.
 #[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BtpHdr {
     flags: BtpFlags,
     opcode: u8,
@@ -352,6 +352,7 @@ impl fmt::Display for BtpHdr {
 
 /// Models the BTP handshake request.
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct HandshakeReq {
     /// The versions supported by the BTP handshake request.
     versions: u32,
@@ -425,6 +426,7 @@ impl HandshakeReq {
 
 /// Models the BTP handshake response.
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct HandshakeResp {
     /// The version of the BTP protocol supported by the responder.
     pub version: u8,

--- a/rs-matter/src/transport/network/btp/test.rs
+++ b/rs-matter/src/transport/network/btp/test.rs
@@ -108,8 +108,8 @@ impl Peripheral {
     async fn expect(&self, data: &[u8], addr: BtAddr) {
         let received = self.peer_receiver.recv().await.unwrap();
 
-        assert_eq!(received.data, data);
-        assert_eq!(received.address, addr);
+        ::core::assert_eq!(received.data, data);
+        ::core::assert_eq!(received.address, addr);
     }
 }
 
@@ -143,8 +143,8 @@ impl Io {
     async fn expect(&self, data: &[u8], addr: BtAddr) {
         let packet = self.recv.recv().await.unwrap();
 
-        assert_eq!(packet.data, data);
-        assert_eq!(packet.address, addr);
+        ::core::assert_eq!(packet.data, data);
+        ::core::assert_eq!(packet.address, addr);
     }
 }
 

--- a/rs-matter/src/transport/network/btp/test.rs
+++ b/rs-matter/src/transport/network/btp/test.rs
@@ -54,7 +54,6 @@ enum PeripheralIncoming {
     Unsubscribed(BtAddr),
     Write {
         address: BtAddr,
-        #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
         data: Vec<u8>,
         gatt_mtu: Option<u16>,
     },
@@ -63,7 +62,6 @@ enum PeripheralIncoming {
 #[derive(Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct PeripheralOutgoing {
-    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     data: Vec<u8>,
     address: BtAddr,
 }
@@ -116,7 +114,6 @@ impl Peripheral {
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct IoPacket {
-    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     data: Vec<u8>,
     address: BtAddr,
 }

--- a/rs-matter/src/transport/network/btp/test.rs
+++ b/rs-matter/src/transport/network/btp/test.rs
@@ -48,18 +48,22 @@ const BASIC_INFO: BasicInfoConfig<'static> = BasicInfoConfig {
 };
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum PeripheralIncoming {
     Subscribed(BtAddr),
     Unsubscribed(BtAddr),
     Write {
         address: BtAddr,
+        #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
         data: Vec<u8>,
         gatt_mtu: Option<u16>,
     },
 }
 
 #[derive(Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct PeripheralOutgoing {
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     data: Vec<u8>,
     address: BtAddr,
 }
@@ -110,7 +114,9 @@ impl Peripheral {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct IoPacket {
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     data: Vec<u8>,
     address: BtAddr,
 }

--- a/rs-matter/src/transport/packet.rs
+++ b/rs-matter/src/transport/packet.rs
@@ -29,6 +29,7 @@ use super::{
 };
 
 #[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PacketHdr {
     pub plain: PlainHdr,
     pub proto: ProtoHdr,

--- a/rs-matter/src/transport/packet.rs
+++ b/rs-matter/src/transport/packet.rs
@@ -28,7 +28,6 @@ use super::{
 };
 
 #[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PacketHdr {
     pub plain: PlainHdr,
     pub proto: ProtoHdr,
@@ -104,5 +103,12 @@ impl PacketHdr {
 impl fmt::Display for PacketHdr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{}][{}]", self.plain, self.proto)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for PacketHdr {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(f, "[{}][{}]", self.plain, self.proto)
     }
 }

--- a/rs-matter/src/transport/packet.rs
+++ b/rs-matter/src/transport/packet.rs
@@ -17,10 +17,9 @@
 
 use core::fmt;
 
-use log::trace;
-
 use crate::crypto::AEAD_MIC_LEN_BYTES;
 use crate::error::Error;
+use crate::fmt::Bytes;
 use crate::utils::storage::{ParseBuf, WriteBuf};
 
 use super::{
@@ -89,14 +88,14 @@ impl PacketHdr {
         self.plain.encode(&mut write_buf)?;
         let plain_hdr_bytes = write_buf.as_slice();
 
-        trace!("unencrypted packet: {:x?}", wb.as_slice());
+        trace!("Unencrypted packet: {}", Bytes(wb.as_slice()));
         let ctr = self.plain.ctr;
         if let Some(e) = enc_key {
             proto_hdr::encrypt_in_place(ctr, local_nodeid, plain_hdr_bytes, wb, e)?;
         }
 
         wb.prepend(plain_hdr_bytes)?;
-        trace!("Full encrypted packet: {:x?}", wb.as_slice());
+        trace!("Full encrypted packet: {}", Bytes(wb.as_slice()));
 
         Ok(())
     }

--- a/rs-matter/src/transport/plain_hdr.rs
+++ b/rs-matter/src/transport/plain_hdr.rs
@@ -17,8 +17,6 @@
 
 use core::fmt;
 
-use log::trace;
-
 use crate::error::*;
 use crate::utils::bitflags::bitflags;
 use crate::utils::storage::{ParseBuf, WriteBuf};
@@ -26,7 +24,8 @@ use crate::utils::storage::{ParseBuf, WriteBuf};
 bitflags! {
     #[repr(transparent)]
     #[derive(Default)]
-    pub struct MsgFlags: u8 { // TODO: defmt
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
+    pub struct MsgFlags: u8 {
         const DSIZ_UNICAST_NODEID = 0x01;
         const DSIZ_GROUPCAST_NODEID = 0x02;
         const SRC_ADDR_PRESENT = 0x04;
@@ -34,6 +33,7 @@ bitflags! {
 }
 
 impl fmt::Display for MsgFlags {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut sep = false;
         for flag in [

--- a/rs-matter/src/transport/plain_hdr.rs
+++ b/rs-matter/src/transport/plain_hdr.rs
@@ -89,7 +89,6 @@ impl defmt::Format for MsgFlags {
 
 // This is the unencrypted message
 #[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PlainHdr {
     flags: MsgFlags,
     pub sess_id: u16,
@@ -245,6 +244,29 @@ impl fmt::Display for PlainHdr {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for PlainHdr {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        if !self.flags.is_empty() {
+            defmt::write!(f, "{},", self.flags);
+        }
+
+        defmt::write!(f, "SID:{:x},CTR:{:x}", self.sess_id, self.ctr);
+
+        if let Some(src_nodeid) = self.get_src_nodeid() {
+            defmt::write!(f, ",SRC:{:x}", src_nodeid);
+        }
+
+        if let Some(dst_nodeid) = self.get_dst_unicast_nodeid() {
+            defmt::write!(f, ",DST:{:x}", dst_nodeid);
+        }
+
+        if let Some(dst_group_nodeid) = self.get_dst_groupcast_nodeid() {
+            defmt::write!(f, ",GRP:{:x}", dst_group_nodeid);
+        }
     }
 }
 

--- a/rs-matter/src/transport/plain_hdr.rs
+++ b/rs-matter/src/transport/plain_hdr.rs
@@ -18,13 +18,11 @@
 use core::fmt;
 
 use crate::error::*;
-use crate::utils::bitflags::bitflags;
 use crate::utils::storage::{ParseBuf, WriteBuf};
 
-bitflags! {
+bitflags::bitflags! {
     #[repr(transparent)]
-    #[derive(Default)]
-    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
+    #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Hash)]
     pub struct MsgFlags: u8 {
         const DSIZ_UNICAST_NODEID = 0x01;
         const DSIZ_GROUPCAST_NODEID = 0x02;
@@ -33,7 +31,6 @@ bitflags! {
 }
 
 impl fmt::Display for MsgFlags {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut sep = false;
         for flag in [
@@ -59,6 +56,34 @@ impl fmt::Display for MsgFlags {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for MsgFlags {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        let mut sep = false;
+        for flag in [
+            Self::SRC_ADDR_PRESENT,
+            Self::DSIZ_UNICAST_NODEID,
+            Self::DSIZ_GROUPCAST_NODEID,
+        ] {
+            if self.contains(flag) {
+                if sep {
+                    defmt::write!(f, "|");
+                }
+
+                let str = match flag {
+                    Self::DSIZ_UNICAST_NODEID => "U",
+                    Self::DSIZ_GROUPCAST_NODEID => "G",
+                    Self::SRC_ADDR_PRESENT => "S",
+                    _ => "?",
+                };
+
+                defmt::write!(f, "{}", str);
+                sep = true;
+            }
+        }
     }
 }
 

--- a/rs-matter/src/transport/plain_hdr.rs
+++ b/rs-matter/src/transport/plain_hdr.rs
@@ -17,15 +17,16 @@
 
 use core::fmt;
 
-use crate::error::*;
-use crate::utils::storage::{ParseBuf, WriteBuf};
-use bitflags::bitflags;
 use log::trace;
+
+use crate::error::*;
+use crate::utils::bitflags::bitflags;
+use crate::utils::storage::{ParseBuf, WriteBuf};
 
 bitflags! {
     #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct MsgFlags: u8 {
+    #[derive(Default)]
+    pub struct MsgFlags: u8 { // TODO: defmt
         const DSIZ_UNICAST_NODEID = 0x01;
         const DSIZ_GROUPCAST_NODEID = 0x02;
         const SRC_ADDR_PRESENT = 0x04;
@@ -63,6 +64,7 @@ impl fmt::Display for MsgFlags {
 
 // This is the unencrypted message
 #[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PlainHdr {
     flags: MsgFlags,
     pub sess_id: u16,

--- a/rs-matter/src/transport/proto_hdr.rs
+++ b/rs-matter/src/transport/proto_hdr.rs
@@ -102,7 +102,6 @@ impl defmt::Format for ExchFlags {
 }
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ProtoHdr {
     pub exch_id: u16,
     exch_flags: ExchFlags,
@@ -311,6 +310,36 @@ impl fmt::Display for ProtoHdr {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for ProtoHdr {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        if !self.is_decoded() {
+            defmt::write!(f, "(encoded)");
+            return;
+        }
+
+        if !self.exch_flags.is_empty() {
+            defmt::write!(f, "{},", self.exch_flags);
+        }
+
+        defmt::write!(
+            f,
+            "EID:{:x},PROTO:{:x},OP:{:x}",
+            self.exch_id,
+            self.proto_id,
+            self.proto_opcode
+        );
+
+        if let Some(ack_msg_ctr) = self.get_ack() {
+            defmt::write!(f, ",ACTR:{:x}", ack_msg_ctr);
+        }
+
+        if let Some(vendor_id) = self.get_vendor() {
+            defmt::write!(f, ",VID:{:x}", vendor_id);
+        }
     }
 }
 

--- a/rs-matter/src/transport/proto_hdr.rs
+++ b/rs-matter/src/transport/proto_hdr.rs
@@ -19,16 +19,14 @@ use core::fmt;
 
 use crate::fmt::Bytes;
 use crate::transport::plain_hdr;
-use crate::utils::bitflags::bitflags;
 use crate::utils::storage::{ParseBuf, WriteBuf};
 use crate::{crypto, error::*};
 
 use super::network::Address;
 
-bitflags! {
+bitflags::bitflags! {
     #[repr(transparent)]
-    #[derive(Default)]
-    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
+    #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Hash)]
     pub struct ExchFlags: u8 {
         const VENDOR = 0x10;
         const SECEX = 0x08;
@@ -39,7 +37,6 @@ bitflags! {
 }
 
 impl fmt::Display for ExchFlags {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut sep = false;
         for flag in [
@@ -69,6 +66,38 @@ impl fmt::Display for ExchFlags {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for ExchFlags {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        let mut sep = false;
+        for flag in [
+            Self::INITIATOR,
+            Self::ACK,
+            Self::RELIABLE,
+            Self::SECEX,
+            Self::VENDOR,
+        ] {
+            if self.contains(flag) {
+                if sep {
+                    defmt::write!(f, "|");
+                }
+
+                let str = match flag {
+                    Self::INITIATOR => "I",
+                    Self::ACK => "A",
+                    Self::RELIABLE => "R",
+                    Self::SECEX => "SX",
+                    Self::VENDOR => "V",
+                    _ => "?",
+                };
+
+                defmt::write!(f, "{}", str);
+                sep = true;
+            }
+        }
     }
 }
 

--- a/rs-matter/src/transport/proto_hdr.rs
+++ b/rs-matter/src/transport/proto_hdr.rs
@@ -15,21 +15,21 @@
  *    limitations under the License.
  */
 
-use bitflags::bitflags;
 use core::fmt;
 
+use log::{trace, warn};
+
 use crate::transport::plain_hdr;
+use crate::utils::bitflags::bitflags;
 use crate::utils::storage::{ParseBuf, WriteBuf};
 use crate::{crypto, error::*};
-
-use log::{trace, warn};
 
 use super::network::Address;
 
 bitflags! {
     #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct ExchFlags: u8 {
+    #[derive(Default)]
+    pub struct ExchFlags: u8 { // TODO: defmt
         const VENDOR = 0x10;
         const SECEX = 0x08;
         const RELIABLE = 0x04;
@@ -72,6 +72,7 @@ impl fmt::Display for ExchFlags {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ProtoHdr {
     pub exch_id: u16,
     exch_flags: ExchFlags,

--- a/rs-matter/src/transport/proto_hdr.rs
+++ b/rs-matter/src/transport/proto_hdr.rs
@@ -17,8 +17,7 @@
 
 use core::fmt;
 
-use log::{trace, warn};
-
+use crate::fmt::Bytes;
 use crate::transport::plain_hdr;
 use crate::utils::bitflags::bitflags;
 use crate::utils::storage::{ParseBuf, WriteBuf};
@@ -29,7 +28,8 @@ use super::network::Address;
 bitflags! {
     #[repr(transparent)]
     #[derive(Default)]
-    pub struct ExchFlags: u8 { // TODO: defmt
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
+    pub struct ExchFlags: u8 {
         const VENDOR = 0x10;
         const SECEX = 0x08;
         const RELIABLE = 0x04;
@@ -39,6 +39,7 @@ bitflags! {
 }
 
 impl fmt::Display for ExchFlags {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut sep = false;
         for flag in [
@@ -229,7 +230,7 @@ impl ProtoHdr {
             self.ack_msg_ctr = parsebuf.le_u32()?;
         }
         trace!("[decode] {}", self);
-        trace!("[rx payload]: {:x?}", parsebuf.as_mut_slice());
+        trace!("[rx payload]: {}", Bytes(parsebuf.as_mut_slice()));
         Ok(())
     }
 

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -19,8 +19,6 @@ use core::fmt;
 use core::num::NonZeroU8;
 use core::time::Duration;
 
-use log::{error, info, trace, warn};
-
 use crate::error::*;
 use crate::transport::exchange::ExchangeId;
 use crate::transport::mrp::ReliableMessage;

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -45,6 +45,7 @@ pub type NocCatIds = [u32; MAX_CAT_IDS_PER_NOC];
 const MATTER_AES128_KEY_SIZE: usize = 16;
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SessionMode {
     // The Case session will capture the local fabric index
     // and the local fabric index

--- a/rs-matter/src/utils/bitflags.rs
+++ b/rs-matter/src/utils/bitflags.rs
@@ -1,0 +1,7 @@
+//! A module that re-exports the standard `bitflags!` macro if `defmt` is not enabled, or `defmt::bitflags!` if `defmt` is enabled.
+
+#[cfg(not(feature = "defmt"))]
+pub use bitflags::bitflags;
+
+#[cfg(feature = "defmt")]
+pub use defmt::bitflags;

--- a/rs-matter/src/utils/cell.rs
+++ b/rs-matter/src/utils/cell.rs
@@ -76,7 +76,7 @@ impl Display for BorrowError {
 #[cfg(feature = "defmt")]
 impl defmt::Format for BorrowError {
     fn format(&self, f: defmt::Formatter<'_>) {
-        display2format!(self).format(f)
+        defmt::write!(f, "already mutably borrowed")
     }
 }
 
@@ -107,7 +107,7 @@ impl Display for BorrowMutError {
 #[cfg(feature = "defmt")]
 impl defmt::Format for BorrowMutError {
     fn format(&self, f: defmt::Formatter<'_>) {
-        display2format!(self).format(f)
+        defmt::write!(f, "already borrowed")
     }
 }
 

--- a/rs-matter/src/utils/cell.rs
+++ b/rs-matter/src/utils/cell.rs
@@ -57,6 +57,7 @@ pub struct BorrowError {
 }
 
 impl Debug for BorrowError {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("BorrowError");
 
@@ -81,6 +82,7 @@ pub struct BorrowMutError {
 }
 
 impl Debug for BorrowMutError {
+    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("BorrowMutError");
 

--- a/rs-matter/src/utils/cell.rs
+++ b/rs-matter/src/utils/cell.rs
@@ -57,7 +57,6 @@ pub struct BorrowError {
 }
 
 impl Debug for BorrowError {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("BorrowError");
 
@@ -74,6 +73,13 @@ impl Display for BorrowError {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for BorrowError {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        display2format!(self).format(f)
+    }
+}
+
 /// An error returned by [`RefCell::try_borrow_mut`].
 #[non_exhaustive]
 pub struct BorrowMutError {
@@ -82,7 +88,6 @@ pub struct BorrowMutError {
 }
 
 impl Debug for BorrowMutError {
-    // TODO: defmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("BorrowMutError");
 
@@ -96,6 +101,13 @@ impl Debug for BorrowMutError {
 impl Display for BorrowMutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt("already borrowed", f)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for BorrowMutError {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        display2format!(self).format(f)
     }
 }
 

--- a/rs-matter/src/utils/cell.rs
+++ b/rs-matter/src/utils/cell.rs
@@ -366,7 +366,7 @@ impl<T: ?Sized> RefCell<T> {
                 // If a borrow occurred, then we must already have an outstanding borrow,
                 // so `borrowed_at` will be `Some`
                 #[cfg(feature = "debug_refcell")]
-                location: self.borrowed_at.get().unwrap(),
+                location: unwrap!(self.borrowed_at.get()),
             }),
         }
     }
@@ -457,7 +457,7 @@ impl<T: ?Sized> RefCell<T> {
                 // If a borrow occurred, then we must already have an outstanding borrow,
                 // so `borrowed_at` will be `Some`
                 #[cfg(feature = "debug_refcell")]
-                location: self.borrowed_at.get().unwrap(),
+                location: unwrap!(self.borrowed_at.get()),
             }),
         }
     }
@@ -552,7 +552,7 @@ impl<T: ?Sized> RefCell<T> {
                 // If a borrow occurred, then we must already have an outstanding borrow,
                 // so `borrowed_at` will be `Some`
                 #[cfg(feature = "debug_refcell")]
-                location: self.borrowed_at.get().unwrap(),
+                location: unwrap!(self.borrowed_at.get()),
             })
         }
     }

--- a/rs-matter/src/utils/epoch.rs
+++ b/rs-matter/src/utils/epoch.rs
@@ -32,7 +32,8 @@ pub fn dummy_epoch() -> Duration {
 
 #[cfg(feature = "std")]
 pub fn sys_epoch() -> Duration {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
+    unwrap!(
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH),
+        "System time is before UNIX_EPOCH"
+    )
 }

--- a/rs-matter/src/utils/init.rs
+++ b/rs-matter/src/utils/init.rs
@@ -36,7 +36,7 @@ pub trait IntoFallibleInit<T>: Init<T, Infallible> {
     fn into_fallible<E>(self) -> impl Init<T, E> {
         unsafe {
             init_from_closure(move |slot| {
-                Self::__init(self, slot).unwrap();
+                unwrap!(Self::__init(self, slot));
 
                 Ok(())
             })
@@ -61,7 +61,7 @@ impl<T> UnsafeCellInit<T> for UnsafeCell<T> {
                 let slot: *mut T = slot as _;
 
                 // Initialize the value
-                value.__init(slot).unwrap();
+                unwrap!(value.__init(slot));
 
                 Ok(())
             })
@@ -74,7 +74,7 @@ impl<T> UnsafeCellInit<T> for UnsafeCell<T> {
 pub trait InitMaybeUninit<T> {
     /// Initialize Self with the given in-place initializer.
     fn init_with<I: Init<T>>(&mut self, init: I) -> &mut T {
-        self.try_init_with(init).unwrap()
+        unwrap!(self.try_init_with(init))
     }
 
     /// Try to initialize Self with the given fallible in-place initializer.

--- a/rs-matter/src/utils/maybe.rs
+++ b/rs-matter/src/utils/maybe.rs
@@ -127,7 +127,7 @@ impl<T, G> Maybe<T, G> {
     /// Re-initialize the `Maybe` value with a new in-place initializer.
     pub fn reinit<I: init::Init<Self>>(&mut self, value: I) {
         // Unwrap is safe because the initializer is infallible
-        Self::try_reinit(self, value).unwrap();
+        unwrap!(Self::try_reinit(self, value));
     }
 
     /// Try to re-initialize the `Maybe` value with a new in-place initializer.

--- a/rs-matter/src/utils/maybe.rs
+++ b/rs-matter/src/utils/maybe.rs
@@ -38,8 +38,10 @@ use super::init;
 /// one of the provided init constructors, and then use one of the `as_ref`, `as_mut`,
 /// `as_deref` and `as_deref_mut` methods to access the wrapped value.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Maybe<T, G = ()> {
     some: bool,
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     value: MaybeUninit<T>,
     _tag: PhantomData<G>,
 }

--- a/rs-matter/src/utils/maybe.rs
+++ b/rs-matter/src/utils/maybe.rs
@@ -38,10 +38,8 @@ use super::init;
 /// one of the provided init constructors, and then use one of the `as_ref`, `as_mut`,
 /// `as_deref` and `as_deref_mut` methods to access the wrapped value.
 #[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Maybe<T, G = ()> {
     some: bool,
-    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     value: MaybeUninit<T>,
     _tag: PhantomData<G>,
 }
@@ -269,6 +267,20 @@ where
 {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.as_ref().hash(state)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T, G> defmt::Format for Maybe<T, G>
+where
+    T: defmt::Format,
+{
+    fn format(&self, f: defmt::Formatter<'_>) {
+        if self.is_none() {
+            defmt::write!(f, "None")
+        } else {
+            defmt::write!(f, "Some({})", unsafe { self.value.assume_init_ref() })
+        }
     }
 }
 

--- a/rs-matter/src/utils/mod.rs
+++ b/rs-matter/src/utils/mod.rs
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+pub mod bitflags;
 pub mod cell;
 pub mod epoch;
 pub mod init;

--- a/rs-matter/src/utils/storage/pooled.rs
+++ b/rs-matter/src/utils/storage/pooled.rs
@@ -126,7 +126,7 @@ where
 
             match result {
                 Either::First(index) => {
-                    let buffer = &mut unsafe { self.pool.get().as_mut() }.unwrap()[index];
+                    let buffer = &mut unwrap!(unsafe { self.pool.get().as_mut() })[index];
 
                     Some(PooledBuffer {
                         index,
@@ -147,8 +147,8 @@ where
             });
 
             index.map(|index| {
-                let buffers = unsafe { self.pool.get().as_mut() }.unwrap();
-                buffers.resize_default(N).unwrap();
+                let buffers = unwrap!(unsafe { self.pool.get().as_mut() });
+                unwrap!(buffers.resize_default(N));
 
                 let buffer = &mut buffers[index];
 

--- a/rs-matter/src/utils/storage/ringbuf.rs
+++ b/rs-matter/src/utils/storage/ringbuf.rs
@@ -64,7 +64,7 @@ impl<const N: usize> RingBuf<N> {
     #[inline(always)]
     pub fn push(&mut self, data: &[u8]) -> usize {
         // Unwrap is safe because the max size of the buffer is N
-        self.buf.resize_default(N).unwrap();
+        unwrap!(self.buf.resize_default(N));
 
         let mut offset = 0;
 
@@ -97,7 +97,7 @@ impl<const N: usize> RingBuf<N> {
     #[inline(always)]
     pub fn push_byte(&mut self, data: u8) -> usize {
         // Unwrap is safe because the max size of the buffer is N
-        self.buf.resize_default(N).unwrap();
+        unwrap!(self.buf.resize_default(N));
 
         self.buf[self.end] = data;
 

--- a/rs-matter/src/utils/storage/ringbuf.rs
+++ b/rs-matter/src/utils/storage/ringbuf.rs
@@ -21,6 +21,7 @@ use crate::utils::init::{init, Init};
 
 /// A ring buffer of a fixed capacity `N` using owned storage.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RingBuf<const N: usize> {
     buf: crate::utils::storage::Vec<u8, N>,
     start: usize,

--- a/rs-matter/src/utils/storage/vec.rs
+++ b/rs-matter/src/utils/storage/vec.rs
@@ -920,6 +920,15 @@ where
     }
 }
 
+impl<T, const N: usize> defmt::Format for Vec<T, N>
+where
+    T: defmt::Format,
+{
+    fn format(&self, f: defmt::Formatter<'_>) {
+        <[T] as defmt::Format>::format(self, f)
+    }
+}
+
 impl<const N: usize> fmt::Write for Vec<u8, N> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         match self.extend_from_slice(s.as_bytes()) {

--- a/rs-matter/src/utils/storage/vec.rs
+++ b/rs-matter/src/utils/storage/vec.rs
@@ -1011,7 +1011,7 @@ impl<T, const N: usize> FromIterator<T> for Vec<T, N> {
     {
         let mut vec = Vec::new();
         for i in iter {
-            vec.push(i).ok().expect("Vec::from_iter overflow");
+            unwrap!(vec.push(i).ok(), "Vec::from_iter overflow");
         }
         vec
     }
@@ -1593,17 +1593,17 @@ mod tests {
         assert_eq!(v[0], 17);
 
         // Old values aren't changed when growing
-        v.resize(2, 18).unwrap();
+        unwrap!(v.resize(2, 18));
         assert_eq!(v[0], 17);
         assert_eq!(v[1], 18);
 
         // Old values aren't changed when length unchanged
-        v.resize(2, 0).unwrap();
+        unwrap!(v.resize(2, 0));
         assert_eq!(v[0], 17);
         assert_eq!(v[1], 18);
 
         // Old values aren't changed when shrinking
-        v.resize(1, 0).unwrap();
+        unwrap!(v.resize(1, 0));
         assert_eq!(v[0], 17);
     }
 
@@ -1613,14 +1613,14 @@ mod tests {
 
         // resize_default is implemented using resize, so just check the
         // correct value is being written.
-        v.resize_default(1).unwrap();
+        unwrap!(v.resize_default(1));
         assert_eq!(v[0], 0);
     }
 
     #[test]
     fn write() {
         let mut v: Vec<u8, 4> = Vec::new();
-        write!(v, "{:x}", 1234).unwrap();
+        write_unwrap!(v, "{:x}", 1234);
         assert_eq!(&v[..], b"4d2");
     }
 
@@ -1628,10 +1628,10 @@ mod tests {
     fn extend_from_slice() {
         let mut v: Vec<u8, 4> = Vec::new();
         assert_eq!(v.len(), 0);
-        v.extend_from_slice(&[1, 2]).unwrap();
+        unwrap!(v.extend_from_slice(&[1, 2]));
         assert_eq!(v.len(), 2);
         assert_eq!(v.as_slice(), &[1, 2]);
-        v.extend_from_slice(&[3]).unwrap();
+        unwrap!(v.extend_from_slice(&[3]));
         assert_eq!(v.len(), 3);
         assert_eq!(v.as_slice(), &[1, 2, 3]);
         assert!(v.extend_from_slice(&[4, 5]).is_err());
@@ -1642,7 +1642,7 @@ mod tests {
     #[test]
     fn from_slice() {
         // Successful construction
-        let v: Vec<u8, 4> = Vec::from_slice(&[1, 2, 3]).unwrap();
+        let v: Vec<u8, 4> = unwrap!(Vec::from_slice(&[1, 2, 3]));
         assert_eq!(v.len(), 3);
         assert_eq!(v.as_slice(), &[1, 2, 3]);
 
@@ -1652,7 +1652,7 @@ mod tests {
 
     #[test]
     fn starts_with() {
-        let v: Vec<_, 8> = Vec::from_slice(b"ab").unwrap();
+        let v: Vec<_, 8> = unwrap!(Vec::from_slice(b"ab"));
         assert!(v.starts_with(&[]));
         assert!(v.starts_with(b""));
         assert!(v.starts_with(b"a"));
@@ -1664,7 +1664,7 @@ mod tests {
 
     #[test]
     fn ends_with() {
-        let v: Vec<_, 8> = Vec::from_slice(b"ab").unwrap();
+        let v: Vec<_, 8> = unwrap!(Vec::from_slice(b"ab"));
         assert!(v.ends_with(&[]));
         assert!(v.ends_with(b""));
         assert!(v.ends_with(b"b"));

--- a/rs-matter/src/utils/storage/vec.rs
+++ b/rs-matter/src/utils/storage/vec.rs
@@ -920,6 +920,7 @@ where
     }
 }
 
+#[cfg(feature = "defmt")]
 impl<T, const N: usize> defmt::Format for Vec<T, N>
 where
     T: defmt::Format,

--- a/rs-matter/src/utils/storage/writebuf.rs
+++ b/rs-matter/src/utils/storage/writebuf.rs
@@ -19,6 +19,7 @@ use crate::error::*;
 use byteorder::{ByteOrder, LittleEndian};
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WriteBuf<'a> {
     pub(crate) buf: &'a mut [u8],
     buf_size: usize,

--- a/rs-matter/src/utils/storage/writebuf.rs
+++ b/rs-matter/src/utils/storage/writebuf.rs
@@ -230,13 +230,13 @@ mod tests {
     fn test_append_le_with_success() {
         let mut test_slice = [0; 22];
         let mut buf = WriteBuf::new(&mut test_slice);
-        buf.reserve(5).unwrap();
+        unwrap!(buf.reserve(5));
 
-        buf.le_u8(1).unwrap();
-        buf.le_u16(65).unwrap();
-        buf.le_u32(0xcafebabe).unwrap();
-        buf.le_u64(0xcafebabecafebabe).unwrap();
-        buf.le_uint(2, 64).unwrap();
+        unwrap!(buf.le_u8(1));
+        unwrap!(buf.le_u16(65));
+        unwrap!(buf.le_u32(0xcafebabe));
+        unwrap!(buf.le_u64(0xcafebabecafebabe));
+        unwrap!(buf.le_uint(2, 64));
         assert_eq!(
             test_slice,
             [
@@ -250,7 +250,7 @@ mod tests {
     fn test_len_param() {
         let mut test_slice = [0; 20];
         let mut buf = WriteBuf::new(&mut test_slice[..5]);
-        buf.reserve(5).unwrap();
+        unwrap!(buf.reserve(5));
 
         let _ = buf.le_u8(1);
         let _ = buf.le_u16(65);
@@ -264,9 +264,9 @@ mod tests {
     fn test_overrun() {
         let mut test_slice = [0; 20];
         let mut buf = WriteBuf::new(&mut test_slice);
-        buf.reserve(4).unwrap();
-        buf.le_u64(0xcafebabecafebabe).unwrap();
-        buf.le_u64(0xcafebabecafebabe).unwrap();
+        unwrap!(buf.reserve(4));
+        unwrap!(buf.le_u64(0xcafebabecafebabe));
+        unwrap!(buf.le_u64(0xcafebabecafebabe));
         // Now the buffer is fully filled up, so no further puts will happen
 
         if buf.le_u8(1).is_ok() {
@@ -290,15 +290,15 @@ mod tests {
     fn test_as_slice() {
         let mut test_slice = [0; 20];
         let mut buf = WriteBuf::new(&mut test_slice);
-        buf.reserve(5).unwrap();
+        unwrap!(buf.reserve(5));
 
-        buf.le_u8(1).unwrap();
-        buf.le_u16(65).unwrap();
-        buf.le_u32(0xcafebabe).unwrap();
-        buf.le_u64(0xcafebabecafebabe).unwrap();
+        unwrap!(buf.le_u8(1));
+        unwrap!(buf.le_u16(65));
+        unwrap!(buf.le_u32(0xcafebabe));
+        unwrap!(buf.le_u64(0xcafebabecafebabe));
 
         let new_slice: [u8; 3] = [0xa, 0xb, 0xc];
-        buf.prepend(&new_slice).unwrap();
+        unwrap!(buf.prepend(&new_slice));
 
         assert_eq!(
             buf.as_slice(),
@@ -313,12 +313,12 @@ mod tests {
     fn test_copy_as_slice() {
         let mut test_slice = [0; 20];
         let mut buf = WriteBuf::new(&mut test_slice);
-        buf.reserve(5).unwrap();
+        unwrap!(buf.reserve(5));
 
-        buf.le_u16(65).unwrap();
+        unwrap!(buf.le_u16(65));
         let new_slice: [u8; 5] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee];
-        buf.copy_from_slice(&new_slice).unwrap();
-        buf.le_u32(65).unwrap();
+        unwrap!(buf.copy_from_slice(&new_slice));
+        unwrap!(buf.le_u32(65));
         assert_eq!(
             test_slice,
             [0, 0, 0, 0, 0, 65, 0, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 65, 0, 0, 0, 0, 0, 0, 0]
@@ -329,9 +329,9 @@ mod tests {
     fn test_copy_as_slice_overrun() {
         let mut test_slice = [0; 20];
         let mut buf = WriteBuf::new(&mut test_slice[..7]);
-        buf.reserve(5).unwrap();
+        unwrap!(buf.reserve(5));
 
-        buf.le_u16(65).unwrap();
+        unwrap!(buf.le_u16(65));
         let new_slice: [u8; 5] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee];
         if buf.copy_from_slice(&new_slice).is_ok() {
             panic!("This should have returned error")
@@ -342,11 +342,11 @@ mod tests {
     fn test_prepend() {
         let mut test_slice = [0; 20];
         let mut buf = WriteBuf::new(&mut test_slice);
-        buf.reserve(5).unwrap();
+        unwrap!(buf.reserve(5));
 
-        buf.le_u16(65).unwrap();
+        unwrap!(buf.le_u16(65));
         let new_slice: [u8; 5] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee];
-        buf.prepend(&new_slice).unwrap();
+        unwrap!(buf.prepend(&new_slice));
         assert_eq!(
             test_slice,
             [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -357,9 +357,9 @@ mod tests {
     fn test_prepend_overrun() {
         let mut test_slice = [0; 20];
         let mut buf = WriteBuf::new(&mut test_slice);
-        buf.reserve(5).unwrap();
+        unwrap!(buf.reserve(5));
 
-        buf.le_u16(65).unwrap();
+        unwrap!(buf.le_u16(65));
         let new_slice: [u8; 6] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
         if buf.prepend(&new_slice).is_ok() {
             panic!("Prepend should return error")
@@ -370,18 +370,18 @@ mod tests {
     fn test_rewind_tail() {
         let mut test_slice = [0; 20];
         let mut buf = WriteBuf::new(&mut test_slice);
-        buf.reserve(5).unwrap();
+        unwrap!(buf.reserve(5));
 
-        buf.le_u16(65).unwrap();
+        unwrap!(buf.le_u16(65));
 
         let anchor = buf.get_tail();
 
         let new_slice: [u8; 5] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee];
-        buf.copy_from_slice(&new_slice).unwrap();
+        unwrap!(buf.copy_from_slice(&new_slice));
         assert_eq!(buf.as_slice(), [65, 0, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,]);
 
         buf.rewind_tail_to(anchor);
-        buf.le_u16(66).unwrap();
+        unwrap!(buf.le_u16(66));
         assert_eq!(buf.as_slice(), [65, 0, 66, 0,]);
     }
 }

--- a/rs-matter/src/utils/sync/blocking.rs
+++ b/rs-matter/src/utils/sync/blocking.rs
@@ -244,7 +244,7 @@ pub mod raw {
             const INIT: Self = StdRawMutex(std::sync::Mutex::new(()));
 
             fn lock<R>(&self, f: impl FnOnce() -> R) -> R {
-                let _guard = self.0.lock().unwrap();
+                let _guard = unwrap!(self.0.lock(), "Mutex lock failed");
 
                 f()
             }

--- a/rs-matter/src/utils/sync/mutex.rs
+++ b/rs-matter/src/utils/sync/mutex.rs
@@ -30,6 +30,7 @@ use super::signal::Signal;
 
 /// Error returned by [`Mutex::try_lock`]
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TryLockError;
 
 /// Async mutex with conditional locking based on the data inside the mutex.


### PR DESCRIPTION
**Update**: Some metrics from this work in the comments below.

Also note that the plan is to support `defmt` **in addition** to our current `log` support which is kept intact. In other words, users will be able to choose between `log` and `defmt` when depending on the `rs-matter` library.

The [`defmt` framework ](https://defmt.ferrous-systems.com/) is in the meantime a very popular alternative to the Rust-standard `log` crate in that it offers a similar ergonomics and API as the `log` one - yet - it helps tremendously in reducing the Flash footprint of an embedded Rust application. It is supported by many many crates, including the Embassy ones, and the Espressif's own `esp-hal` Rust baremetal ones.

The flash size reduction is achieved by actually NOT storing the log-line string literals (e.g. `"foo {}"` as in `info!("foo {}", foo)`) in the flash at all. Instead, `defmt` just stores a 4-byte index of the string literal. The actual strings are available on the host, in a special section of the ELF file (a bit like debug info), but not really in the `.text`/`.rodata` sections of the flash binary. And there is some "transport" arranged between the host and the firmware, which in layman's terms means you need a special monitor to be able to see the logs that the firmware emits realtime, and Linux's `screen` or `miniterm` won't cut it. (But this infra is available for all chips - `probe-rs` and then for ESPs also `espflash monitor`.)

(The same mechanism is applied to any hard-coded strings in `panic!`, `todo!`, `unreachable`, the various `assert*!` and `debug_assert*!` macros etc., so `defmt` is having a slightly larger scope than `log`.)

We've yet to see the fruits of this excercise, but in general it is unbelievable how much space these string literals take.
For reference, on the NRF52, The `rs-matter` demo with Thread + BLE takes:
- ~ 860KB with info-level logging
- ~ 430KB with ALL logging and panic messages stripped. **50% size reduction**

I think - even with `defmt` - 430KB might not be achievable, but I would be happy if with it we are able to hover around the 500KB or even 600KB range +-, because e.g. the NRF52 has only 1MB of flash (not counting external XIP flash where you can't place executable code due to erratas but you could use the XIP flash for arranging firmware updates) so 860KB vs 600KB is the difference between  the possibility to implement a meaningful, relatively complex embedded app in the remaining 400KB PLUS 600KB for `rs-matter`, versus `rs-matter` eating almost all the flash space just for itself.

(Needless to say, these savings are not confined just to the NRF52, but I'm giving an example with the chip which has the smallest amount of executable flash - yet - with BLE + Thread or Wifi connectivity.)

In terms of API, it does look quite similar to what `log` offers, with some restrictions:
- E.g. `info!` `debug!` `warn!` etc. log macros that are intentionally almost identical to the `log` ones
- As mentioned, also efficient replacements for `todo!()`, `unreachable!()`, `panic!`, `assert!` etc. from the rust Core crate. **This is really important**, because the various `panic` strings tend to be quite big, as they contain the full file path name where the panic did happen

One difference between `log` and `defmt` is that where Rust's `log` (and `print!`) rely on types implementing the standard `Debug` and/or `Display` Rust core crates, `defmt` needs implementations of its own `Format` trait (`defmt` does not make a difference between "display" and "debug"), but this is achieved in 90% of the cases with `#[derive(Format)]` just like we do `#[derive(Debug)]`. The `Format` thing is again necessary for efficiency reasons, as `Debug` and `Display` typically contain string literals which end up in the firmware, while `Format` replaces these literals with string indices.

In terms of changes:
- As mentioned, most of the work was just putting an additional `#[cfg_attr(feature = "defmt", derive(defmt::Format))]` mechanically on all `rs-matter` types currently having `#[derive(Debug)]`
- A significant portion was also semi-automatically replacing `.unwrap()` and `.expect("foo")` with the `unwrap!` macro. This you might want to review separately, it is this commit: https://github.com/project-chip/rs-matter/pull/231/commits/a0036ad06f30bd7db0533226fe12bb9b24afb348
- There's also new top-level crate-private module that needs to be top-level for reasons - `fmt.rs` which contains the logic of "use log's `info!` if the user had selected the `log` crate, or `defmt::info!` if the `defmt` feature was selected"
- The rest of the work is manually fixing discrepancies between the two logging frameworks. For example, 
  - `defmt` does not support (for reasons) RFC-2795, i.e. it is not possible to use interpolation as in `info!("Foo={foo}")` so I had to manually rewrite these to the "old way" of `info!("Foo={}", foo)`
  - At some places where we implement `Debug` or `Display` by hand instead of just deriving `Debug`, I had to put a manual implementation for `defmt::Format` side-by-side with the existing Debug and/or Display impls
  - At even some further places, rather than manually deriving `defmt::Format`, to implement it - for simplicity - I just delegate to the existing `Debug` or `Display` impl with the built-in defmt `Debug2Format` or `Display2Format` capabilities. Note that this should only be done where we know the Debug/Display impls use very short string literals like "[", ", ", "{" and so on as these end up preserved in the flash with Debug2Format and Display2Format.

**UPDATE**: I also noticed that the RustCrypto impl tends to `unwrap` or `panic` at quite a few places **on input coming from the other peer**. Not sure why it was left like that, but this is not OK. We should not hard-crash on invalid data coming over the network. These panics and unwraps are now replaced with proper error propagation.