### PR TITLE
More flexible handler chaining; bridge example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,6 +13,9 @@ name = "onoff_light_bt"
 [[bin]]
 name = "speaker"
 
+[[bin]]
+name = "bridge"
+
 [features]
 default = ["log"]
 zeroconf = ["rs-matter/zeroconf"]

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -1,0 +1,258 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! An example Matter Bridge that bridges two fictitious non-Matter devices as On-Off (Lamp) Matter devices.
+//! The example operates over Ethernet for simplicity, but the concrete network protocol is orthogonal to
+//! the notion of a Matter bridge anyway.
+
+use core::pin::pin;
+
+use std::net::UdpSocket;
+
+use embassy_futures::select::select4;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+
+use rs_matter::core::{Matter, MATTER_PORT};
+use rs_matter::data_model::device_types::{
+    DEV_TYPE_AGGREGATOR, DEV_TYPE_BRIDGE, DEV_TYPE_ON_OFF_LIGHT,
+};
+use rs_matter::data_model::networks::unix::UnixNetifs;
+use rs_matter::data_model::objects::{
+    Async, AsyncHandler, AsyncMetadata, Cluster, Dataver, EmptyHandler, Endpoint, EpClMatcher,
+    Node, ReadContext,
+};
+use rs_matter::data_model::on_off::{ClusterHandler as _, OnOffHandler};
+use rs_matter::data_model::root_endpoint;
+use rs_matter::data_model::sdm::net_comm::NetworkType;
+use rs_matter::data_model::subscriptions::Subscriptions;
+use rs_matter::data_model::system_model::desc::{self, ClusterHandler as _};
+use rs_matter::error::Error;
+use rs_matter::mdns::MdnsService;
+use rs_matter::pairing::DiscoveryCapabilities;
+use rs_matter::persist::Psm;
+use rs_matter::respond::DefaultResponder;
+use rs_matter::transport::core::MATTER_SOCKET_BIND_ADDR;
+use rs_matter::utils::select::Coalesce;
+use rs_matter::utils::storage::pooled::PooledBuffers;
+use rs_matter::{clusters, devices, test_device, with};
+
+pub use bridged_device_basic_information::HandlerAdaptor as BridgedHandlerAdaptor;
+
+rs_matter::import!(BridgedDeviceBasicInformation);
+
+#[path = "../common/mdns.rs"]
+mod mdns;
+
+fn main() -> Result<(), Error> {
+    env_logger::init_from_env(
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+
+    // Create the Matter object
+    let matter = Matter::new_default(
+        &test_device::TEST_DEV_DET,
+        test_device::TEST_DEV_COMM,
+        &test_device::TEST_DEV_ATT,
+        MdnsService::Builtin,
+        MATTER_PORT,
+    );
+
+    // Need to call this once
+    matter.initialize_transport_buffers()?;
+
+    // Create the transport buffers
+    let buffers = PooledBuffers::<10, NoopRawMutex, _>::new(0);
+
+    // Create the subscriptions
+    let subscriptions = Subscriptions::<3>::new();
+
+    // Assemble our Data Model handler by composing the predefined Root Endpoint handler with our custom Speaker handler
+    let dm_handler = dm_handler(&matter);
+
+    // Create a default responder capable of handling up to 3 subscriptions
+    // All other subscription requests will be turned down with "resource exhausted"
+    let responder = DefaultResponder::new(&matter, &buffers, &subscriptions, dm_handler);
+
+    // Run the responder with up to 4 handlers (i.e. 4 exchanges can be handled simultaneously)
+    // Clients trying to open more exchanges than the ones currently running will get "I'm busy, please try again later"
+    let mut respond = pin!(responder.run::<4, 4>());
+
+    // Create the Matter UDP socket
+    let socket = async_io::Async::<UdpSocket>::bind(MATTER_SOCKET_BIND_ADDR)?;
+
+    // Run the Matter and mDNS transports
+    let mut mdns = pin!(mdns::run_mdns(&matter));
+    let mut transport = pin!(matter.run(&socket, &socket, DiscoveryCapabilities::IP));
+
+    // Create, load and run the persister
+    let mut psm: Psm<4096> = Psm::new();
+
+    let dir = std::env::temp_dir().join("rs-matter");
+
+    psm.load(&dir, &matter)?;
+
+    let mut persist = pin!(psm.run(dir, &matter));
+
+    // Combine all async tasks in a single one
+    let all = select4(&mut transport, &mut mdns, &mut persist, &mut respond);
+
+    // Run with a simple `block_on`. Any local executor would do.
+    futures_lite::future::block_on(all.coalesce())
+}
+
+/// The Node meta-data describing our Matter device.
+const NODE: Node<'static> = Node {
+    id: 0,
+    endpoints: &[
+        // The root (0) endpoint - as usual.
+        //
+        // Only difference between the root point for a Matter bridge is that it has to declare itself
+        // as having a device type "bridge". In regular (non-bridge) Matter nodes, ep0 has a "root node"
+        //  the device type.
+        Endpoint {
+            id: 0,
+            device_types: devices!(DEV_TYPE_BRIDGE),
+            clusters: root_endpoint::root_endpoint(NetworkType::Ethernet).clusters,
+        },
+        // Endpoint 1 also has a special meaning in a Matter Bridge. It is the so called "aggregator".
+        //
+        // Optionally, it can declare and implement the `Actions` cluster
+        // (see below in the handler the meaning of this cluster).
+        // In any case, this endpoint must to be of the Aggregator device type.
+        Endpoint {
+            id: 1,
+            device_types: devices!(DEV_TYPE_AGGREGATOR),
+            clusters: clusters!(desc::DescHandler::CLUSTER),
+        },
+        // This is the first bridged device. It could have any ID as long as it is not 0 or 1.
+        //
+        // The Matter Bridge needs to declare as many endpoints as there are bridged devices.
+        // If the bridged devices can vary over time, rather than using a static `Node`
+        // definition, one could use an `(Async)MetaData` implementation that returns a node
+        // which references the endpoints off from a `Vec` or a `heapless::Vec`.
+        Endpoint {
+            id: 2,
+            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters: clusters!(desc::DescHandler::CLUSTER, OnOffHandler::CLUSTER),
+        },
+        // This is the second bridged device.
+        //
+        // It could have a cvompletely different device type, yet here - for simplicity - we
+        // just declare another lamp.
+        Endpoint {
+            id: 3,
+            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters: clusters!(desc::DescHandler::CLUSTER, OnOffHandler::CLUSTER),
+        },
+    ],
+};
+
+/// The Data Model handler + meta-data for our Matter Bridge.
+fn dm_handler(matter: &Matter<'_>) -> impl AsyncMetadata + AsyncHandler + 'static {
+    (
+        NODE,
+        root_endpoint::with_eth(
+            &(),
+            &UnixNetifs,
+            matter.rand(),
+            root_endpoint::with_sys(
+                &false,
+                matter.rand(),
+                EmptyHandler
+                    // The next chain is the handler for the "aggregator" endpoint 1.
+                    //
+                    // Note how the descriptor cluster is a bit different compared to the normal ones.
+                    // The `Aggregator` descriptor cluster takes care of declaring all bridged endpoints
+                    // as such.
+                    //
+                    // Note also that implementing the "Actions" cluster (and declaring it in the ep1 meta-data)
+                    // would allow one to designate locations/areas to the bridged devices.
+                    .chain(
+                        EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                        Async(
+                            desc::DescHandler::new_aggregator(Dataver::new_rand(matter.rand()))
+                                .adapt(),
+                        ),
+                    )
+                    // The following chains are the handlers for the bridged devicea corresponding to ep 2 and ep3.
+                    //
+                    // In addition to the usual clusters, every bridged endpoint needs to implement the
+                    // "Bridged" cluster as well.
+                    //
+                    // Note also that we are re-using here the ready-made `OnOffHandler` from `rs-matter` for demoing purposes.
+                    // In production setups, user is expected to define their own handler for their bridge device cluster(s)
+                    // which is likely to do remote calls over a proprietary protocol so as to e.g. retrieve the state of
+                    // the lamp, or to switch it on/off.
+                    .chain(
+                        EpClMatcher::new(Some(2), Some(desc::DescHandler::CLUSTER.id)),
+                        Async(desc::DescHandler::new(Dataver::new_rand(matter.rand())).adapt()),
+                    )
+                    .chain(
+                        EpClMatcher::new(Some(2), Some(OnOffHandler::CLUSTER.id)),
+                        Async(OnOffHandler::new(Dataver::new_rand(matter.rand())).adapt()),
+                    )
+                    .chain(
+                        EpClMatcher::new(Some(3), Some(desc::DescHandler::CLUSTER.id)),
+                        Async(desc::DescHandler::new(Dataver::new_rand(matter.rand())).adapt()),
+                    )
+                    .chain(
+                        EpClMatcher::new(Some(3), Some(OnOffHandler::CLUSTER.id)),
+                        Async(OnOffHandler::new(Dataver::new_rand(matter.rand())).adapt()),
+                    ),
+            ),
+        ),
+    )
+}
+
+#[derive(Clone, Debug)]
+pub struct BridgedClusterHandler {
+    dataver: Dataver,
+}
+
+impl BridgedClusterHandler {
+    pub const fn new(dataver: Dataver) -> Self {
+        Self { dataver }
+    }
+}
+
+impl bridged_device_basic_information::ClusterHandler for BridgedClusterHandler {
+    const CLUSTER: Cluster<'static> = bridged_device_basic_information::FULL_CLUSTER
+        .with_revision(1)
+        .with_features(0)
+        .with_attrs(with!(required))
+        .with_cmds(with!());
+
+    fn dataver(&self) -> u32 {
+        self.dataver.get()
+    }
+
+    fn dataver_changed(&self) {
+        self.dataver.changed();
+    }
+
+    fn reachable(&self, _ctx: &ReadContext<'_>) -> Result<bool, Error> {
+        // This is the only mandatory attribute.
+        //
+        // We always report that the bridged device is reachable,
+        // however - in production setup - the user might want to implement
+        // true reachability logic here.
+        Ok(true)
+    }
+
+    // Note that at least the `node_label` optional attribute is also good to implement,
+    // so that way users can name the bridged devices their own way, using the Matter controller.
+}

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -124,7 +124,7 @@ const NODE: Node<'static> = Node {
         //
         // Only difference between the root point for a Matter bridge is that it has to declare itself
         // as having a device type "bridge". In regular (non-bridge) Matter nodes, ep0 has a "root node"
-        //  the device type.
+        // the device type.
         Endpoint {
             id: 0,
             device_types: devices!(DEV_TYPE_BRIDGE),
@@ -157,7 +157,7 @@ const NODE: Node<'static> = Node {
         },
         // This is the second bridged device.
         //
-        // It could have a cvompletely different device type, yet here - for simplicity - we
+        // It could have a completely different device type, yet here - for simplicity - we
         // just declare another lamp.
         Endpoint {
             id: 3,
@@ -189,8 +189,10 @@ fn dm_handler(matter: &Matter<'_>) -> impl AsyncMetadata + AsyncHandler + 'stati
                     // The `Aggregator` descriptor cluster takes care of declaring all bridged endpoints
                     // as such.
                     //
-                    // Note also that implementing the "Actions" cluster (and declaring it in the ep1 meta-data)
-                    // would allow one to designate locations/areas to the bridged devices.
+                    // Implementing the "Actions" cluster (and declaring it in the ep1 meta-data)
+                    // would allow one to designate locations/areas to the bridged devices. However, this is
+                    // not yet supported by Google home and Apple, as per
+                    // https://www.1home.io/docs/en/server/configure-devices#manage-rooms
                     .chain(
                         EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
                         Async(
@@ -198,7 +200,7 @@ fn dm_handler(matter: &Matter<'_>) -> impl AsyncMetadata + AsyncHandler + 'stati
                                 .adapt(),
                         ),
                     )
-                    // The following chains are the handlers for the bridged devicea corresponding to ep 2 and ep3.
+                    // The following chains are the handlers for the bridged devices corresponding to ep 2 and ep3.
                     //
                     // In addition to the usual clusters, every bridged endpoint needs to implement the
                     // "Bridged" cluster as well.

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -222,11 +222,11 @@ fn dm_handler<'a>(
                 matter.rand(),
                 EmptyHandler
                     .chain(
-                        EpClMatcher::new(1, desc::DescHandler::CLUSTER.id),
+                        EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
                         Async(desc::DescHandler::new(Dataver::new_rand(matter.rand())).adapt()),
                     )
                     .chain(
-                        EpClMatcher::new(1, on_off::OnOffHandler::CLUSTER.id),
+                        EpClMatcher::new(Some(1), Some(on_off::OnOffHandler::CLUSTER.id)),
                         Async(on_off::HandlerAdaptor(on_off)),
                     ),
             ),

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -32,7 +32,7 @@ use rs_matter::data_model::core::IMBuffer;
 use rs_matter::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::data_model::networks::unix::UnixNetifs;
 use rs_matter::data_model::objects::{
-    Async, AsyncHandler, AsyncMetadata, Dataver, EmptyHandler, Endpoint, Node,
+    Async, AsyncHandler, AsyncMetadata, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter::data_model::on_off::{self, ClusterHandler as _};
 use rs_matter::data_model::root_endpoint;
@@ -222,13 +222,11 @@ fn dm_handler<'a>(
                 matter.rand(),
                 EmptyHandler
                     .chain(
-                        1,
-                        desc::DescHandler::CLUSTER.id,
+                        EpClMatcher::new(1, desc::DescHandler::CLUSTER.id),
                         Async(desc::DescHandler::new(Dataver::new_rand(matter.rand())).adapt()),
                     )
                     .chain(
-                        1,
-                        on_off::OnOffHandler::CLUSTER.id,
+                        EpClMatcher::new(1, on_off::OnOffHandler::CLUSTER.id),
                         Async(on_off::HandlerAdaptor(on_off)),
                     ),
             ),

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -228,11 +228,11 @@ where
                 matter.rand(),
                 EmptyHandler
                     .chain(
-                        EpClMatcher::new(1, desc::DescHandler::CLUSTER.id),
+                        EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
                         Async(desc::DescHandler::new(Dataver::new_rand(matter.rand())).adapt()),
                     )
                     .chain(
-                        EpClMatcher::new(1, on_off::OnOffHandler::CLUSTER.id),
+                        EpClMatcher::new(Some(1), Some(on_off::OnOffHandler::CLUSTER.id)),
                         Async(on_off::HandlerAdaptor(on_off)),
                     ),
             ),

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -43,7 +43,7 @@ use rs_matter::data_model::networks::wireless::{
     NetCtlState, NetCtlWithStatusImpl, NoopWirelessNetCtl, WifiNetworks,
 };
 use rs_matter::data_model::objects::{
-    Async, AsyncHandler, AsyncMetadata, Dataver, EmptyHandler, Endpoint, Node,
+    Async, AsyncHandler, AsyncMetadata, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter::data_model::on_off::{self, ClusterHandler as _};
 use rs_matter::data_model::root_endpoint;
@@ -228,13 +228,11 @@ where
                 matter.rand(),
                 EmptyHandler
                     .chain(
-                        1,
-                        desc::DescHandler::CLUSTER.id,
+                        EpClMatcher::new(1, desc::DescHandler::CLUSTER.id),
                         Async(desc::DescHandler::new(Dataver::new_rand(matter.rand())).adapt()),
                     )
                     .chain(
-                        1,
-                        on_off::OnOffHandler::CLUSTER.id,
+                        EpClMatcher::new(1, on_off::OnOffHandler::CLUSTER.id),
                         Async(on_off::HandlerAdaptor(on_off)),
                     ),
             ),

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -37,8 +37,8 @@ use rs_matter::core::{Matter, MATTER_PORT};
 use rs_matter::data_model::device_types::DEV_TYPE_SMART_SPEAKER;
 use rs_matter::data_model::networks::unix::UnixNetifs;
 use rs_matter::data_model::objects::{
-    Async, AsyncHandler, AsyncMetadata, Cluster, Dataver, EmptyHandler, Endpoint, InvokeContext,
-    Node, ReadContext,
+    Async, AsyncHandler, AsyncMetadata, Cluster, Dataver, EmptyHandler, Endpoint, EpClMatcher,
+    InvokeContext, Node, ReadContext,
 };
 use rs_matter::data_model::root_endpoint;
 use rs_matter::data_model::sdm::net_comm::NetworkType;
@@ -152,13 +152,11 @@ fn dm_handler(matter: &Matter<'_>) -> impl AsyncMetadata + AsyncHandler + 'stati
                 matter.rand(),
                 EmptyHandler
                     .chain(
-                        1,
-                        desc::DescHandler::CLUSTER.id,
+                        EpClMatcher::new(1, desc::DescHandler::CLUSTER.id),
                         Async(desc::DescHandler::new(Dataver::new_rand(matter.rand())).adapt()),
                     )
                     .chain(
-                        1,
-                        SpeakerHandler::CLUSTER.id,
+                        EpClMatcher::new(1, SpeakerHandler::CLUSTER.id),
                         SpeakerHandler::new(Dataver::new_rand(matter.rand())).adapt(),
                     ),
             ),

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -53,8 +53,8 @@ use rs_matter::tlv::TLVBuilderParent;
 use rs_matter::transport::core::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::select::Coalesce;
 use rs_matter::utils::storage::pooled::PooledBuffers;
-use rs_matter::with;
 use rs_matter::{clusters, test_device};
+use rs_matter::{devices, with};
 
 // Import the MediaPlayback cluster from `rs-matter`.
 //
@@ -132,7 +132,7 @@ const NODE: Node<'static> = Node {
         root_endpoint::root_endpoint(NetworkType::Ethernet),
         Endpoint {
             id: 1,
-            device_types: &[DEV_TYPE_SMART_SPEAKER],
+            device_types: devices!(DEV_TYPE_SMART_SPEAKER),
             clusters: clusters!(desc::DescHandler::CLUSTER, SpeakerHandler::CLUSTER),
         },
     ],
@@ -152,11 +152,11 @@ fn dm_handler(matter: &Matter<'_>) -> impl AsyncMetadata + AsyncHandler + 'stati
                 matter.rand(),
                 EmptyHandler
                     .chain(
-                        EpClMatcher::new(1, desc::DescHandler::CLUSTER.id),
+                        EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
                         Async(desc::DescHandler::new(Dataver::new_rand(matter.rand())).adapt()),
                     )
                     .chain(
-                        EpClMatcher::new(1, SpeakerHandler::CLUSTER.id),
+                        EpClMatcher::new(Some(1), Some(SpeakerHandler::CLUSTER.id)),
                         SpeakerHandler::new(Dataver::new_rand(matter.rand())).adapt(),
                     ),
             ),

--- a/rs-matter-macros-impl/src/idl.rs
+++ b/rs-matter-macros-impl/src/idl.rs
@@ -22352,6 +22352,8 @@ pub mod unit_testing {
         }
     }
     #[doc = "The handler adaptor for the cluster-specific handler. This adaptor implements the generic `rs-matter` handler trait."]
+    #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+    #[cfg_attr(feature = "defmt", derive(rs_matter_crate::reexport::defmt::Format))]
     pub struct HandlerAdaptor<T>(pub T);
     impl<T> rs_matter_crate::data_model::objects::Handler for HandlerAdaptor<T>
     where

--- a/rs-matter-macros-impl/src/idl/handler.rs
+++ b/rs-matter-macros-impl/src/idl/handler.rs
@@ -249,6 +249,8 @@ pub fn handler_adaptor(
 
     let stream = quote!(
         #[doc = "The handler adaptor for the cluster-specific handler. This adaptor implements the generic `rs-matter` handler trait."]
+        #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(#krate::reexport::defmt::Format))]
         pub struct #handler_adaptor_name<T>(pub T);
 
         impl<T> #krate::data_model::objects::#generic_handler_name for #handler_adaptor_name<T>
@@ -1347,6 +1349,8 @@ mod tests {
             &handler_adaptor(false, cluster, &context),
             &quote!(
                 #[doc = "The handler adaptor for the cluster-specific handler. This adaptor implements the generic `rs-matter` handler trait."]
+                #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+                #[cfg_attr(feature = "defmt", derive(rs_matter_crate::reexport::defmt::Format))]
                 pub struct HandlerAdaptor<T>(pub T);
                 impl<T> rs_matter_crate::data_model::objects::Handler for HandlerAdaptor<T>
                 where

--- a/rs-matter/src/data_model/device_types.rs
+++ b/rs-matter/src/data_model/device_types.rs
@@ -17,24 +17,20 @@
 
 use super::objects::DeviceType;
 
-/// A constant representing the device type for
-/// the root (ep0) endpoint in Matter.
+/// A constant representing the device type for the root (ep0) endpoint in Matter.
 pub const DEV_TYPE_ROOT_NODE: DeviceType = DeviceType {
     dtype: 0x0016,
     drev: 1,
 };
 
-/// A constant representing the device type for
-/// the root (ep0) endpoint in Matter, when the Node represents
-/// a Bridged Matter node.
-pub const DEV_TYPE_BRIDGE: DeviceType = DeviceType {
+/// A constant representing the device type for a bridged device endpoint in the node.
+pub const DEV_TYPE_BRIDGED_NODE: DeviceType = DeviceType {
     dtype: 0x0013,
     drev: 1,
 };
 
-/// A constant representing the device type for
-/// the aggregator (ep1) endpoint in Matter, when the Node represents
-/// a Bridged Matter node.
+/// A constant representing the device type for an aggregator endpoint in the node
+///  when the Node contains bridged endpoints.
 pub const DEV_TYPE_AGGREGATOR: DeviceType = DeviceType {
     dtype: 0x000e,
     drev: 1,

--- a/rs-matter/src/data_model/device_types.rs
+++ b/rs-matter/src/data_model/device_types.rs
@@ -17,16 +17,38 @@
 
 use super::objects::DeviceType;
 
+/// A constant representing the device type for
+/// the root (ep0) endpoint in Matter.
 pub const DEV_TYPE_ROOT_NODE: DeviceType = DeviceType {
     dtype: 0x0016,
     drev: 1,
 };
 
+/// A constant representing the device type for
+/// the root (ep0) endpoint in Matter, when the Node represents
+/// a Bridged Matter node.
+pub const DEV_TYPE_BRIDGE: DeviceType = DeviceType {
+    dtype: 0x0013,
+    drev: 1,
+};
+
+/// A constant representing the device type for
+/// the aggregator (ep1) endpoint in Matter, when the Node represents
+/// a Bridged Matter node.
+pub const DEV_TYPE_AGGREGATOR: DeviceType = DeviceType {
+    dtype: 0x000e,
+    drev: 1,
+};
+
+/// A constant representing the device type for
+/// the On/Off Light cluster in Matter.
 pub const DEV_TYPE_ON_OFF_LIGHT: DeviceType = DeviceType {
     dtype: 0x0100,
     drev: 2,
 };
 
+/// A constant representing the device type for
+/// the Smart Speaker cluster in Matter.
 pub const DEV_TYPE_SMART_SPEAKER: DeviceType = DeviceType {
     dtype: 0x0022,
     drev: 2,

--- a/rs-matter/src/data_model/root_endpoint.rs
+++ b/rs-matter/src/data_model/root_endpoint.rs
@@ -15,8 +15,8 @@
  *    limitations under the License.
  */
 
-use crate::handler_chain_type;
 use crate::utils::rand::Rand;
+use crate::{devices, handler_chain_type};
 
 use super::basic_info::{self, BasicInfoHandler, ClusterHandler as _};
 use super::networks::eth::{EthNetCtl, EthNetwork};
@@ -39,7 +39,7 @@ use super::system_model::desc::{self, ClusterHandler as _, DescHandler};
 pub const fn root_endpoint(net_type: NetworkType) -> Endpoint<'static> {
     Endpoint {
         id: ROOT_ENDPOINT_ID,
-        device_types: &[super::device_types::DEV_TYPE_ROOT_NODE],
+        device_types: devices!(super::device_types::DEV_TYPE_ROOT_NODE),
         clusters: net_type.root_clusters(),
     }
 }
@@ -113,16 +113,19 @@ pub fn with_eth<'a, H>(
     const NETWORK: EthNetwork<'static> = EthNetwork::new("eth");
 
     ChainedHandler::new(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, GenDiagHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(GenDiagHandler::CLUSTER.id)),
         Async(GenDiagHandler::new(Dataver::new_rand(rand), gen_diag, netif_diag).adapt()),
         handler,
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, EthDiagHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(EthDiagHandler::CLUSTER.id)),
         Async(EthDiagHandler::new(Dataver::new_rand(rand)).adapt()),
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, NetCommHandler::<EthNetCtl>::CLUSTER.id),
+        EpClMatcher::new(
+            Some(ROOT_ENDPOINT_ID),
+            Some(NetCommHandler::<EthNetCtl>::CLUSTER.id),
+        ),
         NetCommHandler::new(Dataver::new_rand(rand), &NETWORK, EthNetCtl).adapt(),
     )
 }
@@ -153,16 +156,19 @@ where
     T: NetCtl + NetCtlStatus + WifiDiag,
 {
     ChainedHandler::new(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, GenDiagHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(GenDiagHandler::CLUSTER.id)),
         Async(GenDiagHandler::new(Dataver::new_rand(rand), gen_diag, netif_diag).adapt()),
         handler,
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, WifiDiagHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(WifiDiagHandler::CLUSTER.id)),
         Async(WifiDiagHandler::new(Dataver::new_rand(rand), net_ctl).adapt()),
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, NetCommHandler::<T>::CLUSTER.id),
+        EpClMatcher::new(
+            Some(ROOT_ENDPOINT_ID),
+            Some(NetCommHandler::<T>::CLUSTER.id),
+        ),
         NetCommHandler::new(Dataver::new_rand(rand), networks, net_ctl).adapt(),
     )
 }
@@ -192,16 +198,19 @@ where
     T: NetCtl + NetCtlStatus + ThreadDiag,
 {
     ChainedHandler::new(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, GenDiagHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(GenDiagHandler::CLUSTER.id)),
         Async(GenDiagHandler::new(Dataver::new_rand(rand), gen_diag, netif_diag).adapt()),
         handler,
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, ThreadDiagHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(ThreadDiagHandler::CLUSTER.id)),
         Async(ThreadDiagHandler::new(Dataver::new_rand(rand), net_ctl).adapt()),
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, NetCommHandler::<T>::CLUSTER.id),
+        EpClMatcher::new(
+            Some(ROOT_ENDPOINT_ID),
+            Some(NetCommHandler::<T>::CLUSTER.id),
+        ),
         NetCommHandler::new(Dataver::new_rand(rand), networks, net_ctl).adapt(),
     )
 }
@@ -223,32 +232,32 @@ pub fn with_sys<'a, H>(
     handler: H,
 ) -> SysHandler<'a, H> {
     ChainedHandler::new(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, GrpKeyMgmtHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(GrpKeyMgmtHandler::CLUSTER.id)),
         Async(GrpKeyMgmtHandler::new(Dataver::new_rand(rand)).adapt()),
         handler,
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, AclHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(AclHandler::CLUSTER.id)),
         Async(AclHandler::new(Dataver::new_rand(rand)).adapt()),
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, NocHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(NocHandler::CLUSTER.id)),
         Async(NocHandler::new(Dataver::new_rand(rand)).adapt()),
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, AdminCommHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(AdminCommHandler::CLUSTER.id)),
         Async(AdminCommHandler::new(Dataver::new_rand(rand)).adapt()),
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, GenCommHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(GenCommHandler::CLUSTER.id)),
         Async(GenCommHandler::new(Dataver::new_rand(rand), comm_policy).adapt()),
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, BasicInfoHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(BasicInfoHandler::CLUSTER.id)),
         Async(BasicInfoHandler::new(Dataver::new_rand(rand)).adapt()),
     )
     .chain(
-        EpClMatcher::new(ROOT_ENDPOINT_ID, DescHandler::CLUSTER.id),
+        EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(DescHandler::CLUSTER.id)),
         Async(DescHandler::new(Dataver::new_rand(rand)).adapt()),
     )
 }

--- a/rs-matter/src/data_model/system_model/desc.rs
+++ b/rs-matter/src/data_model/system_model/desc.rs
@@ -40,6 +40,11 @@ impl PartsMatcher for StandardPartsMatcher {
 }
 
 /// A parts matcher suitable for the aggregator endpoints of bridged Matter devices
+///
+/// This matcher matches ALL endpoints that are not the root endpoint (0) and not the aggregator endpoint itself.
+///
+/// For more complex scenarios, where the node needs to contain multiple aggregators, or where the node
+/// might contain non-bridged endpoints, user needs to supply its own `PartsMatcher` implementation.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct AggregatorPartsMatcher;

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -73,20 +73,20 @@ impl<'a> E2eTestHandler<'a> {
         );
 
         let handler = ChainedHandler::new(
-            EpClMatcher::new(ROOT_ENDPOINT_ID, echo_cluster::ID),
+            EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(echo_cluster::ID)),
             Async(EchoHandler::new(2, Dataver::new_rand(matter.rand()))),
             handler,
         )
         .chain(
-            EpClMatcher::new(1, DescHandler::CLUSTER.id),
+            EpClMatcher::new(Some(1), Some(DescHandler::CLUSTER.id)),
             Async(DescHandler::new(Dataver::new_rand(matter.rand())).adapt()),
         )
         .chain(
-            EpClMatcher::new(1, echo_cluster::ID),
+            EpClMatcher::new(Some(1), Some(echo_cluster::ID)),
             Async(EchoHandler::new(3, Dataver::new_rand(matter.rand()))),
         )
         .chain(
-            EpClMatcher::new(1, OnOffHandler::CLUSTER.id),
+            EpClMatcher::new(Some(1), Some(OnOffHandler::CLUSTER.id)),
             Async(OnOffHandler::new(Dataver::new_rand(matter.rand())).adapt()),
         );
 


### PR DESCRIPTION
While it is tempting to think that each handler in a `.chain` of `rs-matter` handlers corresponds to exactly one cluster for an exactly one, concrete endpoint, this might not always be the case, and the user should in fact be free to arrange their handling logic using `.chain` however she wants. Or not use chained handlers at all.

In fact, what `rs-matter` expects is a single, global `(Async)Handler` for the whole node. How this handler is implemented is up to the user.

What this PR does therefore is to make the `ChainedHandler` struct a tad more flexible in no longer assuming that each chain is corresponding to exactly one cluster of an endpoint. I have such a use case downstream in a crate of mine, and so far I was re-inventing my own - more flexible - `ChainedHandler` operating similar to the changes suggested here.

===

This PR also addresses a minor omission of mine - a couple of the generic structs in `rs-matter` (`Async` as well as the auto-generated `ClusterHandler` where the latter adapts the cluster-specific `import!` handler trait to the generic `(Async)Handler` of `rs-matter`) were not `Debug + Clone + Copy + etc.`.

This I also need downstream (of course, since these are generic, they are only e.g. `Copy` if their `T` is `Copy` and so on).

===

Finally, while I'm at it (my downstream crate is a Matter bridge), I implemented a bridge example, as was requested by a user in this discussion: https://github.com/project-chip/rs-matter/discussions/200


