### PR TITLE
Preserve the current session upon fabric removal

### DIFF
--- a/rs-matter/src/data_model/sdm/noc.rs
+++ b/rs-matter/src/data_model/sdm/noc.rs
@@ -534,12 +534,21 @@ impl ClusterHandler for NocHandler {
             .remove(fab_idx, &ctx.exchange().matter().transport_mgr.mdns)
             .is_ok()
         {
+            // If our own session is running on the fabric being removed,
+            // we need to expire it rather than immediately remove it, so that
+            // the response can be sent back properly
+            let expire_sess_id = ctx.exchange().with_session(|sess| {
+                Ok((sess.get_local_fabric_idx() == fab_idx.get()).then_some(sess.id()))
+            })?;
+
+            // Remove all sessions related to the fabric being removed
+            // Mark our own session as expired, so that except the one on which the request is running
             ctx.exchange()
                 .matter()
                 .transport_mgr
                 .session_mgr
                 .borrow_mut()
-                .remove_for_fabric(fab_idx);
+                .remove_for_fabric(fab_idx, expire_sess_id);
 
             // Notify that the fabrics need to be persisted
             // We need to explicitly do this because if the fabric being removed

--- a/rs-matter/src/data_model/sdm/noc.rs
+++ b/rs-matter/src/data_model/sdm/noc.rs
@@ -542,7 +542,7 @@ impl ClusterHandler for NocHandler {
             })?;
 
             // Remove all sessions related to the fabric being removed
-            // Mark our own session as expired, so that except the one on which the request is running
+            // If `expire_sess_id` is Some, the session will be expired instead of removed.
             ctx.exchange()
                 .matter()
                 .transport_mgr

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -202,6 +202,7 @@ impl<'m> TransportMgr<'m> {
 
         session_mgr
             .get(session_id)
+            // Expired sessions are not allowed to initiate new exchanges
             .filter(|sess| !sess.is_expired())
             .ok_or(ErrorCode::NoSession)?;
 

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -200,7 +200,10 @@ impl<'m> TransportMgr<'m> {
     ) -> Result<Exchange<'a>, Error> {
         let mut session_mgr = self.session_mgr.borrow_mut();
 
-        session_mgr.get(session_id).ok_or(ErrorCode::NoSession)?;
+        session_mgr
+            .get(session_id)
+            .filter(|sess| !sess.is_expired())
+            .ok_or(ErrorCode::NoSession)?;
 
         let exch_id = session_mgr.get_next_exch_id();
 
@@ -233,7 +236,6 @@ impl<'m> TransportMgr<'m> {
                 let mut session_mgr = self.session_mgr.borrow_mut();
 
                 let session = session_mgr.get_for_rx(&packet.peer, &packet.header.plain)?;
-
                 let exch_index = session.get_exch_for_rx(&packet.header.proto)?;
 
                 let matches = {

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -736,12 +736,11 @@ impl SessionMgr {
         }
 
         if let Some(expire_sess_id) = expire_sess_id {
-            let our_sess = self
+            let expire_sess = self
                 .sessions
                 .iter_mut()
                 .find(|sess| sess.id == expire_sess_id);
-            if let Some(expire_sess) = our_sess {
-                // If we have a session for ourselves, then we just mark it as expired
+            if let Some(expire_sess) = expire_sess {
                 expire_sess.expired = true;
                 info!(
                     "Marking session with ID {} as expired for fabric index {}",
@@ -777,6 +776,7 @@ impl SessionMgr {
         let mut session = self
             .sessions
             .iter_mut()
+            // Expired sessions are not allowed to initiate new exchanges
             .find(|sess| !sess.expired && sess.is_for_node(fabric_idx, peer_node_id, secure));
 
         if let Some(session) = session.as_mut() {

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -89,6 +89,12 @@ pub struct Session {
     mode: SessionMode,
     pub(crate) exchanges: crate::utils::storage::Vec<Option<ExchangeState>, MAX_EXCHANGES>,
     last_use: Duration,
+    /// If `true` then the session is considered "expired". Session expiration happens
+    /// for the session on behalf of which a fabric is removed.
+    ///
+    /// Expired sessions can still process their ongoing exchanges, but do not accept any new ones.
+    /// Furthermore, expired sessions are the prime candidates for eviction.
+    expired: bool,
     reserved: bool,
 }
 
@@ -117,6 +123,7 @@ impl Session {
             mode: SessionMode::PlainText,
             exchanges: crate::utils::storage::Vec::new(),
             last_use: epoch(),
+            expired: false,
         }
     }
 
@@ -144,7 +151,14 @@ impl Session {
             mode: SessionMode::PlainText,
             exchanges: crate::utils::storage::Vec::new(),
             last_use: epoch(),
+            expired: false,
         })
+    }
+
+    /// Get the internal ID of the session
+    /// This ID is guaranteed to be unique across all sessions
+    pub const fn id(&self) -> u32 {
+        self.id
     }
 
     pub fn get_local_sess_id(&self) -> u16 {
@@ -224,6 +238,11 @@ impl Session {
             && self.peer_addr == *rx_peer
             && self.is_encrypted() == rx_plain.is_encrypted()
             && !self.reserved
+    }
+
+    /// Return `true` if the session is expired.
+    pub(crate) fn is_expired(&self) -> bool {
+        self.expired
     }
 
     pub fn upgrade_fabric_idx(&mut self, fabric_idx: NonZeroU8) -> Result<(), Error> {
@@ -441,7 +460,7 @@ impl fmt::Display for Session {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "peer: {:?}, peer_nodeid: {:?}, local: {}, remote: {}, msg_ctr: {}, mode: {:?}, ts: {:?}",
+            "peer: {:?}, peer_nodeid: {:?}, local: {}, remote: {}, msg_ctr: {}, mode: {:?}, ts: {:?}, expired: {}",
             self.peer_addr,
             self.peer_nodeid,
             self.local_sess_id,
@@ -449,6 +468,7 @@ impl fmt::Display for Session {
             self.msg_ctr,
             self.mode,
             self.last_use,
+            self.expired,
         )
     }
 }
@@ -639,9 +659,18 @@ impl SessionMgr {
         let mut lru_index = None;
         let mut lru_ts = (self.epoch)();
         for (i, s) in self.sessions.iter().enumerate() {
-            if s.last_use < lru_ts && !s.reserved && s.exchanges.iter().all(Option::is_none) {
+            if (s.expired || s.last_use < lru_ts)
+                && !s.reserved
+                && s.exchanges.iter().all(Option::is_none)
+            {
                 lru_ts = s.last_use;
                 lru_index = Some(i);
+
+                if s.expired {
+                    // Expired sessons are the prime candidates for eviction,
+                    // so we can break early
+                    break;
+                }
             }
         }
 
@@ -690,18 +719,42 @@ impl SessionMgr {
     }
 
     /// This assumes that the higher layer has taken care of doing anything required
-    /// as per the spec before the sessions are removed
-    pub fn remove_for_fabric(&mut self, fabric_idx: NonZeroU8) {
+    /// as per the spec before the sessions are removed or expired
+    pub fn remove_for_fabric(&mut self, fabric_idx: NonZeroU8, expire_sess_id: Option<u32>) {
         loop {
-            let Some(index) = self
-                .sessions
-                .iter()
-                .position(|sess| sess.get_local_fabric_idx() == fabric_idx.get())
-            else {
+            let Some(index) = self.sessions.iter().position(|sess| {
+                sess.get_local_fabric_idx() == fabric_idx.get() && Some(sess.id) != expire_sess_id
+            }) else {
                 break;
             };
 
+            info!(
+                "Dropping session with ID {} for fabric index {} immediately",
+                self.sessions[index].id, fabric_idx
+            );
             self.sessions.swap_remove(index);
+        }
+
+        if let Some(expire_sess_id) = expire_sess_id {
+            let our_sess = self
+                .sessions
+                .iter_mut()
+                .find(|sess| sess.id == expire_sess_id);
+            if let Some(expire_sess) = our_sess {
+                // If we have a session for ourselves, then we just mark it as expired
+                expire_sess.expired = true;
+                info!(
+                    "Marking session with ID {} as expired for fabric index {}",
+                    expire_sess_id,
+                    fabric_idx.get()
+                );
+            } else {
+                warn!(
+                    "No session with ID {} found for fabric index {} to mark as expired",
+                    expire_sess_id,
+                    fabric_idx.get()
+                );
+            }
         }
     }
 
@@ -724,7 +777,7 @@ impl SessionMgr {
         let mut session = self
             .sessions
             .iter_mut()
-            .find(|sess| sess.is_for_node(fabric_idx, peer_node_id, secure));
+            .find(|sess| !sess.expired && sess.is_for_node(fabric_idx, peer_node_id, secure));
 
         if let Some(session) = session.as_mut() {
             session.update_last_used(self.epoch);


### PR DESCRIPTION
This PR addresses #242 by implementing similar logic to the one in the Matter C++ SDK:
- (Preserved) As before, all sessions for the fabric which is being removed are immediately removed. We might expire them instead (see below), but I still read the spec as if those need to be removed immediately, despite any ongoing exchanges on those.
- (New) However, if the session on behalf of which the NOC "remove session" request is coming is _also_ belonging to the removed fabric, rather than hard-removing this session, it is instead marked as expired.

Expired sessions:
- Work just fine for ongoing exchanges, _including taking NEW exchanges on that session_ (turns out Google controller does initiate a one final exchange on the session on behalf of which the fabric is removed). This behavior also makes it possible for the "remove fabric" operation to complete normally, sending "Yes sir, removed" response to the controller;
- Are the first to be removed in case the device gets in a "too many sessions" state;
- **Cannot** be used for reporting data on subscriptions thus rendering all subscriptions for the removed fabric inoperable and logically removed (as per Matter spec).
