### PR TITLE
Better error logging on SC peer status reports

### DIFF
--- a/rs-matter/src/dm/endpoints.rs
+++ b/rs-matter/src/dm/endpoints.rs
@@ -226,11 +226,7 @@ where
 /// - `comm_policy`: The commissioning policy to be used for the `GenCommHandler`.
 /// - `rand`: A random number generator.
 /// - `handler`: The handler to be decorated.
-pub fn with_sys<'a, H>(
-    comm_policy: &'a dyn CommPolicy,
-    rand: Rand,
-    handler: H,
-) -> SysHandler<'a, H> {
+pub fn with_sys<H>(comm_policy: &dyn CommPolicy, rand: Rand, handler: H) -> SysHandler<'_, H> {
     ChainedHandler::new(
         EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(GrpKeyMgmtHandler::CLUSTER.id)),
         Async(GrpKeyMgmtHandler::new(Dataver::new_rand(rand)).adapt()),

--- a/rs-matter/src/sc/pake.rs
+++ b/rs-matter/src/sc/pake.rs
@@ -20,7 +20,7 @@ use core::{fmt::Write, time::Duration};
 use crate::crypto;
 use crate::error::{Error, ErrorCode};
 use crate::mdns::{Mdns, ServiceMode};
-use crate::sc::{complete_with_status, OpCode};
+use crate::sc::{check_opcode, complete_with_status, OpCode};
 use crate::tlv::{get_root_node_struct, FromTLV, OctetStr, TLVElement, TagType, ToTLV};
 use crate::transport::exchange::{Exchange, ExchangeId};
 use crate::transport::session::{ReservedSession, SessionMode};
@@ -254,7 +254,7 @@ impl Pake {
         mut session: ReservedSession<'_>,
         spake2p: &mut Spake2P,
     ) -> Result<(), Error> {
-        exchange.rx()?.meta().check_opcode(OpCode::PASEPake3)?;
+        check_opcode(exchange, OpCode::PASEPake3)?;
 
         let cA = extract_pasepake_1_or_3_params(exchange.rx()?.payload())?;
         let (status, ke) = spake2p.handle_cA(cA);
@@ -314,7 +314,7 @@ impl Pake {
         exchange: &mut Exchange<'_>,
         spake2p: &mut Spake2P,
     ) -> Result<(), Error> {
-        exchange.rx()?.meta().check_opcode(OpCode::PASEPake1)?;
+        check_opcode(exchange, OpCode::PASEPake1)?;
 
         let pA = extract_pasepake_1_or_3_params(exchange.rx()?.payload())?;
         let mut pB: [u8; 65] = [0; 65];
@@ -346,8 +346,9 @@ impl Pake {
         exchange: &mut Exchange<'_>,
         spake2p: &mut Spake2P,
     ) -> Result<(), Error> {
+        check_opcode(exchange, OpCode::PBKDFParamRequest)?;
+
         let rx = exchange.rx()?;
-        rx.meta().check_opcode(OpCode::PBKDFParamRequest)?;
 
         let mut our_random = [0; 32];
         let mut initiator_random = [0; 32];

--- a/rs-matter/src/transport/proto_hdr.rs
+++ b/rs-matter/src/transport/proto_hdr.rs
@@ -258,7 +258,7 @@ impl ProtoHdr {
             self.ack_msg_ctr = parsebuf.le_u32()?;
         }
         trace!("[decode] {}", self);
-        trace!("[rx payload]: {}", Bytes(parsebuf.as_mut_slice()));
+        trace!("[rx payload]: {}", Bytes(parsebuf.as_slice()));
         Ok(())
     }
 


### PR DESCRIPTION
I'm still chasing a weird problem with Apple Home + Thread, where Apple rejects our CASE-Sigma2 reply (#261).
This PR is improving our logging a bit in that it is logging not just the expected SC op-code, but also what we actually received, and moreover - if the received op-code was a StatusReport (which would indicate an error), the error details of the status report.

===

I had to generify a bit the `ParseBuf` type (the peer of `WriteBuf`) so that it can also parse off from a `&[u8]` slice. Previously, it always needed `&mut [u8]` because of the `decrypt_in_place` method, which now has a `where` clause.

`ParseBuf` (and the new `ReadBuf`) can/are used for both parsing the Matter message headers, as well as the payload, when the payload is not a TLV, as is the case with Status Report messages. For the latter case, no decrypt-in-place is necessary, as the message payload and the proto header are already decrypted.