### PR TITLE
Allow sending standalone acks without flushing the RX buffer

### DIFF
--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -1094,6 +1094,10 @@ impl<'a> Exchange<'a> {
             let tx = self.id.init_send(self.matter).await?;
 
             if self.pending_ack()? {
+                // Check whether we still need to send an ACK.
+                // Necessary because we `.await` above, and while we are awaiting, the transport
+                // might automatically send an ACK for us.
+                // (That is, if the global RX transport buffer happens to be already empty and if the other peer re-sends the message.)
                 tx.complete::<MessageMeta>(0, 0, sc::OpCode::MRPStandAloneAck.into())?;
             }
         }

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -1091,12 +1091,11 @@ impl<'a> Exchange<'a> {
     #[inline(always)]
     pub async fn acknowledge(&mut self) -> Result<(), Error> {
         if self.pending_ack()? {
-            self.send_with(|exchange, _| {
-                Ok(exchange
-                    .pending_ack()?
-                    .then_some(sc::OpCode::MRPStandAloneAck.into()))
-            })
-            .await?;
+            let tx = self.id.init_send(self.matter).await?;
+
+            if self.pending_ack()? {
+                tx.complete::<MessageMeta>(0, 0, sc::OpCode::MRPStandAloneAck.into())?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
We don't necessarily need this _right now_, but then why not?

Background:
The `Exchange` transport layer public API is designed in such a way, that in order to send/TX a Matter payload, you do need to have consumed the pending RX payload (either by processing it, or saving to a user-supplied buffer with `recv_into`) from the internal Matter transport buffer. Or else calling `Exchange::send*` will do it for you anyway.

This is necessary for the case where the payload being TXed needs an ACK. Which is most often than not the case anyway. Why is sending a reliable message requiring that the internal Matter RX buffer is free-d / empty? Because the ACK for the  message being sent _itself_ needs to be received _somewhere_ (so that we stop re-sending it and exit the e.g. `Exchange::send_with` loop) - and - by design the rs-matter transport maintains a single pair of RX/TX buffers (but then again, the user can (and should, for slow processing) always `recv_into` before the actual processing starts).

The above does not apply for "standalone ACKs" (`Exchange::acknowledge`) because these are not reliable messages and thus do not require the other peer to "acknowledge our acknowledgement" so to say.

So this is all just a small ergonomic improvement, where - prior to starting a slow processing - the user can now call `Exchange::acknowledge` prior to actually processing the RX Matter buffer - without having to save this buffer into his/her own storage. As per above, we don't use that (yet), but why not having it if possible?
