### PR TITLE
Add headers and module docu to the mDNS implementations

### DIFF
--- a/rs-matter/src/mdns/astro.rs
+++ b/rs-matter/src/mdns/astro.rs
@@ -1,3 +1,22 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! A MacOS-specific mDNS implementation based on the `astro-dnssd` crate.
+
 use std::collections::BTreeMap;
 
 use astro_dnssd::{DNSServiceBuilder, RegisteredDnsService};

--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -1,3 +1,25 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! The built-in mDNS implementation of `rs-matter`.
+//!
+//! Can be used on any OS / platform, as long as the platform-specific mDNS implementation
+//! (if there is one) is stopped and not running on the mDNS port 5353.
+
 use core::net::IpAddr;
 use core::pin::pin;
 
@@ -25,7 +47,6 @@ use self::proto::Services;
 
 pub use proto::Host;
 
-#[path = "proto.rs"]
 mod proto;
 
 pub const MDNS_SOCKET_BIND_ADDR: SocketAddr =

--- a/rs-matter/src/mdns/builtin/proto.rs
+++ b/rs-matter/src/mdns/builtin/proto.rs
@@ -1,3 +1,20 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 use core::fmt::Write;
 use core::net::{Ipv4Addr, Ipv6Addr};
 

--- a/rs-matter/src/mdns/zeroconf.rs
+++ b/rs-matter/src/mdns/zeroconf.rs
@@ -1,3 +1,23 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! A Linux-specific mDNS implementation based on the `zeroconf` crate
+//! (requires the Avahi daemon to be installed and running)
+
 use std::collections::BTreeMap;
 use std::sync::mpsc::{sync_channel, SyncSender};
 


### PR DESCRIPTION
I accidentally found out that all our mDNS modules are missing the Matter headers so I added those, as well as a short module-level documentation to each mDNS impl we are currently having.

Also, the `proto` module (which is a private sub-module of our "builtin" mDNS impl) is moved where it shuld be (it used to have a `path = ` annotation hack on top of the module, which is likely confusing.