### PR TITLE
Introduce zbus to rs-matter. Proxies for BlueZ, NetworkManager, wpa-supplicant, systemd-resolved and Avahi

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.83"
 [features]
 default = ["os", "rustcrypto", "log"]
 #default = ["os", "mbedtls", "log"] mbedtls is broken since several months - check the root cause
-os = ["std", "backtrace", "critical-section/std", "embassy-sync/std", "embassy-time/std"]
+os = ["std", "backtrace", "critical-section/std", "embassy-sync/std", "embassy-time/std", "zbus", "futures-lite"]
 std = ["alloc", "rand"]
 backtrace = []
 alloc = ["defmt?/alloc"]
@@ -75,6 +75,8 @@ x509-cert = { version = "0.2", default-features = false, features = ["pem"], opt
 rand = { version = "0.8", optional = true, default-features = false, features = ["std", "std_rng"] }
 async-io = { version = "2", optional = true, default-features = false }
 async-compat = { version = "0.2", optional = true, default-features = false }
+zbus = { version = "5.8", optional = true }
+futures-lite = { version = "1", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "espidf")))'.dependencies]
 bitflags = "2"

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -76,7 +76,7 @@ rand = { version = "0.8", optional = true, default-features = false, features = 
 async-io = { version = "2", optional = true, default-features = false }
 async-compat = { version = "0.2", optional = true, default-features = false }
 zbus = { version = "5.8", optional = true }
-futures-lite = { version = "1", optional = true }
+futures-lite = { version = "2", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "espidf")))'.dependencies]
 bitflags = "2"

--- a/rs-matter/src/mdns/astro.rs
+++ b/rs-matter/src/mdns/astro.rs
@@ -1,3 +1,22 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! A MacOS-specific mDNS implementation based on the `astro-dnssd` crate.
+
 use std::collections::BTreeMap;
 
 use astro_dnssd::{DNSServiceBuilder, RegisteredDnsService};

--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -1,3 +1,25 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! The built-in mDNS implementation of `rs-matter`.
+//!
+//! Can be used on any OS / platform, as long as the platform-specific mDNS implementation
+//! (if there is one) is stopped and not running on the mDNS port 5353.
+
 use core::net::IpAddr;
 use core::pin::pin;
 
@@ -25,7 +47,6 @@ use self::proto::Services;
 
 pub use proto::Host;
 
-#[path = "proto.rs"]
 mod proto;
 
 pub const MDNS_SOCKET_BIND_ADDR: SocketAddr =

--- a/rs-matter/src/mdns/builtin/proto.rs
+++ b/rs-matter/src/mdns/builtin/proto.rs
@@ -1,3 +1,20 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 use core::fmt::Write;
 use core::net::{Ipv4Addr, Ipv6Addr};
 

--- a/rs-matter/src/mdns/zeroconf.rs
+++ b/rs-matter/src/mdns/zeroconf.rs
@@ -1,3 +1,23 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! A Linux-specific mDNS implementation based on the `zeroconf` crate
+//! (requires the Avahi daemon to be installed and running)
+
 use std::collections::BTreeMap;
 use std::sync::mpsc::{sync_channel, SyncSender};
 

--- a/rs-matter/src/transport/network.rs
+++ b/rs-matter/src/transport/network.rs
@@ -15,10 +15,8 @@
  *    limitations under the License.
  */
 
-use core::{
-    fmt::{self, Debug, Display},
-    pin::pin,
-};
+use core::fmt::{self, Debug, Display};
+use core::pin::pin;
 
 pub use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
@@ -28,6 +26,7 @@ use crate::error::{Error, ErrorCode};
 
 pub mod btp;
 pub mod udp;
+pub mod wifi;
 
 // Maximum UDP RX packet size per Matter spec
 pub const MAX_RX_PACKET_SIZE: usize = 1583;

--- a/rs-matter/src/transport/network/wifi.rs
+++ b/rs-matter/src/transport/network/wifi.rs
@@ -15,18 +15,5 @@
  *    limitations under the License.
  */
 
-pub mod bitflags;
-pub mod cell;
-pub mod codec;
-pub mod epoch;
-pub mod init;
-pub mod iter;
-pub mod maybe;
-pub mod rand;
-pub mod select;
-pub mod storage;
-pub mod sync;
 #[cfg(feature = "std")]
-pub mod zbus;
-#[cfg(feature = "std")]
-pub mod zbus_proxies;
+pub mod wpa_supp;

--- a/rs-matter/src/transport/network/wifi/wpa_supp.rs
+++ b/rs-matter/src/transport/network/wifi/wpa_supp.rs
@@ -1,0 +1,386 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Wifi network controller implementation based on the wpa-supplicant D-Bus service.
+
+use core::cell::{Cell, RefCell};
+
+use std::collections::HashMap;
+use std::process::Command;
+
+use embassy_futures::select::Either;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+
+use futures_lite::StreamExt;
+
+use zbus::zvariant::{ObjectPath, Value};
+use zbus::Connection;
+
+use crate::dm::clusters::net_comm::{
+    NetCtl, NetCtlError, NetworkScanInfo, NetworkType, WiFiBandEnum, WiFiSecurityBitmap,
+    WirelessCreds,
+};
+use crate::dm::clusters::wifi_diag::{WifiDiag, WirelessDiag};
+use crate::dm::networks::NetChangeNotif;
+use crate::error::{Error, ErrorCode};
+use crate::utils::sync::blocking::Mutex;
+use crate::utils::zbus_proxies::wpa_supp::bss::BSSProxy;
+use crate::utils::zbus_proxies::wpa_supp::interface::InterfaceProxy;
+
+/// A `NetCtl`, `WirelessDiag`, `WifiDiag` and `NetChangeNotif` implementation based on the `wpa-supplicant` service.
+///
+/// Suitable for use with embedded Linux devices that do have the `wpa-supplicant` service running over D-Bus
+/// but don't have the `NetworkManager` service available.
+pub struct WpaSuppCtl<'a, T> {
+    interface: InterfaceProxy<'a>,
+    connection: &'a Connection,
+    ip_stack_ctl: T,
+    ssid_info: Mutex<NoopRawMutex, RefCell<SSIDInfo>>,
+}
+
+impl<'a, T> WpaSuppCtl<'a, T>
+where
+    T: IpStackCtl,
+{
+    /// Create a new `WpaSuppCtl` instance.
+    ///
+    /// # Arguments
+    /// * `connection` - A reference to the D-Bus connection.
+    /// * `interface` - The D-Bus object path of Wifi interface object.
+    /// * `ip_stack_ctl` - An instance of a type implementing the `IpStackCtl` trait, which is used to control the IP stack.
+    ///
+    /// # Returns
+    /// A `zbus::Result<Self>` containing the new `WpaSuppCtl` instance on success.
+    pub async fn new(
+        connection: &'a Connection,
+        interface: ObjectPath<'a>,
+        ip_stack_ctl: T,
+    ) -> zbus::Result<Self> {
+        Ok(Self {
+            interface: InterfaceProxy::builder(connection)
+                .path(interface)?
+                .build()
+                .await?,
+            connection,
+            ip_stack_ctl,
+            ssid_info: Mutex::new(RefCell::new(SSIDInfo::new())),
+        })
+    }
+
+    /// Return a reference to the `InterfaceProxy`.
+    pub const fn interface(&self) -> &InterfaceProxy<'_> {
+        &self.interface
+    }
+
+    /// Return a reference to the D-Bus connection.
+    pub const fn connection(&self) -> &Connection {
+        self.connection
+    }
+
+    async fn wait_changed(&self) -> Result<bool, zbus::Error> {
+        let mut authorized = self.interface.receive_sta_authorized().await?;
+        let mut deauthorized = self.interface.receive_sta_deauthorized().await?;
+
+        loop {
+            let ip_stack_changed = self.ip_stack_ctl.wait_changed();
+
+            embassy_futures::select::select3(
+                authorized.next(),
+                deauthorized.next(),
+                ip_stack_changed,
+            )
+            .await;
+
+            let bss = self.interface.current_bss().await?;
+
+            let ssid = if !bss.is_empty() {
+                let bss_info = BSSProxy::builder(self.connection)
+                    .path(bss)?
+                    .build()
+                    .await?;
+
+                Some(bss_info.ssid().await?)
+            } else {
+                None
+            };
+
+            let (changed, connected) = self.update_connected(ssid);
+
+            if changed {
+                break Ok(connected);
+            }
+        }
+    }
+
+    async fn wait_connected(&self) -> Result<(), zbus::Error> {
+        loop {
+            if self.wait_changed().await? {
+                return Ok(());
+            }
+        }
+    }
+
+    fn update_connected(&self, ssid: Option<Vec<u8>>) -> (bool, bool) {
+        self.ssid_info.lock(|ssid_info| {
+            let mut ssid_info = ssid_info.borrow_mut();
+
+            let was_connected =
+                ssid_info.is_connected() && self.ip_stack_ctl.is_connected().unwrap_or(false);
+
+            ssid_info.connected = ssid;
+
+            (
+                was_connected != ssid_info.is_connected()
+                    && self.ip_stack_ctl.is_connected().unwrap_or(false),
+                ssid_info.is_connected(),
+            )
+        })
+    }
+}
+
+/// A trait for controlling the IP stack, allowing for connection management and change notifications.
+///
+/// This trait is necessary, because `wpa-supplicant` does not control the IP stack directly.
+///
+/// One possible implementation would be to just invoke the command line `dhclient` utility on the
+/// wireless interface. Another possibility would be to use the DHCP client in the `edge-mdns` crate for Ipv4
+/// and then additionally assign a pre-computed link-local IP address to the interface for Ipv6.
+pub trait IpStackCtl {
+    /// Connect the IP stack by e.g. configuring the network interface via DHCP (for IPv4) and SLAAC (for IPv6).
+    async fn connect(&self) -> Result<(), NetCtlError>;
+
+    /// Wait for changes in the IP stack, such as connection status changes or network configuration updates.
+    async fn wait_changed(&self);
+
+    /// Check if the IP stack is currently connected.
+    fn is_connected(&self) -> Result<bool, NetCtlError>;
+}
+
+impl<T> IpStackCtl for &T
+where
+    T: IpStackCtl,
+{
+    async fn connect(&self) -> Result<(), NetCtlError> {
+        T::connect(self).await
+    }
+
+    async fn wait_changed(&self) {
+        T::wait_changed(self).await;
+    }
+
+    fn is_connected(&self) -> Result<bool, NetCtlError> {
+        T::is_connected(self)
+    }
+}
+
+/// An `IpStackCtl` implementation for the linux `dhclient` command-line utility.
+pub struct DhClientCtl {
+    ifname: String,
+    connected: Mutex<NoopRawMutex, Cell<bool>>,
+}
+
+impl DhClientCtl {
+    /// Create a new `DhClientCtl` instance.
+    ///
+    /// # Arguments
+    /// * `ifname` - The name of the network interface to control (e.g., "wlan0").
+    pub fn new(ifname: &str) -> Self {
+        Self {
+            ifname: ifname.to_string(),
+            connected: Mutex::new(Cell::new(false)),
+        }
+    }
+}
+
+impl IpStackCtl for DhClientCtl {
+    async fn connect(&self) -> Result<(), NetCtlError> {
+        Command::new("dhclient")
+            .arg("-nw")
+            .arg(&self.ifname)
+            .status()
+            .map_err(|_| NetCtlError::Other(ErrorCode::NoNetworkInterface.into()))?;
+
+        self.connected.lock(|connected| connected.set(true));
+
+        Ok(())
+    }
+
+    async fn wait_changed(&self) {
+        // Implement the logic to wait for changes in the IP stack.
+        core::future::pending::<()>().await
+    }
+
+    fn is_connected(&self) -> Result<bool, NetCtlError> {
+        Ok(self.connected.lock(|connected| connected.get()))
+    }
+}
+
+impl<T> NetCtl for WpaSuppCtl<'_, T>
+where
+    T: IpStackCtl,
+{
+    fn net_type(&self) -> NetworkType {
+        NetworkType::Wifi
+    }
+
+    async fn scan<F>(&self, network: Option<&[u8]>, mut f: F) -> Result<(), NetCtlError>
+    where
+        F: FnMut(&NetworkScanInfo) -> Result<(), Error>,
+    {
+        let mut args = HashMap::new();
+
+        let active = Value::from("active");
+        args.insert("Type", &active);
+
+        let ssids = network.map(|network| vec![network.to_vec()].into());
+        if ssids.is_some() {
+            #[allow(clippy::unnecessary_unwrap)]
+            args.insert("SSIDs", ssids.as_ref().unwrap());
+        }
+
+        let mut scan_done = self.interface.receive_scan_done().await?;
+
+        self.interface.scan(args).await?;
+
+        while scan_done.next().await.is_none() {}
+
+        let bsss = self.interface.bsss().await?;
+
+        for bss in bsss {
+            let bss_info = BSSProxy::builder(self.connection)
+                .path(bss)?
+                .build()
+                .await?;
+
+            // TODO: Only leave the infrastructure ones, remove the ad-hocs
+
+            let mut security = WiFiSecurityBitmap::WEP;
+            if !bss_info.wpa().await?.is_empty() {
+                // TODO
+                security |= WiFiSecurityBitmap::WPA_PERSONAL;
+            }
+
+            let network_scan_info = NetworkScanInfo::Wifi {
+                security,
+                ssid: &bss_info.ssid().await?,
+                bssid: &bss_info.bssid().await?,
+                channel: 11,              // TODO bss_info.frequency().await? as u8,
+                band: WiFiBandEnum::V2G4, // TODO
+                rssi: bss_info.signal().await? as i8,
+            };
+
+            f(&network_scan_info)?;
+        }
+
+        Ok(())
+    }
+
+    async fn connect(&self, creds: &WirelessCreds<'_>) -> Result<(), NetCtlError> {
+        let WirelessCreds::Wifi { ssid, pass } = creds else {
+            return Err(NetCtlError::Other(ErrorCode::InvalidAction.into()));
+        };
+
+        // TODO: Maybe just add our own network
+        self.interface.remove_all_networks().await?;
+
+        let mut args = HashMap::new();
+
+        self.ssid_info.lock(|ssid_info| {
+            let mut ssid_info = ssid_info.borrow_mut();
+            ssid_info.requested = Some(ssid.to_vec());
+        });
+
+        let arg_ssid = (*ssid).into();
+        args.insert("ssid", &arg_ssid);
+
+        let arg_pass = (*pass).into();
+        args.insert("psk", &arg_pass);
+
+        let network = self.interface.add_network(args).await?;
+
+        self.interface.select_network(&network).await?;
+
+        let timer = embassy_time::Timer::after(embassy_time::Duration::from_secs(30));
+        let connected = self.wait_connected();
+
+        match embassy_futures::select::select(connected, timer).await {
+            Either::First(result) => {
+                result?;
+
+                Ok(())
+            }
+            Either::Second(_) => {
+                self.interface.remove_all_networks().await?;
+
+                Err(NetCtlError::AuthFailure)
+            }
+        }
+    }
+}
+
+impl<T> WirelessDiag for WpaSuppCtl<'_, T>
+where
+    T: IpStackCtl,
+{
+    fn connected(&self) -> Result<bool, Error> {
+        Ok(self.ssid_info.lock(|ssid_info| {
+            ssid_info.borrow().is_connected() && self.ip_stack_ctl.is_connected().unwrap_or(false)
+        }))
+    }
+}
+
+impl<T> WifiDiag for WpaSuppCtl<'_, T> where T: IpStackCtl {} // TODO
+
+impl<T> NetChangeNotif for WpaSuppCtl<'_, T>
+where
+    T: IpStackCtl,
+{
+    async fn wait_changed(&self) {
+        let _ = WpaSuppCtl::wait_changed(self).await;
+    }
+}
+
+#[derive(Debug)]
+struct SSIDInfo {
+    requested: Option<Vec<u8>>,
+    connected: Option<Vec<u8>>,
+}
+
+impl SSIDInfo {
+    const fn new() -> Self {
+        Self {
+            requested: None,
+            connected: None,
+        }
+    }
+
+    fn is_connected(&self) -> bool {
+        self.requested.is_some() && self.requested == self.connected
+    }
+}
+
+impl From<zbus::Error> for Error {
+    fn from(_: zbus::Error) -> Self {
+        ErrorCode::NoNetworkInterface.into()
+    }
+}
+
+impl From<zbus::Error> for NetCtlError {
+    fn from(value: zbus::Error) -> Self {
+        NetCtlError::Other(value.into())
+    }
+}

--- a/rs-matter/src/utils/zbus.rs
+++ b/rs-matter/src/utils/zbus.rs
@@ -15,18 +15,6 @@
  *    limitations under the License.
  */
 
-pub mod bitflags;
-pub mod cell;
-pub mod codec;
-pub mod epoch;
-pub mod init;
-pub mod iter;
-pub mod maybe;
-pub mod rand;
-pub mod select;
-pub mod storage;
-pub mod sync;
-#[cfg(feature = "std")]
-pub mod zbus;
-#[cfg(feature = "std")]
-pub mod zbus_proxies;
+//! A re-export of the `zbus` crate, which provides D-Bus support in Rust.
+
+pub use ::zbus::*;

--- a/rs-matter/src/utils/zbus_proxies.rs
+++ b/rs-matter/src/utils/zbus_proxies.rs
@@ -15,18 +15,6 @@
  *    limitations under the License.
  */
 
-pub mod bitflags;
-pub mod cell;
-pub mod codec;
-pub mod epoch;
-pub mod init;
-pub mod iter;
-pub mod maybe;
-pub mod rand;
-pub mod select;
-pub mod storage;
-pub mod sync;
-#[cfg(feature = "std")]
-pub mod zbus;
-#[cfg(feature = "std")]
-pub mod zbus_proxies;
+//! A set of zbus proxies for various Linux services.
+
+pub mod wpa_supp;

--- a/rs-matter/src/utils/zbus_proxies/avahi.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi.rs
@@ -15,10 +15,19 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! zbus proxies for `org.freedesktop.resolve1`.
+//!
+//! All proxy traits are generated using introspection (i.e. `zbus-xmlgen file ...`),
+//! with introspection (.xml) files as available here (circa 2025-07-15):
+//! https://github.com/avahi/avahi/tree/master/avahi-daemon
 
-pub mod avahi;
-pub mod bluez;
-pub mod nm;
-pub mod resolve;
-pub mod wpa_supp;
+pub mod address_resolver;
+pub mod domain_browser;
+pub mod entry_group;
+pub mod host_name_resolver;
+pub mod record_browser;
+pub mod server;
+pub mod server2;
+pub mod service_browser;
+pub mod service_resolver;
+pub mod service_type_browser;

--- a/rs-matter/src/utils/zbus_proxies/avahi/address_resolver.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi/address_resolver.rs
@@ -1,0 +1,48 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.Avahi.AddressResolver`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.Avahi.AddressResolver",
+    assume_defaults = true
+)]
+pub trait AddressResolver {
+    /// Free method
+    fn free(&self) -> zbus::Result<()>;
+
+    /// Start method
+    fn start(&self) -> zbus::Result<()>;
+
+    /// Failure signal
+    #[zbus(signal)]
+    fn failure(&self, error: &str) -> zbus::Result<()>;
+
+    /// Found signal
+    #[zbus(signal)]
+    fn found(
+        &self,
+        interface: i32,
+        protocol: i32,
+        aprotocol: i32,
+        address: &str,
+        name: &str,
+        flags: u32,
+    ) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/avahi/domain_browser.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi/domain_browser.rs
@@ -1,0 +1,59 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.Avahi.DomainBrowser`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.Avahi.DomainBrowser",
+    assume_defaults = true
+)]
+pub trait DomainBrowser {
+    /// Free method
+    fn free(&self) -> zbus::Result<()>;
+
+    /// Start method
+    fn start(&self) -> zbus::Result<()>;
+
+    /// AllForNow signal
+    #[zbus(signal)]
+    fn all_for_now(&self) -> zbus::Result<()>;
+
+    /// CacheExhausted signal
+    #[zbus(signal)]
+    fn cache_exhausted(&self) -> zbus::Result<()>;
+
+    /// Failure signal
+    #[zbus(signal)]
+    fn failure(&self, error: &str) -> zbus::Result<()>;
+
+    /// ItemNew signal
+    #[zbus(signal)]
+    fn item_new(&self, interface: i32, protocol: i32, domain: &str, flags: u32)
+        -> zbus::Result<()>;
+
+    /// ItemRemove signal
+    #[zbus(signal)]
+    fn item_remove(
+        &self,
+        interface: i32,
+        protocol: i32,
+        domain: &str,
+        flags: u32,
+    ) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/avahi/entry_group.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi/entry_group.rs
@@ -1,0 +1,107 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.Avahi.EntryGroup`
+
+use zbus::proxy;
+
+#[proxy(interface = "org.freedesktop.Avahi.EntryGroup", assume_defaults = true)]
+pub trait EntryGroup {
+    /// AddAddress method
+    fn add_address(
+        &self,
+        interface: i32,
+        protocol: i32,
+        flags: u32,
+        name: &str,
+        address: &str,
+    ) -> zbus::Result<()>;
+
+    /// AddRecord method
+    #[allow(clippy::too_many_arguments)]
+    fn add_record(
+        &self,
+        interface: i32,
+        protocol: i32,
+        flags: u32,
+        name: &str,
+        clazz: u16,
+        type_: u16,
+        ttl: u32,
+        rdata: &[u8],
+    ) -> zbus::Result<()>;
+
+    /// AddService method
+    #[allow(clippy::too_many_arguments)]
+    fn add_service(
+        &self,
+        interface: i32,
+        protocol: i32,
+        flags: u32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        host: &str,
+        port: u16,
+        txt: &[&[u8]],
+    ) -> zbus::Result<()>;
+
+    /// AddServiceSubtype method
+    #[allow(clippy::too_many_arguments)]
+    fn add_service_subtype(
+        &self,
+        interface: i32,
+        protocol: i32,
+        flags: u32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        subtype: &str,
+    ) -> zbus::Result<()>;
+
+    /// Commit method
+    fn commit(&self) -> zbus::Result<()>;
+
+    /// Free method
+    fn free(&self) -> zbus::Result<()>;
+
+    /// GetState method
+    fn get_state(&self) -> zbus::Result<i32>;
+
+    /// IsEmpty method
+    fn is_empty(&self) -> zbus::Result<bool>;
+
+    /// Reset method
+    fn reset(&self) -> zbus::Result<()>;
+
+    /// UpdateServiceTxt method
+    #[allow(clippy::too_many_arguments)]
+    fn update_service_txt(
+        &self,
+        interface: i32,
+        protocol: i32,
+        flags: u32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        txt: &[&[u8]],
+    ) -> zbus::Result<()>;
+
+    /// StateChanged signal
+    #[zbus(signal)]
+    fn state_changed(&self, state: i32, error: &str) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/avahi/host_name_resolver.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi/host_name_resolver.rs
@@ -1,0 +1,48 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.Avahi.HostNameResolver`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.Avahi.HostNameResolver",
+    assume_defaults = true
+)]
+pub trait HostNameResolver {
+    /// Free method
+    fn free(&self) -> zbus::Result<()>;
+
+    /// Start method
+    fn start(&self) -> zbus::Result<()>;
+
+    /// Failure signal
+    #[zbus(signal)]
+    fn failure(&self, error: &str) -> zbus::Result<()>;
+
+    /// Found signal
+    #[zbus(signal)]
+    fn found(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        aprotocol: i32,
+        address: &str,
+        flags: u32,
+    ) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/avahi/record_browser.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi/record_browser.rs
@@ -1,0 +1,70 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.Avahi.RecordBrowser`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.Avahi.RecordBrowser",
+    assume_defaults = true
+)]
+pub trait RecordBrowser {
+    /// Free method
+    fn free(&self) -> zbus::Result<()>;
+
+    /// Start method
+    fn start(&self) -> zbus::Result<()>;
+
+    /// AllForNow signal
+    #[zbus(signal)]
+    fn all_for_now(&self) -> zbus::Result<()>;
+
+    /// CacheExhausted signal
+    #[zbus(signal)]
+    fn cache_exhausted(&self) -> zbus::Result<()>;
+
+    /// Failure signal
+    #[zbus(signal)]
+    fn failure(&self, error: &str) -> zbus::Result<()>;
+
+    /// ItemNew signal
+    #[zbus(signal)]
+    fn item_new(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        clazz: u16,
+        type_: u16,
+        rdata: Vec<u8>,
+        flags: u32,
+    ) -> zbus::Result<()>;
+
+    /// ItemRemove signal
+    #[zbus(signal)]
+    fn item_remove(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        clazz: u16,
+        type_: u16,
+        rdata: Vec<u8>,
+        flags: u32,
+    ) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/avahi/server.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi/server.rs
@@ -1,0 +1,192 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.Avahi.Server`
+
+#![allow(clippy::type_complexity)]
+
+use zbus::{proxy, zvariant::OwnedObjectPath};
+
+#[proxy(interface = "org.freedesktop.Avahi.Server", assume_defaults = true)]
+pub trait Server {
+    /// AddressResolverNew method
+    fn address_resolver_new(
+        &self,
+        interface: i32,
+        protocol: i32,
+        address: &str,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// DomainBrowserNew method
+    fn domain_browser_new(
+        &self,
+        interface: i32,
+        protocol: i32,
+        domain: &str,
+        btype: i32,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// EntryGroupNew method
+    fn entry_group_new(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// GetAPIVersion method
+    #[zbus(name = "GetAPIVersion")]
+    fn get_apiversion(&self) -> zbus::Result<u32>;
+
+    /// GetAlternativeHostName method
+    fn get_alternative_host_name(&self, name: &str) -> zbus::Result<String>;
+
+    /// GetAlternativeServiceName method
+    fn get_alternative_service_name(&self, name: &str) -> zbus::Result<String>;
+
+    /// GetDomainName method
+    fn get_domain_name(&self) -> zbus::Result<String>;
+
+    /// GetHostName method
+    fn get_host_name(&self) -> zbus::Result<String>;
+
+    /// GetHostNameFqdn method
+    fn get_host_name_fqdn(&self) -> zbus::Result<String>;
+
+    /// GetLocalServiceCookie method
+    fn get_local_service_cookie(&self) -> zbus::Result<u32>;
+
+    /// GetNetworkInterfaceIndexByName method
+    fn get_network_interface_index_by_name(&self, name: &str) -> zbus::Result<i32>;
+
+    /// GetNetworkInterfaceNameByIndex method
+    fn get_network_interface_name_by_index(&self, index: i32) -> zbus::Result<String>;
+
+    /// GetState method
+    fn get_state(&self) -> zbus::Result<i32>;
+
+    /// GetVersionString method
+    fn get_version_string(&self) -> zbus::Result<String>;
+
+    /// HostNameResolverNew method
+    fn host_name_resolver_new(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        aprotocol: i32,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// IsNSSSupportAvailable method
+    #[zbus(name = "IsNSSSupportAvailable")]
+    fn is_nsssupport_available(&self) -> zbus::Result<bool>;
+
+    /// RecordBrowserNew method
+    #[allow(clippy::too_many_arguments)]
+    fn record_browser_new(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        clazz: u16,
+        type_: u16,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// ResolveAddress method
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_address(
+        &self,
+        interface: i32,
+        protocol: i32,
+        address: &str,
+        flags: u32,
+    ) -> zbus::Result<(i32, i32, i32, String, String, u32)>;
+
+    /// ResolveHostName method
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_host_name(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        aprotocol: i32,
+        flags: u32,
+    ) -> zbus::Result<(i32, i32, String, i32, String, u32)>;
+
+    /// ResolveService method
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_service(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        aprotocol: i32,
+        flags: u32,
+    ) -> zbus::Result<(
+        i32,
+        i32,
+        String,
+        String,
+        String,
+        String,
+        i32,
+        String,
+        u16,
+        Vec<Vec<u8>>,
+        u32,
+    )>;
+
+    /// ServiceBrowserNew method
+    fn service_browser_new(
+        &self,
+        interface: i32,
+        protocol: i32,
+        type_: &str,
+        domain: &str,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// ServiceResolverNew method
+    #[allow(clippy::too_many_arguments)]
+    fn service_resolver_new(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        aprotocol: i32,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// ServiceTypeBrowserNew method
+    fn service_type_browser_new(
+        &self,
+        interface: i32,
+        protocol: i32,
+        domain: &str,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// SetHostName method
+    fn set_host_name(&self, name: &str) -> zbus::Result<()>;
+
+    /// StateChanged signal
+    #[zbus(signal)]
+    fn state_changed(&self, state: i32, error: &str) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/avahi/server2.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi/server2.rs
@@ -1,0 +1,192 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.Avahi.Server2`
+
+#![allow(clippy::type_complexity)]
+
+use zbus::{proxy, zvariant::OwnedObjectPath};
+
+#[proxy(interface = "org.freedesktop.Avahi.Server2", assume_defaults = true)]
+pub trait Server2 {
+    /// AddressResolverPrepare method
+    fn address_resolver_prepare(
+        &self,
+        interface: i32,
+        protocol: i32,
+        address: &str,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// DomainBrowserPrepare method
+    fn domain_browser_prepare(
+        &self,
+        interface: i32,
+        protocol: i32,
+        domain: &str,
+        btype: i32,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// EntryGroupNew method
+    fn entry_group_new(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// GetAPIVersion method
+    #[zbus(name = "GetAPIVersion")]
+    fn get_apiversion(&self) -> zbus::Result<u32>;
+
+    /// GetAlternativeHostName method
+    fn get_alternative_host_name(&self, name: &str) -> zbus::Result<String>;
+
+    /// GetAlternativeServiceName method
+    fn get_alternative_service_name(&self, name: &str) -> zbus::Result<String>;
+
+    /// GetDomainName method
+    fn get_domain_name(&self) -> zbus::Result<String>;
+
+    /// GetHostName method
+    fn get_host_name(&self) -> zbus::Result<String>;
+
+    /// GetHostNameFqdn method
+    fn get_host_name_fqdn(&self) -> zbus::Result<String>;
+
+    /// GetLocalServiceCookie method
+    fn get_local_service_cookie(&self) -> zbus::Result<u32>;
+
+    /// GetNetworkInterfaceIndexByName method
+    fn get_network_interface_index_by_name(&self, name: &str) -> zbus::Result<i32>;
+
+    /// GetNetworkInterfaceNameByIndex method
+    fn get_network_interface_name_by_index(&self, index: i32) -> zbus::Result<String>;
+
+    /// GetState method
+    fn get_state(&self) -> zbus::Result<i32>;
+
+    /// GetVersionString method
+    fn get_version_string(&self) -> zbus::Result<String>;
+
+    /// HostNameResolverPrepare method
+    fn host_name_resolver_prepare(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        aprotocol: i32,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// IsNSSSupportAvailable method
+    #[zbus(name = "IsNSSSupportAvailable")]
+    fn is_nsssupport_available(&self) -> zbus::Result<bool>;
+
+    /// RecordBrowserPrepare method
+    #[allow(clippy::too_many_arguments)]
+    fn record_browser_prepare(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        clazz: u16,
+        type_: u16,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// ResolveAddress method
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_address(
+        &self,
+        interface: i32,
+        protocol: i32,
+        address: &str,
+        flags: u32,
+    ) -> zbus::Result<(i32, i32, i32, String, String, u32)>;
+
+    /// ResolveHostName method
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_host_name(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        aprotocol: i32,
+        flags: u32,
+    ) -> zbus::Result<(i32, i32, String, i32, String, u32)>;
+
+    /// ResolveService method
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_service(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        aprotocol: i32,
+        flags: u32,
+    ) -> zbus::Result<(
+        i32,
+        i32,
+        String,
+        String,
+        String,
+        String,
+        i32,
+        String,
+        u16,
+        Vec<Vec<u8>>,
+        u32,
+    )>;
+
+    /// ServiceBrowserPrepare method
+    fn service_browser_prepare(
+        &self,
+        interface: i32,
+        protocol: i32,
+        type_: &str,
+        domain: &str,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// ServiceResolverPrepare method
+    #[allow(clippy::too_many_arguments)]
+    fn service_resolver_prepare(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        aprotocol: i32,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// ServiceTypeBrowserPrepare method
+    fn service_type_browser_prepare(
+        &self,
+        interface: i32,
+        protocol: i32,
+        domain: &str,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// SetHostName method
+    fn set_host_name(&self, name: &str) -> zbus::Result<()>;
+
+    /// StateChanged signal
+    #[zbus(signal)]
+    fn state_changed(&self, state: i32, error: &str) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/avahi/service_browser.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi/service_browser.rs
@@ -1,0 +1,68 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.Avahi.ServiceBrowser`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.Avahi.ServiceBrowser",
+    assume_defaults = true
+)]
+pub trait ServiceBrowser {
+    /// Free method
+    fn free(&self) -> zbus::Result<()>;
+
+    /// Start method
+    fn start(&self) -> zbus::Result<()>;
+
+    /// AllForNow signal
+    #[zbus(signal)]
+    fn all_for_now(&self) -> zbus::Result<()>;
+
+    /// CacheExhausted signal
+    #[zbus(signal)]
+    fn cache_exhausted(&self) -> zbus::Result<()>;
+
+    /// Failure signal
+    #[zbus(signal)]
+    fn failure(&self, error: &str) -> zbus::Result<()>;
+
+    /// ItemNew signal
+    #[zbus(signal)]
+    fn item_new(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        flags: u32,
+    ) -> zbus::Result<()>;
+
+    /// ItemRemove signal
+    #[zbus(signal)]
+    fn item_remove(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        flags: u32,
+    ) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/avahi/service_resolver.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi/service_resolver.rs
@@ -1,0 +1,53 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.Avahi.ServiceResolver`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.Avahi.ServiceResolver",
+    assume_defaults = true
+)]
+pub trait ServiceResolver {
+    /// Free method
+    fn free(&self) -> zbus::Result<()>;
+
+    /// Start method
+    fn start(&self) -> zbus::Result<()>;
+
+    /// Failure signal
+    #[zbus(signal)]
+    fn failure(&self, error: &str) -> zbus::Result<()>;
+
+    /// Found signal
+    #[zbus(signal)]
+    fn found(
+        &self,
+        interface: i32,
+        protocol: i32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        host: &str,
+        aprotocol: i32,
+        address: &str,
+        port: u16,
+        txt: Vec<Vec<u8>>,
+        flags: u32,
+    ) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/avahi/service_type_browser.rs
+++ b/rs-matter/src/utils/zbus_proxies/avahi/service_type_browser.rs
@@ -1,0 +1,66 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.Avahi.ServiceTypeBrowser`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.Avahi.ServiceTypeBrowser",
+    assume_defaults = true
+)]
+pub trait ServiceTypeBrowser {
+    /// Free method
+    fn free(&self) -> zbus::Result<()>;
+
+    /// Start method
+    fn start(&self) -> zbus::Result<()>;
+
+    /// AllForNow signal
+    #[zbus(signal)]
+    fn all_for_now(&self) -> zbus::Result<()>;
+
+    /// CacheExhausted signal
+    #[zbus(signal)]
+    fn cache_exhausted(&self) -> zbus::Result<()>;
+
+    /// Failure signal
+    #[zbus(signal)]
+    fn failure(&self, error: &str) -> zbus::Result<()>;
+
+    /// ItemNew signal
+    #[zbus(signal)]
+    fn item_new(
+        &self,
+        interface: i32,
+        protocol: i32,
+        type_: &str,
+        domain: &str,
+        flags: u32,
+    ) -> zbus::Result<()>;
+
+    /// ItemRemove signal
+    #[zbus(signal)]
+    fn item_remove(
+        &self,
+        interface: i32,
+        protocol: i32,
+        type_: &str,
+        domain: &str,
+        flags: u32,
+    ) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez.rs
@@ -1,0 +1,51 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! zbus proxies for BlueZ.
+//!
+//! All proxy traits are either:
+//! - Generated using introspection (i.e. `zbus-xmlgen system zbus-xmlgen system org.bluez /org/bluez`)
+//! - ... or by introspecting predefined introspection XML files from here: https://github.com/bluez-rs/bluez-async/tree/main/bluez-generated/specs
+//! - ... or manually by consulting the BlueZ D-Bus interface definitions as documented here:
+//!   https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc circa 2025-07-15
+//! - ... or by running the `bluezapi2qt` tool from https://github.com/KDE/bluez-qt/tree/master/tools/bluezapi2qt on the ".txt" BlueZ API definitions
+//!   as available in the BlueZ GIT repo from above until commit hash 85460c32d1334f5edad021d214eb997e6f462b30
+
+pub mod adapter;
+pub mod admin_policy_set;
+pub mod agent;
+pub mod agent_manager;
+pub mod battery;
+pub mod battery_provider_manager;
+pub mod device;
+pub mod gatt_characteristic;
+pub mod gatt_descriptor;
+pub mod gatt_manager;
+pub mod gatt_profile;
+pub mod gatt_service;
+pub mod health_device;
+pub mod health_manager;
+pub mod le_advertisement;
+pub mod le_advertising_manager;
+pub mod media;
+pub mod media_control;
+pub mod network;
+pub mod network_server;
+pub mod profile_manager;
+pub mod sim_access;
+pub mod thermometer_manager;
+pub mod thermometer_watcher;

--- a/rs-matter/src/utils/zbus_proxies/bluez/adapter.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/adapter.rs
@@ -1,0 +1,124 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.bluez.Adapter1`
+
+use zbus::{
+    proxy,
+    zvariant::{ObjectPath, Value},
+};
+
+#[proxy(interface = "org.bluez.Adapter1", default_service = "org.bluez")]
+pub trait Adapter {
+    /// GetDiscoveryFilters method
+    fn get_discovery_filters(&self) -> zbus::Result<Vec<String>>;
+
+    /// RemoveDevice method
+    fn remove_device(&self, device: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// SetDiscoveryFilter method
+    fn set_discovery_filter(
+        &self,
+        properties: std::collections::HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// StartDiscovery method
+    fn start_discovery(&self) -> zbus::Result<()>;
+
+    /// StopDiscovery method
+    fn stop_discovery(&self) -> zbus::Result<()>;
+
+    /// Address property
+    #[zbus(property)]
+    fn address(&self) -> zbus::Result<String>;
+
+    /// AddressType property
+    #[zbus(property)]
+    fn address_type(&self) -> zbus::Result<String>;
+
+    /// Alias property
+    #[zbus(property)]
+    fn alias(&self) -> zbus::Result<String>;
+    #[zbus(property)]
+    fn set_alias(&self, value: &str) -> zbus::Result<()>;
+
+    /// Class property
+    #[zbus(property)]
+    fn class(&self) -> zbus::Result<u32>;
+
+    /// Discoverable property
+    #[zbus(property)]
+    fn discoverable(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_discoverable(&self, value: bool) -> zbus::Result<()>;
+
+    /// DiscoverableTimeout property
+    #[zbus(property)]
+    fn discoverable_timeout(&self) -> zbus::Result<u32>;
+    #[zbus(property)]
+    fn set_discoverable_timeout(&self, value: u32) -> zbus::Result<()>;
+
+    /// Discovering property
+    #[zbus(property)]
+    fn discovering(&self) -> zbus::Result<bool>;
+
+    /// ExperimentalFeatures property
+    #[zbus(property)]
+    fn experimental_features(&self) -> zbus::Result<Vec<String>>;
+
+    /// Manufacturer property
+    #[zbus(property)]
+    fn manufacturer(&self) -> zbus::Result<u16>;
+
+    /// Modalias property
+    #[zbus(property)]
+    fn modalias(&self) -> zbus::Result<String>;
+
+    /// Name property
+    #[zbus(property)]
+    fn name(&self) -> zbus::Result<String>;
+
+    /// Pairable property
+    #[zbus(property)]
+    fn pairable(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_pairable(&self, value: bool) -> zbus::Result<()>;
+
+    /// PairableTimeout property
+    #[zbus(property)]
+    fn pairable_timeout(&self) -> zbus::Result<u32>;
+    #[zbus(property)]
+    fn set_pairable_timeout(&self, value: u32) -> zbus::Result<()>;
+
+    /// Powered property
+    #[zbus(property)]
+    fn powered(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_powered(&self, value: bool) -> zbus::Result<()>;
+
+    /// Roles property
+    #[zbus(property)]
+    fn roles(&self) -> zbus::Result<Vec<String>>;
+
+    /// UUIDs property
+    #[zbus(property, name = "UUIDs")]
+    fn uuids(&self) -> zbus::Result<Vec<String>>;
+
+    /// Version property
+    #[zbus(property)]
+    fn version(&self) -> zbus::Result<u8>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/admin_policy_set.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/admin_policy_set.rs
@@ -15,8 +15,12 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.AdminPolicySet1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(interface = "org.bluez.AdminPolicySet1", assume_defaults = true)]
+pub trait AdminPolicySet {
+    /// SetServiceAllowList method
+    fn set_service_allow_list(&self, uuids: &[&str]) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/agent.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/agent.rs
@@ -1,0 +1,47 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.bluez.Agent1`
+
+use zbus::{proxy, zvariant::ObjectPath};
+
+#[proxy(interface = "org.bluez.Agent1", assume_defaults = true)]
+pub trait Agent {
+    /// AuthorizeService method
+    fn authorize_service(&self, device: &ObjectPath<'_>, uuid: &str) -> zbus::Result<()>;
+
+    /// Cancel method
+    fn cancel(&self) -> zbus::Result<()>;
+
+    /// DisplayPinCode method
+    fn display_pin_code(&self, device: &ObjectPath<'_>, pincode: &str) -> zbus::Result<()>;
+
+    /// Release method
+    fn release(&self) -> zbus::Result<()>;
+
+    /// RequestAuthorization method
+    fn request_authorization(&self, device: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// RequestConfirmation method
+    fn request_confirmation(&self, device: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// RequestPasskey method
+    fn request_passkey(&self, device: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// RequestPinCode method
+    fn request_pin_code(&self, device: &ObjectPath<'_>) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/agent_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/agent_manager.rs
@@ -15,8 +15,22 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.AgentManager1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::{proxy, zvariant::ObjectPath};
+
+#[proxy(
+    interface = "org.bluez.AgentManager1",
+    default_service = "org.bluez",
+    default_path = "/org/bluez"
+)]
+pub trait AgentManager {
+    /// RegisterAgent method
+    fn register_agent(&self, agent: &ObjectPath<'_>, capability: &str) -> zbus::Result<()>;
+
+    /// RequestDefaultAgent method
+    fn request_default_agent(&self, agent: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// UnregisterAgent method
+    fn unregister_agent(&self, agent: &ObjectPath<'_>) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/battery.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/battery.rs
@@ -15,8 +15,13 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.Battery1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(interface = "org.bluez.Battery1", assume_defaults = true)]
+pub trait Battery {
+    /// Percentage property
+    #[zbus(property)]
+    fn percentage(&self) -> zbus::Result<u8>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/battery_provider_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/battery_provider_manager.rs
@@ -15,8 +15,18 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.BatteryProviderManager1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::{proxy, zvariant::ObjectPath};
+
+#[proxy(
+    interface = "org.bluez.BatteryProviderManager1",
+    default_service = "org.bluez"
+)]
+pub trait BatteryProviderManager {
+    /// RegisterBatteryProvider method
+    fn register_battery_provider(&self, provider: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// UnregisterBatteryProvider method
+    fn unregister_battery_provider(&self, provider: &ObjectPath<'_>) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/device.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/device.rs
@@ -1,0 +1,132 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.bluez.Device1`
+
+use std::collections::HashMap;
+
+use zbus::{
+    proxy,
+    zvariant::{OwnedObjectPath, OwnedValue},
+};
+
+#[proxy(interface = "org.bluez.Device1", assume_defaults = true)]
+pub trait Device {
+    /// CancelPairing method
+    fn cancel_pairing(&self) -> zbus::Result<()>;
+
+    /// Connect method
+    fn connect(&self) -> zbus::Result<()>;
+
+    /// ConnectProfile method
+    fn connect_profile(&self, uuid: &str) -> zbus::Result<()>;
+
+    /// Disconnect method
+    fn disconnect(&self) -> zbus::Result<()>;
+
+    /// DisconnectProfile method
+    fn disconnect_profile(&self, uuid: &str) -> zbus::Result<()>;
+
+    /// Pair method
+    fn pair(&self) -> zbus::Result<()>;
+
+    /// Adapter property
+    #[zbus(property)]
+    fn adapter(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Address property
+    #[zbus(property)]
+    fn address(&self) -> zbus::Result<String>;
+
+    /// AddressType property
+    #[zbus(property)]
+    fn address_type(&self) -> zbus::Result<String>;
+
+    /// Alias property
+    #[zbus(property)]
+    fn alias(&self) -> zbus::Result<String>;
+    #[zbus(property)]
+    fn set_alias(&self, value: &str) -> zbus::Result<()>;
+
+    /// Appearance property
+    #[zbus(property)]
+    fn appearance(&self) -> zbus::Result<u16>;
+
+    /// Blocked property
+    #[zbus(property)]
+    fn blocked(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_blocked(&self, value: bool) -> zbus::Result<()>;
+
+    /// Class property
+    #[zbus(property)]
+    fn class(&self) -> zbus::Result<u32>;
+
+    /// Connected property
+    #[zbus(property)]
+    fn connected(&self) -> zbus::Result<bool>;
+
+    /// Icon property
+    #[zbus(property)]
+    fn icon(&self) -> zbus::Result<String>;
+
+    /// LegacyPairing property
+    #[zbus(property)]
+    fn legacy_pairing(&self) -> zbus::Result<bool>;
+
+    /// ManufacturerData property
+    #[zbus(property)]
+    fn manufacturer_data(&self) -> zbus::Result<HashMap<u16, OwnedValue>>;
+
+    /// Modalias property
+    #[zbus(property)]
+    fn modalias(&self) -> zbus::Result<String>;
+
+    /// Name property
+    #[zbus(property)]
+    fn name(&self) -> zbus::Result<String>;
+
+    /// Paired property
+    #[zbus(property)]
+    fn paired(&self) -> zbus::Result<bool>;
+
+    /// RSSI property
+    #[zbus(property, name = "RSSI")]
+    fn rssi(&self) -> zbus::Result<i16>;
+
+    /// ServiceData property
+    #[zbus(property)]
+    fn service_data(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+
+    /// ServicesResolved property
+    #[zbus(property)]
+    fn services_resolved(&self) -> zbus::Result<bool>;
+
+    /// Trusted property
+    #[zbus(property)]
+    fn trusted(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_trusted(&self, value: bool) -> zbus::Result<()>;
+
+    /// TxPower property
+    #[zbus(property)]
+    fn tx_power(&self) -> zbus::Result<i16>;
+
+    /// UUIDs property
+    #[zbus(property, name = "UUIDs")]
+    fn uuids(&self) -> zbus::Result<Vec<String>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/gatt_characteristic.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/gatt_characteristic.rs
@@ -1,0 +1,78 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.bluez.GattCharacteristic1`
+
+use std::collections::HashMap;
+
+use zbus::{
+    proxy,
+    zvariant::{OwnedFd, OwnedObjectPath, Value},
+};
+
+#[proxy(interface = "org.bluez.GattCharacteristic1", assume_defaults = true)]
+pub trait GattCharacteristic {
+    /// AcquireNotify method
+    fn acquire_notify(&self, options: HashMap<&str, &Value<'_>>) -> zbus::Result<(OwnedFd, u16)>;
+
+    /// AcquireWrite method
+    fn acquire_write(&self, options: HashMap<&str, &Value<'_>>) -> zbus::Result<(OwnedFd, u16)>;
+
+    /// ReadValue method
+    fn read_value(&self, options: HashMap<&str, &Value<'_>>) -> zbus::Result<Vec<u8>>;
+
+    /// StartNotify method
+    fn start_notify(&self) -> zbus::Result<()>;
+
+    /// StopNotify method
+    fn stop_notify(&self) -> zbus::Result<()>;
+
+    /// WriteValue method
+    fn write_value(&self, value: &[u8], options: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// Flags property
+    #[zbus(property)]
+    fn flags(&self) -> zbus::Result<Vec<String>>;
+
+    /// MTU property
+    #[zbus(property, name = "MTU")]
+    fn mtu(&self) -> zbus::Result<u16>;
+
+    /// NotifyAcquired property
+    #[zbus(property)]
+    fn notify_acquired(&self) -> zbus::Result<bool>;
+
+    /// Notifying property
+    #[zbus(property)]
+    fn notifying(&self) -> zbus::Result<bool>;
+
+    /// Service property
+    #[zbus(property)]
+    fn service(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// UUID property
+    #[zbus(property, name = "UUID")]
+    fn uuid(&self) -> zbus::Result<String>;
+
+    /// Value property
+    #[zbus(property)]
+    fn value(&self) -> zbus::Result<Vec<u8>>;
+
+    /// WriteAcquired property
+    #[zbus(property)]
+    fn write_acquired(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/gatt_descriptor.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/gatt_descriptor.rs
@@ -1,0 +1,46 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.bluez.GattDescriptor1`
+
+use std::collections::HashMap;
+
+use zbus::{
+    proxy,
+    zvariant::{OwnedObjectPath, Value},
+};
+
+#[proxy(interface = "org.bluez.GattDescriptor1", assume_defaults = true)]
+pub trait GattDescriptor {
+    /// ReadValue method
+    fn read_value(&self, options: HashMap<&str, &Value<'_>>) -> zbus::Result<Vec<u8>>;
+
+    /// WriteValue method
+    fn write_value(&self, value: &[u8], options: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// Characteristic property
+    #[zbus(property)]
+    fn characteristic(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// UUID property
+    #[zbus(property, name = "UUID")]
+    fn uuid(&self) -> zbus::Result<String>;
+
+    /// Value property
+    #[zbus(property)]
+    fn value(&self) -> zbus::Result<Vec<u8>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/gatt_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/gatt_manager.rs
@@ -15,8 +15,24 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.GattManager1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use std::collections::HashMap;
+
+use zbus::{
+    proxy,
+    zvariant::{ObjectPath, Value},
+};
+
+#[proxy(interface = "org.bluez.GattManager1", default_service = "org.bluez")]
+pub trait GattManager {
+    /// RegisterApplication method
+    fn register_application(
+        &self,
+        application: &ObjectPath<'_>,
+        options: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// UnregisterApplication method
+    fn unregister_application(&self, application: &ObjectPath<'_>) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/gatt_profile.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/gatt_profile.rs
@@ -15,8 +15,12 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.GattProfile1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(interface = "org.bluez.GattProfile1", assume_defaults = true)]
+pub trait GattProfile {
+    /// Release method
+    fn release(&self) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/gatt_service.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/gatt_service.rs
@@ -15,8 +15,25 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.GattService1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::{proxy, zvariant::OwnedObjectPath};
+
+#[proxy(interface = "org.bluez.GattService1", assume_defaults = true)]
+pub trait GattService {
+    /// Device property
+    #[zbus(property)]
+    fn device(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Includes property
+    #[zbus(property)]
+    fn includes(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Primary property
+    #[zbus(property)]
+    fn primary(&self) -> zbus::Result<bool>;
+
+    /// UUID property
+    #[zbus(property, name = "UUID")]
+    fn uuid(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/health_device.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/health_device.rs
@@ -1,0 +1,45 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.bluez.HealthDevice1`
+
+use zbus::{
+    proxy,
+    zvariant::{ObjectPath, OwnedObjectPath},
+};
+
+#[proxy(interface = "org.bluez.HealthDevice1", assume_defaults = true)]
+pub trait HealthDevice {
+    /// ChannelConnected method
+    fn channel_connected(&self, channel: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// ChannelDeleted method
+    fn channel_deleted(&self, channel: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// CreateChannel method
+    fn create_channel(
+        &self,
+        application: &ObjectPath<'_>,
+        configuration: &str,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// DestroyChannel method
+    fn destroy_channel(&self, channel: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// Echo method
+    fn echo(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/health_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/health_manager.rs
@@ -15,8 +15,27 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.HealthManager1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use std::collections::HashMap;
+
+use zbus::{
+    proxy,
+    zvariant::{ObjectPath, OwnedObjectPath, Value},
+};
+
+#[proxy(
+    interface = "org.bluez.HealthManager1",
+    default_service = "org.bluez",
+    default_path = "/org/bluez"
+)]
+pub trait HealthManager {
+    /// CreateApplication method
+    fn create_application(
+        &self,
+        config: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// DestroyApplication method
+    fn destroy_application(&self, application: &ObjectPath<'_>) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/le_advertisement.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/le_advertisement.rs
@@ -15,8 +15,12 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.LEAdvertisement1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(interface = "org.bluez.LEAdvertisement1", assume_defaults = true)]
+pub trait LEAdvertisement {
+    /// Release method
+    fn release(&self) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/le_advertising_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/le_advertising_manager.rs
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.bluez.LEAdvertisingManager1`
+
+use std::collections::HashMap;
+
+use zbus::{
+    proxy,
+    zvariant::{ObjectPath, Value},
+};
+
+#[proxy(
+    interface = "org.bluez.LEAdvertisingManager1",
+    default_service = "org.bluez"
+)]
+pub trait LEAdvertisingManager {
+    /// RegisterAdvertisement method
+    fn register_advertisement(
+        &self,
+        advertisement: &ObjectPath<'_>,
+        options: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// UnregisterAdvertisement method
+    fn unregister_advertisement(&self, service: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// ActiveInstances property
+    #[zbus(property)]
+    fn active_instances(&self) -> zbus::Result<u8>;
+
+    /// SupportedIncludes property
+    #[zbus(property)]
+    fn supported_includes(&self) -> zbus::Result<Vec<String>>;
+
+    /// SupportedInstances property
+    #[zbus(property)]
+    fn supported_instances(&self) -> zbus::Result<u8>;
+
+    /// SupportedSecondaryChannels property
+    #[zbus(property)]
+    fn supported_secondary_channels(&self) -> zbus::Result<Vec<String>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/media.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/media.rs
@@ -1,0 +1,62 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.bluez.Media1`
+
+use std::collections::HashMap;
+
+use zbus::{
+    proxy,
+    zvariant::{ObjectPath, Value},
+};
+
+#[proxy(interface = "org.bluez.Media1", default_service = "org.bluez")]
+pub trait Media {
+    /// RegisterApplication method
+    fn register_application(
+        &self,
+        application: &ObjectPath<'_>,
+        options: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// RegisterEndpoint method
+    fn register_endpoint(
+        &self,
+        endpoint: &ObjectPath<'_>,
+        properties: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// RegisterPlayer method
+    fn register_player(
+        &self,
+        player: &ObjectPath<'_>,
+        properties: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// UnregisterApplication method
+    fn unregister_application(&self, application: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// UnregisterEndpoint method
+    fn unregister_endpoint(&self, endpoint: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// UnregisterPlayer method
+    fn unregister_player(&self, player: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// SupportedUUIDs property
+    #[zbus(property, name = "SupportedUUIDs")]
+    fn supported_uuids(&self) -> zbus::Result<Vec<String>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/media_control.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/media_control.rs
@@ -15,8 +15,17 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.MediaControl1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::{proxy, zvariant::OwnedObjectPath};
+
+#[proxy(interface = "org.bluez.MediaControl1", assume_defaults = true)]
+pub trait MediaControl {
+    /// Connected property
+    #[zbus(property)]
+    fn connected(&self) -> zbus::Result<bool>;
+
+    /// Player property
+    #[zbus(property)]
+    fn player(&self) -> zbus::Result<OwnedObjectPath>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/network.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/network.rs
@@ -15,8 +15,27 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.Network1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(interface = "org.bluez.Network1", assume_defaults = true)]
+pub trait Network {
+    /// Connect method
+    fn connect(&self, uuid: &str) -> zbus::Result<String>;
+
+    /// Disconnect method
+    fn disconnect(&self) -> zbus::Result<()>;
+
+    /// Connected property
+    #[zbus(property)]
+    fn connected(&self) -> zbus::Result<bool>;
+
+    /// Interface property
+    #[zbus(property)]
+    fn interface(&self) -> zbus::Result<String>;
+
+    /// UUID property
+    #[zbus(property, name = "UUID")]
+    fn uuid(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/network_server.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/network_server.rs
@@ -15,8 +15,15 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.NetworkServer1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(interface = "org.bluez.NetworkServer1", default_service = "org.bluez")]
+pub trait NetworkServer {
+    /// Register method
+    fn register(&self, uuid: &str, bridge: &str) -> zbus::Result<()>;
+
+    /// Unregister method
+    fn unregister(&self, uuid: &str) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/profile_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/profile_manager.rs
@@ -15,8 +15,29 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.ProfileManager1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use std::collections::HashMap;
+
+use zbus::{
+    proxy,
+    zvariant::{ObjectPath, Value},
+};
+
+#[proxy(
+    interface = "org.bluez.ProfileManager1",
+    default_service = "org.bluez",
+    default_path = "/org/bluez"
+)]
+pub trait ProfileManager {
+    /// RegisterProfile method
+    fn register_profile(
+        &self,
+        profile: &ObjectPath<'_>,
+        uuid: &str,
+        options: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// UnregisterProfile method
+    fn unregister_profile(&self, profile: &ObjectPath<'_>) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/sim_access.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/sim_access.rs
@@ -15,8 +15,12 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.SimAccess1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(interface = "org.bluez.SimAccess1", assume_defaults = true)]
+pub trait SimAccess {
+    /// Disconnect method
+    fn disconnect(&self) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/thermometer_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/thermometer_manager.rs
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.bluez.ThermometerManager1`
+
+use zbus::{proxy, zvariant::ObjectPath};
+
+#[proxy(interface = "org.bluez.ThermometerManager1", assume_defaults = true)]
+pub trait ThermometerManager {
+    /// DisableIntermediateMeasurement method
+    fn disable_intermediate_measurement(&self, agent: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// EnableIntermediateMeasurement method
+    fn enable_intermediate_measurement(&self, agent: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// RegisterWatcher method
+    fn register_watcher(&self, agent: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// UnregisterWatcher method
+    fn unregister_watcher(&self, agent: &ObjectPath<'_>) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/bluez/thermometer_watcher.rs
+++ b/rs-matter/src/utils/zbus_proxies/bluez/thermometer_watcher.rs
@@ -15,8 +15,14 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.bluez.ThermometerWatcher1`
 
-pub mod bluez;
-pub mod nm;
-pub mod wpa_supp;
+use std::collections::HashMap;
+
+use zbus::{proxy, zvariant::Value};
+
+#[proxy(interface = "org.bluez.ThermometerWatcher1", assume_defaults = true)]
+pub trait ThermometerWatcher {
+    /// MeasurementReceived method
+    fn measurement_received(&self, measurement: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm.rs
@@ -1,0 +1,39 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! zbus proxies for NetworkManager.
+//!
+//! All proxy traits are either generated using introspection (i.e. `zbus-xmlgen system org.freedesktop.NetworkManager /org/freedesktop/NetworkManager`)
+//! or manually by consulting the NetworkManager D-Bus interface definitions
+//! as documented here: https://networkmanager.dev/docs/api/latest/spec.html circa 2025-07-15
+
+pub mod access_point;
+pub mod active;
+pub mod agent_manager;
+pub mod checkpoint;
+pub mod connection;
+pub mod device;
+pub mod dhcp4config;
+pub mod dhcp6config;
+pub mod dns_manager;
+pub mod ip4config;
+pub mod ip6config;
+pub mod network_manager;
+pub mod ppp;
+pub mod settings;
+pub mod vpn_connection;
+pub mod wifi_p2ppeer;

--- a/rs-matter/src/utils/zbus_proxies/nm/access_point.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/access_point.rs
@@ -1,0 +1,70 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.AccessPoint`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.AccessPoint",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait AccessPoint {
+    /// Flags property
+    #[zbus(property)]
+    fn flags(&self) -> zbus::Result<u32>;
+
+    /// WpaFlags property
+    #[zbus(property)]
+    fn wpa_flags(&self) -> zbus::Result<u32>;
+
+    /// RsnFlags property
+    #[zbus(property)]
+    fn rsn_flags(&self) -> zbus::Result<u32>;
+
+    /// ssid property
+    #[zbus(property)]
+    fn ssid(&self) -> zbus::Result<Vec<u8>>;
+
+    /// Frequency property
+    #[zbus(property)]
+    fn frequency(&self) -> zbus::Result<u32>;
+
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Mode property
+    #[zbus(property)]
+    fn mode(&self) -> zbus::Result<u32>;
+
+    /// MaxBitrate property
+    #[zbus(property)]
+    fn max_bitrate(&self) -> zbus::Result<u32>;
+
+    /// Bandwidth property
+    #[zbus(property)]
+    fn bandwidth(&self) -> zbus::Result<u32>;
+
+    /// Strength property
+    #[zbus(property)]
+    fn strength(&self) -> zbus::Result<u8>;
+
+    /// LastSeen property
+    #[zbus(property)]
+    fn last_seen(&self) -> zbus::Result<i32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/active.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/active.rs
@@ -1,0 +1,99 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Connection.Active`
+
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Connection.Active",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Active {
+    /// StateChanged signal
+    #[zbus(signal, name = "StateChanged")]
+    fn act_state_changed_signal(&self, state: u32, reason: u32) -> zbus::Result<()>;
+
+    /// Connection property
+    #[zbus(property)]
+    fn connection(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Controller property
+    #[zbus(property)]
+    fn controller(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Default property
+    #[zbus(property)]
+    fn default(&self) -> zbus::Result<bool>;
+
+    /// Default6 property
+    #[zbus(property)]
+    fn default6(&self) -> zbus::Result<bool>;
+
+    /// Devices property
+    #[zbus(property)]
+    fn devices(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Dhcp4Config property
+    #[zbus(property)]
+    fn dhcp4_config(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Dhcp6Config property
+    #[zbus(property)]
+    fn dhcp6_config(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Id property
+    #[zbus(property)]
+    fn id(&self) -> zbus::Result<String>;
+
+    /// Ip4Config property
+    #[zbus(property)]
+    fn ip4_config(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Ip6Config property
+    #[zbus(property)]
+    fn ip6_config(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Master property
+    #[zbus(property)]
+    fn master(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// SpecificObject property
+    #[zbus(property)]
+    fn specific_object(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// State property
+    #[zbus(property, name = "State")]
+    fn act_state(&self) -> zbus::Result<u32>;
+
+    /// StateFlags property
+    #[zbus(property)]
+    fn state_flags(&self) -> zbus::Result<u32>;
+
+    /// Type property
+    #[zbus(property)]
+    fn type_(&self) -> zbus::Result<String>;
+
+    /// Uuid property
+    #[zbus(property)]
+    fn uuid(&self) -> zbus::Result<String>;
+
+    /// Vpn property
+    #[zbus(property)]
+    fn vpn(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/agent_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/agent_manager.rs
@@ -15,7 +15,22 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.AgentManager`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.AgentManager",
+    default_service = "org.freedesktop.NetworkManager",
+    default_path = "/org/freedesktop/NetworkManager/AgentManager"
+)]
+pub trait AgentManager {
+    /// Register method
+    fn register(&self, identifier: &str) -> zbus::Result<()>;
+
+    /// RegisterWithCapabilities method
+    fn register_with_capabilities(&self, identifier: &str, capabilities: u32) -> zbus::Result<()>;
+
+    /// Unregister method
+    fn unregister(&self) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/checkpoint.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/checkpoint.rs
@@ -15,7 +15,25 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Checkpoint`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Checkpoint",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Checkpoint {
+    /// Devices property
+    #[zbus(property)]
+    fn devices(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Created property
+    #[zbus(property)]
+    fn created(&self) -> zbus::Result<i64>;
+
+    /// RollbackTimeout property
+    #[zbus(property)]
+    fn rollback_timeout(&self) -> zbus::Result<u32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/connection.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/connection.rs
@@ -1,0 +1,88 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Settings.Connection`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{OwnedValue, Value};
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Settings.Connection",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Connection {
+    /// ClearSecrets method
+    fn clear_secrets(&self) -> zbus::Result<()>;
+
+    /// Delete method
+    fn delete(&self) -> zbus::Result<()>;
+
+    /// GetSecrets method
+    fn get_secrets(
+        &self,
+        setting_name: &str,
+    ) -> zbus::Result<HashMap<String, HashMap<String, OwnedValue>>>;
+
+    /// GetSettings method
+    fn get_settings(&self) -> zbus::Result<HashMap<String, HashMap<String, OwnedValue>>>;
+
+    /// Save method
+    fn save(&self) -> zbus::Result<()>;
+
+    /// Update method
+    fn update(&self, properties: HashMap<&str, HashMap<&str, &Value<'_>>>) -> zbus::Result<()>;
+
+    /// Update2 method
+    fn update2(
+        &self,
+        settings: HashMap<&str, HashMap<&str, &Value<'_>>>,
+        flags: u32,
+        args: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<HashMap<String, OwnedValue>>;
+
+    /// UpdateUnsaved method
+    fn update_unsaved(
+        &self,
+        properties: HashMap<&str, HashMap<&str, &Value<'_>>>,
+    ) -> zbus::Result<()>;
+
+    /// Removed signal
+    #[zbus(signal)]
+    fn removed(&self) -> zbus::Result<()>;
+
+    /// Updated signal
+    #[zbus(signal)]
+    fn updated(&self) -> zbus::Result<()>;
+
+    /// Filename property
+    #[zbus(property)]
+    fn filename(&self) -> zbus::Result<String>;
+
+    /// Flags property
+    #[zbus(property)]
+    fn flags(&self) -> zbus::Result<u32>;
+
+    /// Unsaved property
+    #[zbus(property)]
+    fn unsaved(&self) -> zbus::Result<bool>;
+
+    /// VersionId property
+    #[zbus(property)]
+    fn version_id(&self) -> zbus::Result<u64>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device.rs
@@ -1,0 +1,225 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device`
+
+#![allow(clippy::type_complexity)]
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
+
+pub mod adsl;
+pub mod bluetooth;
+pub mod bond;
+pub mod bridge;
+pub mod dummy;
+pub mod generic;
+pub mod hsr;
+pub mod infiniband;
+pub mod ip_tunnel;
+pub mod ipvlan;
+pub mod loopback;
+pub mod lowpan;
+pub mod macsec;
+pub mod macvlan;
+pub mod modem;
+pub mod olpc_mesh;
+pub mod ovs_bridge;
+pub mod ovs_interface;
+pub mod ovs_port;
+pub mod ppp;
+pub mod statistics;
+pub mod team;
+pub mod tun;
+pub mod veth;
+pub mod vlan;
+pub mod vrf;
+pub mod vxlan;
+pub mod wifi_p2p;
+pub mod wired;
+pub mod wireguard;
+pub mod wireless;
+pub mod wpan;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Device {
+    /// Delete method
+    fn delete(&self) -> zbus::Result<()>;
+
+    /// Disconnect method
+    fn disconnect(&self) -> zbus::Result<()>;
+
+    /// GetAppliedConnection method
+    fn get_applied_connection(
+        &self,
+        flags: u32,
+    ) -> zbus::Result<(HashMap<String, HashMap<String, OwnedValue>>, u64)>;
+
+    /// Reapply method
+    fn reapply(
+        &self,
+        connection: HashMap<&str, HashMap<&str, &Value<'_>>>,
+        version_id: u64,
+        flags: u32,
+    ) -> zbus::Result<()>;
+
+    /// StateChanged signal
+    #[zbus(signal, name = "StateChanged")]
+    fn dev_state_changed_signal(
+        &self,
+        new_state: u32,
+        old_state: u32,
+        reason: u32,
+    ) -> zbus::Result<()>;
+
+    /// ActiveConnection property
+    #[zbus(property)]
+    fn active_connection(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Autoconnect property
+    #[zbus(property)]
+    fn autoconnect(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_autoconnect(&self, value: bool) -> zbus::Result<()>;
+
+    /// AvailableConnections property
+    #[zbus(property)]
+    fn available_connections(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Capabilities property
+    #[zbus(property)]
+    fn capabilities(&self) -> zbus::Result<u32>;
+
+    /// DeviceType property
+    #[zbus(property)]
+    fn device_type(&self) -> zbus::Result<u32>;
+
+    /// Dhcp4Config property
+    #[zbus(property)]
+    fn dhcp4_config(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Dhcp6Config property
+    #[zbus(property)]
+    fn dhcp6_config(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Driver property
+    #[zbus(property)]
+    fn driver(&self) -> zbus::Result<String>;
+
+    /// DriverVersion property
+    #[zbus(property)]
+    fn driver_version(&self) -> zbus::Result<String>;
+
+    /// FirmwareMissing property
+    #[zbus(property)]
+    fn firmware_missing(&self) -> zbus::Result<bool>;
+
+    /// FirmwareVersion property
+    #[zbus(property)]
+    fn firmware_version(&self) -> zbus::Result<String>;
+
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Interface property
+    #[zbus(property)]
+    fn interface(&self) -> zbus::Result<String>;
+
+    /// InterfaceFlags property
+    #[zbus(property)]
+    fn interface_flags(&self) -> zbus::Result<u32>;
+
+    /// Ip4Address property
+    #[zbus(property)]
+    fn ip4_address(&self) -> zbus::Result<u32>;
+
+    /// Ip4Config property
+    #[zbus(property)]
+    fn ip4_config(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Ip4Connectivity property
+    #[zbus(property)]
+    fn ip4_connectivity(&self) -> zbus::Result<u32>;
+
+    /// Ip6Config property
+    #[zbus(property)]
+    fn ip6_config(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Ip6Connectivity property
+    #[zbus(property)]
+    fn ip6_connectivity(&self) -> zbus::Result<u32>;
+
+    /// IpInterface property
+    #[zbus(property)]
+    fn ip_interface(&self) -> zbus::Result<String>;
+
+    /// LldpNeighbors property
+    #[zbus(property)]
+    fn lldp_neighbors(&self) -> zbus::Result<Vec<HashMap<String, OwnedValue>>>;
+
+    /// Managed property
+    #[zbus(property)]
+    fn managed(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_managed(&self, value: bool) -> zbus::Result<()>;
+
+    /// Metered property
+    #[zbus(property)]
+    fn metered(&self) -> zbus::Result<u32>;
+
+    /// Mtu property
+    #[zbus(property)]
+    fn mtu(&self) -> zbus::Result<u32>;
+
+    /// NmPluginMissing property
+    #[zbus(property)]
+    fn nm_plugin_missing(&self) -> zbus::Result<bool>;
+
+    /// Path property
+    #[zbus(property)]
+    fn path(&self) -> zbus::Result<String>;
+
+    /// PhysicalPortId property
+    #[zbus(property)]
+    fn physical_port_id(&self) -> zbus::Result<String>;
+
+    /// Ports property
+    #[zbus(property)]
+    fn ports(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Real property
+    #[zbus(property)]
+    fn real(&self) -> zbus::Result<bool>;
+
+    /// State property
+    #[zbus(property, name = "State")]
+    fn dev_state(&self) -> zbus::Result<u32>;
+
+    /// StateReason property
+    #[zbus(property)]
+    fn state_reason(&self) -> zbus::Result<(u32, u32)>;
+
+    /// Udi property
+    #[zbus(property)]
+    fn udi(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/adsl.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/adsl.rs
@@ -15,7 +15,16 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Adsl`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Adsl",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Adsl {
+    /// Carrier property
+    #[zbus(property)]
+    fn carrier(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/bluetooth.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/bluetooth.rs
@@ -15,7 +15,24 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Bridge`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Bluetooth",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Bluetooth {
+    /// Name property
+    #[zbus(property)]
+    fn name(&self) -> zbus::Result<String>;
+
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// BtCapabilities property
+    #[zbus(property)]
+    fn bt_capabilities(&self) -> zbus::Result<u32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/bond.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/bond.rs
@@ -15,7 +15,25 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Bridge`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Bond",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Bond {
+    /// Carrier property
+    #[zbus(property)]
+    fn carrier(&self) -> zbus::Result<bool>;
+
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Slaves property
+    #[zbus(property)]
+    fn slaves(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/bridge.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/bridge.rs
@@ -15,7 +15,25 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Bridge`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Bridge",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Bridge {
+    /// Carrier property
+    #[zbus(property)]
+    fn carrier(&self) -> zbus::Result<bool>;
+
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Slaves property
+    #[zbus(property)]
+    fn slaves(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/dummy.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/dummy.rs
@@ -15,7 +15,16 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Dummy`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Dummy",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Dummy {
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/generic.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/generic.rs
@@ -15,7 +15,20 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Generic`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Generic",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Dummy {
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// TypeDescription property
+    #[zbus(property)]
+    fn type_description(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/hsr.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/hsr.rs
@@ -1,0 +1,46 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Hsr`
+
+use zbus::{proxy, zvariant::OwnedObjectPath};
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Hsr",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Hsr {
+    /// SupervisionAddress property
+    #[zbus(property)]
+    fn supervision_address(&self) -> zbus::Result<String>;
+
+    /// Port1 property
+    #[zbus(property)]
+    fn port1(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Port2 property
+    #[zbus(property)]
+    fn port2(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// MulticastSpec property
+    #[zbus(property)]
+    fn multicast_spec(&self) -> zbus::Result<u8>;
+
+    /// Prp property
+    #[zbus(property)]
+    fn prp(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/infiniband.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/infiniband.rs
@@ -15,7 +15,20 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Infiniband`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Infiniband",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Infiniband {
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Carrier property
+    #[zbus(property)]
+    fn carrier(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/ip_tunnel.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/ip_tunnel.rs
@@ -1,0 +1,79 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.IPTunnel`
+
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.IPTunnel",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait IPTunnel {
+    /// Mode property
+    #[zbus(property)]
+    fn mode(&self) -> zbus::Result<u32>;
+
+    /// Parent property
+    #[zbus(property)]
+    fn parent(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Local property
+    #[zbus(property)]
+    fn local(&self) -> zbus::Result<String>;
+
+    /// Remote property
+    #[zbus(property)]
+    fn remote(&self) -> zbus::Result<String>;
+
+    /// Ttl property
+    #[zbus(property)]
+    fn ttl(&self) -> zbus::Result<u8>;
+
+    /// Tos property
+    #[zbus(property)]
+    fn tos(&self) -> zbus::Result<u8>;
+
+    /// PathMtuDiscovery property
+    #[zbus(property)]
+    fn path_mtu_discovery(&self) -> zbus::Result<bool>;
+
+    /// InputKey property
+    #[zbus(property)]
+    fn input_key(&self) -> zbus::Result<String>;
+
+    /// OutputKey property
+    #[zbus(property)]
+    fn output_key(&self) -> zbus::Result<String>;
+
+    /// EncapsulationLimit property
+    #[zbus(property)]
+    fn encapsulation_limit(&self) -> zbus::Result<u8>;
+
+    /// FlowLabel property
+    #[zbus(property)]
+    fn flow_label(&self) -> zbus::Result<u32>;
+
+    /// FwMark property
+    #[zbus(property)]
+    fn fw_mark(&self) -> zbus::Result<u32>;
+
+    /// Flags property
+    #[zbus(property)]
+    fn flags(&self) -> zbus::Result<u32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/ipvlan.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/ipvlan.rs
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Ipvlan`
+
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Ipvlan",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Ipvlan {
+    /// Parent property
+    #[zbus(property)]
+    fn parent(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Vepa property
+    #[zbus(property)]
+    fn vepa(&self) -> zbus::Result<bool>;
+
+    /// Mode property
+    #[zbus(property)]
+    fn mode(&self) -> zbus::Result<String>;
+
+    /// Private property
+    #[zbus(property)]
+    fn private(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/loopback.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/loopback.rs
@@ -15,7 +15,12 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Loopback`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Loopback",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Loopback {}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/lowpan.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/lowpan.rs
@@ -15,7 +15,21 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Lowpan`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Lowpan",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Lowpan {
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Parent property
+    #[zbus(property)]
+    fn parent(&self) -> zbus::Result<OwnedObjectPath>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/macsec.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/macsec.rs
@@ -1,0 +1,79 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Macsec`
+
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Macsec",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Macsec {
+    /// Parent property
+    #[zbus(property)]
+    fn parent(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Sci property
+    #[zbus(property)]
+    fn sci(&self) -> zbus::Result<u64>;
+
+    /// IcvLength property
+    #[zbus(property)]
+    fn icv_length(&self) -> zbus::Result<u8>;
+
+    /// CipherSuite property
+    #[zbus(property)]
+    fn cipher_suite(&self) -> zbus::Result<u64>;
+
+    /// Window property
+    #[zbus(property)]
+    fn window(&self) -> zbus::Result<u32>;
+
+    /// EncodingSa property
+    #[zbus(property)]
+    fn encoding_sa(&self) -> zbus::Result<u8>;
+
+    /// Validation property
+    #[zbus(property)]
+    fn validation(&self) -> zbus::Result<String>;
+
+    /// Encrypt property
+    #[zbus(property)]
+    fn encrypt(&self) -> zbus::Result<bool>;
+
+    /// Protect property
+    #[zbus(property)]
+    fn protect(&self) -> zbus::Result<bool>;
+
+    /// IncludeSci property
+    #[zbus(property)]
+    fn include_sci(&self) -> zbus::Result<bool>;
+
+    /// Es property
+    #[zbus(property)]
+    fn es(&self) -> zbus::Result<bool>;
+
+    /// Scb property
+    #[zbus(property)]
+    fn scb(&self) -> zbus::Result<bool>;
+
+    /// ReplayProtect property
+    #[zbus(property)]
+    fn replay_protect(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/macvlan.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/macvlan.rs
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Macvlan`
+
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Macvlan",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Macvlan {
+    /// Parent property
+    #[zbus(property)]
+    fn parent(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Mode property
+    #[zbus(property)]
+    fn mode(&self) -> zbus::Result<String>;
+
+    /// NoPromisc property
+    #[zbus(property)]
+    fn no_promisc(&self) -> zbus::Result<bool>;
+
+    /// Tap property
+    #[zbus(property)]
+    fn tap(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/modem.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/modem.rs
@@ -1,0 +1,46 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Modem`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Modem",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Modem {
+    /// ModemCapabilities property
+    #[zbus(property)]
+    fn modem_capabilities(&self) -> zbus::Result<u32>;
+
+    /// CurrentCapabilities property
+    #[zbus(property)]
+    fn current_capabilities(&self) -> zbus::Result<u32>;
+
+    /// DeviceId property
+    #[zbus(property)]
+    fn device_id(&self) -> zbus::Result<String>;
+
+    /// OperatorCode property
+    #[zbus(property)]
+    fn operator_code(&self) -> zbus::Result<String>;
+
+    /// Apn property
+    #[zbus(property)]
+    fn apn(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/olpc_mesh.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/olpc_mesh.rs
@@ -15,7 +15,25 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.OlpcMesh`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.OlpcMesh",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait OlpcMesh {
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Companion property
+    #[zbus(property)]
+    fn companion(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// ActiveChannel property
+    #[zbus(property)]
+    fn active_channel(&self) -> zbus::Result<u32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/ovs_bridge.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/ovs_bridge.rs
@@ -15,7 +15,17 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.OvsBridge`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.OvsBridge",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait OvsBridge {
+    /// Slaves property
+    #[zbus(property)]
+    fn slaves(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/ovs_interface.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/ovs_interface.rs
@@ -15,7 +15,12 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.OvsInterface`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.OvsInterface",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait OvsInterface {}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/ovs_port.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/ovs_port.rs
@@ -15,7 +15,17 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.OvsPort`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.OvsPort",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait OvsPort {
+    /// Slaves property
+    #[zbus(property)]
+    fn slaves(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/ppp.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/ppp.rs
@@ -15,7 +15,12 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Ppp`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Ppp",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Ppp {}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/statistics.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/statistics.rs
@@ -15,7 +15,26 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Statistics`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Statistics",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Statistics {
+    /// RefreshRateMs property
+    #[zbus(property)]
+    fn refresh_rate_ms(&self) -> zbus::Result<u32>;
+    #[zbus(property)]
+    fn set_refresh_rate_ms(&self, value: u32) -> zbus::Result<()>;
+
+    /// RxBytes property
+    #[zbus(property)]
+    fn rx_bytes(&self) -> zbus::Result<u64>;
+
+    /// TxBytes property
+    #[zbus(property)]
+    fn tx_bytes(&self) -> zbus::Result<u64>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/team.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/team.rs
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Team`
+
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Team",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Team {
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Carrier property
+    #[zbus(property)]
+    fn carrier(&self) -> zbus::Result<bool>;
+
+    /// Slaves property
+    #[zbus(property)]
+    fn slaves(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Config property
+    #[zbus(property)]
+    fn config(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/tun.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/tun.rs
@@ -1,0 +1,54 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Tun`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Tun",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Tun {
+    /// Owner property
+    #[zbus(property)]
+    fn owner(&self) -> zbus::Result<i64>;
+
+    /// Group
+    #[zbus(property)]
+    fn group(&self) -> zbus::Result<i64>;
+
+    /// Mode property
+    #[zbus(property)]
+    fn mode(&self) -> zbus::Result<u32>;
+
+    /// NoPi property
+    #[zbus(property)]
+    fn no_pi(&self) -> zbus::Result<bool>;
+
+    /// VnetHdr property
+    #[zbus(property)]
+    fn vnet_hdr(&self) -> zbus::Result<bool>;
+
+    /// MultiQueue property
+    #[zbus(property)]
+    fn multi_queue(&self) -> zbus::Result<bool>;
+
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/veth.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/veth.rs
@@ -15,7 +15,17 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Veth`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Veth",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Veth {
+    /// Peer property
+    #[zbus(property)]
+    fn slaves(&self) -> zbus::Result<OwnedObjectPath>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/vlan.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/vlan.rs
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Vlan`
+
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Vlan",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Vlan {
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Carrier property
+    #[zbus(property)]
+    fn carrier(&self) -> zbus::Result<bool>;
+
+    /// Parent property
+    #[zbus(property)]
+    fn parent(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// VlanId property
+    #[zbus(property)]
+    fn vlan_id(&self) -> zbus::Result<u32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/vrf.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/vrf.rs
@@ -15,7 +15,16 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Vrf`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Vrf",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Vrf {
+    /// Table property
+    #[zbus(property)]
+    fn table(&self) -> zbus::Result<u32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/vxlan.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/vxlan.rs
@@ -1,0 +1,95 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Vxlan`
+
+use zbus::proxy;
+use zbus::zvariant::OwnedObjectPath;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Vxlan",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Vxlan {
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Parent property
+    #[zbus(property)]
+    fn parent(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Id property
+    #[zbus(property)]
+    fn id(&self) -> zbus::Result<u32>;
+
+    /// Group property
+    #[zbus(property)]
+    fn group(&self) -> zbus::Result<String>;
+
+    /// Local property
+    #[zbus(property)]
+    fn local(&self) -> zbus::Result<String>;
+
+    /// Tos property
+    #[zbus(property)]
+    fn tos(&self) -> zbus::Result<u8>;
+
+    /// Ttl property
+    #[zbus(property)]
+    fn ttl(&self) -> zbus::Result<u8>;
+
+    /// Learning property
+    #[zbus(property)]
+    fn learning(&self) -> zbus::Result<bool>;
+
+    /// Ageing property
+    #[zbus(property)]
+    fn ageing(&self) -> zbus::Result<u32>;
+
+    /// Limit property
+    #[zbus(property)]
+    fn limit(&self) -> zbus::Result<u32>;
+
+    /// DstPort property
+    #[zbus(property)]
+    fn dst_port(&self) -> zbus::Result<u16>;
+
+    /// SrcPortMin property
+    #[zbus(property)]
+    fn src_port_min(&self) -> zbus::Result<u16>;
+
+    /// SrcPortMax property
+    #[zbus(property)]
+    fn src_port_max(&self) -> zbus::Result<u16>;
+
+    /// Proxy property
+    #[zbus(property)]
+    fn proxy(&self) -> zbus::Result<bool>;
+
+    /// Rsc property
+    #[zbus(property)]
+    fn rsc(&self) -> zbus::Result<bool>;
+
+    /// L2miss property
+    #[zbus(property)]
+    fn l2miss(&self) -> zbus::Result<bool>;
+
+    /// L3miss property
+    #[zbus(property)]
+    fn l3miss(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/wifi_p2p.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/wifi_p2p.rs
@@ -1,0 +1,51 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.WifiP2P`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, Value};
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.WifiP2P",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait WifiP2P {
+    /// StartFind method
+    fn start_find(&self, options: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// StopFind method
+    fn stop_find(&self) -> zbus::Result<()>;
+
+    /// PeerAdded signal
+    #[zbus(signal)]
+    fn peer_added(&self, peer: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// PeerRemoved signal
+    #[zbus(signal)]
+    fn peer_removed(&self, peer: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Peers property
+    #[zbus(property)]
+    fn peers(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/wired.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/wired.rs
@@ -1,0 +1,46 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Wired`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Wired",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Wired {
+    /// Carrier property
+    #[zbus(property)]
+    fn carrier(&self) -> zbus::Result<bool>;
+
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// PermHwAddress property
+    #[zbus(property)]
+    fn perm_hw_address(&self) -> zbus::Result<String>;
+
+    /// S390Subchannels property
+    #[zbus(property, name = "S390Subchannels")]
+    fn s390subchannels(&self) -> zbus::Result<Vec<String>>;
+
+    /// Speed property
+    #[zbus(property)]
+    fn speed(&self) -> zbus::Result<u32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/wireguard.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/wireguard.rs
@@ -15,7 +15,24 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.WireGuard`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.WireGuard",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait WireGuard {
+    /// PublicKey property
+    #[zbus(property)]
+    fn public_key(&self) -> zbus::Result<Vec<u8>>;
+
+    /// ListenPort property
+    #[zbus(property)]
+    fn listen_port(&self) -> zbus::Result<u16>;
+
+    /// FwMark property
+    #[zbus(property)]
+    fn fw_mark(&self) -> zbus::Result<u32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/wireless.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/wireless.rs
@@ -1,0 +1,78 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Wireless`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, Value};
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Wireless",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Wireless {
+    /// GetAccessPoints method
+    fn get_access_points(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// GetAllAccessPoints method
+    fn get_all_access_points(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// RequestScan method
+    fn request_scan(&self, options: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// AccessPointAdded signal
+    #[zbus(signal)]
+    fn access_point_added(&self, access_point: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// AccessPointRemoved signal
+    #[zbus(signal)]
+    fn access_point_removed(&self, access_point: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// AccessPoints property
+    #[zbus(property)]
+    fn access_points(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// ActiveAccessPoint property
+    #[zbus(property)]
+    fn active_access_point(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Bitrate property
+    #[zbus(property)]
+    fn bitrate(&self) -> zbus::Result<u32>;
+
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// LastScan property
+    #[zbus(property)]
+    fn last_scan(&self) -> zbus::Result<i64>;
+
+    /// Mode property
+    #[zbus(property)]
+    fn mode(&self) -> zbus::Result<u32>;
+
+    /// PermHwAddress property
+    #[zbus(property)]
+    fn perm_hw_address(&self) -> zbus::Result<String>;
+
+    /// WirelessCapabilities property
+    #[zbus(property)]
+    fn wireless_capabilities(&self) -> zbus::Result<u32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/device/wpan.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/device/wpan.rs
@@ -15,7 +15,16 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Device.Wpan`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Wpan",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait Wpan {
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/dhcp4config.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/dhcp4config.rs
@@ -15,7 +15,19 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.DHCP4Config`
 
-pub mod nm;
-pub mod wpa_supp;
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::OwnedValue;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.DHCP4Config",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait DHCP4Config {
+    /// Options property
+    #[zbus(property)]
+    fn options(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/dhcp6config.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/dhcp6config.rs
@@ -15,7 +15,19 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.DHCP6Config`
 
-pub mod nm;
-pub mod wpa_supp;
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::OwnedValue;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.DHCP6Config",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait DHCP6Config {
+    /// Options property
+    #[zbus(property)]
+    fn options(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/dns_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/dns_manager.rs
@@ -1,0 +1,42 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.DnsManager`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::OwnedValue;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.DnsManager",
+    default_service = "org.freedesktop.NetworkManager",
+    default_path = "/org/freedesktop/NetworkManager/DnsManager"
+)]
+pub trait DnsManager {
+    /// Configuration property
+    #[zbus(property)]
+    fn configuration(&self) -> zbus::Result<Vec<HashMap<String, OwnedValue>>>;
+
+    /// Mode property
+    #[zbus(property)]
+    fn mode(&self) -> zbus::Result<String>;
+
+    /// RcManager property
+    #[zbus(property)]
+    fn rc_manager(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/ip4config.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/ip4config.rs
@@ -1,0 +1,81 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.IP4Config`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::OwnedValue;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.IP4Config",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait IP4Config {
+    /// AddressData property
+    #[zbus(property)]
+    fn address_data(&self) -> zbus::Result<Vec<HashMap<String, OwnedValue>>>;
+
+    /// Addresses property
+    #[zbus(property)]
+    fn addresses(&self) -> zbus::Result<Vec<Vec<u32>>>;
+
+    /// DnsOptions property
+    #[zbus(property)]
+    fn dns_options(&self) -> zbus::Result<Vec<String>>;
+
+    /// DnsPriority property
+    #[zbus(property)]
+    fn dns_priority(&self) -> zbus::Result<i32>;
+
+    /// Domains property
+    #[zbus(property)]
+    fn domains(&self) -> zbus::Result<Vec<String>>;
+
+    /// Gateway property
+    #[zbus(property)]
+    fn gateway(&self) -> zbus::Result<String>;
+
+    /// NameserverData property
+    #[zbus(property)]
+    fn nameserver_data(&self) -> zbus::Result<Vec<HashMap<String, OwnedValue>>>;
+
+    /// Nameservers property
+    #[zbus(property)]
+    fn nameservers(&self) -> zbus::Result<Vec<u32>>;
+
+    /// RouteData property
+    #[zbus(property)]
+    fn route_data(&self) -> zbus::Result<Vec<HashMap<String, OwnedValue>>>;
+
+    /// Routes property
+    #[zbus(property)]
+    fn routes(&self) -> zbus::Result<Vec<Vec<u32>>>;
+
+    /// Searches property
+    #[zbus(property)]
+    fn searches(&self) -> zbus::Result<Vec<String>>;
+
+    /// WinsServerData property
+    #[zbus(property)]
+    fn wins_server_data(&self) -> zbus::Result<Vec<String>>;
+
+    /// WinsServers property
+    #[zbus(property)]
+    fn wins_servers(&self) -> zbus::Result<Vec<u32>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/ip6config.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/ip6config.rs
@@ -1,0 +1,71 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.IP6Config`
+
+#![allow(clippy::type_complexity)]
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::OwnedValue;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.IP6Config",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait IP6Config {
+    /// AddressData property
+    #[zbus(property)]
+    fn address_data(&self) -> zbus::Result<Vec<HashMap<String, OwnedValue>>>;
+
+    /// Addresses property
+    #[zbus(property)]
+    fn addresses(&self) -> zbus::Result<Vec<(Vec<u8>, u32, Vec<u8>)>>;
+
+    /// DnsOptions property
+    #[zbus(property)]
+    fn dns_options(&self) -> zbus::Result<Vec<String>>;
+
+    /// DnsPriority property
+    #[zbus(property)]
+    fn dns_priority(&self) -> zbus::Result<i32>;
+
+    /// Domains property
+    #[zbus(property)]
+    fn domains(&self) -> zbus::Result<Vec<String>>;
+
+    /// Gateway property
+    #[zbus(property)]
+    fn gateway(&self) -> zbus::Result<String>;
+
+    /// Nameservers property
+    #[zbus(property)]
+    fn nameservers(&self) -> zbus::Result<Vec<Vec<u8>>>;
+
+    /// RouteData property
+    #[zbus(property)]
+    fn route_data(&self) -> zbus::Result<Vec<HashMap<String, OwnedValue>>>;
+
+    /// Routes property
+    #[zbus(property)]
+    fn routes(&self) -> zbus::Result<Vec<(Vec<u8>, u32, Vec<u8>, u32)>>;
+
+    /// Searches property
+    #[zbus(property)]
+    fn searches(&self) -> zbus::Result<Vec<String>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/network_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/network_manager.rs
@@ -1,0 +1,255 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager",
+    default_service = "org.freedesktop.NetworkManager",
+    default_path = "/org/freedesktop/NetworkManager"
+)]
+pub trait NetworkManager {
+    /// ActivateConnection method
+    fn activate_connection(
+        &self,
+        connection: &ObjectPath<'_>,
+        device: &ObjectPath<'_>,
+        specific_object: &ObjectPath<'_>,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// AddAndActivateConnection method
+    fn add_and_activate_connection(
+        &self,
+        connection: HashMap<&str, std::collections::HashMap<&str, &Value<'_>>>,
+        device: &ObjectPath<'_>,
+        specific_object: &ObjectPath<'_>,
+    ) -> zbus::Result<(OwnedObjectPath, OwnedObjectPath)>;
+
+    /// AddAndActivateConnection2 method
+    #[allow(clippy::too_many_arguments)]
+    fn add_and_activate_connection2(
+        &self,
+        connection: HashMap<&str, std::collections::HashMap<&str, &Value<'_>>>,
+        device: &ObjectPath<'_>,
+        specific_object: &ObjectPath<'_>,
+        options: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<(
+        OwnedObjectPath,
+        OwnedObjectPath,
+        HashMap<String, OwnedValue>,
+    )>;
+
+    /// CheckConnectivity method
+    fn check_connectivity(&self) -> zbus::Result<u32>;
+
+    /// CheckpointAdjustRollbackTimeout method
+    fn checkpoint_adjust_rollback_timeout(
+        &self,
+        checkpoint: &ObjectPath<'_>,
+        add_timeout: u32,
+    ) -> zbus::Result<()>;
+
+    /// CheckpointCreate method
+    fn checkpoint_create(
+        &self,
+        devices: &[&ObjectPath<'_>],
+        rollback_timeout: u32,
+        flags: u32,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// CheckpointDestroy method
+    fn checkpoint_destroy(&self, checkpoint: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// CheckpointRollback method
+    fn checkpoint_rollback(
+        &self,
+        checkpoint: &ObjectPath<'_>,
+    ) -> zbus::Result<HashMap<String, u32>>;
+
+    /// DeactivateConnection method
+    fn deactivate_connection(&self, active_connection: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// Enable method
+    fn enable(&self, enable: bool) -> zbus::Result<()>;
+
+    /// GetAllDevices method
+    fn get_all_devices(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// GetDeviceByIpIface method
+    fn get_device_by_ip_iface(&self, iface: &str) -> zbus::Result<OwnedObjectPath>;
+
+    /// GetDevices method
+    fn get_devices(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// GetLogging method
+    fn get_logging(&self) -> zbus::Result<(String, String)>;
+
+    /// GetPermissions method
+    fn get_permissions(&self) -> zbus::Result<HashMap<String, String>>;
+
+    /// Reload method
+    fn reload(&self, flags: u32) -> zbus::Result<()>;
+
+    /// SetLogging method
+    fn set_logging(&self, level: &str, domains: &str) -> zbus::Result<()>;
+
+    /// Sleep method
+    fn sleep(&self, sleep: bool) -> zbus::Result<()>;
+
+    /// state method
+    #[zbus(name = "state")]
+    fn nm_state(&self) -> zbus::Result<u32>;
+
+    /// CheckPermissions signal
+    #[zbus(signal)]
+    fn check_permissions(&self) -> zbus::Result<()>;
+
+    /// DeviceAdded signal
+    #[zbus(signal)]
+    fn device_added(&self, device_path: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// DeviceRemoved signal
+    #[zbus(signal)]
+    fn device_removed(&self, device_path: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// StateChanged signal
+    #[zbus(signal, name = "StateChanged")]
+    fn nm_state_changed(&self, state: u32) -> zbus::Result<()>;
+
+    /// ActivatingConnection property
+    #[zbus(property)]
+    fn activating_connection(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// ActiveConnections property
+    #[zbus(property)]
+    fn active_connections(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// AllDevices property
+    #[zbus(property)]
+    fn all_devices(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Capabilities property
+    #[zbus(property)]
+    fn capabilities(&self) -> zbus::Result<Vec<u32>>;
+
+    /// Checkpoints property
+    #[zbus(property)]
+    fn checkpoints(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Connectivity property
+    #[zbus(property)]
+    fn connectivity(&self) -> zbus::Result<u32>;
+
+    /// ConnectivityCheckAvailable property
+    #[zbus(property)]
+    fn connectivity_check_available(&self) -> zbus::Result<bool>;
+
+    /// ConnectivityCheckEnabled property
+    #[zbus(property)]
+    fn connectivity_check_enabled(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_connectivity_check_enabled(&self, value: bool) -> zbus::Result<()>;
+
+    /// ConnectivityCheckUri property
+    #[zbus(property)]
+    fn connectivity_check_uri(&self) -> zbus::Result<String>;
+
+    /// Devices property
+    #[zbus(property)]
+    fn devices(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// GlobalDnsConfiguration property
+    #[zbus(property)]
+    fn global_dns_configuration(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+    #[zbus(property)]
+    fn set_global_dns_configuration(
+        &self,
+        // TODO value: HashMap<&str, &Value<'_>>,
+        value: Value<'_>,
+    ) -> zbus::Result<()>;
+
+    /// Metered property
+    #[zbus(property)]
+    fn metered(&self) -> zbus::Result<u32>;
+
+    /// NetworkingEnabled property
+    #[zbus(property)]
+    fn networking_enabled(&self) -> zbus::Result<bool>;
+
+    /// PrimaryConnection property
+    #[zbus(property)]
+    fn primary_connection(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// PrimaryConnectionType property
+    #[zbus(property)]
+    fn primary_connection_type(&self) -> zbus::Result<String>;
+
+    /// RadioFlags property
+    #[zbus(property)]
+    fn radio_flags(&self) -> zbus::Result<u32>;
+
+    /// Startup property
+    #[zbus(property)]
+    fn startup(&self) -> zbus::Result<bool>;
+
+    /// State property
+    #[zbus(property)]
+    fn state(&self) -> zbus::Result<u32>;
+
+    /// Version property
+    #[zbus(property)]
+    fn version(&self) -> zbus::Result<String>;
+
+    /// VersionInfo property
+    #[zbus(property)]
+    fn version_info(&self) -> zbus::Result<Vec<u32>>;
+
+    /// WimaxEnabled property
+    #[zbus(property)]
+    fn wimax_enabled(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_wimax_enabled(&self, value: bool) -> zbus::Result<()>;
+
+    /// WimaxHardwareEnabled property
+    #[zbus(property)]
+    fn wimax_hardware_enabled(&self) -> zbus::Result<bool>;
+
+    /// WirelessEnabled property
+    #[zbus(property)]
+    fn wireless_enabled(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_wireless_enabled(&self, value: bool) -> zbus::Result<()>;
+
+    /// WirelessHardwareEnabled property
+    #[zbus(property)]
+    fn wireless_hardware_enabled(&self) -> zbus::Result<bool>;
+
+    /// WwanEnabled property
+    #[zbus(property)]
+    fn wwan_enabled(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_wwan_enabled(&self, value: bool) -> zbus::Result<()>;
+
+    /// WwanHardwareEnabled property
+    #[zbus(property)]
+    fn wwan_hardware_enabled(&self) -> zbus::Result<bool>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/ppp.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/ppp.rs
@@ -1,0 +1,44 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.PPP`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::Value;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.PPP",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait PPP {
+    /// NeedSecrets method
+    fn need_secrets(&self) -> zbus::Result<(String, String)>;
+
+    /// SetIpv4Config method
+    fn set_ipv4_config(&self, config: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// SetIpv6Config method
+    fn set_ipv6_config(&self, config: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// SetState method
+    fn set_state(&self, state: u32) -> zbus::Result<()>;
+
+    /// SetIfindex method
+    fn set_ifindex(&self, ifindex: i32) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/settings.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/settings.rs
@@ -1,0 +1,85 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.Settings`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Settings",
+    default_service = "org.freedesktop.NetworkManager",
+    default_path = "/org/freedesktop/NetworkManager/Settings"
+)]
+pub trait Settings {
+    /// AddConnection method
+    fn add_connection(
+        &self,
+        connection: HashMap<&str, HashMap<&str, &Value<'_>>>,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// AddConnection2 method
+    fn add_connection2(
+        &self,
+        settings: HashMap<&str, HashMap<&str, &Value<'_>>>,
+        flags: u32,
+        args: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<(OwnedObjectPath, HashMap<String, OwnedValue>)>;
+
+    /// AddConnectionUnsaved method
+    fn add_connection_unsaved(
+        &self,
+        connection: HashMap<&str, HashMap<&str, &Value<'_>>>,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// GetConnectionByUuid method
+    fn get_connection_by_uuid(&self, uuid: &str) -> zbus::Result<OwnedObjectPath>;
+
+    /// ListConnections method
+    fn list_connections(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// LoadConnections method
+    fn load_connections(&self, filenames: &[&str]) -> zbus::Result<(bool, Vec<String>)>;
+
+    /// ReloadConnections method
+    fn reload_connections(&self) -> zbus::Result<bool>;
+
+    /// SaveHostname method
+    fn save_hostname(&self, hostname: &str) -> zbus::Result<()>;
+
+    /// ConnectionRemoved signal
+    #[zbus(signal)]
+    fn connection_removed(&self, connection: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// NewConnection signal
+    #[zbus(signal)]
+    fn new_connection(&self, connection: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// CanModify property
+    #[zbus(property)]
+    fn can_modify(&self) -> zbus::Result<bool>;
+
+    /// Connections property
+    #[zbus(property)]
+    fn connections(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Hostname property
+    #[zbus(property)]
+    fn hostname(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/vpn_connection.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/vpn_connection.rs
@@ -15,7 +15,24 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.VPN.Connection`
 
-pub mod nm;
-pub mod wpa_supp;
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.VPN.Connection",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait VPNConnection {
+    /// VpnStateChanged signal
+    #[zbus(signal)]
+    fn vpn_state_changed_signal(&self, state: u32, reason: u32) -> zbus::Result;
+
+    /// VpnState property
+    #[zbus(property)]
+    fn vpn_state(&self) -> zbus::Result<u32>;
+
+    /// Banner property
+    #[zbus(property)]
+    fn banner(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/nm/wifi_p2ppeer.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/wifi_p2ppeer.rs
@@ -1,0 +1,66 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.NetworkManager.AccessPoint`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.WifiP2PPeer",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+pub trait WifiP2PPeer {
+    /// Name property
+    #[zbus(property)]
+    fn name(&self) -> zbus::Result<String>;
+
+    /// Flags property
+    #[zbus(property)]
+    fn flags(&self) -> zbus::Result<u32>;
+
+    /// Manufacturer property
+    #[zbus(property)]
+    fn manufacturer(&self) -> zbus::Result<String>;
+
+    /// Model property
+    #[zbus(property)]
+    fn model(&self) -> zbus::Result<String>;
+
+    /// ModelNumber property
+    #[zbus(property)]
+    fn model_number(&self) -> zbus::Result<String>;
+
+    /// Serial property
+    #[zbus(property)]
+    fn serial(&self) -> zbus::Result<String>;
+
+    /// WfdIEs property
+    #[zbus(property)]
+    fn wfd_ies(&self) -> zbus::Result<Vec<u8>>;
+
+    /// HwAddress property
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+
+    /// Strength property
+    #[zbus(property)]
+    fn strength(&self) -> zbus::Result<u8>;
+
+    /// LastSeen property
+    #[zbus(property)]
+    fn last_seen(&self) -> zbus::Result<i32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/resolve.rs
+++ b/rs-matter/src/utils/zbus_proxies/resolve.rs
@@ -15,9 +15,9 @@
  *    limitations under the License.
  */
 
-//! A set of zbus proxies for various Linux services.
+//! zbus proxies for `org.freedesktop.resolve1`.
+//!
+//! All proxy traits are generated using introspection (i.e. `zbus-xmlgen system org.freedesktop.resolve1 /org/freedesktop/resolve1`).
+//! Also look here: https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.resolve1.html
 
-pub mod bluez;
-pub mod nm;
-pub mod resolve;
-pub mod wpa_supp;
+pub mod manager;

--- a/rs-matter/src/utils/zbus_proxies/resolve/manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/resolve/manager.rs
@@ -1,0 +1,233 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `org.freedesktop.resolve1.Manager`
+
+#![allow(clippy::type_complexity)]
+
+use std::collections::HashMap;
+
+use zbus::{
+    proxy,
+    zvariant::{ObjectPath, OwnedObjectPath},
+};
+
+#[proxy(
+    interface = "org.freedesktop.resolve1.Manager",
+    default_service = "org.freedesktop.resolve1",
+    default_path = "/org/freedesktop/resolve1"
+)]
+pub trait Manager {
+    /// FlushCaches method
+    fn flush_caches(&self) -> zbus::Result<()>;
+
+    /// GetLink method
+    fn get_link(&self, ifindex: i32) -> zbus::Result<OwnedObjectPath>;
+
+    /// RegisterService method
+    #[allow(clippy::too_many_arguments)]
+    fn register_service(
+        &self,
+        name: &str,
+        name_template: &str,
+        type_: &str,
+        service_port: u16,
+        service_priority: u16,
+        service_weight: u16,
+        txt_datas: &[HashMap<&str, &[u8]>],
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// ResetServerFeatures method
+    fn reset_server_features(&self) -> zbus::Result<()>;
+
+    /// ResetStatistics method
+    fn reset_statistics(&self) -> zbus::Result<()>;
+
+    /// ResolveAddress method
+    fn resolve_address(
+        &self,
+        ifindex: i32,
+        family: i32,
+        address: &[u8],
+        flags: u64,
+    ) -> zbus::Result<(Vec<(i32, String)>, u64)>;
+
+    /// ResolveHostname method
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_hostname(
+        &self,
+        ifindex: i32,
+        name: &str,
+        family: i32,
+        flags: u64,
+    ) -> zbus::Result<(Vec<(i32, i32, Vec<u8>)>, String, u64)>;
+
+    /// ResolveRecord method
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_record(
+        &self,
+        ifindex: i32,
+        name: &str,
+        class: u16,
+        type_: u16,
+        flags: u64,
+    ) -> zbus::Result<(Vec<(i32, u16, u16, Vec<u8>)>, u64)>;
+
+    /// ResolveService method
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::type_complexity)]
+    fn resolve_service(
+        &self,
+        ifindex: i32,
+        name: &str,
+        type_: &str,
+        domain: &str,
+        family: i32,
+        flags: u64,
+    ) -> zbus::Result<(
+        Vec<(u16, u16, u16, String, Vec<(i32, i32, Vec<u8>)>, String)>,
+        Vec<Vec<u8>>,
+        String,
+        String,
+        String,
+        u64,
+    )>;
+
+    /// RevertLink method
+    fn revert_link(&self, ifindex: i32) -> zbus::Result<()>;
+
+    /// SetLinkDNS method
+    #[zbus(name = "SetLinkDNS")]
+    fn set_link_dns(&self, ifindex: i32, addresses: &[&(i32, &[u8])]) -> zbus::Result<()>;
+
+    /// SetLinkDNSEx method
+    #[zbus(name = "SetLinkDNSEx")]
+    fn set_link_dnsex(
+        &self,
+        ifindex: i32,
+        addresses: &[&(i32, &[u8], u16, &str)],
+    ) -> zbus::Result<()>;
+
+    /// SetLinkDNSOverTLS method
+    #[zbus(name = "SetLinkDNSOverTLS")]
+    fn set_link_dnsover_tls(&self, ifindex: i32, mode: &str) -> zbus::Result<()>;
+
+    /// SetLinkDNSSEC method
+    #[zbus(name = "SetLinkDNSSEC")]
+    fn set_link_dnssec(&self, ifindex: i32, mode: &str) -> zbus::Result<()>;
+
+    /// SetLinkDNSSECNegativeTrustAnchors method
+    #[zbus(name = "SetLinkDNSSECNegativeTrustAnchors")]
+    fn set_link_dnssecnegative_trust_anchors(
+        &self,
+        ifindex: i32,
+        names: &[&str],
+    ) -> zbus::Result<()>;
+
+    /// SetLinkDefaultRoute method
+    fn set_link_default_route(&self, ifindex: i32, enable: bool) -> zbus::Result<()>;
+
+    /// SetLinkDomains method
+    fn set_link_domains(&self, ifindex: i32, domains: &[&(&str, bool)]) -> zbus::Result<()>;
+
+    /// SetLinkLLMNR method
+    #[zbus(name = "SetLinkLLMNR")]
+    fn set_link_llmnr(&self, ifindex: i32, mode: &str) -> zbus::Result<()>;
+
+    /// SetLinkMulticastDNS method
+    #[zbus(name = "SetLinkMulticastDNS")]
+    fn set_link_multicast_dns(&self, ifindex: i32, mode: &str) -> zbus::Result<()>;
+
+    /// UnregisterService method
+    fn unregister_service(&self, service_path: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// CacheStatistics property
+    #[zbus(property)]
+    fn cache_statistics(&self) -> zbus::Result<(u64, u64, u64)>;
+
+    /// CurrentDNSServer property
+    #[zbus(property, name = "CurrentDNSServer")]
+    fn current_dnsserver(&self) -> zbus::Result<(i32, i32, Vec<u8>)>;
+
+    /// CurrentDNSServerEx property
+    #[zbus(property, name = "CurrentDNSServerEx")]
+    fn current_dnsserver_ex(&self) -> zbus::Result<(i32, i32, Vec<u8>, u16, String)>;
+
+    /// DNS property
+    #[zbus(property, name = "DNS")]
+    fn dns(&self) -> zbus::Result<Vec<(i32, i32, Vec<u8>)>>;
+
+    /// DNSEx property
+    #[zbus(property, name = "DNSEx")]
+    fn dnsex(&self) -> zbus::Result<Vec<(i32, i32, Vec<u8>, u16, String)>>;
+
+    /// DNSOverTLS property
+    #[zbus(property, name = "DNSOverTLS")]
+    fn dnsover_tls(&self) -> zbus::Result<String>;
+
+    /// DNSSEC property
+    #[zbus(property, name = "DNSSEC")]
+    fn dnssec(&self) -> zbus::Result<String>;
+
+    /// DNSSECNegativeTrustAnchors property
+    #[zbus(property, name = "DNSSECNegativeTrustAnchors")]
+    fn dnssecnegative_trust_anchors(&self) -> zbus::Result<Vec<String>>;
+
+    /// DNSSECStatistics property
+    #[zbus(property, name = "DNSSECStatistics")]
+    fn dnssecstatistics(&self) -> zbus::Result<(u64, u64, u64, u64)>;
+
+    /// DNSSECSupported property
+    #[zbus(property, name = "DNSSECSupported")]
+    fn dnssecsupported(&self) -> zbus::Result<bool>;
+
+    /// DNSStubListener property
+    #[zbus(property, name = "DNSStubListener")]
+    fn dnsstub_listener(&self) -> zbus::Result<String>;
+
+    /// Domains property
+    #[zbus(property)]
+    fn domains(&self) -> zbus::Result<Vec<(i32, String, bool)>>;
+
+    /// FallbackDNS property
+    #[zbus(property, name = "FallbackDNS")]
+    fn fallback_dns(&self) -> zbus::Result<Vec<(i32, i32, Vec<u8>)>>;
+
+    /// FallbackDNSEx property
+    #[zbus(property, name = "FallbackDNSEx")]
+    fn fallback_dnsex(&self) -> zbus::Result<Vec<(i32, i32, Vec<u8>, u16, String)>>;
+
+    /// LLMNR property
+    #[zbus(property, name = "LLMNR")]
+    fn llmnr(&self) -> zbus::Result<String>;
+
+    /// LLMNRHostname property
+    #[zbus(property, name = "LLMNRHostname")]
+    fn llmnrhostname(&self) -> zbus::Result<String>;
+
+    /// MulticastDNS property
+    #[zbus(property, name = "MulticastDNS")]
+    fn multicast_dns(&self) -> zbus::Result<String>;
+
+    /// ResolvConfMode property
+    #[zbus(property)]
+    fn resolv_conf_mode(&self) -> zbus::Result<String>;
+
+    /// TransactionStatistics property
+    #[zbus(property)]
+    fn transaction_statistics(&self) -> zbus::Result<(u64, u64)>;
+}

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp.rs
@@ -15,18 +15,17 @@
  *    limitations under the License.
  */
 
-pub mod bitflags;
-pub mod cell;
-pub mod codec;
-pub mod epoch;
-pub mod init;
-pub mod iter;
-pub mod maybe;
-pub mod rand;
-pub mod select;
-pub mod storage;
-pub mod sync;
-#[cfg(feature = "std")]
-pub mod zbus;
-#[cfg(feature = "std")]
-pub mod zbus_proxies;
+//! zbus proxies for wpa-supplicant.
+//!
+//! All proxy traits are manually implemented based on the wpa-supplicant D-Bus interface definitions
+//! as documented here: https://w1.fi/wpa_supplicant/devel/dbus.html circa 2025-07-15
+
+pub mod bss;
+pub mod group;
+pub mod interface;
+pub mod network;
+pub mod p2pdevice;
+pub mod peer;
+pub mod persistent_group;
+pub mod wpa_supplicant;
+pub mod wps;

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/bss.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/bss.rs
@@ -1,0 +1,81 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `fi.w1.wpa_supplicant1.Interface.BSS`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{OwnedValue, Value};
+
+#[proxy(
+    interface = "fi.w1.wpa_supplicant1.Interface.BSS",
+    assume_defaults = true
+)]
+pub trait BSS {
+    /// PropertiesChanged signal
+    #[zbus(signal)]
+    fn properties_changed(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// BSSID property
+    #[zbus(property)]
+    fn bssid(&self) -> zbus::Result<Vec<u8>>;
+
+    /// SSID property
+    #[zbus(property)]
+    fn ssid(&self) -> zbus::Result<Vec<u8>>;
+
+    /// WPA property
+    #[zbus(property)]
+    fn wpa(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+
+    /// RSN property
+    #[zbus(property)]
+    fn rsn(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+
+    /// WPS property
+    #[zbus(property)]
+    fn wps(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+
+    /// IEs property
+    #[zbus(property)]
+    fn ies(&self) -> zbus::Result<Vec<u8>>;
+
+    /// Privacy property
+    #[zbus(property)]
+    fn privacy(&self) -> zbus::Result<bool>;
+
+    /// Mode property
+    #[zbus(property)]
+    fn mode(&self) -> zbus::Result<String>;
+
+    /// Frequency property
+    #[zbus(property)]
+    fn frequency(&self) -> zbus::Result<u16>;
+
+    /// Rates property
+    #[zbus(property)]
+    fn rates(&self) -> zbus::Result<Vec<u32>>;
+
+    /// Signal property
+    #[zbus(property)]
+    fn signal(&self) -> zbus::Result<i16>;
+
+    /// Age property
+    #[zbus(property)]
+    fn age(&self) -> zbus::Result<u32>;
+}

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/group.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/group.rs
@@ -1,0 +1,85 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `fi.w1.wpa_supplicant1.Interface.Group`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, Value};
+
+#[proxy(
+    interface = "fi.w1.wpa_supplicant1.Interface.Group",
+    assume_defaults = true
+)]
+pub trait Group {
+    /// PropertiesChanged signal
+    #[zbus(signal)]
+    fn properties_changed(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// Members property
+    #[zbus(property)]
+    fn members(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Group property
+    #[zbus(property)]
+    fn group(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Role property
+    #[zbus(property)]
+    fn role(&self) -> zbus::Result<String>;
+
+    /// SSID property
+    #[zbus(property)]
+    fn ssid(&self) -> zbus::Result<Vec<u8>>;
+
+    /// BSSID property
+    #[zbus(property)]
+    fn bssid(&self) -> zbus::Result<Vec<u8>>;
+
+    /// Frequency property
+    #[zbus(property)]
+    fn frequency(&self) -> zbus::Result<u16>;
+
+    /// Passphrase property
+    #[zbus(property)]
+    fn passphrase(&self) -> zbus::Result<String>;
+
+    /// PSK property
+    #[zbus(property)]
+    fn psk(&self) -> zbus::Result<Vec<u8>>;
+
+    /// WPSVendorExtensions property
+    #[zbus(property)]
+    fn wps_vendor_extensions(&self) -> zbus::Result<Vec<Vec<u8>>>;
+
+    /// PeerJoined signal
+    #[zbus(signal)]
+    fn peer_joined(
+        &self,
+        path: ObjectPath<'_>,
+        properties: HashMap<&str, Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// PeerDisconnected signal
+    #[zbus(signal)]
+    fn peer_disconnected(
+        &self,
+        path: ObjectPath<'_>,
+        properties: HashMap<&str, Value<'_>>,
+    ) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/interface.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/interface.rs
@@ -1,0 +1,279 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `fi.w1.wpa_supplicant1.Interface`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
+
+#[proxy(interface = "fi.w1.wpa_supplicant1.Interface", assume_defaults = true)]
+pub trait Interface {
+    /// AddBlob method
+    fn add_blob(&self, name: &str, data: &[u8]) -> zbus::Result<()>;
+
+    /// AddNetwork method
+    fn add_network(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<OwnedObjectPath>;
+
+    /// AutoScan method
+    fn auto_scan(&self, arg: &str) -> zbus::Result<()>;
+
+    /// Disconnect method
+    fn disconnect(&self) -> zbus::Result<()>;
+
+    /// EAPLogoff method
+    #[zbus(name = "EAPLogoff")]
+    fn eaplogoff(&self) -> zbus::Result<()>;
+
+    /// EAPLogon method
+    #[zbus(name = "EAPLogon")]
+    fn eaplogon(&self) -> zbus::Result<()>;
+
+    /// FlushBSS method
+    #[zbus(name = "FlushBSS")]
+    fn flush_bss(&self, age: u32) -> zbus::Result<()>;
+
+    /// GetBlob method
+    fn get_blob(&self, name: &str) -> zbus::Result<Vec<u8>>;
+
+    /// NetworkReply method
+    fn network_reply(&self, network: &ObjectPath<'_>, field: &str, value: &str)
+        -> zbus::Result<()>;
+
+    /// Reassociate method
+    fn reassociate(&self) -> zbus::Result<()>;
+
+    /// Reattach method
+    fn reattach(&self) -> zbus::Result<()>;
+
+    /// Reconnect method
+    fn reconnect(&self) -> zbus::Result<()>;
+
+    /// RemoveAllNetworks method
+    fn remove_all_networks(&self) -> zbus::Result<()>;
+
+    /// RemoveBlob method
+    fn remove_blob(&self, name: &str) -> zbus::Result<()>;
+
+    /// RemoveNetwork method
+    fn remove_network(&self, path: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// Scan method
+    fn scan(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// SelectNetwork method
+    fn select_network(&self, path: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// SetPKCS11EngineAndModulePath method
+    #[zbus(name = "SetPKCS11EngineAndModulePath")]
+    fn set_pkcs11engine_and_module_path(
+        &self,
+        pkcs11_engine_path: &str,
+        pkcs11_module_path: &str,
+    ) -> zbus::Result<()>;
+
+    /// SignalPoll method
+    fn signal_poll(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+
+    /// SubscribeProbeReq method
+    fn subscribe_probe_req(&self) -> zbus::Result<()>;
+
+    /// TDLSDiscover method
+    #[zbus(name = "TDLSDiscover")]
+    fn tdlsdiscover(&self, peer_address: &str) -> zbus::Result<()>;
+
+    /// TDLSSetup method
+    #[zbus(name = "TDLSSetup")]
+    fn tdlssetup(&self, peer_address: &str) -> zbus::Result<()>;
+
+    /// TDLSStatus method
+    #[zbus(name = "TDLSStatus")]
+    fn tdlsstatus(&self, peer_address: &str) -> zbus::Result<String>;
+
+    /// TDLSTeardown method
+    #[zbus(name = "TDLSTeardown")]
+    fn tdlsteardown(&self, peer_address: &str) -> zbus::Result<()>;
+
+    /// UnsubscribeProbeReq method
+    fn unsubscribe_probe_req(&self) -> zbus::Result<()>;
+
+    /// BSSAdded signal
+    #[zbus(signal, name = "BSSAdded")]
+    fn bssadded(
+        &self,
+        path: ObjectPath<'_>,
+        properties: HashMap<&str, Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// BSSRemoved signal
+    #[zbus(signal, name = "BSSRemoved")]
+    fn bssremoved(&self, path: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// BlobAdded signal
+    #[zbus(signal)]
+    fn blob_added(&self, name: &str) -> zbus::Result<()>;
+
+    /// BlobRemoved signal
+    #[zbus(signal)]
+    fn blob_removed(&self, name: &str) -> zbus::Result<()>;
+
+    /// Certification signal
+    #[zbus(signal)]
+    fn certification(&self, certification: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// EAP signal
+    #[zbus(signal, name = "EAP")]
+    fn eap(&self, status: &str, parameter: &str) -> zbus::Result<()>;
+
+    /// NetworkRequest signal
+    #[zbus(signal)]
+    fn network_request(&self, network: ObjectPath<'_>, field: &str, txt: &str) -> zbus::Result<()>;
+
+    /// NetworkAdded signal
+    #[zbus(signal)]
+    fn network_added(
+        &self,
+        path: ObjectPath<'_>,
+        properties: HashMap<&str, Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// NetworkRemoved signal
+    #[zbus(signal)]
+    fn network_removed(&self, path: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// NetworkSelected signal
+    #[zbus(signal)]
+    fn network_selected(&self, path: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// ProbeRequest signal
+    #[zbus(signal)]
+    fn probe_request(&self, args: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// PropertiesChanged signal
+    #[zbus(signal)]
+    fn properties_changed(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// ScanDone signal
+    #[zbus(signal)]
+    fn scan_done(&self, success: bool) -> zbus::Result<()>;
+
+    /// StaAuthorized signal
+    #[zbus(signal)]
+    fn sta_authorized(&self, name: &str) -> zbus::Result<()>;
+
+    /// StaDeauthorized signal
+    #[zbus(signal)]
+    fn sta_deauthorized(&self, name: &str) -> zbus::Result<()>;
+
+    /// ApScan property
+    #[zbus(property)]
+    fn ap_scan(&self) -> zbus::Result<u32>;
+    #[zbus(property)]
+    fn set_ap_scan(&self, value: u32) -> zbus::Result<()>;
+
+    /// BSSExpireAge property
+    #[zbus(property, name = "BSSExpireAge")]
+    fn bssexpire_age(&self) -> zbus::Result<u32>;
+    #[zbus(property, name = "BSSExpireAge")]
+    fn set_bssexpire_age(&self, value: u32) -> zbus::Result<()>;
+
+    /// BSSExpireCount property
+    #[zbus(property, name = "BSSExpireCount")]
+    fn bssexpire_count(&self) -> zbus::Result<u32>;
+    #[zbus(property, name = "BSSExpireCount")]
+    fn set_bssexpire_count(&self, value: u32) -> zbus::Result<()>;
+
+    /// BSSs property
+    #[zbus(property, name = "BSSs")]
+    fn bsss(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Blobs property
+    #[zbus(property)]
+    // TODO fn blobs(&self) -> zbus::Result<std::collections::HashMap<String, Vec<u8>>>;
+    fn blobs(&self) -> zbus::Result<Vec<String>>;
+
+    /// BridgeIfname property
+    #[zbus(property)]
+    fn bridge_ifname(&self) -> zbus::Result<String>;
+
+    /// Capabilities property
+    #[zbus(property)]
+    fn capabilities(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+
+    /// Country property
+    #[zbus(property)]
+    fn country(&self) -> zbus::Result<String>;
+    #[zbus(property)]
+    fn set_country(&self, value: &str) -> zbus::Result<()>;
+
+    /// CurrentAuthMode property
+    #[zbus(property)]
+    fn current_auth_mode(&self) -> zbus::Result<String>;
+
+    /// CurrentBSS property
+    #[zbus(property, name = "CurrentBSS")]
+    fn current_bss(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// CurrentNetwork property
+    #[zbus(property)]
+    fn current_network(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// DisconnectReason property
+    #[zbus(property)]
+    fn disconnect_reason(&self) -> zbus::Result<i32>;
+
+    /// Driver property
+    #[zbus(property)]
+    fn driver(&self) -> zbus::Result<String>;
+
+    /// FastReauth property
+    #[zbus(property)]
+    fn fast_reauth(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_fast_reauth(&self, value: bool) -> zbus::Result<()>;
+
+    /// Ifname property
+    #[zbus(property)]
+    fn ifname(&self) -> zbus::Result<String>;
+
+    /// Networks property
+    #[zbus(property)]
+    fn networks(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// PKCS11EnginePath property
+    #[zbus(property, name = "PKCS11EnginePath")]
+    fn pkcs11engine_path(&self) -> zbus::Result<String>;
+
+    /// PKCS11ModulePath property
+    #[zbus(property, name = "PKCS11ModulePath")]
+    fn pkcs11module_path(&self) -> zbus::Result<String>;
+
+    /// ScanInterval property
+    #[zbus(property)]
+    fn scan_interval(&self) -> zbus::Result<i32>;
+    #[zbus(property)]
+    fn set_scan_interval(&self, value: i32) -> zbus::Result<()>;
+
+    /// Scanning property
+    #[zbus(property)]
+    fn scanning(&self) -> zbus::Result<bool>;
+
+    /// State property
+    #[zbus(property)]
+    fn state(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/network.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/network.rs
@@ -1,0 +1,45 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `fi.w1.wpa_supplicant1.Interface.Network`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{OwnedValue, Value};
+
+#[proxy(
+    interface = "fi.w1.wpa_supplicant1.Interface.Network",
+    assume_defaults = true
+)]
+pub trait Network {
+    /// PropertiesChanged signal
+    #[zbus(signal)]
+    fn properties_changed(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// Enabled property
+    #[zbus(property)]
+    fn enabled(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_enabled(&self, enabled: bool) -> zbus::Result<()>;
+
+    /// Properties property
+    #[zbus(property, name = "Properties")]
+    fn props(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+    #[zbus(property, name = "Properties")]
+    fn set_props(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/p2pdevice.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/p2pdevice.rs
@@ -1,0 +1,261 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `fi.w1.wpa_supplicant1.Interface.P2PDevice`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
+
+#[proxy(
+    interface = "fi.w1.wpa_supplicant1.Interface.P2PDevice",
+    assume_defaults = true
+)]
+pub trait P2PDevice {
+    /// AddPersistentGroup method
+    fn add_persistent_group(
+        &self,
+        args: HashMap<&str, &Value<'_>>,
+    ) -> zbus::Result<OwnedObjectPath>;
+
+    /// AddService method
+    fn add_service(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// Connect method
+    fn connect(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<String>;
+
+    /// DeleteService method
+    fn delete_service(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// Disconnect method
+    fn disconnect(&self) -> zbus::Result<()>;
+
+    /// ExtendedListen method
+    fn extended_listen(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// Find method
+    fn find(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// Flush method
+    fn flush(&self) -> zbus::Result<()>;
+
+    /// FlushService method
+    fn flush_service(&self) -> zbus::Result<()>;
+
+    /// GroupAdd method
+    fn group_add(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// Cancel method
+    fn cancel(&self) -> zbus::Result<()>;
+
+    /// Invite method
+    fn invite(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// Listen method
+    fn listen(&self, timeout: i32) -> zbus::Result<()>;
+
+    /// PresenceRequest method
+    fn presence_request(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// ProvisionDiscoveryRequest method
+    fn provision_discovery_request(
+        &self,
+        peer: &ObjectPath<'_>,
+        config_method: &str,
+    ) -> zbus::Result<()>;
+
+    /// RejectPeer method
+    fn reject_peer(&self, peer: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// RemoveClient method
+    fn remove_client(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// RemoveAllPersistentGroups method
+    fn remove_all_persistent_groups(&self) -> zbus::Result<()>;
+
+    /// RemovePersistentGroup method
+    fn remove_persistent_group(&self, path: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// ServiceDiscoveryCancelRequest method
+    fn service_discovery_cancel_request(&self, args: u64) -> zbus::Result<()>;
+
+    /// ServiceDiscoveryExternal method
+    fn service_discovery_external(&self, arg: i32) -> zbus::Result<()>;
+
+    /// ServiceDiscoveryRequest method
+    fn service_discovery_request(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<u64>;
+
+    /// ServiceDiscoveryResponse method
+    fn service_discovery_response(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<()>;
+
+    /// ServiceUpdate method
+    fn service_update(&self) -> zbus::Result<()>;
+
+    /// StopFind method TODO: Isn't this `FindStopped`?
+    fn stop_find(&self) -> zbus::Result<()>;
+
+    /// DeviceFound signal
+    #[zbus(signal)]
+    fn device_found(&self, path: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// DeviceLost signal
+    #[zbus(signal)]
+    fn device_lost(&self, path: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// GONegotiationFailure signal
+    #[zbus(signal, name = "GONegotiationFailure")]
+    fn gonegotiation_failure(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// GONegotiationRequest signal
+    #[zbus(signal, name = "GONegotiationRequest")]
+    fn gonegotiation_request(
+        &self,
+        path: ObjectPath<'_>,
+        dev_passwd_id: i32,
+        dev_go_intent: u8, // TODO
+    ) -> zbus::Result<()>;
+
+    /// GONegotiationSuccess signal
+    #[zbus(signal, name = "GONegotiationSuccess")]
+    fn gonegotiation_success(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// GroupFinished signal
+    #[zbus(signal)]
+    fn group_finished(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// GroupStarted signal
+    #[zbus(signal)]
+    fn group_started(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// InvitationResult signal
+    #[zbus(signal)]
+    fn invitation_result(&self, invite_result: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// P2PStateChanged signal
+    #[zbus(signal, name = "P2PStateChanged")]
+    fn p2pstate_changed(&self, states: HashMap<&str, &str>) -> zbus::Result<()>;
+
+    /// PersistentGroupAdded signal
+    #[zbus(signal)]
+    fn persistent_group_added(
+        &self,
+        path: ObjectPath<'_>,
+        properties: HashMap<&str, Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// PersistentGroupRemoved signal
+    #[zbus(signal)]
+    fn persistent_group_removed(&self, path: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// ProvisionDiscoveryFailure signal
+    #[zbus(signal)]
+    fn provision_discovery_failure(
+        &self,
+        peer_object: ObjectPath<'_>,
+        status: i32,
+    ) -> zbus::Result<()>;
+
+    /// ProvisionDiscoveryPBCRequest signal
+    #[zbus(signal, name = "ProvisionDiscoveryPBCRequest")]
+    fn provision_discovery_pbcrequest(&self, peer_object: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// ProvisionDiscoveryPBCResponse signal
+    #[zbus(signal, name = "ProvisionDiscoveryPBCResponse")]
+    fn provision_discovery_pbcresponse(&self, peer_object: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// ProvisionDiscoveryRequestDisplayPin signal
+    #[zbus(signal)]
+    fn provision_discovery_request_display_pin(
+        &self,
+        peer_object: ObjectPath<'_>,
+        pin: &str,
+    ) -> zbus::Result<()>;
+
+    /// ProvisionDiscoveryRequestEnterPin signal
+    #[zbus(signal)]
+    fn provision_discovery_request_enter_pin(
+        &self,
+        peer_object: ObjectPath<'_>,
+    ) -> zbus::Result<()>;
+
+    /// ProvisionDiscoveryResponseDisplayPin signal
+    #[zbus(signal)]
+    fn provision_discovery_response_display_pin(
+        &self,
+        peer_object: ObjectPath<'_>,
+        pin: &str,
+    ) -> zbus::Result<()>;
+
+    /// ProvisionDiscoveryResponseEnterPin signal
+    #[zbus(signal)]
+    fn provision_discovery_response_enter_pin(
+        &self,
+        peer_object: ObjectPath<'_>,
+    ) -> zbus::Result<()>;
+
+    /// ServiceDiscoveryRequest signal
+    #[zbus(signal)]
+    fn service_discovery_request(&self, sd_request: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// ServiceDiscoveryResponse signal
+    #[zbus(signal)]
+    fn service_discovery_response(&self, sd_response: HashMap<&str, Value<'_>>)
+        -> zbus::Result<()>;
+
+    /// WpsFailed signal
+    #[zbus(signal)]
+    fn wps_failed(&self, name: &str, args: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// InvitationReceived signal
+    #[zbus(signal)]
+    fn invitation_received(&self, args: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// GroupFormationFailure signal
+    #[zbus(signal)]
+    fn group_formation_failure(&self, reason: &str) -> zbus::Result<()>;
+
+    /// Group property
+    #[zbus(property)]
+    fn group(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// P2PDeviceConfig property
+    #[zbus(property, name = "P2PDeviceConfig")]
+    fn p2pdevice_config(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+    #[zbus(property, name = "P2PDeviceConfig")]
+    fn set_p2pdevice_config(
+        &self,
+        // TODO value: HashMap<&str, &Value<'_>>,
+        value: Value<'_>,
+    ) -> zbus::Result<()>;
+
+    /// PeerGO property
+    #[zbus(property, name = "PeerGO")]
+    fn peer_go(&self) -> zbus::Result<OwnedObjectPath>;
+
+    /// Peers property
+    #[zbus(property)]
+    fn peers(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// PersistentGroups property
+    #[zbus(property)]
+    fn persistent_groups(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// Role property
+    #[zbus(property)]
+    fn role(&self) -> zbus::Result<String>;
+}

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/peer.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/peer.rs
@@ -1,0 +1,93 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `fi.w1.wpa_supplicant1.Interface.Peer`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{OwnedObjectPath, Value};
+
+#[proxy(
+    interface = "fi.w1.wpa_supplicant1.Interface.Peer",
+    assume_defaults = true
+)]
+pub trait Peer {
+    /// PropertiesChanged signal
+    #[zbus(signal)]
+    fn properties_changed(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// DeviceName property
+    #[zbus(property)]
+    fn device_name(&self) -> zbus::Result<String>;
+
+    /// Manufacturer property
+    #[zbus(property)]
+    fn manufacturer(&self) -> zbus::Result<String>;
+
+    /// ModelName property
+    #[zbus(property)]
+    fn model_name(&self) -> zbus::Result<String>;
+
+    /// ModelNumber property
+    #[zbus(property)]
+    fn model_number(&self) -> zbus::Result<String>;
+
+    /// SerialNumber property
+    #[zbus(property)]
+    fn serial_number(&self) -> zbus::Result<String>;
+
+    /// PrimaryDeviceType property
+    #[zbus(property)]
+    fn primary_device_type(&self) -> zbus::Result<Vec<u8>>;
+
+    /// ConfigMethod property
+    #[zbus(property)]
+    fn config_method(&self) -> zbus::Result<u16>;
+
+    /// Level property
+    #[zbus(property)]
+    fn level(&self) -> zbus::Result<i32>;
+
+    /// DeviceCapability property
+    #[zbus(property)]
+    fn device_capability(&self) -> zbus::Result<u8>;
+
+    /// GroupCapability property
+    #[zbus(property)]
+    fn group_capability(&self) -> zbus::Result<u8>;
+
+    /// SecondaryDeviceTypes property
+    #[zbus(property)]
+    fn secondary_device_types(&self) -> zbus::Result<Vec<Vec<u8>>>;
+
+    /// VendorExtension property
+    #[zbus(property)]
+    fn vendor_extension(&self) -> zbus::Result<Vec<Vec<u8>>>;
+
+    /// IEs property
+    #[zbus(property)]
+    fn ies(&self) -> zbus::Result<Vec<u8>>;
+
+    /// DeviceAddress property
+    #[zbus(property)]
+    fn device_address(&self) -> zbus::Result<Vec<u8>>;
+
+    /// Groups property
+    #[zbus(property)]
+    fn groups(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/persistent_group.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/persistent_group.rs
@@ -15,18 +15,23 @@
  *    limitations under the License.
  */
 
-pub mod bitflags;
-pub mod cell;
-pub mod codec;
-pub mod epoch;
-pub mod init;
-pub mod iter;
-pub mod maybe;
-pub mod rand;
-pub mod select;
-pub mod storage;
-pub mod sync;
-#[cfg(feature = "std")]
-pub mod zbus;
-#[cfg(feature = "std")]
-pub mod zbus_proxies;
+//! # D-Bus interface proxy for: `fi.w1.wpa_supplicant1.Interface.PersistentGroup`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{OwnedValue, Value};
+
+#[proxy(
+    interface = "fi.w1.wpa_supplicant1.Interface.PersistentGroup",
+    assume_defaults = true
+)]
+pub trait PersistentGroup {
+    /// PropertiesChanged signal
+    #[zbus(signal)]
+    fn properties_changed(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// Properties property
+    #[zbus(property, name = "Properties")]
+    fn props(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
+}

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/wpa_supplicant.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/wpa_supplicant.rs
@@ -1,0 +1,94 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `fi.w1.wpa_supplicant1`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, Value};
+
+#[proxy(
+    interface = "fi.w1.wpa_supplicant1",
+    default_service = "fi.w1.wpa_supplicant1",
+    default_path = "/fi/w1/wpa_supplicant1"
+)]
+pub trait WPASupplicant {
+    /// CreateInterface method
+    fn create_interface(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<OwnedObjectPath>;
+
+    /// ExpectDisconnect method
+    fn expect_disconnect(&self) -> zbus::Result<()>;
+
+    /// GetInterface method
+    fn get_interface(&self, ifname: &str) -> zbus::Result<OwnedObjectPath>;
+
+    /// RemoveInterface method
+    fn remove_interface(&self, path: &ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// InterfaceAdded signal
+    #[zbus(signal)]
+    fn interface_added(
+        &self,
+        path: ObjectPath<'_>,
+        properties: HashMap<&str, Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// InterfaceRemoved signal
+    #[zbus(signal)]
+    fn interface_removed(&self, path: ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// PropertiesChanged signal
+    #[zbus(signal)]
+    fn properties_changed(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// Capabilities property
+    #[zbus(property)]
+    fn capabilities(&self) -> zbus::Result<Vec<String>>;
+
+    /// DebugLevel property
+    #[zbus(property)]
+    fn debug_level(&self) -> zbus::Result<String>;
+    #[zbus(property)]
+    fn set_debug_level(&self, value: &str) -> zbus::Result<()>;
+
+    /// DebugShowKeys property
+    #[zbus(property)]
+    fn debug_show_keys(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_debug_show_keys(&self, value: bool) -> zbus::Result<()>;
+
+    /// DebugTimestamp property
+    #[zbus(property)]
+    fn debug_timestamp(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_debug_timestamp(&self, value: bool) -> zbus::Result<()>;
+
+    /// EapMethods property
+    #[zbus(property)]
+    fn eap_methods(&self) -> zbus::Result<Vec<String>>;
+
+    /// Interfaces property
+    #[zbus(property)]
+    fn interfaces(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    /// WFDIEs property
+    #[zbus(property, name = "WFDIEs")]
+    fn wfdies(&self) -> zbus::Result<Vec<u8>>;
+    #[zbus(property, name = "WFDIEs")]
+    fn set_wfdies(&self, value: &[u8]) -> zbus::Result<()>;
+}

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/wps.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/wps.rs
@@ -1,0 +1,59 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! # D-Bus interface proxy for: `fi.w1.wpa_supplicant1.Interface.WPS`
+
+use std::collections::HashMap;
+
+use zbus::proxy;
+use zbus::zvariant::{OwnedValue, Value};
+
+#[proxy(
+    interface = "fi.w1.wpa_supplicant1.Interface.WPS",
+    assume_defaults = true
+)]
+pub trait WPS {
+    /// Start method
+    fn start(&self, args: HashMap<&str, &Value<'_>>) -> zbus::Result<HashMap<String, OwnedValue>>;
+
+    /// Cancel method
+    fn cancel(&self) -> zbus::Result<()>;
+
+    /// Credentials signal
+    #[zbus(signal)]
+    fn credentials(&self, credentials: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// Event signal
+    #[zbus(signal)]
+    fn event(&self, name: &str, args: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// PropertiesChanged signal
+    #[zbus(signal)]
+    fn properties_changed(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+
+    /// ConfigMethods property
+    #[zbus(property)]
+    fn config_methods(&self) -> zbus::Result<String>;
+    #[zbus(property)]
+    fn set_config_methods(&self, value: &str) -> zbus::Result<()>;
+
+    /// ProcessCredentials property
+    #[zbus(property)]
+    fn process_credentials(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_process_credentials(&self, value: bool) -> zbus::Result<()>;
+}


### PR DESCRIPTION
Addresses #271 
NOTE: Review/merge **after** #273 !

(While this is an enormously large PR with a 100+ changed files, do note that 99.9% of those are new files which are simply zbus interface proxies - no careful review of those necessary.)

This PR introduces `zbus` and a bunch of carefully curated (I hope!) pure-Rust zbus proxy interfaces for those services that we'll need in `rs-matter` for embedded Linux use cases:
- systemd-resolved (for mDNS)
- Avahi (for mDNS)
- wpa-supplicant (for Wifi management on Linux embedded that does not run the Network Manager daemon)
- NetworkManager (for Wifi management on Linux - embedded or not - that does run the Network Manager daemon)
- BlueZ (for BLE) - will supersede the current BlueZ GATT implementation which uses the `bluer` crate

The zbus proxies do not aim to be super user friendly (they are 1:1 what their XML introspection/docu prescribes and therefore e.g. use untyped `HashMap` based dicts where in some cases a strongly-typed Rust `struct` can fit) but DO aim to be complete in exposing all of the interfaces supported by a particular dBus daemon (hence the large number of proxy interfaces).

Also:
- The PR introduces an (incomplete yet) `NetCtl` trait implementation on top of wpa-supplicant dBus APIs that will be finished later; this is just a POC that the interfaces are defined correctly - don't pay attention to Gemini complaining in there
- A usage of these will start popping up in the next weeks, with the Avahi and systemd-resolved mDNS responders already implemented as part of the "mDNS responder overhaul" PR in #275
