### PR TITLE
Wifi management via wpa_supplicant over dBus

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,7 +21,7 @@ name = "media_player"
 name = "bridge"
 
 [features]
-default = ["log"]
+default = ["log", "zbus"]
 log = []
 zbus = ["rs-matter/zbus"]
 astro-dnssd = ["rs-matter/astro-dnssd"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,7 +21,7 @@ name = "media_player"
 name = "bridge"
 
 [features]
-default = ["log", "zbus"]
+default = ["log"]
 log = []
 zbus = ["rs-matter/zbus"]
 astro-dnssd = ["rs-matter/astro-dnssd"]

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 rust-version = "1.83"
 
 [features]
-default = ["os", "rustcrypto", "log", "zbus"]
+default = ["os", "rustcrypto", "log"]
 #default = ["os", "mbedtls", "log"] mbedtls is broken since several months - check the root cause
 astro-dnssd = ["os", "dep:astro-dnssd"]
 zeroconf = ["os", "dep:zeroconf"]

--- a/rs-matter/src/dm/networks/wireless.rs
+++ b/rs-matter/src/dm/networks/wireless.rs
@@ -777,20 +777,16 @@ impl NetCtlState {
     ) -> Result<R, NetCtlError> {
         self.network_id.clear();
 
-        if result.is_ok() {
-            if let Some(network_id) = network_id {
-                unwrap!(self.network_id.extend_from_slice(network_id));
-            }
+        if let Some(network_id) = network_id {
+            unwrap!(self.network_id.extend_from_slice(network_id));
+        }
 
-            if let Some((status, err_code)) =
-                NetworkCommissioningStatusEnum::map_ctl_status(&result)
-            {
-                self.networking_status = Some(status);
-                self.connect_error_value = err_code;
-            } else {
-                self.networking_status = None;
-                self.connect_error_value = None;
-            }
+        if let Some((status, err_code)) = NetworkCommissioningStatusEnum::map_ctl_status(&result) {
+            self.networking_status = Some(status);
+            self.connect_error_value = err_code;
+        } else {
+            self.networking_status = None;
+            self.connect_error_value = None;
         }
 
         result

--- a/rs-matter/src/dm/networks/wireless.rs
+++ b/rs-matter/src/dm/networks/wireless.rs
@@ -777,16 +777,20 @@ impl NetCtlState {
     ) -> Result<R, NetCtlError> {
         self.network_id.clear();
 
-        if let Some(network_id) = network_id {
-            unwrap!(self.network_id.extend_from_slice(network_id));
-        }
+        if result.is_ok() {
+            if let Some(network_id) = network_id {
+                unwrap!(self.network_id.extend_from_slice(network_id));
+            }
 
-        if let Some((status, err_code)) = NetworkCommissioningStatusEnum::map_ctl_status(&result) {
-            self.networking_status = Some(status);
-            self.connect_error_value = err_code;
-        } else {
-            self.networking_status = None;
-            self.connect_error_value = None;
+            if let Some((status, err_code)) =
+                NetworkCommissioningStatusEnum::map_ctl_status(&result)
+            {
+                self.networking_status = Some(status);
+                self.connect_error_value = err_code;
+            } else {
+                self.networking_status = None;
+                self.connect_error_value = None;
+            }
         }
 
         result
@@ -896,7 +900,7 @@ where
     where
         F: FnMut(&net_comm::NetworkScanInfo) -> Result<(), Error>,
     {
-        NetCtlState::update_with_mutex(self.state, network, self.net_ctl.scan(network, f).await)
+        self.net_ctl.scan(network, f).await
     }
 
     async fn connect(&self, creds: &WirelessCreds<'_>) -> Result<(), NetCtlError> {

--- a/rs-matter/src/transport/network/wifi/wpa_supp.rs
+++ b/rs-matter/src/transport/network/wifi/wpa_supp.rs
@@ -17,39 +17,48 @@
 
 //! Wifi network controller implementation based on the wpa-supplicant D-Bus service.
 
-use core::cell::{Cell, RefCell};
+use core::cell::RefCell;
 
 use std::collections::HashMap;
-use std::process::Command;
 
-use embassy_futures::select::Either;
+use embassy_futures::select::{select, Either};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 
+use embassy_time::{Duration, Timer};
 use futures_lite::StreamExt;
 
-use zbus::zvariant::{ObjectPath, Value};
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
 use zbus::Connection;
 
 use crate::dm::clusters::net_comm::{
     NetCtl, NetCtlError, NetworkScanInfo, NetworkType, WiFiBandEnum, WiFiSecurityBitmap,
     WirelessCreds,
 };
-use crate::dm::clusters::wifi_diag::{WifiDiag, WirelessDiag};
+use crate::dm::clusters::wifi_diag::{SecurityTypeEnum, WiFiVersionEnum, WifiDiag, WirelessDiag};
 use crate::dm::networks::NetChangeNotif;
 use crate::error::{Error, ErrorCode};
-use crate::utils::sync::blocking::Mutex;
+use crate::tlv::Nullable;
+use crate::utils::sync::{blocking, IfMutex};
 use crate::utils::zbus_proxies::wpa_supp::bss::BSSProxy;
 use crate::utils::zbus_proxies::wpa_supp::interface::InterfaceProxy;
+use crate::utils::zbus_proxies::wpa_supp::wpa_supplicant::WPASupplicantProxy;
+
+#[cfg(unix)]
+pub mod unix;
 
 /// A `NetCtl`, `WirelessDiag`, `WifiDiag` and `NetChangeNotif` implementation based on the `wpa-supplicant` service.
 ///
 /// Suitable for use with embedded Linux devices that do have the `wpa-supplicant` service running over D-Bus
 /// but don't have the `NetworkManager` service available.
-pub struct WpaSuppCtl<'a, T> {
-    interface: InterfaceProxy<'a>,
+pub struct WpaSuppCtl<'a, T>
+where
+    T: IpStackCtl,
+{
     connection: &'a Connection,
+    ifname: &'a str,
     ip_stack_ctl: T,
-    ssid_info: Mutex<NoopRawMutex, RefCell<SSIDInfo>>,
+    network: IfMutex<NoopRawMutex, Option<OwnedObjectPath>>,
+    wifi_conn_info: blocking::Mutex<NoopRawMutex, RefCell<Option<WifiConnInfo>>>,
 }
 
 impl<'a, T> WpaSuppCtl<'a, T>
@@ -60,30 +69,19 @@ where
     ///
     /// # Arguments
     /// * `connection` - A reference to the D-Bus connection.
-    /// * `interface` - The D-Bus object path of Wifi interface object.
+    /// * `interface_path` - The D-Bus object path of Wifi interface object.
     /// * `ip_stack_ctl` - An instance of a type implementing the `IpStackCtl` trait, which is used to control the IP stack.
     ///
     /// # Returns
-    /// A `zbus::Result<Self>` containing the new `WpaSuppCtl` instance on success.
-    pub async fn new(
-        connection: &'a Connection,
-        interface: ObjectPath<'a>,
-        ip_stack_ctl: T,
-    ) -> zbus::Result<Self> {
-        Ok(Self {
-            interface: InterfaceProxy::builder(connection)
-                .path(interface)?
-                .build()
-                .await?,
+    /// The new `WpaSuppCtl` instance.
+    pub const fn new(connection: &'a Connection, ifname: &'a str, ip_stack_ctl: T) -> Self {
+        Self {
             connection,
+            ifname,
             ip_stack_ctl,
-            ssid_info: Mutex::new(RefCell::new(SSIDInfo::new())),
-        })
-    }
-
-    /// Return a reference to the `InterfaceProxy`.
-    pub const fn interface(&self) -> &InterfaceProxy<'_> {
-        &self.interface
+            network: IfMutex::new(None),
+            wifi_conn_info: blocking::Mutex::new(RefCell::new(None)),
+        }
     }
 
     /// Return a reference to the D-Bus connection.
@@ -91,64 +89,361 @@ where
         self.connection
     }
 
-    async fn wait_changed(&self) -> Result<bool, zbus::Error> {
-        let mut authorized = self.interface.receive_sta_authorized().await?;
-        let mut deauthorized = self.interface.receive_sta_deauthorized().await?;
+    /// Create a wpa-supplicant interface proxy for out interface name
+    async fn interface(&self) -> Result<InterfaceProxy<'a>, zbus::Error> {
+        let wpas = WPASupplicantProxy::new(self.connection).await?;
+        let interface_path = wpas.get_interface(self.ifname).await?;
+
+        InterfaceProxy::builder(self.connection)
+            .path(interface_path.clone())?
+            .build()
+            .await
+    }
+
+    /// Wait for the interface state as follows:
+    /// - If `for_connection` is true, wait until the interface is connected to a network.
+    /// - If `for_connection` is false, wait until the interface state changes (e.g., connected, disconnected or other change).
+    async fn wait(&self, for_connection: bool) -> Result<(), Error> {
+        let interface = self.interface().await?;
+
+        let mut iface_state_changed = interface.receive_state_changed().await;
 
         loop {
-            let ip_stack_changed = self.ip_stack_ctl.wait_changed();
+            let bss = interface.current_bss().await?;
 
-            embassy_futures::select::select3(
-                authorized.next(),
-                deauthorized.next(),
-                ip_stack_changed,
-            )
-            .await;
+            let (changed, connected) = if bss.len() > 1 {
+                self.network_scan_info(&bss, |info| {
+                    let info = info.map(WifiConnInfo::new);
 
-            let bss = self.interface.current_bss().await?;
-
-            let ssid = if !bss.is_empty() {
-                let bss_info = BSSProxy::builder(self.connection)
-                    .path(bss)?
-                    .build()
-                    .await?;
-
-                Some(bss_info.ssid().await?)
+                    Ok(self.update_wifi_conn_info(info))
+                })
+                .await?
             } else {
-                None
+                self.update_wifi_conn_info(None)
             };
 
-            let (changed, connected) = self.update_connected(ssid);
-
-            if changed {
-                break Ok(connected);
+            if for_connection && connected || !for_connection && changed {
+                break Ok(());
             }
+
+            let ip_stack_changed = self.ip_stack_ctl.wait_changed();
+
+            select(iface_state_changed.next(), ip_stack_changed).await;
         }
     }
 
-    async fn wait_connected(&self) -> Result<(), zbus::Error> {
-        loop {
-            if self.wait_changed().await? {
-                return Ok(());
-            }
-        }
-    }
+    /// Update the cached WiFi connection information and return whether it has changed and whether it has connected.
+    fn update_wifi_conn_info(&self, new_wifi_conn_info: Option<WifiConnInfo>) -> (bool, bool) {
+        self.wifi_conn_info.lock(|wifi_conn_info| {
+            let mut wifi_conn_info = wifi_conn_info.borrow_mut();
 
-    fn update_connected(&self, ssid: Option<Vec<u8>>) -> (bool, bool) {
-        self.ssid_info.lock(|ssid_info| {
-            let mut ssid_info = ssid_info.borrow_mut();
+            let changed = if *wifi_conn_info != new_wifi_conn_info {
+                *wifi_conn_info = new_wifi_conn_info;
+                true
+            } else {
+                false
+            };
 
-            let was_connected =
-                ssid_info.is_connected() && self.ip_stack_ctl.is_connected().unwrap_or(false);
+            let connected = Self::connected(wifi_conn_info.as_ref());
 
-            ssid_info.connected = ssid;
-
-            (
-                was_connected != ssid_info.is_connected()
-                    && self.ip_stack_ctl.is_connected().unwrap_or(false),
-                ssid_info.is_connected(),
-            )
+            (changed, connected)
         })
+    }
+
+    /// Check if the provided WiFi connecton info represents a connected network.
+    fn connected(wifi_conn_info: Option<&WifiConnInfo>) -> bool {
+        wifi_conn_info.is_some()
+    }
+
+    /// Remove the currently connected network, if any.
+    async fn remove_network(&self, network: &mut Option<OwnedObjectPath>) -> zbus::Result<()> {
+        let interface = self.interface().await?;
+
+        if let Some(network_path) = network.clone() {
+            if interface.remove_network(&network_path).await.is_ok() {
+                network.take();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get the network scan information for a given BSS object path.
+    async fn network_scan_info<F, R>(&self, bss: &ObjectPath<'_>, f: F) -> Result<R, Error>
+    where
+        F: FnOnce(Option<&NetworkScanInfo>) -> Result<R, Error>,
+    {
+        let bss_info = BSSProxy::builder(self.connection)
+            .path(bss)?
+            .build()
+            .await?;
+
+        if bss_info.mode().await? == "infrastructure" {
+            let wpa = bss_info.wpa().await?;
+            let rsn = bss_info.rsn().await?;
+
+            let security = if wpa.is_empty() && rsn.is_empty() {
+                WiFiSecurityBitmap::UNENCRYPTED
+            } else {
+                let str_list_val = |key, map: &HashMap<String, OwnedValue>| {
+                    let str_list: Vec<String> = map
+                        .get(key)
+                        .cloned()
+                        .and_then(|w| w.clone().try_into().ok())
+                        .unwrap_or_default();
+
+                    str_list
+                };
+
+                let mut security = WiFiSecurityBitmap::empty();
+
+                let wpa_key_mgmt = str_list_val("KeyMgmt", &wpa);
+
+                if wpa_key_mgmt.contains(&"wpa-none".to_string()) {
+                    security |= WiFiSecurityBitmap::WEP;
+                }
+
+                if wpa_key_mgmt.contains(&"wpa-psk".to_string()) {
+                    security |= WiFiSecurityBitmap::WPA_PERSONAL;
+                }
+
+                let rsn_key_mgmt = str_list_val("KeyMgmt", &rsn);
+
+                if rsn_key_mgmt.contains(&"wpa-psk".to_string())
+                    || rsn_key_mgmt.contains(&"wpa-ft-psk".to_string())
+                    || rsn_key_mgmt.contains(&"wpa-psk-sha256".to_string())
+                {
+                    security |= WiFiSecurityBitmap::WPA_2_PERSONAL;
+                }
+
+                if rsn_key_mgmt.contains(&"sae".to_string()) {
+                    security |= WiFiSecurityBitmap::WPA_3_PERSONAL
+                }
+
+                security
+            };
+
+            let (band, channel) = band_and_channel(bss_info.frequency().await? as u32);
+
+            let network_scan_info = NetworkScanInfo::Wifi {
+                security,
+                ssid: &bss_info.ssid().await?,
+                bssid: &bss_info.bssid().await?,
+                band,
+                channel,
+                rssi: bss_info.signal().await?.min(i8::MIN as _).max(i8::MAX as _) as i8,
+            };
+
+            f(Some(&network_scan_info))
+        } else {
+            // Skip ad-hoc networks, we are only interested in infrastructure ones
+            f(None)
+        }
+    }
+}
+
+impl<T> Drop for WpaSuppCtl<'_, T>
+where
+    T: IpStackCtl,
+{
+    fn drop(&mut self) {
+        // Remove the network on drop
+        let _ = futures_lite::future::block_on(async {
+            let mut network = self.network.lock().await;
+
+            self.remove_network(&mut network).await
+        });
+    }
+}
+
+impl<T> NetCtl for WpaSuppCtl<'_, T>
+where
+    T: IpStackCtl,
+{
+    fn net_type(&self) -> NetworkType {
+        NetworkType::Wifi
+    }
+
+    async fn scan<F>(&self, network: Option<&[u8]>, mut f: F) -> Result<(), NetCtlError>
+    where
+        F: FnMut(&NetworkScanInfo) -> Result<(), Error>,
+    {
+        const SCAN_RETRIES: usize = 3;
+        const SCAN_RETRIES_SLEEP_SEC: u64 = 5;
+
+        let _guard = self.network.lock().await;
+
+        let mut args = HashMap::new();
+
+        let active = Value::from("active");
+        args.insert("Type", &active);
+
+        let ssids = network.map(|network| vec![network.to_vec()].into());
+        if ssids.is_some() {
+            #[allow(clippy::unnecessary_unwrap)]
+            args.insert("SSIDs", ssids.as_ref().unwrap());
+        }
+
+        let interface = self.interface().await?;
+
+        let mut scan_done = interface.receive_scan_done().await?;
+
+        for _ in 0..SCAN_RETRIES {
+            // Sometimes we do get a "Scan Rejected error"
+            // Therefore, try several times
+
+            if interface.scan(args.clone()).await.is_ok() {
+                // Scan started successfully
+
+                // Wait for the scan to complete
+                while scan_done.next().await.is_none() {}
+
+                break;
+            }
+
+            Timer::after(Duration::from_secs(SCAN_RETRIES_SLEEP_SEC)).await;
+        }
+
+        let bsss = interface.bsss().await?;
+
+        for bss in bsss {
+            self.network_scan_info(&bss, |info| {
+                if let Some(info) = info {
+                    f(info)?;
+                }
+
+                Ok(())
+            })
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn connect(&self, creds: &WirelessCreds<'_>) -> Result<(), NetCtlError> {
+        const CONNECT_TIMEOUT_SECS: u64 = 30;
+
+        let mut network = self.network.lock().await;
+
+        let WirelessCreds::Wifi { ssid, pass } = creds else {
+            return Err(NetCtlError::Other(ErrorCode::InvalidAction.into()));
+        };
+
+        let interface = self.interface().await?;
+
+        self.remove_network(&mut network).await?;
+
+        let mut args = HashMap::new();
+
+        let arg_ssid = core::str::from_utf8(ssid).unwrap().into();
+        args.insert("ssid", &arg_ssid);
+
+        let arg_pass = core::str::from_utf8(pass).unwrap().into();
+        if !pass.is_empty() {
+            args.insert("psk", &arg_pass);
+        }
+
+        let network_path = interface.add_network(args).await?;
+
+        *network = Some(network_path.clone());
+
+        interface.select_network(&network_path).await?;
+
+        // First try to connect on the Wifi level
+
+        let connected = self.wait(true);
+        let timeout = Timer::after(Duration::from_secs(CONNECT_TIMEOUT_SECS));
+
+        match select(connected, timeout).await {
+            Either::First(_) => (),
+            Either::Second(_) => {
+                self.remove_network(&mut network).await?;
+                return Err(NetCtlError::AuthFailure);
+            }
+        }
+
+        // Then try to bring up the IP stack (e.g., via DHCP for IPv4 and SLAAC for IPv6)
+
+        match self.ip_stack_ctl.connect().await {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // If the IP stack connection failed, remove the network
+                self.remove_network(&mut network).await?;
+                Err(e)
+            }
+        }
+    }
+}
+
+impl<T> WirelessDiag for WpaSuppCtl<'_, T>
+where
+    T: IpStackCtl,
+{
+    fn connected(&self) -> Result<bool, Error> {
+        Ok(self.wifi_conn_info.lock(|ssid_info| {
+            Self::connected(ssid_info.borrow().as_ref())
+                && self.ip_stack_ctl.is_connected().unwrap_or(false)
+        }))
+    }
+}
+
+impl<T> WifiDiag for WpaSuppCtl<'_, T>
+where
+    T: IpStackCtl,
+{
+    fn bssid(&self, f: &mut dyn FnMut(Option<&[u8]>) -> Result<(), Error>) -> Result<(), Error> {
+        self.wifi_conn_info.lock(|wifi_conn_info| {
+            let wifi_conn_info = wifi_conn_info.borrow();
+            if let Some(wifi_conn_info) = wifi_conn_info.as_ref() {
+                f(Some(&wifi_conn_info.bssid))
+            } else {
+                f(None)
+            }
+        })
+    }
+
+    fn security_type(&self) -> Result<Nullable<SecurityTypeEnum>, Error> {
+        // TODO: Figure out how to get this
+        Ok(Nullable::none())
+    }
+
+    fn wi_fi_version(&self) -> Result<Nullable<WiFiVersionEnum>, Error> {
+        // TODO: Figure out how to get this
+        Ok(Nullable::none())
+    }
+
+    fn channel_number(&self) -> Result<Nullable<u16>, Error> {
+        Ok(self.wifi_conn_info.lock(|wifi_conn_info| {
+            let wifi_conn_info = wifi_conn_info.borrow();
+            if let Some(wifi_conn_info) = wifi_conn_info.as_ref() {
+                Nullable::some(wifi_conn_info.channel)
+            } else {
+                Nullable::none()
+            }
+        }))
+    }
+
+    fn rssi(&self) -> Result<Nullable<i8>, Error> {
+        Ok(self.wifi_conn_info.lock(|wifi_conn_info| {
+            let wifi_conn_info = wifi_conn_info.borrow();
+            if let Some(wifi_conn_info) = wifi_conn_info.as_ref() {
+                Nullable::some(wifi_conn_info.rssi)
+            } else {
+                Nullable::none()
+            }
+        }))
+    }
+}
+
+impl<T> NetChangeNotif for WpaSuppCtl<'_, T>
+where
+    T: IpStackCtl,
+{
+    async fn wait_changed(&self) {
+        let wait_wifi = self.wait(false);
+        let wait_ip = self.ip_stack_ctl.wait_changed();
+
+        select(wait_wifi, wait_ip).await;
     }
 }
 
@@ -187,189 +482,43 @@ where
     }
 }
 
-/// An `IpStackCtl` implementation for the linux `dhclient` command-line utility.
-pub struct DhClientCtl {
-    ifname: String,
-    connected: Mutex<NoopRawMutex, Cell<bool>>,
+/// An owned variant of `NetworkScanInfo::Wifi`.
+/// Used for caching the connected BSS so that it can be returned by the
+/// non-async `WifiDiag` methods.
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+struct WifiConnInfo {
+    security: WiFiSecurityBitmap,
+    ssid: Vec<u8>,
+    bssid: Vec<u8>,
+    band: WiFiBandEnum,
+    channel: u16,
+    rssi: i8,
 }
 
-impl DhClientCtl {
-    /// Create a new `DhClientCtl` instance.
-    ///
-    /// # Arguments
-    /// * `ifname` - The name of the network interface to control (e.g., "wlan0").
-    pub fn new(ifname: &str) -> Self {
-        Self {
-            ifname: ifname.to_string(),
-            connected: Mutex::new(Cell::new(false)),
-        }
-    }
-}
-
-impl IpStackCtl for DhClientCtl {
-    async fn connect(&self) -> Result<(), NetCtlError> {
-        Command::new("dhclient")
-            .arg("-nw")
-            .arg(&self.ifname)
-            .status()
-            .map_err(|_| NetCtlError::Other(ErrorCode::NoNetworkInterface.into()))?;
-
-        self.connected.lock(|connected| connected.set(true));
-
-        Ok(())
-    }
-
-    async fn wait_changed(&self) {
-        // Implement the logic to wait for changes in the IP stack.
-        core::future::pending::<()>().await
-    }
-
-    fn is_connected(&self) -> Result<bool, NetCtlError> {
-        Ok(self.connected.lock(|connected| connected.get()))
-    }
-}
-
-impl<T> NetCtl for WpaSuppCtl<'_, T>
-where
-    T: IpStackCtl,
-{
-    fn net_type(&self) -> NetworkType {
-        NetworkType::Wifi
-    }
-
-    async fn scan<F>(&self, network: Option<&[u8]>, mut f: F) -> Result<(), NetCtlError>
-    where
-        F: FnMut(&NetworkScanInfo) -> Result<(), Error>,
-    {
-        let mut args = HashMap::new();
-
-        let active = Value::from("active");
-        args.insert("Type", &active);
-
-        let ssids = network.map(|network| vec![network.to_vec()].into());
-        if ssids.is_some() {
-            #[allow(clippy::unnecessary_unwrap)]
-            args.insert("SSIDs", ssids.as_ref().unwrap());
-        }
-
-        let mut scan_done = self.interface.receive_scan_done().await?;
-
-        self.interface.scan(args).await?;
-
-        while scan_done.next().await.is_none() {}
-
-        let bsss = self.interface.bsss().await?;
-
-        for bss in bsss {
-            let bss_info = BSSProxy::builder(self.connection)
-                .path(bss)?
-                .build()
-                .await?;
-
-            // TODO: Only leave the infrastructure ones, remove the ad-hocs
-
-            let mut security = WiFiSecurityBitmap::WEP;
-            if !bss_info.wpa().await?.is_empty() {
-                // TODO
-                security |= WiFiSecurityBitmap::WPA_PERSONAL;
-            }
-
-            let network_scan_info = NetworkScanInfo::Wifi {
-                security,
-                ssid: &bss_info.ssid().await?,
-                bssid: &bss_info.bssid().await?,
-                channel: 11,              // TODO bss_info.frequency().await? as u8,
-                band: WiFiBandEnum::V2G4, // TODO
-                rssi: bss_info.signal().await? as i8,
-            };
-
-            f(&network_scan_info)?;
-        }
-
-        Ok(())
-    }
-
-    async fn connect(&self, creds: &WirelessCreds<'_>) -> Result<(), NetCtlError> {
-        let WirelessCreds::Wifi { ssid, pass } = creds else {
-            return Err(NetCtlError::Other(ErrorCode::InvalidAction.into()));
+impl WifiConnInfo {
+    /// Create a new `WifiConnInfo` from the given `NetworkScanInfo::Wifi`.
+    fn new(scan_info: &NetworkScanInfo) -> Self {
+        let NetworkScanInfo::Wifi {
+            security,
+            ssid,
+            bssid,
+            channel,
+            band,
+            rssi,
+        } = scan_info
+        else {
+            // Not possible, because `WpaSupp` only produces scan info of type `Wifi`
+            unreachable!();
         };
 
-        // TODO: Maybe just add our own network
-        self.interface.remove_all_networks().await?;
-
-        let mut args = HashMap::new();
-
-        self.ssid_info.lock(|ssid_info| {
-            let mut ssid_info = ssid_info.borrow_mut();
-            ssid_info.requested = Some(ssid.to_vec());
-        });
-
-        let arg_ssid = (*ssid).into();
-        args.insert("ssid", &arg_ssid);
-
-        let arg_pass = (*pass).into();
-        args.insert("psk", &arg_pass);
-
-        let network = self.interface.add_network(args).await?;
-
-        self.interface.select_network(&network).await?;
-
-        let timer = embassy_time::Timer::after(embassy_time::Duration::from_secs(30));
-        let connected = self.wait_connected();
-
-        match embassy_futures::select::select(connected, timer).await {
-            Either::First(result) => {
-                result?;
-
-                Ok(())
-            }
-            Either::Second(_) => {
-                self.interface.remove_all_networks().await?;
-
-                Err(NetCtlError::AuthFailure)
-            }
-        }
-    }
-}
-
-impl<T> WirelessDiag for WpaSuppCtl<'_, T>
-where
-    T: IpStackCtl,
-{
-    fn connected(&self) -> Result<bool, Error> {
-        Ok(self.ssid_info.lock(|ssid_info| {
-            ssid_info.borrow().is_connected() && self.ip_stack_ctl.is_connected().unwrap_or(false)
-        }))
-    }
-}
-
-impl<T> WifiDiag for WpaSuppCtl<'_, T> where T: IpStackCtl {} // TODO
-
-impl<T> NetChangeNotif for WpaSuppCtl<'_, T>
-where
-    T: IpStackCtl,
-{
-    async fn wait_changed(&self) {
-        let _ = WpaSuppCtl::wait_changed(self).await;
-    }
-}
-
-#[derive(Debug)]
-struct SSIDInfo {
-    requested: Option<Vec<u8>>,
-    connected: Option<Vec<u8>>,
-}
-
-impl SSIDInfo {
-    const fn new() -> Self {
         Self {
-            requested: None,
-            connected: None,
+            security: *security,
+            ssid: ssid.to_vec(),
+            bssid: bssid.to_vec(),
+            band: *band,
+            channel: *channel,
+            rssi: *rssi,
         }
-    }
-
-    fn is_connected(&self) -> bool {
-        self.requested.is_some() && self.requested == self.connected
     }
 }
 
@@ -377,4 +526,60 @@ impl From<zbus::Error> for NetCtlError {
     fn from(value: zbus::Error) -> Self {
         NetCtlError::Other(value.into())
     }
+}
+
+// See https://github.com/project-chip/connectedhomeip/blob/cd5fec9ba9be0c39f3c11f67d57b18b6bb2b4289/src/platform/Linux/ConnectivityManagerImpl.cpp#L1937
+fn band_and_channel(freq: u32) -> (WiFiBandEnum, u16) {
+    let mut band = WiFiBandEnum::V2G4;
+
+    let channel = if freq <= 931 {
+        if freq >= 916 {
+            ((freq - 916) * 2) - 1
+        } else if freq >= 902 {
+            (freq - 902) * 2
+        } else if freq >= 863 {
+            (freq - 863) * 2
+        } else {
+            1
+        }
+    } else if freq <= 2472 {
+        (freq - 2412) / 5 + 1
+    } else if freq == 2484 {
+        14
+    } else if (3600..=3700).contains(&freq) {
+        // Note: There are not many devices supports this band, and this band contains rational frequency in MHz, need to figure out
+        // the behavior of wpa_supplicant in this case.
+        band = WiFiBandEnum::V3G65;
+        0
+    } else if (5035..=5945).contains(&freq) || freq == 5960 || freq == 5980 {
+        band = WiFiBandEnum::V5G;
+        (freq - 5000) / 5
+    } else if freq >= 5955 {
+        band = WiFiBandEnum::V6G;
+        (freq - 5950) / 5
+    } else if freq >= 58000 {
+        band = WiFiBandEnum::V60G;
+
+        // Note: Some channel has the same center frequency but different bandwidth. Should figure out wpa_supplicant's behavior in
+        // this case. Also, wpa_supplicant's frequency property is uint16 infact.
+        match freq {
+            58_320 => 1,
+            60_480 => 2,
+            62_640 => 3,
+            64_800 => 4,
+            66_960 => 5,
+            69_120 => 6,
+            59_400 => 9,
+            61_560 => 10,
+            63_720 => 11,
+            65_880 => 12,
+            68_040 => 13,
+            _ => 0,
+        }
+    } else {
+        // Unknown channel
+        0
+    };
+
+    (band, channel as u16)
 }

--- a/rs-matter/src/transport/network/wifi/wpa_supp/unix.rs
+++ b/rs-matter/src/transport/network/wifi/wpa_supp/unix.rs
@@ -1,0 +1,175 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Unix-specific implementation of `IpStackCtl` using the `dhclient` command-line utility.
+
+use core::cell::RefCell;
+
+use std::process::Command;
+
+use embassy_futures::select::{select, Either};
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_time::{Duration, Timer};
+
+use crate::dm::clusters::net_comm::NetCtlError;
+use crate::dm::networks::unix::{UnixNetif, UnixNetifs};
+use crate::error::{Error, ErrorCode};
+use crate::transport::network::wifi::wpa_supp::IpStackCtl;
+use crate::utils::ipv6::create_link_local_ipv6;
+use crate::utils::sync::blocking;
+
+/// An `IpStackCtl` implementation for the linux `dhclient` command-line utility.
+///
+/// NOTE: Running `dhclient` might require certain privileges for the Unix user on behalf of which
+/// `rs-matter` and thus this code is running. For development/testing, it is easiest to run the
+/// application with `sudo`, but for production, it is recommended to make sure the user has appropriate permissions.
+pub struct DhClientCtl {
+    ifname: String,
+    self_assign_link_local_ipv6: bool,
+    netif: blocking::Mutex<NoopRawMutex, RefCell<Option<UnixNetif>>>,
+}
+
+impl DhClientCtl {
+    /// Create a new `DhClientCtl` instance.
+    ///
+    /// # Arguments
+    /// - `ifname` - The name of the network interface to control (e.g., "wlan0").
+    /// - `self_assign_link_local_ipv6` - If true, self-assign a link-local IPv6 address derived from the MAC address of the interface.
+    ///   Note that while `self_assign_link_local_ipv6` does generate a proper link-local Ipv6 address derived from the network interface
+    ///   MAC, it does not really implement the SLAAC protocol in that it does not check whether the generated address is already in use.
+    pub fn new(ifname: &str, self_assign_link_local_ipv6: bool) -> Self {
+        Self {
+            ifname: ifname.to_string(),
+            self_assign_link_local_ipv6,
+            netif: blocking::Mutex::new(RefCell::new(None)),
+        }
+    }
+
+    /// Wait for the interface state as follows:
+    /// - If `for_connection` is true, wait until the interface is connected.
+    /// - If `for_connection` is false, wait until the interface state changes (e.g., connected, disconnected or other change).
+    async fn wait(&self, for_connection: bool) {
+        const WAIT_TIMEOUT_SECS: u64 = 1;
+
+        loop {
+            let (changed, connected) = self.update_netif(self.fetch_netif().ok());
+
+            if for_connection && connected || !for_connection && changed {
+                break;
+            }
+
+            Timer::after(Duration::from_secs(WAIT_TIMEOUT_SECS)).await;
+        }
+    }
+
+    /// Update the cached network interface information and return whether it has changed and whether it has connected.
+    fn update_netif(&self, new_netif: Option<UnixNetif>) -> (bool, bool) {
+        self.netif.lock(|netif_ref| {
+            let mut netif = netif_ref.borrow_mut();
+
+            let changed = if *netif != new_netif {
+                *netif = new_netif;
+                true
+            } else {
+                false
+            };
+
+            let connected = Self::connected(netif.as_ref());
+
+            (changed, connected)
+        })
+    }
+
+    /// Fetch the current network interface information by name.
+    fn fetch_netif(&self) -> Result<UnixNetif, Error> {
+        UnixNetifs
+            .get()?
+            .into_iter()
+            .find(|netif| netif.name == self.ifname)
+            .ok_or_else(|| ErrorCode::NoNetworkInterface.into())
+    }
+
+    /// Check if the network interface is connected.
+    fn connected(netif: Option<&UnixNetif>) -> bool {
+        netif.is_some_and(|netif| {
+            netif.operational && !netif.ipv4addrs.is_empty() && !netif.ipv6addrs.is_empty()
+        })
+    }
+}
+
+impl IpStackCtl for DhClientCtl {
+    async fn connect(&self) -> Result<(), NetCtlError> {
+        const CONNECT_TIMEOUT_SECS: u64 = 15;
+
+        // 1) If the user requested, self-assign a MAC-derived link-local ipv6 addr
+        // Necessary, because the `dhclient` coming with certain Linux distros (Ubunut + NetworkManager)
+        // seems not to configure any Ipv6 addresses on the interface, even if SLAAC is enabled.
+
+        let netif = self.fetch_netif().map_err(NetCtlError::Other)?;
+
+        self.update_netif(Some(netif.clone()));
+
+        if self.self_assign_link_local_ipv6 {
+            let ipv6 = create_link_local_ipv6(&unwrap!(netif.hw_addr[..6].try_into()));
+
+            if let Err(e) = Command::new("ip")
+                .arg("-6")
+                .arg("addr")
+                .arg("add")
+                .arg(format!("{}/10", ipv6))
+                .arg("dev")
+                .arg(&self.ifname)
+                .status()
+            {
+                warn!(
+                    "Assigning link-local IPv6 address {} on interface {} failed: {:?}",
+                    ipv6, self.ifname, e
+                );
+            }
+        }
+
+        // 2) invoke `dhclient` on the interface. This will:
+        // - Get a DHCP lease for an Ipv4 address
+        // - Use SLAAC to configure an ipv6 address
+        Command::new("dhclient")
+            .arg("-nw")
+            .arg(&self.ifname)
+            .status()
+            .map_err(|e| {
+                error!("Error running `dhclient`: {:?}", e);
+
+                NetCtlError::Other(ErrorCode::NoNetworkInterface.into())
+            })?;
+
+        let timeout = Timer::after(Duration::from_secs(CONNECT_TIMEOUT_SECS));
+        let connected = self.wait(true);
+
+        match select(connected, timeout).await {
+            Either::First(_) => Ok(()),
+            Either::Second(_) => Err(NetCtlError::IpBindFailed),
+        }
+    }
+
+    async fn wait_changed(&self) {
+        self.wait(false).await
+    }
+
+    fn is_connected(&self) -> Result<bool, NetCtlError> {
+        self.netif
+            .lock(|netif| Ok(Self::connected(netif.borrow().as_ref())))
+    }
+}

--- a/rs-matter/src/utils/ipv6.rs
+++ b/rs-matter/src/utils/ipv6.rs
@@ -15,19 +15,21 @@
  *    limitations under the License.
  */
 
-pub mod bitflags;
-pub mod cell;
-pub mod codec;
-pub mod epoch;
-pub mod init;
-pub mod ipv6;
-pub mod iter;
-pub mod maybe;
-pub mod rand;
-pub mod select;
-pub mod storage;
-pub mod sync;
-#[cfg(feature = "zbus")]
-pub mod zbus;
-#[cfg(feature = "zbus")]
-pub mod zbus_proxies;
+use core::net::Ipv6Addr;
+
+/// Create a link-local IPv6 address from a MAC address.
+///
+/// Note that this function does not perform any SLAAC-related operations
+/// like checking whether the generated address is already in use.
+pub fn create_link_local_ipv6(mac: &[u8; 6]) -> Ipv6Addr {
+    Ipv6Addr::new(
+        0xfe80,
+        0,
+        0,
+        0,
+        u16::from_be_bytes([mac[0] ^ 0x02, mac[1]]),
+        u16::from_be_bytes([mac[2], 0xff]),
+        u16::from_be_bytes([0xfe, mac[3]]),
+        u16::from_be_bytes([mac[4], mac[5]]),
+    )
+}

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/bss.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/bss.rs
@@ -23,8 +23,8 @@ use zbus::proxy;
 use zbus::zvariant::{OwnedValue, Value};
 
 #[proxy(
-    interface = "fi.w1.wpa_supplicant1.Interface.BSS",
-    assume_defaults = true
+    interface = "fi.w1.wpa_supplicant1.BSS",
+    default_service = "fi.w1.wpa_supplicant1"
 )]
 pub trait BSS {
     /// PropertiesChanged signal
@@ -32,27 +32,27 @@ pub trait BSS {
     fn properties_changed(&self, properties: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
 
     /// BSSID property
-    #[zbus(property)]
+    #[zbus(property, name = "BSSID")]
     fn bssid(&self) -> zbus::Result<Vec<u8>>;
 
     /// SSID property
-    #[zbus(property)]
+    #[zbus(property, name = "SSID")]
     fn ssid(&self) -> zbus::Result<Vec<u8>>;
 
     /// WPA property
-    #[zbus(property)]
+    #[zbus(property, name = "WPA")]
     fn wpa(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
 
     /// RSN property
-    #[zbus(property)]
+    #[zbus(property, name = "RSN")]
     fn rsn(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
 
     /// WPS property
-    #[zbus(property)]
+    #[zbus(property, name = "WPS")]
     fn wps(&self) -> zbus::Result<HashMap<String, OwnedValue>>;
 
     /// IEs property
-    #[zbus(property)]
+    #[zbus(property, name = "IEs")]
     fn ies(&self) -> zbus::Result<Vec<u8>>;
 
     /// Privacy property

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/group.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/group.rs
@@ -23,8 +23,8 @@ use zbus::proxy;
 use zbus::zvariant::{ObjectPath, OwnedObjectPath, Value};
 
 #[proxy(
-    interface = "fi.w1.wpa_supplicant1.Interface.Group",
-    assume_defaults = true
+    interface = "fi.w1.wpa_supplicant1.Group",
+    default_service = "fi.w1.wpa_supplicant1"
 )]
 pub trait Group {
     /// PropertiesChanged signal
@@ -44,11 +44,11 @@ pub trait Group {
     fn role(&self) -> zbus::Result<String>;
 
     /// SSID property
-    #[zbus(property)]
+    #[zbus(property, name = "SSID")]
     fn ssid(&self) -> zbus::Result<Vec<u8>>;
 
     /// BSSID property
-    #[zbus(property)]
+    #[zbus(property, name = "BSSID")]
     fn bssid(&self) -> zbus::Result<Vec<u8>>;
 
     /// Frequency property
@@ -64,7 +64,7 @@ pub trait Group {
     fn psk(&self) -> zbus::Result<Vec<u8>>;
 
     /// WPSVendorExtensions property
-    #[zbus(property)]
+    #[zbus(property, name = "WPSVendorExtensions")]
     fn wps_vendor_extensions(&self) -> zbus::Result<Vec<Vec<u8>>>;
 
     /// PeerJoined signal

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/interface.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/interface.rs
@@ -22,7 +22,10 @@ use std::collections::HashMap;
 use zbus::proxy;
 use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
 
-#[proxy(interface = "fi.w1.wpa_supplicant1.Interface", assume_defaults = true)]
+#[proxy(
+    interface = "fi.w1.wpa_supplicant1.Interface",
+    default_service = "fi.w1.wpa_supplicant1"
+)]
 pub trait Interface {
     /// AddBlob method
     fn add_blob(&self, name: &str, data: &[u8]) -> zbus::Result<()>;

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/network.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/network.rs
@@ -23,8 +23,8 @@ use zbus::proxy;
 use zbus::zvariant::{OwnedValue, Value};
 
 #[proxy(
-    interface = "fi.w1.wpa_supplicant1.Interface.Network",
-    assume_defaults = true
+    interface = "fi.w1.wpa_supplicant1.Network",
+    default_service = "fi.w1.wpa_supplicant1"
 )]
 pub trait Network {
     /// PropertiesChanged signal

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/p2pdevice.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/p2pdevice.rs
@@ -24,7 +24,7 @@ use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
 
 #[proxy(
     interface = "fi.w1.wpa_supplicant1.Interface.P2PDevice",
-    assume_defaults = true
+    default_service = "fi.w1.wpa_supplicant1"
 )]
 pub trait P2PDevice {
     /// AddPersistentGroup method

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/peer.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/peer.rs
@@ -23,8 +23,8 @@ use zbus::proxy;
 use zbus::zvariant::{OwnedObjectPath, Value};
 
 #[proxy(
-    interface = "fi.w1.wpa_supplicant1.Interface.Peer",
-    assume_defaults = true
+    interface = "fi.w1.wpa_supplicant1.Peer",
+    default_service = "fi.w1.wpa_supplicant1"
 )]
 pub trait Peer {
     /// PropertiesChanged signal

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/persistent_group.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/persistent_group.rs
@@ -23,8 +23,8 @@ use zbus::proxy;
 use zbus::zvariant::{OwnedValue, Value};
 
 #[proxy(
-    interface = "fi.w1.wpa_supplicant1.Interface.PersistentGroup",
-    assume_defaults = true
+    interface = "fi.w1.wpa_supplicant1.PersistentGroup",
+    default_service = "fi.w1.wpa_supplicant1"
 )]
 pub trait PersistentGroup {
     /// PropertiesChanged signal

--- a/rs-matter/src/utils/zbus_proxies/wpa_supp/wps.rs
+++ b/rs-matter/src/utils/zbus_proxies/wpa_supp/wps.rs
@@ -24,7 +24,7 @@ use zbus::zvariant::{OwnedValue, Value};
 
 #[proxy(
     interface = "fi.w1.wpa_supplicant1.Interface.WPS",
-    assume_defaults = true
+    default_service = "fi.w1.wpa_supplicant1"
 )]
 pub trait WPS {
     /// Start method


### PR DESCRIPTION
~~(TBD: Not yet marked ready for review as I need to test the latest round of changes.)~~

This PR is completing the not-really-working-for-typechecking-only `wpa_supp` module that was part of the original zbus-enablement PR #271

With it, we are now able to talk to the `wpa_supplicant` Linux daemon over dBus, and thus do a Matter BLE commissioning on Linux, which is managing the system's Wifi networks for real.

Note that while having support for driving `wpa_supplicant` directly is good to have in `rs-matter` (Matter C++ SDK has it as well and that's their primary way of driving Wifi networks for Linux), I expect that the upcoming NetworkManager-over-dBus support to be _the_ solution for Wifi networks management on Linux, including for (most) embedded use cases except the tiniest ones where NM is not installed.
