### PR TITLE
Wifi management via NetworkManager over dBus

### DIFF
--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -17,16 +17,18 @@
 
 //! An example Matter device that implements the On/Off Light cluster over Wifi with commissioning over Bluetooth (Linux only).
 //!
-//! Some Linux systems might require the user running the app have elevated permissions, so run with `sudo`!
-//! E.g. `sudo ./onoff_light_bt <your-wlan-interface-name>`
-//!
-//! The example uses the BlueZ BLE stack and the `wpa_supplicant` daemon to connect to BT and to manage Wifi networks.
+//! The example uses the BlueZ BLE stack and either the `NetworkManager` or directly the `wpa_supplicant` daemon
+//! to connect to BT and to manage Wifi networks.
 //! Therefore, it is likely to run only on Linux-based systems (e.g., Ubuntu, Debian, etc.), because BlueZ is Linux-specific.
+//!
+//! Do note that running the app with the `wpa_supplicant` daemon, some Linux systems might require the user running the app to have
+//! elevated permissions, so run with `sudo`!
+//! E.g. `sudo ./onoff_light_bt <your-wlan-interface-name>`
 //!
 //! Utilizing `wpa_supplicant` and `dhclient` to manage Wifi networks is useful primarily in embedded Linux scenarios,
 //! where - moreover - the Linux stack does not have NetworkManager installed. For regular Linux systems, or for embedded
-//! Linux systems having NetworkManager, look at the forthcoming `onoff_light_bt_nm` example instead, as it would be much
-//! more straightfoward to run in that it would not need elevated permissions, nor the presence of the `dhclient` command.
+//! Linux systems having NetworkManager, using the NetworkManager code-path is recommended, as it is much
+//! more straightfoward to run it, in that it does not need elevated permissions, nor the presence of the `dhclient` and `ip` commands.
 
 use core::pin::pin;
 
@@ -57,6 +59,7 @@ use rs_matter::persist::Psm;
 use rs_matter::respond::DefaultResponder;
 use rs_matter::transport::network::btp::bluez::BluezGattPeripheral;
 use rs_matter::transport::network::btp::{Btp, BtpContext};
+use rs_matter::transport::network::wifi::nm::NetMgrCtl;
 use rs_matter::transport::network::wifi::wpa_supp::unix::DhClientCtl;
 use rs_matter::transport::network::wifi::wpa_supp::WpaSuppCtl;
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
@@ -77,23 +80,29 @@ fn main() -> Result<(), Error> {
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "debug"),
     );
 
-    let mut args = std::env::args();
-
-    let if_name = if args.len() > 2 {
-        eprintln!("Usage: onoff_light_bt [if_name]");
+    let args = std::env::args().into_iter().skip(1).collect::<Vec<_>>();
+    if args.len() > 2 {
+        eprintln!("Usage: onoff_light_bt [-w] [if_name]");
+        eprintln!(
+            "  -w      - use wpa_supplicant to manage Wifi networks (default is NetworkManager)"
+        );
         eprintln!("  if_name - the name of the Wifi interface to use, e.g. 'wlan0', 'wlx80afca061a16', etc.");
         eprintln!("            If not set, defaults to 'wlan0'.");
 
         return Ok(());
-    } else if args.len() == 1 {
-        warn!("Ran without params, using 'wlan0' as the Wifi interface name");
+    }
 
-        "wlan0".to_string()
+    let use_wpa_supp = args.iter().any(|arg| arg == "-w");
+    if use_wpa_supp {
+        warn!("Using wpa_supplicant to manage Wifi networks, make sure you run with `sudo`!");
     } else {
-        let if_name = args.nth(1).unwrap();
-        info!("Using Wifi network interface: {if_name}");
-        if_name
-    };
+        info!("Using NetworkManager to manage Wifi networks");
+    }
+
+    let if_name = args.into_iter().find(|arg| arg != "-w").unwrap_or_else(|| {
+        warn!("Ran without iface arg, using 'wlan0' as the Wifi interface name");
+        "wlan0".into()
+    });
 
     // Create the Matter object
     let matter = Matter::new_default(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, MATTER_PORT);
@@ -117,21 +126,32 @@ fn main() -> Result<(), Error> {
 
     // The network controller based on `wpa_supplicant` and `dhclient`.
     let net_ctl_state = NetCtlState::new_with_mutex::<NoopRawMutex>();
-    let net_ctl = NetCtlWithStatusImpl::new(
+
+    let wpa_supp = NetCtlWithStatusImpl::new(
         &net_ctl_state,
         WpaSuppCtl::new(&connection, &if_name, DhClientCtl::new(&if_name, true)),
     );
+    let nm = NetCtlWithStatusImpl::new(&net_ctl_state, NetMgrCtl::new(&connection, &if_name));
 
     // Assemble our Data Model handler by composing the predefined Root Endpoint handler with the On/Off handler
-    let dm_handler = dm_handler(&matter, &on_off, &net_ctl, &networks);
+    let wpa_supp_dm_handler = dm_handler(&matter, &on_off, &wpa_supp, &networks);
+    let nm_dm_handler = dm_handler(&matter, &on_off, &nm, &networks);
 
     // Create a default responder capable of handling up to 3 subscriptions
     // All other subscription requests will be turned down with "resource exhausted"
-    let responder = DefaultResponder::new(&matter, &buffers, &subscriptions, dm_handler);
+    let wpa_supp_responder =
+        DefaultResponder::new(&matter, &buffers, &subscriptions, wpa_supp_dm_handler);
+    let nm_responder = DefaultResponder::new(&matter, &buffers, &subscriptions, nm_dm_handler);
 
     // Run the responder with up to 4 handlers (i.e. 4 exchanges can be handled simultaneously)
     // Clients trying to open more exchanges than the ones currently running will get "I'm busy, please try again later"
-    let mut respond = pin!(responder.run::<4, 4>());
+    let mut respond = pin!(async {
+        if use_wpa_supp {
+            wpa_supp_responder.run::<4, 4>().await
+        } else {
+            nm_responder.run::<4, 4>().await
+        }
+    });
 
     // This is a sample code that simulates state changes triggered by the HAL
     // Changes will be properly communicated to the Matter controllers and other Matter apps (i.e. Google Home, Alexa), thanks to subscriptions

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 rust-version = "1.83"
 
 [features]
-default = ["os", "rustcrypto", "log", "zbus"]
+default = ["os", "rustcrypto", "log"]
 #default = ["os", "mbedtls", "log"] mbedtls is broken since several months - check the root cause
 astro-dnssd = ["os", "dep:astro-dnssd"]
 zeroconf = ["os", "dep:zeroconf"]

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 rust-version = "1.83"
 
 [features]
-default = ["os", "rustcrypto", "log"]
+default = ["os", "rustcrypto", "log", "zbus"]
 #default = ["os", "mbedtls", "log"] mbedtls is broken since several months - check the root cause
 astro-dnssd = ["os", "dep:astro-dnssd"]
 zeroconf = ["os", "dep:zeroconf"]

--- a/rs-matter/src/transport/network/wifi.rs
+++ b/rs-matter/src/transport/network/wifi.rs
@@ -17,4 +17,6 @@
 
 pub mod band;
 #[cfg(feature = "zbus")]
+pub mod nm;
+#[cfg(feature = "zbus")]
 pub mod wpa_supp;

--- a/rs-matter/src/transport/network/wifi/band.rs
+++ b/rs-matter/src/transport/network/wifi/band.rs
@@ -80,6 +80,19 @@ pub fn band_and_channel(freq: u32) -> Option<(WiFiBandEnum, u16)> {
     (channel > 0).then_some((band, channel as _))
 }
 
+/// Convert a signal strength percentage (0-100) to an RSSI value in dBm.
+///
+/// Note that the conversion is a rough approximation:
+/// - 0% corresponds to -100 dBm (no signal)
+/// - 100% corresponds to -30 dBm (excellent signal)
+pub fn signal_strength_to_rssi(strength_perc: u8) -> i8 {
+    let strength_perc = strength_perc.clamp(0, 100);
+
+    // Convert percentage to dBm
+    // 0% -> -100 dBm, 100% -> -30 dBm
+    (strength_perc / 2) as i8 - 100
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -151,5 +164,18 @@ mod tests {
         assert_eq!(Some((V60G, 5)), band_and_channel(66960));
         assert_eq!(Some((V60G, 9)), band_and_channel(59400));
         assert_eq!(Some((V60G, 10)), band_and_channel(61560));
+    }
+
+    #[test]
+    fn test_signal_strength_to_rssi() {
+        use super::signal_strength_to_rssi;
+
+        assert_eq!(signal_strength_to_rssi(0), -100);
+        assert_eq!(signal_strength_to_rssi(50), -75);
+        assert_eq!(signal_strength_to_rssi(100), -50);
+        assert_eq!(signal_strength_to_rssi(25), -88);
+        assert_eq!(signal_strength_to_rssi(75), -63);
+        assert_eq!(signal_strength_to_rssi(110), -50); // Clamped to 100%
+        assert_eq!(signal_strength_to_rssi(150), -50); // Clamped to 100%
     }
 }

--- a/rs-matter/src/transport/network/wifi/nm.rs
+++ b/rs-matter/src/transport/network/wifi/nm.rs
@@ -43,7 +43,7 @@ use crate::dm::clusters::wifi_diag::{SecurityTypeEnum, WiFiVersionEnum, WifiDiag
 use crate::dm::networks::NetChangeNotif;
 use crate::error::{Error, ErrorCode};
 use crate::tlv::Nullable;
-use crate::transport::network::wifi::band::band_and_channel;
+use crate::transport::network::wifi::band::{band_and_channel, signal_strength_to_rssi};
 use crate::utils::sync::{blocking, IfMutex};
 use crate::utils::zbus_proxies::nm::access_point::AccessPointProxy;
 use crate::utils::zbus_proxies::nm::connection::ConnectionProxy;
@@ -236,11 +236,7 @@ impl<'a> NetMgrCtl<'a> {
                 bssid: &bssid,
                 band,
                 channel,
-                rssi: bss_info
-                    .strength()
-                    .await?
-                    .min(i8::MIN as _)
-                    .max(i8::MAX as _) as i8,
+                rssi: signal_strength_to_rssi(bss_info.strength().await?),
             };
 
             f(Some(&network_scan_info))

--- a/rs-matter/src/transport/network/wifi/nm.rs
+++ b/rs-matter/src/transport/network/wifi/nm.rs
@@ -1,0 +1,521 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Wifi network controller implementation based on the NetworkManager D-Bus service.
+
+// TODO: It is possible to get all Ipv4 and Ipv6 netifs via NetworkManager, so we can also implement
+// the `NetifDiag` trait (with some caching, as it is non-async), thus getting rid of the `UnixNetifs` type
+// when NM is used.
+
+use core::cell::RefCell;
+
+use std::collections::HashMap;
+
+use embassy_futures::select::{select, select3, Either, Either3};
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+
+use embassy_time::{Duration, Timer};
+use futures_lite::StreamExt;
+
+use uuid::Uuid;
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, Value};
+use zbus::Connection;
+
+use crate::dm::clusters::net_comm::{
+    NetCtl, NetCtlError, NetworkScanInfo, NetworkType, WiFiBandEnum, WiFiSecurityBitmap,
+    WirelessCreds,
+};
+use crate::dm::clusters::wifi_diag::{SecurityTypeEnum, WiFiVersionEnum, WifiDiag, WirelessDiag};
+use crate::dm::networks::NetChangeNotif;
+use crate::error::{Error, ErrorCode};
+use crate::tlv::Nullable;
+use crate::transport::network::wifi::band::band_and_channel;
+use crate::utils::sync::{blocking, IfMutex};
+use crate::utils::zbus_proxies::nm::access_point::AccessPointProxy;
+use crate::utils::zbus_proxies::nm::connection::ConnectionProxy;
+use crate::utils::zbus_proxies::nm::device::wireless::WirelessProxy;
+use crate::utils::zbus_proxies::nm::device::DeviceProxy;
+use crate::utils::zbus_proxies::nm::network_manager::NetworkManagerProxy;
+use crate::utils::zbus_proxies::nm::{NM80211ApSecurityFlags, NM80211Mode, NMDeviceState};
+
+/// A `NetCtl`, `WirelessDiag`, `WifiDiag` and `NetChangeNotif` implementation based on the `NetworkManager` service.
+///
+/// Suitable for use with embedded Linux devices that do have the `NetworkManager` service running over D-Bus.
+pub struct NetMgrCtl<'a> {
+    connection: &'a Connection,
+    ifname: &'a str,
+    net_conn: IfMutex<NoopRawMutex, Option<OwnedObjectPath>>,
+    wifi_conn_info: blocking::Mutex<NoopRawMutex, RefCell<Option<WifiConnInfo>>>,
+}
+
+impl<'a> NetMgrCtl<'a> {
+    /// Create a new `NetMgrCtl` instance.
+    ///
+    /// # Arguments
+    /// * `connection` - A reference to the D-Bus connection.
+    /// * `interface_path` - The D-Bus object path of Wifi interface object.
+    ///
+    /// # Returns
+    /// The new `NetMgrCtl` instance.
+    pub const fn new(connection: &'a Connection, ifname: &'a str) -> Self {
+        Self {
+            connection,
+            ifname,
+            net_conn: IfMutex::new(None),
+            wifi_conn_info: blocking::Mutex::new(RefCell::new(None)),
+        }
+    }
+
+    /// Return a reference to the D-Bus connection.
+    pub const fn connection(&self) -> &Connection {
+        self.connection
+    }
+
+    /// Create a wpa-supplicant interface proxy for out interface name
+    async fn mgr(&self) -> Result<NetworkManagerProxy<'a>, zbus::Error> {
+        NetworkManagerProxy::new(self.connection).await
+    }
+
+    async fn device(&self) -> Result<OwnedObjectPath, zbus::Error> {
+        self.mgr().await?.get_device_by_ip_iface(self.ifname).await
+    }
+
+    /// Wait for the interface state as follows:
+    /// - If `for_connection` is true, wait until the interface is connected to a network.
+    /// - If `for_connection` is false, wait until the interface state changes (e.g., connected, disconnected or other change).
+    async fn wait(&self, for_connection: bool) -> Result<(), Error> {
+        let device = self.device().await?;
+
+        let interface = DeviceProxy::new(self.connection, &device).await?;
+        let wifi = WirelessProxy::new(self.connection, &device).await?;
+
+        let mut iface_state_changed = interface.receive_dev_state_changed().await;
+
+        loop {
+            let bss = wifi.active_access_point().await?;
+
+            let (changed, connected) = if bss.len() > 1 {
+                let connected = interface.dev_state().await? == NMDeviceState::Activated as _;
+
+                self.network_scan_info(&bss, |info| {
+                    let info = info.map(|info| WifiConnInfo::new(info, connected));
+
+                    Ok(self.update_wifi_conn_info(info))
+                })
+                .await?
+            } else {
+                self.update_wifi_conn_info(None)
+            };
+
+            if for_connection && connected || !for_connection && changed {
+                break Ok(());
+            }
+
+            iface_state_changed.next().await;
+        }
+    }
+
+    /// Update the cached WiFi connection information and return whether it has changed and whether it has connected.
+    fn update_wifi_conn_info(&self, new_wifi_conn_info: Option<WifiConnInfo>) -> (bool, bool) {
+        self.wifi_conn_info.lock(|wifi_conn_info| {
+            let mut wifi_conn_info = wifi_conn_info.borrow_mut();
+
+            let changed = if *wifi_conn_info != new_wifi_conn_info {
+                *wifi_conn_info = new_wifi_conn_info;
+                true
+            } else {
+                false
+            };
+
+            let connected = Self::connected(wifi_conn_info.as_ref());
+
+            (changed, connected)
+        })
+    }
+
+    /// Check if the provided WiFi connecton info represents a connected network.
+    fn connected(wifi_conn_info: Option<&WifiConnInfo>) -> bool {
+        wifi_conn_info.map(|info| info.connected).unwrap_or(false)
+    }
+
+    /// Remove our connection, if any.
+    async fn remove_net_conn(&self, net_conn: &mut Option<OwnedObjectPath>) -> zbus::Result<()> {
+        let interface = self.mgr().await?;
+
+        if let Some(net_conn_path) = net_conn.clone() {
+            if interface
+                .deactivate_connection(&net_conn_path)
+                .await
+                .is_ok()
+            {
+                let net_conn_proxy = ConnectionProxy::new(self.connection, &net_conn_path).await?;
+                net_conn_proxy.delete().await?;
+
+                net_conn.take();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get the network scan information for a given BSS object path.
+    async fn network_scan_info<F, R>(&self, bss: &ObjectPath<'_>, f: F) -> Result<R, Error>
+    where
+        F: FnOnce(Option<&NetworkScanInfo>) -> Result<R, Error>,
+    {
+        let bss_info = AccessPointProxy::new(self.connection, bss).await?;
+
+        if bss_info.mode().await? == NM80211Mode::Infra as _ {
+            let wpa = NM80211ApSecurityFlags::from_bits_truncate(bss_info.wpa_flags().await?);
+            let rsn = NM80211ApSecurityFlags::from_bits_truncate(bss_info.rsn_flags().await?);
+
+            let security = if wpa.is_empty() && rsn.is_empty() {
+                WiFiSecurityBitmap::UNENCRYPTED
+            } else {
+                let mut security = WiFiSecurityBitmap::empty();
+
+                if !wpa
+                    .union(rsn)
+                    .intersection(
+                        NM80211ApSecurityFlags::PAIR_WEP40 | NM80211ApSecurityFlags::PAIR_WEP104,
+                    )
+                    .is_empty()
+                {
+                    security |= WiFiSecurityBitmap::WEP;
+                }
+
+                if wpa.contains(NM80211ApSecurityFlags::KEY_MGMT_PSK) {
+                    security |= WiFiSecurityBitmap::WPA_PERSONAL;
+                }
+
+                if rsn.contains(NM80211ApSecurityFlags::KEY_MGMT_PSK) {
+                    security |= WiFiSecurityBitmap::WPA_2_PERSONAL;
+                }
+
+                // TODO
+                // if rsn_key_mgmt.contains(&"sae".to_string()) {
+                //     security |= WiFiSecurityBitmap::WPA_3_PERSONAL
+                // }
+
+                security
+            };
+
+            // If we can't determine the band and channel we prefer to still report the network
+            // even if with unknown band and channel.
+            let (band, channel) =
+                band_and_channel(bss_info.frequency().await?).unwrap_or((WiFiBandEnum::V2G4, 0));
+
+            let bssid = {
+                let bssid_str = bss_info.hw_address().await?;
+
+                let result: Result<heapless::Vec<_, 8>, _> = bssid_str
+                    .split(':')
+                    .map(|s| u8::from_str_radix(s, 16))
+                    .collect();
+
+                result.map_err(|_| Error::from(ErrorCode::Invalid))?
+            };
+
+            let network_scan_info = NetworkScanInfo::Wifi {
+                security,
+                ssid: &bss_info.ssid().await?,
+                bssid: &bssid,
+                band,
+                channel,
+                rssi: bss_info
+                    .strength()
+                    .await?
+                    .min(i8::MIN as _)
+                    .max(i8::MAX as _) as i8,
+            };
+
+            f(Some(&network_scan_info))
+        } else {
+            // Skip ad-hoc networks, we are only interested in infrastructure ones
+            f(None)
+        }
+    }
+}
+
+impl Drop for NetMgrCtl<'_> {
+    fn drop(&mut self) {
+        // Remove the network on drop
+        let _ = futures_lite::future::block_on(async {
+            let mut network = self.net_conn.lock().await;
+
+            self.remove_net_conn(&mut network).await
+        });
+    }
+}
+
+impl NetCtl for NetMgrCtl<'_> {
+    fn net_type(&self) -> NetworkType {
+        NetworkType::Wifi
+    }
+
+    async fn scan<F>(&self, network: Option<&[u8]>, mut f: F) -> Result<(), NetCtlError>
+    where
+        F: FnMut(&NetworkScanInfo) -> Result<(), Error>,
+    {
+        const SCAN_DONE_TIMEOUT_SEC: u64 = 3;
+
+        let _guard = self.net_conn.lock().await;
+
+        let mut args = HashMap::new();
+
+        let active = Value::from("active");
+        args.insert("Type", &active);
+
+        let ssids = network.map(|network| vec![network.to_vec()].into());
+        if ssids.is_some() {
+            #[allow(clippy::unnecessary_unwrap)]
+            args.insert("SSIDs", ssids.as_ref().unwrap());
+        }
+
+        let device_path = self.device().await?;
+
+        let wifi = WirelessProxy::new(self.connection, &device_path).await?;
+
+        let mut ap_added = wifi.receive_access_point_added().await?;
+        let mut ap_removed = wifi.receive_access_point_added().await?;
+
+        wifi.request_scan(args.clone()).await?;
+
+        loop {
+            // Wait for the scan to complete
+            //
+            // NOTE: It seems NetworkManager - unlike `wpa_supplicant` - does not provide a way to
+            // to get a "Scan done" signal, so we just monitor the "access point added / removed"
+            // signals and timeout if we don't see one incoming after a few seconds
+
+            let ap_added = ap_added.next();
+            let ap_removed = ap_removed.next();
+            let timeout = Timer::after(Duration::from_secs(SCAN_DONE_TIMEOUT_SEC));
+
+            if matches!(
+                select3(ap_added, ap_removed, timeout).await,
+                Either3::Third(_)
+            ) {
+                break;
+            }
+        }
+
+        let bsss = wifi.access_points().await?;
+
+        for bss in bsss {
+            self.network_scan_info(&bss, |info| {
+                if let Some(info) = info {
+                    f(info)?;
+                }
+
+                Ok(())
+            })
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn connect(&self, creds: &WirelessCreds<'_>) -> Result<(), NetCtlError> {
+        const CONNECT_TIMEOUT_SECS: u64 = 30;
+
+        let mut net_conn = self.net_conn.lock().await;
+
+        let WirelessCreds::Wifi { ssid, pass } = creds else {
+            return Err(NetCtlError::Other(ErrorCode::InvalidAction.into()));
+        };
+
+        let mgr = self.mgr().await?;
+
+        self.remove_net_conn(&mut net_conn).await?;
+
+        let utf8_err = |_| NetCtlError::Other(ErrorCode::Invalid.into());
+
+        let conn_uuid = Uuid::new_v4().hyphenated().to_string();
+
+        let arg_conn_uuid = conn_uuid.as_str().into();
+        let arg_conn_type = "802-11-wireless".into();
+        let arg_security = "wpa-psk".into();
+        let arg_ssid = (*ssid).into();
+        // For some reason, `NetworkManager` wants the PSK to be a string
+        let arg_pass = core::str::from_utf8(pass).map_err(utf8_err)?.into();
+        let arg_ipv4_method = "auto".into();
+        let arg_ipv6_method = "auto".into();
+
+        let args: &[(_, &[_])] = &[
+            (
+                "connection",
+                &[
+                    ("id", &arg_conn_uuid),
+                    ("uuid", &arg_conn_uuid),
+                    ("type", &arg_conn_type),
+                ],
+            ),
+            ("802-11-wireless", &[("ssid", &arg_ssid)]),
+            (
+                "802-11-wireless-security",
+                if pass.is_empty() {
+                    &[]
+                } else {
+                    &[("key-mgmt", &arg_security), ("psk", &arg_pass)]
+                },
+            ),
+            ("ipv4", &[("method", &arg_ipv4_method)]),
+            ("ipv6", &[("method", &arg_ipv6_method)]),
+        ];
+
+        let args = args
+            .iter()
+            .map(|(k, v)| (*k, (*v).iter().map(|(k, v)| (*k, *v)).collect()))
+            .collect::<HashMap<&str, HashMap<&str, &Value<'_>>>>();
+
+        let device_path = self.device().await?;
+        let (_, net_conn_path) = mgr
+            .add_and_activate_connection(
+                args,
+                &device_path,
+                &OwnedObjectPath::try_from("/").unwrap(),
+            )
+            .await?;
+
+        *net_conn = Some(net_conn_path.clone());
+
+        let connected = self.wait(true);
+        let timeout = Timer::after(Duration::from_secs(CONNECT_TIMEOUT_SECS));
+
+        match select(connected, timeout).await {
+            Either::First(_) => info!("Connected to Wifi network: {}", self.ifname),
+            Either::Second(_) => {
+                error!(
+                    "Connection to Wifi network timed out: {}, assuming auth failure",
+                    self.ifname
+                );
+
+                if let Err(e2) = self.remove_net_conn(&mut net_conn).await {
+                    warn!(
+                        "Failed to remove network after connection timeout: {:?}",
+                        e2
+                    );
+                }
+                return Err(NetCtlError::AuthFailure);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl WirelessDiag for NetMgrCtl<'_> {
+    fn connected(&self) -> Result<bool, Error> {
+        Ok(self
+            .wifi_conn_info
+            .lock(|ssid_info| Self::connected(ssid_info.borrow().as_ref())))
+    }
+}
+
+impl WifiDiag for NetMgrCtl<'_> {
+    fn bssid(&self, f: &mut dyn FnMut(Option<&[u8]>) -> Result<(), Error>) -> Result<(), Error> {
+        self.wifi_conn_info.lock(|wifi_conn_info| {
+            let wifi_conn_info = wifi_conn_info.borrow();
+            if let Some(wifi_conn_info) = wifi_conn_info.as_ref() {
+                f(Some(&wifi_conn_info.bssid))
+            } else {
+                f(None)
+            }
+        })
+    }
+
+    fn security_type(&self) -> Result<Nullable<SecurityTypeEnum>, Error> {
+        // TODO: Figure out how to get this
+        Ok(Nullable::none())
+    }
+
+    fn wi_fi_version(&self) -> Result<Nullable<WiFiVersionEnum>, Error> {
+        // TODO: Figure out how to get this
+        Ok(Nullable::none())
+    }
+
+    fn channel_number(&self) -> Result<Nullable<u16>, Error> {
+        Ok(self.wifi_conn_info.lock(|wifi_conn_info| {
+            let wifi_conn_info = wifi_conn_info.borrow();
+            if let Some(wifi_conn_info) = wifi_conn_info.as_ref() {
+                Nullable::some(wifi_conn_info.channel)
+            } else {
+                Nullable::none()
+            }
+        }))
+    }
+
+    fn rssi(&self) -> Result<Nullable<i8>, Error> {
+        Ok(self.wifi_conn_info.lock(|wifi_conn_info| {
+            let wifi_conn_info = wifi_conn_info.borrow();
+            if let Some(wifi_conn_info) = wifi_conn_info.as_ref() {
+                Nullable::some(wifi_conn_info.rssi)
+            } else {
+                Nullable::none()
+            }
+        }))
+    }
+}
+
+impl NetChangeNotif for NetMgrCtl<'_> {
+    async fn wait_changed(&self) {
+        let _ = self.wait(false).await;
+    }
+}
+
+/// An owned variant of `NetworkScanInfo::Wifi`.
+/// Used for caching the connected BSS so that it can be returned by the
+/// non-async `WifiDiag` methods.
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+struct WifiConnInfo {
+    connected: bool,
+    security: WiFiSecurityBitmap,
+    ssid: Vec<u8>,
+    bssid: Vec<u8>,
+    band: WiFiBandEnum,
+    channel: u16,
+    rssi: i8,
+}
+
+impl WifiConnInfo {
+    /// Create a new `WifiConnInfo` from the given `NetworkScanInfo::Wifi`.
+    fn new(scan_info: &NetworkScanInfo, connected: bool) -> Self {
+        let NetworkScanInfo::Wifi {
+            security,
+            ssid,
+            bssid,
+            channel,
+            band,
+            rssi,
+        } = scan_info
+        else {
+            // Not possible, because `WpaSupp` only produces scan info of type `Wifi`
+            unreachable!();
+        };
+
+        Self {
+            connected,
+            security: *security,
+            ssid: ssid.to_vec(),
+            bssid: bssid.to_vec(),
+            band: *band,
+            channel: *channel,
+            rssi: *rssi,
+        }
+    }
+}

--- a/rs-matter/src/transport/network/wifi/nm.rs
+++ b/rs-matter/src/transport/network/wifi/nm.rs
@@ -294,7 +294,7 @@ impl NetCtl for NetMgrCtl<'_> {
         loop {
             // Wait for the scan to complete
             //
-            // NOTE: It seems NetworkManager - unlike `wpa_supplicant` - does not provide a way to
+            // NOTE: It seems NetworkManager - unlike `wpa_supplicant` - does not provide a way
             // to get a "Scan done" signal, so we just monitor the "access point added / removed"
             // signals and timeout if we don't see one incoming after a few seconds
 

--- a/rs-matter/src/utils/zbus_proxies/nm.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm.rs
@@ -21,6 +21,8 @@
 //! or manually by consulting the NetworkManager D-Bus interface definitions
 //! as documented here: https://networkmanager.dev/docs/api/latest/spec.html circa 2025-07-15
 
+use crate::utils::bitflags::bitflags;
+
 pub mod access_point;
 pub mod active;
 pub mod agent_manager;
@@ -37,3 +39,93 @@ pub mod ppp;
 pub mod settings;
 pub mod vpn_connection;
 pub mod wifi_p2ppeer;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[repr(u32)]
+pub enum NMDeviceState {
+    /// the device's state is unknown
+    Unknown = 0,
+    /// the device is recognized, but not managed by NetworkManager
+    Unmanaged = 10,
+    /// the device is managed by NetworkManager, but is not available for use.
+    /// Reasons may include the wireless switched off, missing firmware, no ethernet carrier,
+    /// missing supplicant or modem manager, etc.
+    Unavailable = 20,
+    /// the device can be activated, but is currently idle and not connected to a network.
+    Disconnected = 30,
+    /// the device is preparing the connection to the network.
+    /// This may include operations like changing the MAC address, setting physical link properties,
+    /// and anything else required to connect to the requested network.
+    Prepare = 40,
+    /// the device is connecting to the requested network.
+    /// This may include operations like associating with the WiFi AP, dialing the modem,
+    /// connecting to the remote Bluetooth device, etc.
+    Config = 50,
+    /// the device requires more information to continue connecting to the requested network.
+    /// This includes secrets like WiFi passphrases, login passwords, PIN codes, etc.
+    NeedAuth = 60,
+    /// the device is requesting IPv4 and/or IPv6 addresses and routing information from the network.
+    IpConfig = 70,
+    /// the device is checking whether further action is required for the requested network connection.
+    /// This may include checking whether only local network access is available, whether a captive portal is blocking access to the Internet, etc.
+    IpCheck = 80,
+    /// the device is waiting for a secondary connection (like a VPN) which must activated before the device can be activated
+    Secondaries = 90,
+    /// the device has a network connection, either local or global.
+    Activated = 100,
+    /// a disconnection from the current network connection was requested, and the device is cleaning up resources used
+    /// for that connection. The network connection may still be valid.
+    Deactivating = 110,
+    /// the device failed to connect to the requested network and is cleaning up the connection request
+    Failed = 120,
+}
+
+/// NMState values indicate the current overall networking state.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[repr(u32)]
+pub enum NM80211Mode {
+    /// the device or access point mode is unknown
+    Unknown = 0,
+    /// for both devices and access point objects, indicates the object
+    /// is part of an Ad-Hoc 802.11 network without a central coordinating access point.
+    Adhoc = 1,
+    /// the device or access point is in infrastructure mode.
+    /// For devices, this indicates the device is an 802.11 client/station.
+    /// For access point objects, this indicates the object is an access point that provides connectivity to clients.
+    Infra = 2,
+    /// the device is an access point/hotspot.
+    /// Not valid for access point objects; used only for hotspot mode on the local machine.
+    Ap = 3,
+}
+
+bitflags! {
+    /// 802.11 access point security and authentication flags.
+    /// These flags describe the current security requirements of an access point as determined from the access point's beacon.
+    #[repr(transparent)]
+    #[derive(Default)]
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
+    pub struct NM80211ApSecurityFlags: u32 {
+        /// the access point has no special security requirements
+        const NONE = 0x00;
+        /// 40/64-bit WEP is supported for pairwise/unicast encryption
+        const PAIR_WEP40 = 0x01;
+        /// 104/128-bit WEP is supported for pairwise/unicast encryption
+        const PAIR_WEP104 = 0x02;
+        /// TKIP is supported for pairwise/unicast encryption
+        const PAIR_TKIP = 0x04;
+        /// AES/CCMP is supported for pairwise/unicast encryption
+        const PAIR_CCMP = 0x08;
+        /// 40/64-bit WEP is supported for group/broadcast encryption
+        const GROUP_WEP40 = 0x10;
+        /// 104/128-bit WEP is supported for group/broadcast encryption
+        const GROUP_WEP104 = 0x20;
+        /// TKIP is supported for group/broadcast encryption
+        const GROUP_TKIP = 0x40;
+        /// AES/CCMP is supported for group/broadcast encryption
+        const GROUP_CCMP = 0x80;
+        /// WPA/RSN Pre-Shared Key encryption is supported
+        const KEY_MGMT_PSK = 0x100;
+        /// 802.1x authentication and key management is supported
+        const KEY_MGMT_802_1X = 0x200;
+    }
+}

--- a/rs-matter/src/utils/zbus_proxies/nm.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm.rs
@@ -41,6 +41,7 @@ pub mod vpn_connection;
 pub mod wifi_p2ppeer;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u32)]
 pub enum NMDeviceState {
     /// the device's state is unknown
@@ -82,6 +83,7 @@ pub enum NMDeviceState {
 
 /// NMState values indicate the current overall networking state.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u32)]
 pub enum NM80211Mode {
     /// the device or access point mode is unknown

--- a/rs-matter/src/utils/zbus_proxies/nm/network_manager.rs
+++ b/rs-matter/src/utils/zbus_proxies/nm/network_manager.rs
@@ -39,7 +39,7 @@ pub trait NetworkManager {
     /// AddAndActivateConnection method
     fn add_and_activate_connection(
         &self,
-        connection: HashMap<&str, std::collections::HashMap<&str, &Value<'_>>>,
+        connection: HashMap<&str, HashMap<&str, &Value<'_>>>,
         device: &ObjectPath<'_>,
         specific_object: &ObjectPath<'_>,
     ) -> zbus::Result<(OwnedObjectPath, OwnedObjectPath)>;
@@ -48,7 +48,7 @@ pub trait NetworkManager {
     #[allow(clippy::too_many_arguments)]
     fn add_and_activate_connection2(
         &self,
-        connection: HashMap<&str, std::collections::HashMap<&str, &Value<'_>>>,
+        connection: HashMap<&str, HashMap<&str, &Value<'_>>>,
         device: &ObjectPath<'_>,
         specific_object: &ObjectPath<'_>,
         options: HashMap<&str, &Value<'_>>,


### PR DESCRIPTION
**UPDATE: NOTE: #283 needs to be merged first as this PR is on top of it.**

This PR is very similar in spirit to #279 in that it brings Wifi connectivity management for (embedded) Linux, however based on the NetworkManager daemon, over dBus and using the (pure Rust) zbus NM bindings we have in the meantime.

There are two topics which are not addressed by this PR and are left to subsequent PRs:

1. **Reporting on Linux network interfaces (i.e. implementation for the `NetifDiag` rs-matter trait)**

We do have a "standard" `NetifDiag` impl already which works on any Unix OS - `UnixNetifs`.
However - and when using NetworkManager specifically - we can do better in that we don't need `UnixNetifs` because NetworkManager **itself** provides a dBus API for enumerating the details of all Linux/Unix network interfaces available in the OS.

It is not like urgent to implement this, but why not?

2. **Wireless connections persistence**

Unlike `wpa_supplicant` which does not have any persistence (that is, aside from `/etc` conf files), NetworkManager **does** have a built-in Connection Persistence API, available over dBus.

The above is a bit at odds with the built-in rs-matter Wifi/Thread connections' persistence we provide in the form of the `WirelessNetworks` struct, which implements the `net_comm::Networks` trait pf `rs-matter`.

Given that NetworkManager has its own persistence, we have three choices how to deal with it:

- Continue using `WirelessNetworks` and thus rely on the built-in rs-matter wireless networks persistence. Whatever Wifi connection is created in NetworkManager - it is considered transient and is removed when the dBus connection to NetworkManager is dropped (actually, when the `NetCtl` trait impl is dropped) => this is what this PR implements currently

- Don't use the built-in rs-matter `WirelessNetworks` impl, and implement a new wireless networks persistence, which relies squarely on the persistence mechanism of NetworkManager. This has pros and cons, in that wireless networks need to only be persisted once commissioning is over, while NetworkManager seems not to allow using a Wifi connection which is not persisted inside it yet, so we have to see how to implement this exactly, and whether this is a good idea

- Use both the NetworkManager peristence and the built-in `WirelessNetworks` struct and keep those in sync. Seems like the worst of both worlds, I'm mentioning just for completeness
