### PR TITLE
Unit tests and clippy

### DIFF
--- a/rs-matter-macros/src/idl/parser.rs
+++ b/rs-matter-macros/src/idl/parser.rs
@@ -264,7 +264,7 @@ pub enum Whitespace<'a> {
 /// Parses whitespace (space/tab/newline and comments).
 ///
 /// returns the content of the comment
-fn whitespace_group(span: Span) -> IResult<Span, Whitespace<'_>, ParseError> {
+fn whitespace_group(span: Span<'_>) -> IResult<Span<'_>, Whitespace<'_>, ParseError<'_>> {
     // NOTE: split into cases intentional. Using an ALT pattern here
     //       seems to slow down things quite a bit (as whitespace is used a lot
     //       inside our parsing)
@@ -379,7 +379,7 @@ fn whitespace1(span: Span) -> IResult<Span, Option<DocComment>, ParseError> {
 /// Parses a name id, of the form /[a-zA-Z_][a-zA-Z0-9_]*/
 ///
 /// Returns the parsed id as a string slice
-fn parse_id(span: Span) -> IResult<Span, &str, ParseError> {
+fn parse_id(span: Span<'_>) -> IResult<Span<'_>, &str, ParseError<'_>> {
     parse_id_span(span).map(|(span, data)| (span, *data.fragment()))
 }
 

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -74,7 +74,7 @@ impl ToTLV for AuthMode {
         AccessControlEntryAuthModeEnum::from(*self).to_tlv(tag, &mut tw)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         TLV::u8(tag, AccessControlEntryAuthModeEnum::from(*self) as _).into_tlv_iter()
     }
 }
@@ -315,7 +315,7 @@ impl<'a> AccessReq<'a> {
     }
 
     /// Return the accessor of the request
-    pub fn accessor(&self) -> &Accessor {
+    pub fn accessor(&self) -> &Accessor<'_> {
         self.accessor
     }
 

--- a/rs-matter/src/cert.rs
+++ b/rs-matter/src/cert.rs
@@ -680,7 +680,7 @@ impl<'a> CertRef<'a> {
         Ok(w.as_slice().len())
     }
 
-    pub fn verify_chain_start(&self) -> CertVerifier {
+    pub fn verify_chain_start(&self) -> CertVerifier<'_> {
         CertVerifier::new(self)
     }
 

--- a/rs-matter/src/crypto.rs
+++ b/rs-matter/src/crypto.rs
@@ -97,7 +97,7 @@ impl ToTLV for KeyPair {
         tw.end_container()
     }
 
-    fn tlv_iter(&self, _tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, _tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         unimplemented!("Not implemented for `KeyPair`");
 
         #[allow(unreachable_code)]

--- a/rs-matter/src/dm/types/attribute.rs
+++ b/rs-matter/src/dm/types/attribute.rs
@@ -268,7 +268,7 @@ impl AttrDetails<'_> {
         }
     }
 
-    pub fn cluster(&self) -> Result<&Cluster, Error> {
+    pub fn cluster(&self) -> Result<&Cluster<'_>, Error> {
         self.node
             .endpoint(self.endpoint_id)
             .and_then(|endpoint| endpoint.cluster(self.cluster_id))

--- a/rs-matter/src/dm/types/privilege.rs
+++ b/rs-matter/src/dm/types/privilege.rs
@@ -51,7 +51,7 @@ impl ToTLV for Privilege {
         AccessControlEntryPrivilegeEnum::from(*self).to_tlv(tag, tw)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         TLV::u8(tag, AccessControlEntryPrivilegeEnum::from(*self) as _).into_tlv_iter()
     }
 }

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -97,7 +97,7 @@ impl ToTLV for IMStatusCode {
         tw.u16(tag, *self as _)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         TLV::u16(tag, *self as _).into_tlv_iter()
     }
 }
@@ -586,7 +586,7 @@ impl<'a> WriteReqRef<'a> {
             .unwrap_or(Ok(false))
     }
 
-    pub fn write_requests(&self) -> Result<TLVArray<'a, AttrData>, Error> {
+    pub fn write_requests(&self) -> Result<TLVArray<'a, AttrData<'_>>, Error> {
         TLVArray::new(self.0.r#struct()?.find_ctx(2)?)
     }
 
@@ -957,7 +957,7 @@ impl ToTLV for CmdPath {
         self.path.to_tlv(tag, tw)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         self.path.tlv_iter(tag)
     }
 }

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -68,7 +68,7 @@ pub trait ToTLV {
 
     /// Serialize the type as an iterator of `TLV` instances by potentially borrowing
     /// data from the type.
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>>;
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>>;
 }
 
 impl<T> ToTLV for &T
@@ -79,7 +79,7 @@ where
         (*self).to_tlv(tag, tw)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         (*self).tlv_iter(tag)
     }
 }
@@ -101,7 +101,7 @@ impl ToTLV for TLVElement<'_> {
         }
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         TLVElementTLVIter::Start(tag, self.clone())
     }
 }
@@ -158,7 +158,7 @@ impl ToTLV for TLVValue<'_> {
         tw.tlv(tag, self)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         TLV::new(tag, self.clone()).into_tlv_iter()
     }
 }

--- a/rs-matter/src/tlv/traits/array.rs
+++ b/rs-matter/src/tlv/traits/array.rs
@@ -64,7 +64,7 @@ where
         self.as_slice().to_tlv(tag, tw)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         tlv_array_iter(tag, self.iter())
     }
 }

--- a/rs-matter/src/tlv/traits/bitflags.rs
+++ b/rs-matter/src/tlv/traits/bitflags.rs
@@ -50,7 +50,7 @@ macro_rules! bitflags_tlv {
             fn tlv_iter(
                 &self,
                 tag: $crate::tlv::TLVTag,
-            ) -> impl Iterator<Item = Result<$crate::tlv::TLV, $crate::error::Error>> {
+            ) -> impl Iterator<Item = Result<$crate::tlv::TLV<'_>, $crate::error::Error>> {
                 $crate::tlv::TLV::$type(tag, self.bits()).into_tlv_iter()
             }
         }

--- a/rs-matter/src/tlv/traits/container.rs
+++ b/rs-matter/src/tlv/traits/container.rs
@@ -235,7 +235,7 @@ impl<T, C> ToTLV for TLVContainer<'_, T, C> {
         self.element.to_tlv(tag, tw)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         self.element.tlv_iter(tag)
     }
 }
@@ -341,7 +341,7 @@ where
         }
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         match self {
             Self::Array(array) => EitherIter::First(array.tlv_iter(tag)),
             Self::Slice(slice) => EitherIter::Second(slice.tlv_iter(tag)),

--- a/rs-matter/src/tlv/traits/maybe.rs
+++ b/rs-matter/src/tlv/traits/maybe.rs
@@ -98,7 +98,7 @@ impl<T: ToTLV> ToTLV for Maybe<T, AsNullable> {
         }
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         match self.as_opt_ref() {
             None => EitherIter::First(TLV::null(tag).into_tlv_iter()),
             Some(s) => EitherIter::Second(s.tlv_iter(tag)),
@@ -132,7 +132,7 @@ impl<T: ToTLV> ToTLV for Maybe<T, AsOptional> {
         }
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         use crate::tlv::EitherIter;
 
         match self.as_opt_ref() {
@@ -160,7 +160,7 @@ impl<T: ToTLV> ToTLV for Option<T> {
         }
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         match self.as_ref() {
             None => EitherIter::First(empty()),
             Some(s) => EitherIter::Second(s.tlv_iter(tag)),

--- a/rs-matter/src/tlv/traits/octets.rs
+++ b/rs-matter/src/tlv/traits/octets.rs
@@ -77,7 +77,7 @@ impl ToTLV for Octets<'_> {
         tw.str(tag, self.0)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         TLV::str(tag, self.0).into_tlv_iter()
     }
 }
@@ -163,7 +163,7 @@ impl<const N: usize> ToTLV for OctetsOwned<N> {
         tw.str(tag, &self.vec)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         TLV::str(tag, self.vec.as_slice()).into_tlv_iter()
     }
 }

--- a/rs-matter/src/tlv/traits/primitive.rs
+++ b/rs-matter/src/tlv/traits/primitive.rs
@@ -51,7 +51,7 @@ macro_rules! totlv_for {
                     tw.$t(tag, *self)
                 }
 
-                fn tlv_iter(&self, tag: $crate::tlv::TLVTag) -> impl Iterator<Item = Result<$crate::tlv::TLV, Error>> {
+                fn tlv_iter(&self, tag: $crate::tlv::TLVTag) -> impl Iterator<Item = Result<$crate::tlv::TLV<'_>, Error>> {
                     $crate::tlv::TLV::$t(tag, *self).into_tlv_iter()
                 }
             }
@@ -67,7 +67,7 @@ macro_rules! totlv_for_nonzero {
                     tw.$t(tag, self.get())
                 }
 
-                fn tlv_iter(&self, tag: $crate::tlv::TLVTag) -> impl Iterator<Item = Result<$crate::tlv::TLV, Error>> {
+                fn tlv_iter(&self, tag: $crate::tlv::TLVTag) -> impl Iterator<Item = Result<$crate::tlv::TLV<'_>, Error>> {
                     $crate::tlv::TLV::$t(tag, self.get()).into_tlv_iter()
                 }
             }

--- a/rs-matter/src/tlv/traits/vec.rs
+++ b/rs-matter/src/tlv/traits/vec.rs
@@ -70,7 +70,7 @@ where
         self.as_slice().to_tlv(tag, tw)
     }
 
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV, Error>> {
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         tlv_array_iter(tag, self.iter())
     }
 }

--- a/rs-matter/src/transport/network/wifi.rs
+++ b/rs-matter/src/transport/network/wifi.rs
@@ -15,5 +15,6 @@
  *    limitations under the License.
  */
 
+pub mod band;
 #[cfg(feature = "zbus")]
 pub mod wpa_supp;

--- a/rs-matter/src/transport/network/wifi/band.rs
+++ b/rs-matter/src/transport/network/wifi/band.rs
@@ -1,0 +1,155 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! A utility for converting a Wifi frequency to a Wifi band and channel
+
+use crate::dm::clusters::net_comm::WiFiBandEnum;
+
+/// Convert a Wifi frequency to a Wifi band and channel.
+///
+/// Return a tuple of `(WiFiBandEnum, u16)` where `WiFiBandEnum` is the band and `u16NonZeroU16` is the channel.
+/// If the frequency is not valid, return `None`.
+///
+/// See https://github.com/project-chip/connectedhomeip/blob/cd5fec9ba9be0c39f3c11f67d57b18b6bb2b4289/src/platform/Linux/ConnectivityManagerImpl.cpp#L1937
+pub fn band_and_channel(freq: u32) -> Option<(WiFiBandEnum, u16)> {
+    let mut band = WiFiBandEnum::V2G4;
+
+    let channel = if freq <= 931 {
+        if freq >= 916 {
+            ((freq - 916) * 2) - 1
+        } else if freq >= 902 {
+            (freq - 902) * 2
+        } else if freq >= 863 {
+            (freq - 863) * 2
+        } else {
+            1
+        }
+    } else if freq <= 2472 {
+        (freq - 2412) / 5 + 1
+    } else if freq == 2484 {
+        14
+    } else if (3600..=3700).contains(&freq) {
+        // Note: There are not many devices supports this band, and this band contains rational frequency in MHz, need to figure out
+        // the behavior of wpa_supplicant in this case.
+        band = WiFiBandEnum::V3G65;
+        0
+    } else if (5035..=5945).contains(&freq) || freq == 5960 || freq == 5980 {
+        band = WiFiBandEnum::V5G;
+        (freq - 5000) / 5
+    } else if (5955..58_000).contains(&freq) {
+        band = WiFiBandEnum::V6G;
+        (freq - 5950) / 5
+    } else if freq >= 58_000 {
+        band = WiFiBandEnum::V60G;
+
+        // Note: Some channel has the same center frequency but different bandwidth. Should figure out wpa_supplicant's behavior in
+        // this case. Also, wpa_supplicant's frequency property is uint16 infact.
+        match freq {
+            58_320 => 1,
+            60_480 => 2,
+            62_640 => 3,
+            64_800 => 4,
+            66_960 => 5,
+            69_120 => 6,
+            59_400 => 9,
+            61_560 => 10,
+            63_720 => 11,
+            65_880 => 12,
+            68_040 => 13,
+            _ => 0,
+        }
+    } else {
+        // Unknown channel
+        0
+    };
+
+    (channel > 0).then_some((band, channel as _))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_band_and_channel() {
+        // Not testing the 900MHz 802.11ah band, as it is country-specific and the likelyhood
+        // of having a device operating there is near 0%
+        //
+        // Branches for 900MHz band kept in the code for completeness, but not tested.
+
+        use super::band_and_channel;
+        use crate::dm::clusters::net_comm::WiFiBandEnum::{V2G4, V5G, V60G, V6G};
+
+        assert_eq!(Some((V2G4, 1)), band_and_channel(2412));
+        assert_eq!(Some((V2G4, 6)), band_and_channel(2437));
+        assert_eq!(Some((V2G4, 11)), band_and_channel(2462));
+        assert_eq!(Some((V2G4, 14)), band_and_channel(2484));
+        assert_eq!(None, band_and_channel(5000));
+
+        assert_eq!(Some((V5G, 7)), band_and_channel(5035));
+        assert_eq!(Some((V5G, 8)), band_and_channel(5040));
+        assert_eq!(Some((V5G, 9)), band_and_channel(5048));
+        assert_eq!(Some((V5G, 11)), band_and_channel(5055));
+        assert_eq!(Some((V5G, 12)), band_and_channel(5060));
+        assert_eq!(Some((V5G, 16)), band_and_channel(5080));
+
+        assert_eq!(Some((V5G, 36)), band_and_channel(5180));
+        assert_eq!(Some((V5G, 38)), band_and_channel(5190));
+        assert_eq!(Some((V5G, 40)), band_and_channel(5200));
+        assert_eq!(Some((V5G, 42)), band_and_channel(5210));
+        assert_eq!(Some((V5G, 44)), band_and_channel(5220));
+        assert_eq!(Some((V5G, 46)), band_and_channel(5230));
+        assert_eq!(Some((V5G, 48)), band_and_channel(5240));
+        assert_eq!(Some((V5G, 52)), band_and_channel(5260));
+        assert_eq!(Some((V5G, 56)), band_and_channel(5280));
+        assert_eq!(Some((V5G, 60)), band_and_channel(5300));
+        assert_eq!(Some((V5G, 64)), band_and_channel(5320));
+        assert_eq!(Some((V5G, 100)), band_and_channel(5500));
+        assert_eq!(Some((V5G, 104)), band_and_channel(5520));
+        assert_eq!(Some((V5G, 108)), band_and_channel(5540));
+        assert_eq!(Some((V5G, 112)), band_and_channel(5560));
+        assert_eq!(Some((V5G, 116)), band_and_channel(5580));
+        assert_eq!(Some((V5G, 120)), band_and_channel(5600));
+        assert_eq!(Some((V5G, 124)), band_and_channel(5620));
+        assert_eq!(Some((V5G, 128)), band_and_channel(5640));
+        assert_eq!(Some((V5G, 132)), band_and_channel(5660));
+        assert_eq!(Some((V5G, 136)), band_and_channel(5680));
+        assert_eq!(Some((V5G, 140)), band_and_channel(5700));
+        assert_eq!(Some((V5G, 144)), band_and_channel(5720));
+        assert_eq!(Some((V5G, 149)), band_and_channel(5745));
+        assert_eq!(Some((V5G, 153)), band_and_channel(5765));
+        assert_eq!(Some((V5G, 157)), band_and_channel(5785));
+        assert_eq!(Some((V5G, 161)), band_and_channel(5805));
+        assert_eq!(Some((V5G, 165)), band_and_channel(5825));
+
+        assert_eq!(Some((V5G, 187)), band_and_channel(5935));
+        assert_eq!(Some((V5G, 192)), band_and_channel(5960));
+        assert_eq!(Some((V5G, 196)), band_and_channel(5980));
+
+        assert_eq!(None, band_and_channel(5950));
+
+        assert_eq!(Some((V6G, 1)), band_and_channel(5955));
+        assert_eq!(Some((V6G, 5)), band_and_channel(5975));
+        assert_eq!(Some((V6G, 9)), band_and_channel(5995));
+
+        assert_eq!(Some((V60G, 1)), band_and_channel(58320));
+        assert_eq!(Some((V60G, 2)), band_and_channel(60480));
+        assert_eq!(Some((V60G, 3)), band_and_channel(62640));
+        assert_eq!(Some((V60G, 4)), band_and_channel(64800));
+        assert_eq!(Some((V60G, 5)), band_and_channel(66960));
+        assert_eq!(Some((V60G, 9)), band_and_channel(59400));
+        assert_eq!(Some((V60G, 10)), band_and_channel(61560));
+    }
+}

--- a/rs-matter/src/utils/ipv6.rs
+++ b/rs-matter/src/utils/ipv6.rs
@@ -38,6 +38,10 @@ pub fn create_link_local_ipv6(mac: &[u8; 6]) -> Ipv6Addr {
 mod tests {
     use super::*;
 
+    use crate::alloc::string::ToString;
+
+    extern crate alloc;
+
     #[test]
     fn test_create_link_local_ipv6() {
         let mac = [0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc];

--- a/rs-matter/src/utils/ipv6.rs
+++ b/rs-matter/src/utils/ipv6.rs
@@ -33,3 +33,23 @@ pub fn create_link_local_ipv6(mac: &[u8; 6]) -> Ipv6Addr {
         u16::from_be_bytes([mac[4], mac[5]]),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_link_local_ipv6() {
+        let mac = [0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc];
+        let ipv6 = create_link_local_ipv6(&mac);
+        assert_eq!(ipv6.to_string(), "fe80::1034:56ff:fe78:9abc");
+
+        let mac2 = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let ipv6_2 = create_link_local_ipv6(&mac2);
+        assert_eq!(ipv6_2.to_string(), "fe80::211:22ff:fe33:4455");
+
+        let mac3 = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        let ipv6_3 = create_link_local_ipv6(&mac3);
+        assert_eq!(ipv6_3.to_string(), "fe80::302:3ff:fe04:506");
+    }
+}


### PR DESCRIPTION
This PR contains two separate, unrelated commits:
- Commit 1: A follow-up to #279: Cover `band_and_channel` as well as `create_link_local_ipv6` with a unit tests; move `band_and_channel` to a shared module, as we'll need it for #281
- Commit 2: Run `cargo clippy --allow-dirty --fix` on the `rs-matter` workspace; this we need because latest Rust stable as well as nightly became more demanding in terms of explicitly typing out the anonymous lifetimes of functions. Without this 2nd commit, the CI for the 1st commit would fail, because the CI of `rs-matter` in general fails currently, because Rust stable changed in the meantime

EDIT: Also a minor Commit 3 which fixes the CI for `no_std` builds.