### PR TITLE
Enable chunking on attributes containing arrays

### DIFF
--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -72,7 +72,7 @@ static PSM: StaticCell<Psm<4096>> = StaticCell::new();
 static UNIT_TESTING_DATA: StaticCell<RefCell<UnitTestingHandlerData>> = StaticCell::new();
 
 fn main() -> Result<(), Error> {
-    // Enable detailed backtraces for debugging RefCell borrowing issues
+    // Enable detailed backtraces for debugging test failures
     std::env::set_var("RUST_BACKTRACE", "1");
 
     // Special logging configuration compatible with ConnectedHomeIP YAML tests

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -462,6 +462,7 @@ impl content_launcher::ClusterAsyncHandler for ContentHandler {
 
                 builder.set(RANDOM_MEDIA_HEADERS[index])
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 

--- a/rs-matter-macros/src/idl.rs
+++ b/rs-matter-macros/src/idl.rs
@@ -22927,7 +22927,7 @@ pub mod unit_testing {
         ) -> Result<(), rs_matter_crate::error::Error> {
             if let Some(mut writer) = reply.with_dataver(self.0.dataver())? {
                 if ctx.attr().is_system() {
-                    ctx.attr().cluster()?.read(ctx.attr().attr_id, writer)
+                    ctx.attr().cluster()?.read(ctx.attr(), writer)
                 } else {
                     match AttributeId::try_from(ctx.attr().attr_id)? {
                         AttributeId::Boolean => {

--- a/rs-matter-macros/src/idl/handler.rs
+++ b/rs-matter-macros/src/idl/handler.rs
@@ -298,7 +298,7 @@ pub fn handler_adaptor(
             ) -> Result<(), #krate::error::Error> {
                 if let Some(mut writer) = reply.with_dataver(self.0.dataver())? {
                     if ctx.attr().is_system() {
-                        ctx.attr().cluster()?.read(ctx.attr().attr_id, writer)
+                        ctx.attr().cluster()?.read(ctx.attr(), writer)
                     } else {
                         #read_stream
                     }
@@ -1408,7 +1408,7 @@ mod tests {
                     ) -> Result<(), rs_matter_crate::error::Error> {
                         if let Some(mut writer) = reply.with_dataver(self.0.dataver())? {
                             if ctx.attr().is_system() {
-                                ctx.attr().cluster()?.read(ctx.attr().attr_id, writer)
+                                ctx.attr().cluster()?.read(ctx.attr(), writer)
                             } else {
                                 match AttributeId::try_from(ctx.attr().attr_id)? {
                                     AttributeId::OnOff => {

--- a/rs-matter/src/cert.rs
+++ b/rs-matter/src/cert.rs
@@ -815,7 +815,7 @@ pub trait CertConsumer {
 
 #[cfg(test)]
 mod tests {
-    use crate::tlv::{FromTLV, TLVElement, TLVWriter, TagType, ToTLV};
+    use crate::tlv::{FromTLV, TLVElement, TagType, ToTLV};
     use crate::utils::storage::WriteBuf;
 
     use super::CertRef;
@@ -932,8 +932,7 @@ mod tests {
             let cert = unwrap!(CertRef::from_tlv(&root));
             let mut buf = [0u8; 1024];
             let mut wb = WriteBuf::new(&mut buf);
-            let mut tw = TLVWriter::new(&mut wb);
-            unwrap!(cert.to_tlv(&TagType::Anonymous, &mut tw));
+            unwrap!(cert.to_tlv(&TagType::Anonymous, &mut wb));
 
             let root2 = TLVElement::new(wb.as_slice());
             let cert2 = unwrap!(CertRef::from_tlv(&root2));

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -16,7 +16,6 @@
  */
 
 use core::cell::{Cell, RefCell};
-use core::iter::Peekable;
 use core::num::NonZeroU8;
 use core::pin::pin;
 use core::time::Duration;
@@ -24,14 +23,13 @@ use core::time::Duration;
 use embassy_futures::select::select3;
 use embassy_time::{Instant, Timer};
 
-use crate::error::*;
+use crate::error::{Error, ErrorCode};
 use crate::im::{
-    AttrStatus, IMStatusCode, InvReqRef, InvRespTag, OpCode, ReadReqRef, ReportDataReq,
-    ReportDataTag, StatusResp, SubscribeReqRef, SubscribeResp, TimedReq, WriteReqRef, WriteRespTag,
-    PROTO_ID_INTERACTION_MODEL,
+    IMStatusCode, InvReq, InvRespTag, OpCode, ReadReq, ReportDataReq, ReportDataTag, StatusResp,
+    SubscribeReq, SubscribeResp, TimedReq, WriteReq, WriteRespTag, PROTO_ID_INTERACTION_MODEL,
 };
 use crate::respond::ExchangeHandler;
-use crate::tlv::{get_root_node_struct, FromTLV, TLVElement, TLVTag, TLVWrite, TLVWriter};
+use crate::tlv::{get_root_node_struct, FromTLV, Nullable, TLVElement, TLVTag, TLVWrite};
 use crate::transport::exchange::{Exchange, MAX_EXCHANGE_RX_BUF_SIZE, MAX_EXCHANGE_TX_BUF_SIZE};
 use crate::utils::storage::pooled::BufferAccess;
 use crate::utils::storage::WriteBuf;
@@ -102,39 +100,46 @@ where
 
     /// Answer a responding exchange using the `DataModelHandler` instance wrapped by this exchange handler.
     pub async fn handle(&self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
-        let mut timeout_instant = None;
-
-        loop {
-            let mut repeat = false;
-
-            if exchange.rx().is_err() {
-                exchange.recv_fetch().await?;
-            }
-
+        let fetch_meta = |exchange: &mut Exchange| {
             let meta = exchange.rx()?.meta();
             if meta.proto_id != PROTO_ID_INTERACTION_MODEL {
                 Err(ErrorCode::InvalidProto)?;
             }
 
-            match meta.opcode::<OpCode>()? {
-                OpCode::ReadRequest => self.read(exchange).await?,
-                OpCode::WriteRequest => {
-                    repeat = self.write(exchange, timeout_instant.take()).await?;
-                }
-                OpCode::InvokeRequest => self.invoke(exchange, timeout_instant.take()).await?,
-                OpCode::SubscribeRequest => self.subscribe(exchange).await?,
-                OpCode::TimedRequest => {
-                    timeout_instant = Some(self.timed(exchange).await?);
-                    repeat = true;
-                }
-                opcode => {
-                    error!("Invalid opcode: {:?}", opcode);
-                    Err(ErrorCode::InvalidOpcode)?
-                }
-            }
+            Result::<_, Error>::Ok(meta)
+        };
 
-            if !repeat {
-                break;
+        if exchange.rx().is_err() {
+            exchange.recv_fetch().await?;
+        }
+
+        let mut meta = fetch_meta(exchange)?;
+
+        let timeout_instant = if meta.opcode::<OpCode>()? == OpCode::TimedRequest {
+            let timeout = self.timed(exchange).await?;
+
+            exchange.recv_fetch().await?;
+            meta = fetch_meta(exchange)?;
+
+            Some(timeout)
+        } else {
+            None
+        };
+
+        // TODO: Handle the cases where we receive a timeout request
+        // before read and subscribe. This is probably not allowed.
+
+        match meta.opcode::<OpCode>()? {
+            OpCode::ReadRequest => self.read(exchange).await?,
+            OpCode::WriteRequest => self.write(exchange, timeout_instant).await?,
+            OpCode::InvokeRequest => self.invoke(exchange, timeout_instant).await?,
+            OpCode::SubscribeRequest => self.subscribe(exchange).await?,
+            OpCode::TimedRequest => {
+                Self::send_status(exchange, IMStatusCode::InvalidAction).await?
+            }
+            opcode => {
+                error!("Invalid opcode: {:?}", opcode);
+                Err(ErrorCode::InvalidOpcode)?
             }
         }
 
@@ -144,217 +149,98 @@ where
         Ok(())
     }
 
+    /// Respond to a `ReadReq` request.
     async fn read(&self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
-        let Some(mut tx) = self.tx_buffer(exchange).await? else {
+        let Some((mut tx, rx)) = self.buffers(exchange).await? else {
             return Ok(());
         };
+
+        let read_req = ReadReq::new(TLVElement::new(&rx));
+        debug!("IM: Read request: {:?}", read_req);
+
+        let req = ReportDataReq::Read(&read_req);
 
         let mut wb = WriteBuf::new(&mut tx);
 
         let metadata = self.handler.lock().await;
-
-        let req = ReadReqRef::new(TLVElement::new(exchange.rx()?.payload()));
-        debug!("IM: Read request: {:?}", req);
-
-        let req = ReportDataReq::Read(&req);
-
-        let accessor = exchange.accessor()?;
-
-        // Will the clusters that are to be invoked await?
-        let mut awaits = false;
-
-        for item in metadata.node().read(&req, &exchange.accessor()?)? {
-            if item?
-                .map(|attr| {
-                    self.handler.read_awaits(ReadContextInstance::new(
-                        exchange,
-                        &self.handler,
-                        &self.buffers,
-                        &attr,
-                    ))
-                })
-                .unwrap_or(false)
-            {
-                awaits = true;
-                break;
-            }
-        }
-
-        if !awaits {
-            // No, they won't. Answer the request by directly using the RX packet
-            // of the transport layer, as the operation won't await.
-
-            let node = metadata.node();
-            let mut attrs = node.read(&req, &accessor)?.peekable();
-
-            if !req
-                .respond(
-                    &self.handler,
-                    &self.buffers,
-                    exchange,
-                    None,
-                    &mut attrs,
-                    &mut wb,
-                    true,
-                )
-                .await?
-            {
-                drop(attrs);
-
-                exchange.send(OpCode::ReportData, wb.as_slice()).await?;
-
-                // TODO: We are unconditionally using `suppress_resp = true` here.
-                // However, the spec is a bit unclear when `suppress_resp = true` is allowed.
-                //
-                // At one place, it says this is a decision of the caller (i.e. what we do)
-                // At another place, it says it is a decision of the caller, but _only_ if the
-                // sets of attributes and events to be reported are both empty.
-                //
-                // I've also noticed the other peer (Google Controller) to reply with a status code
-                // (that we don't expect due to `suppress_resp = true`) in the case of malformed response...
-                //
-                // Resolve this discrepancy in future.
-                // Self::recv_status(exchange).await?;
-
-                return Ok(());
-            }
-        }
-
-        // The clusters will await.
-        // Allocate a separate RX buffer then and copy the RX packet into this buffer,
-        // so as not to hold on to the transport layer (single) RX packet for too long
-        // and block send / receive for everybody
-
-        let Some(rx) = self.rx_buffer(exchange).await? else {
-            return Ok(());
-        };
-
-        let req = ReadReqRef::new(TLVElement::new(&rx));
-        let req = ReportDataReq::Read(&req);
-
         let node = metadata.node();
-        let mut attrs = node.read(&req, &accessor)?.peekable();
 
-        loop {
-            let more_chunks = req
-                .respond(
-                    &self.handler,
-                    &self.buffers,
-                    exchange,
-                    None,
-                    &mut attrs,
-                    &mut wb,
-                    true,
-                )
-                .await?;
+        let mut resp = ReportDataResponder::new(
+            &req,
+            &node,
+            None,
+            HandlerInvoker::new(exchange, &self.handler, &self.buffers),
+        );
 
-            exchange.send(OpCode::ReportData, wb.as_slice()).await?;
+        resp.respond(&mut wb, true).await?;
 
-            if more_chunks && !Self::recv_status_success(exchange).await? {
+        Ok(())
+    }
+
+    /// Respond to a `WriteReq` request.
+    ///
+    /// Arguments:
+    /// - `exchange` - the exchange to respond to
+    /// - `timeout_instant` - an optional timeout instant, if the request is a timed request
+    async fn write(
+        &self,
+        exchange: &mut Exchange<'_>,
+        timeout_instant: Option<Duration>,
+    ) -> Result<(), Error> {
+        while exchange.rx().is_ok() {
+            // Loop while there are more write request chunks to process
+
+            let Some((mut tx, rx)) = self.buffers(exchange).await? else {
+                break;
+            };
+
+            let req = WriteReq::new(TLVElement::new(&rx));
+            debug!("IM: Write request: {:?}", req);
+
+            let timed = req.timed_request()?;
+
+            if self.timed_out(exchange, timeout_instant, timed).await? {
                 break;
             }
 
-            if !more_chunks {
-                break;
+            let mut wb = WriteBuf::new(&mut tx);
+
+            let metadata = self.handler.lock().await;
+            let node = metadata.node();
+
+            let mut resp = WriteResponder::new(
+                &req,
+                &node,
+                HandlerInvoker::new(exchange, &self.handler, &self.buffers),
+            );
+
+            resp.respond(self, &mut wb).await?;
+
+            if req.more_chunks()? {
+                // This write request is just one of the chunks, so we need to wait and process
+                // the next chunk as well
+                exchange.recv_fetch().await?;
             }
         }
 
         Ok(())
     }
 
-    async fn write(
-        &self,
-        exchange: &mut Exchange<'_>,
-        timeout_instant: Option<Duration>,
-    ) -> Result<bool, Error> {
-        let req = WriteReqRef::new(TLVElement::new(exchange.rx()?.payload()));
-        debug!("IM: Write request: {:?}", req);
-
-        let timed = req.timed_request()?;
-
-        if self.timed_out(exchange, timeout_instant, timed).await? {
-            return Ok(false);
-        }
-
-        let Some(mut tx) = self.tx_buffer(exchange).await? else {
-            return Ok(false);
-        };
-
-        let mut wb = WriteBuf::new(&mut tx);
-
-        let metadata = self.handler.lock().await;
-
-        let req = WriteReqRef::new(TLVElement::new(exchange.rx()?.payload()));
-
-        // Will the clusters that are to be invoked await?
-        let mut awaits = false;
-
-        for item in metadata.node().write(&req, &exchange.accessor()?)? {
-            if item?
-                .map(|(attr, _)| {
-                    self.handler.write_awaits(WriteContextInstance::new(
-                        exchange,
-                        &self.handler,
-                        &self.buffers,
-                        &attr,
-                        &TLVElement::new(&[]),
-                        &(),
-                    ))
-                })
-                .unwrap_or(false)
-            {
-                awaits = true;
-                break;
-            }
-        }
-
-        let more_chunks = if awaits {
-            // Yes, they will
-            // Allocate a separate RX buffer then and copy the RX packet into this buffer,
-            // so as not to hold on to the transport layer (single) RX packet for too long
-            // and block send / receive for everybody
-
-            let Some(rx) = self.rx_buffer(exchange).await? else {
-                return Ok(false);
-            };
-
-            let req = WriteReqRef::new(TLVElement::new(&rx));
-
-            req.respond(
-                &self.handler,
-                &self.buffers,
-                exchange,
-                &metadata.node(),
-                self,
-                &mut wb,
-            )
-            .await?
-        } else {
-            // No, they won't. Answer the request by directly using the RX packet
-            // of the transport layer, as the operation won't await.
-
-            req.respond(
-                &self.handler,
-                &self.buffers,
-                exchange,
-                &metadata.node(),
-                self,
-                &mut wb,
-            )
-            .await?
-        };
-
-        exchange.send(OpCode::WriteResponse, wb.as_slice()).await?;
-
-        Ok(more_chunks)
-    }
-
+    /// Respond to an `InvokeReq` request.
+    ///
+    /// Arguments:
+    /// - `exchange` - the exchange to respond to
+    /// - `timeout_instant` - an optional timeout instant, if the request is a timed request
     async fn invoke(
         &self,
         exchange: &mut Exchange<'_>,
         timeout_instant: Option<Duration>,
     ) -> Result<(), Error> {
-        let req = InvReqRef::new(TLVElement::new(exchange.rx()?.payload()));
+        let Some((mut tx, rx)) = self.buffers(exchange).await? else {
+            return Ok(());
+        };
+
+        let req = InvReq::new(TLVElement::new(&rx));
         debug!("IM: Invoke request: {:?}", req);
 
         let timed = req.timed_request()?;
@@ -363,91 +249,29 @@ where
             return Ok(());
         }
 
-        let Some(mut tx) = self.tx_buffer(exchange).await? else {
-            return Ok(());
-        };
-
         let mut wb = WriteBuf::new(&mut tx);
 
         let metadata = self.handler.lock().await;
+        let node = metadata.node();
 
-        let req = InvReqRef::new(TLVElement::new(exchange.rx()?.payload()));
+        let mut resp = InvokeResponder::new(
+            &req,
+            &node,
+            HandlerInvoker::new(exchange, &self.handler, &self.buffers),
+        );
 
-        // Will the clusters that are to be invoked await?
-        let mut awaits = false;
-
-        for item in metadata.node().invoke(&req, &exchange.accessor()?)? {
-            if item?
-                .map(|(cmd, _)| {
-                    self.handler.invoke_awaits(InvokeContextInstance::new(
-                        exchange,
-                        &self.handler,
-                        &self.buffers,
-                        &cmd,
-                        &TLVElement::new(&[]),
-                        &(),
-                    ))
-                })
-                .unwrap_or(false)
-            {
-                awaits = true;
-                break;
-            }
-        }
-
-        if awaits {
-            // Yes, they will
-            // Allocate a separate RX buffer then and copy the RX packet into this buffer,
-            // so as not to hold on to the transport layer (single) RX packet for too long
-            // and block send / receive for everybody
-
-            let Some(rx) = self.rx_buffer(exchange).await? else {
-                return Ok(());
-            };
-
-            let req = InvReqRef::new(TLVElement::new(&rx));
-
-            req.respond(
-                &self.handler,
-                &self.buffers,
-                exchange,
-                &metadata.node(),
-                self,
-                &mut wb,
-                false,
-            )
-            .await?;
-        } else {
-            // No, they won't. Answer the request by directly using the RX packet
-            // of the transport layer, as the operation won't await.
-
-            req.respond(
-                &self.handler,
-                &self.buffers,
-                exchange,
-                &metadata.node(),
-                self,
-                &mut wb,
-                false,
-            )
-            .await?;
-        }
-
-        exchange.send(OpCode::InvokeResponse, wb.as_slice()).await?;
-
-        Ok(())
+        resp.respond(self, &mut wb, false).await
     }
 
+    /// Respond to a `SubscribeReq` request by priming the subscription (i.e. doing an initial data report)
+    /// and if the priming is successful, sending a `SubscribeResp` response to the peer and registering
+    /// the subscription details in the `Subscriptions` instance.
     async fn subscribe(&self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
-        let Some(rx) = self.rx_buffer(exchange).await? else {
+        let Some((mut tx, rx)) = self.buffers(exchange).await? else {
             return Ok(());
         };
 
-        let Some(mut tx) = self.tx_buffer(exchange).await? else {
-            return Ok(());
-        };
-
-        let req = SubscribeReqRef::new(TLVElement::new(&rx));
+        let req = SubscribeReq::new(TLVElement::new(&rx));
         debug!("IM: Subscribe request: {:?}", req);
 
         if let Err(err) = self.validate_subscribe(&req).await {
@@ -540,8 +364,8 @@ where
         Ok(())
     }
 
-    /// Validates the subscription request.
-    async fn validate_subscribe(&self, req: &SubscribeReqRef<'_>) -> Result<(), Error> {
+    /// Validates the subscription request
+    async fn validate_subscribe(&self, req: &SubscribeReq<'_>) -> Result<(), Error> {
         // As per spec, we need to validate that the subscription request
         // contains existing endpoints, clusters and attributes, and if not
         // we should (a bit surprisingly) return InvalidAction
@@ -571,6 +395,8 @@ where
         Ok(())
     }
 
+    /// Process all valid subscriptions in an endless loop, checking for changes
+    /// and reporting them to the peers.
     pub async fn process_subscriptions(&self, matter: &Matter<'_>) -> Result<(), Error> {
         loop {
             // TODO: Un-hardcode these 4 seconds of waiting when the more precise change detection logic is implemented
@@ -674,6 +500,15 @@ where
         }
     }
 
+    /// Process one valid subscription, reporting the data to the peer.
+    ///
+    /// Arguments:
+    /// - `matter` - a reference to the `Matter` instance
+    /// - `fabric_idx` - the fabric index of the peer
+    /// - `peer_node_id` - the node ID of the peer
+    /// - `session_id` - the session ID of the peer, if any
+    /// - `id` - the subscription ID
+    /// - `rx` - the received and saved data for the subscription, when the subscription was primed
     async fn process_subscription(
         &self,
         matter: &Matter<'_>,
@@ -721,6 +556,7 @@ where
         }
     }
 
+    /// Process a `TimedReq` request, which is used to set a timeout for the following Write/Invoke request.
     async fn timed(&self, exchange: &mut Exchange<'_>) -> Result<Duration, Error> {
         let req = TimedReq::from_tlv(&get_root_node_struct(exchange.rx()?.payload())?)?;
         debug!("IM: Timed request: {:?}", req);
@@ -732,6 +568,7 @@ where
         Ok(timeout_instant)
     }
 
+    /// A utility to check whether a timed request has timed out, and if so, send a timout status response
     async fn timed_out(
         &self,
         exchange: &mut Exchange<'_>,
@@ -760,6 +597,16 @@ where
         }
     }
 
+    /// A utility to respond with a `ReportData` response to a subscription request, which is used to report data to the peer.
+    ///
+    /// Arguments:
+    /// - `id` - the subscription ID
+    /// - `fabric_idx` - the fabric index of the peer
+    /// - `peer_node_id` - the node ID of the peer
+    /// - `rx` - the received data for the subscription, when the subscription was primed
+    /// - `tx` - the TX buffer to write the response to
+    /// - `exchange` - the exchange to respond to
+    /// - `with_dataver` - whether to include the data version in the response
     #[allow(clippy::too_many_arguments)]
     async fn report_data(
         &self,
@@ -776,53 +623,70 @@ where
     {
         let mut wb = WriteBuf::new(tx);
 
-        let req = SubscribeReqRef::new(TLVElement::new(rx));
+        let sub_req = SubscribeReq::new(TLVElement::new(rx));
         let req = if with_dataver {
-            ReportDataReq::Subscribe(&req)
+            ReportDataReq::Subscribe(&sub_req)
         } else {
-            ReportDataReq::SubscribeReport(&req)
+            ReportDataReq::SubscribeReport(&sub_req)
         };
 
         let metadata = self.handler.lock().await;
+        let node = metadata.node();
 
-        let accessor = exchange.accessor()?;
+        let mut resp = ReportDataResponder::new(
+            &req,
+            &node,
+            Some(id),
+            HandlerInvoker::new(exchange, &self.handler, &self.buffers),
+        );
 
-        {
-            let node = metadata.node();
-            let mut attrs = node.read(&req, &accessor)?.peekable();
+        let sub_valid = resp.respond(&mut wb, false).await?;
 
-            loop {
-                let more_chunks = req
-                    .respond(
-                        &self.handler,
-                        &self.buffers,
-                        exchange,
-                        Some(id),
-                        &mut attrs,
-                        &mut wb,
-                        false,
-                    )
-                    .await?;
+        if !sub_valid {
+            debug!(
+                "Subscription [F:{:x},P:{:x}]::{} removed during reporting",
+                fabric_idx, peer_node_id, id
+            );
+        }
 
-                exchange.send(OpCode::ReportData, wb.as_slice()).await?;
+        Ok(sub_valid)
+    }
 
-                if !Self::recv_status_success(exchange).await? {
-                    debug!(
-                        "Subscription [F:{:x},P:{:x}]::{} removed during reporting",
-                        fabric_idx, peer_node_id, id
-                    );
-                    return Ok(false);
-                }
-
-                if !more_chunks {
-                    break;
-                }
+    /// A utility to fetch a pair of TX/RX buffers for processing an Interaction Model request.
+    ///
+    /// If there are no free buffers available, this method will send a `Busy` status response to the peer.
+    ///
+    /// Upon returning:
+    /// - The RX buffer will contain the payload of the received Interaction Model request
+    /// - The TX buffer will be resized to `MAX_EXCHANGE_TX_BUF_SIZE` and will be ready to be written to
+    ///
+    /// Returns:
+    /// - `Ok(Some((tx, rx)))` - if both TX and RX buffers are available
+    /// - `Ok(None)` - if no buffers are available, and a `Busy` status response has been sent
+    /// - `Err(Error)` - if an error occurred while fetching the buffers or sending the status response
+    async fn buffers(
+        &self,
+        exchange: &mut Exchange<'_>,
+    ) -> Result<Option<(B::Buffer<'a>, B::Buffer<'a>)>, Error> {
+        if let Some(tx) = self.tx_buffer(exchange).await? {
+            if let Some(rx) = self.rx_buffer(exchange).await? {
+                return Ok(Some((tx, rx)));
             }
         }
 
-        Ok(true)
+        Ok(None)
     }
 
+    /// A utility to fetch a RX buffer for processing an Interaction Model request.
+    ///
+    /// If there are no free buffers available, this method will send a `Busy` status response to the peer.
+    ///
+    /// Upon returning, the RX buffer will contain the payload of the received Interaction Model request.
+    ///
+    /// Returns:
+    /// - `Ok(Some(rx))` - if a RX buffer is available
+    /// - `Ok(None)` - if no RX buffer is available, and a `Busy` status response has been sent
+    /// - `Err(Error)` - if an error occurred while fetching the buffer or sending the status response
     async fn rx_buffer(&self, exchange: &mut Exchange<'_>) -> Result<Option<B::Buffer<'a>>, Error> {
         if let Some(mut buffer) = self.buffer(exchange).await? {
             let rx = exchange.rx()?;
@@ -841,6 +705,16 @@ where
         }
     }
 
+    /// A utility to fetch a TX buffer for processing an Interaction Model request.
+    ///
+    /// If there are no free buffers available, this method will send a `Busy` status response to the peer.
+    ///
+    /// Upon returning, the TX buffer will be resized to `MAX_EXCHANGE_TX_BUF_SIZE` and will be ready to be written to.
+    ///
+    /// Returns:
+    /// - `Ok(Some(tx))` - if a TX buffer is available
+    /// - `Ok(None)` - if no TX buffer is available, and a `Busy` status response has been sent
+    /// - `Err(Error)` - if an error occurred while fetching the buffer or sending the status response
     async fn tx_buffer(&self, exchange: &mut Exchange<'_>) -> Result<Option<B::Buffer<'a>>, Error> {
         if let Some(mut buffer) = self.buffer(exchange).await? {
             // Always safe as `IMBuffer` is defined to be `MAX_EXCHANGE_RX_BUF_SIZE`, which is bigger than `MAX_EXCHANGE_TX_BUF_SIZE`
@@ -848,12 +722,21 @@ where
 
             Ok(Some(buffer))
         } else {
-            Self::send_status(exchange, IMStatusCode::Busy).await?;
-
             Ok(None)
         }
     }
 
+    /// A utility to fetch a buffer for processing an Interaction Model request.
+    ///
+    /// If there are no free buffers available, this method will send a `Busy` status response to the peer.
+    ///
+    /// Upon returning, the buffer will be UNINITIALIZED. I.e. it is up to the user to resize it appropriately
+    /// if it is to be used for sending a response, or to fill it with data, if it is to be used for receiving data.
+    ///
+    /// Returns:
+    /// - `Ok(Some(buffer))` - if a buffer is available
+    /// - `Ok(None)` - if no buffer is available, and a `Busy` status response has been sent
+    /// - `Err(Error)` - if an error occurred while fetching the buffer or sending the status response
     async fn buffer(&self, exchange: &mut Exchange<'_>) -> Result<Option<B::Buffer<'a>>, Error> {
         if let Some(buffer) = self.buffers.get().await {
             Ok(Some(buffer))
@@ -864,37 +747,7 @@ where
         }
     }
 
-    async fn recv_status_success(exchange: &mut Exchange<'_>) -> Result<bool, Error> {
-        let rx = exchange.recv().await?;
-        let opcode = rx.meta().proto_opcode;
-
-        if opcode != OpCode::StatusResponse as u8 {
-            warn!(
-                "Got opcode {:02x}, while expecting status code {:02x}",
-                opcode,
-                OpCode::StatusResponse as u8
-            );
-
-            return Err(ErrorCode::Invalid.into());
-        }
-
-        let resp = StatusResp::from_tlv(&get_root_node_struct(rx.payload())?)?;
-
-        if resp.status == IMStatusCode::Success {
-            Ok(true)
-        } else {
-            warn!(
-                "Got status response {:?}, aborting interaction",
-                resp.status
-            );
-
-            drop(rx);
-            exchange.acknowledge().await?;
-
-            Ok(false)
-        }
-    }
-
+    /// A utility to send a status response to the peer.
     async fn send_status(exchange: &mut Exchange<'_>, status: IMStatusCode) -> Result<(), Error> {
         exchange
             .send_with(|_, wb| {
@@ -927,115 +780,332 @@ where
     }
 }
 
-impl<'a> ReportDataReq<'a> {
-    // This is the amount of space we reserve for other things to be attached towards
-    // the end of long reads.
+/// This type responds with a `ReportData` response to all of:
+/// - A `ReadReq`
+/// - A `SubscribeReq`
+/// - A `SubscribeReportReq` (i.e. once a valid recorded subscription is detected as in a need to be reported on)
+///
+/// The responder handles chunking as needed. I.e. if reported data is too large to fit into a single
+/// Matter message, it will send the data in multiple chunks (i.e. with multiple Matter messages), waiting for
+/// a `Success` response from the peer after each chunk, and then continuing to send the next chunk until all data is sent.
+struct ReportDataResponder<'a, 'b, 'c, D, B> {
+    req: &'a ReportDataReq<'a>,
+    node: &'a Node<'a>,
+    subscription_id: Option<u32>,
+    invoker: HandlerInvoker<'b, 'c, D, B>,
+}
+
+impl<'a, 'b, 'c, D, B> ReportDataResponder<'a, 'b, 'c, D, B>
+where
+    D: AsyncHandler,
+    B: BufferAccess<IMBuffer>,
+{
+    // This is the amount of space we reserve for the structure/array closing TLVs
+    // to be attached towards the end of long reads
     const LONG_READS_TLV_RESERVE_SIZE: usize = 24;
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn respond<T, B, I>(
-        &self,
-        handler: T,
-        buffers: B,
-        exchange: &Exchange<'_>,
+    /// Create a new `ReportDataResponder`.
+    const fn new(
+        req: &'a ReportDataReq<'a>,
+        node: &'a Node<'a>,
         subscription_id: Option<u32>,
-        attrs: &mut Peekable<I>,
+        invoker: HandlerInvoker<'b, 'c, D, B>,
+    ) -> Self {
+        Self {
+            req,
+            node,
+            subscription_id,
+            invoker,
+        }
+    }
+
+    /// Respond to the request with a `ReportData` response, possibly with more than one
+    /// chunk if the data is too large to fit into a single Matter message.
+    ///
+    /// Arguments:
+    /// - `wb` - the buffer to use while sending the response
+    /// - `suppress_last_resp` - whether to suppress the response from the peer. When multiple Matter messages are
+    ///   being sent due to chunking, this is valid for the last chunk only, as the others - by necessity need to have a
+    ///   status response by the other peer
+    async fn respond(
+        &mut self,
         wb: &mut WriteBuf<'_>,
-        suppress_resp: bool,
-    ) -> Result<bool, Error>
-    where
-        T: DataModelHandler,
-        B: BufferAccess<IMBuffer>,
-        I: Iterator<Item = Result<Result<AttrDetails<'a>, AttrStatus>, Error>>,
-    {
-        wb.reset();
-        wb.shrink(Self::LONG_READS_TLV_RESERVE_SIZE)?;
+        suppress_last_resp: bool,
+    ) -> Result<bool, Error> {
+        let accessor = self.invoker.exchange().accessor()?;
 
-        let mut tw = TLVWriter::new(wb);
+        self.start_reply(wb)?;
 
-        tw.start_struct(&TLVTag::Anonymous)?;
+        for item in self.node.read(self.req, &accessor)? {
+            let item = item?;
 
-        if let Some(subscription_id) = subscription_id {
-            assert!(matches!(
-                self,
-                ReportDataReq::Subscribe(_) | ReportDataReq::SubscribeReport(_)
-            ));
-            tw.u32(
-                &TLVTag::Context(ReportDataTag::SubscriptionId as u8),
-                subscription_id,
-            )?;
-        } else {
-            assert!(matches!(self, ReportDataReq::Read(_)));
-        }
+            loop {
+                let result = self.invoker.process_read(&item, &mut *wb).await;
 
-        let has_requests = self.attr_requests()?.is_some();
+                match result {
+                    Ok(()) => break,
+                    Err(err) if err.code() == ErrorCode::NoSpace => {
+                        let array_attr = item.as_ref().ok().filter(|attr| {
+                            attr.list_index.is_none()
+                                // The whole attribute is requested
+                                // Check if it is an array, and if so, send it as individual items instead
+                                && self
+                                    .node
+                                    .endpoint(attr.endpoint_id)
+                                    .and_then(|e| e.cluster(attr.cluster_id))
+                                    .and_then(|c| c.attribute(attr.attr_id))
+                                    .map(|a| a.quality.contains(Quality::ARRAY))
+                                    .unwrap_or(false)
+                        });
 
-        if has_requests {
-            tw.start_array(&TLVTag::Context(ReportDataTag::AttributeReports as u8))?;
-        }
-
-        while let Some(item) = attrs.peek() {
-            match item {
-                Ok(item) => {
-                    if ReadReplyInstance::handle_read(exchange, item, &handler, &buffers, &mut tw)
-                        .await?
-                    {
-                        attrs.next();
-                    } else {
-                        break;
+                        if let Some(array_attr) = array_attr {
+                            if self.send_array_items(array_attr, wb).await? {
+                                break;
+                            } else {
+                                return Ok(false);
+                            }
+                        } else if !self.send(true, false, wb).await? {
+                            return Ok(false);
+                        }
                     }
-                }
-                Err(_) => {
-                    attrs.next().transpose()?;
+                    Err(err) => Err(err)?,
                 }
             }
         }
 
-        wb.expand(Self::LONG_READS_TLV_RESERVE_SIZE)?;
-        let tw = wb;
+        self.send(false, suppress_last_resp, wb).await
+    }
 
-        if has_requests {
-            tw.end_container()?;
+    /// Send the items of an array attribute one by one, until the end of the array is reached.
+    ///
+    /// The data is potentially sent in multiple chunks if it cannot fit into a single Matter message.
+    ///
+    /// Arguments:
+    /// - `attr` - the array attribute to send the items of
+    /// - `wb` - the buffer to use while sending the items
+    async fn send_array_items(
+        &mut self,
+        attr: &AttrDetails<'_>,
+        wb: &mut WriteBuf<'_>,
+    ) -> Result<bool, Error> {
+        let mut attr = attr.clone();
+
+        // First generate an empty array
+        let mut list_index = None;
+        attr.list_chunked = true;
+        attr.list_index = Some(Nullable::new(list_index));
+
+        loop {
+            let pos = wb.get_tail();
+
+            let result = self.invoker.read(&attr, &mut *wb).await;
+
+            if result.is_err() {
+                // If we got an error, we rewind to the position before the read
+                // and handle it accordingly
+                wb.rewind_to(pos);
+            }
+
+            match result {
+                Ok(()) => {
+                    // The empty array payload was sent
+                    // Now iterate over the array and send each item one by one as separate payload
+
+                    let new_list_index = if let Some(list_index) = list_index {
+                        list_index + 1
+                    } else {
+                        0
+                    };
+
+                    list_index = Some(new_list_index);
+                    attr.list_index = Some(Nullable::some(new_list_index));
+                }
+                Err(err) if err.code() == ErrorCode::NoSpace => {
+                    if !self.send(true, false, wb).await? {
+                        return Ok(false);
+                    }
+                }
+                Err(err) if err.code() == ErrorCode::ConstraintError => break, // Got to the end of the array
+                Err(err) => Err(err)?,
+            }
         }
 
-        let more_chunks = attrs.peek().is_some();
+        Ok(true)
+    }
+
+    /// Send the reply to the peer, potentially opening another reply.
+    ///
+    /// Arguments:
+    /// - `more_chunks`: whether there are more chunks to send. If `true`, this will initiate another reply in `wb`
+    /// - `suppress_last_resp`: whether to suppress the response from the peer. Note that if `more_chunks` is `true`,
+    ///   `suppress_last_resp` MUST be true and therefore it is set unconditionally
+    /// - `wb`: the buffer containing the reply. Once the reply is sent, the buffer is re-initialized for a new reply if `more_chunks` is `true`
+    async fn send(
+        &mut self,
+        more_chunks: bool,
+        suppress_last_resp: bool,
+        wb: &mut WriteBuf<'_>,
+    ) -> Result<bool, Error> {
+        self.end_reply(more_chunks, suppress_last_resp, wb)?;
+
+        self.invoker
+            .exchange()
+            .send(OpCode::ReportData, wb.as_slice())
+            .await?;
+
+        let cont: bool = if more_chunks || !suppress_last_resp {
+            self.recv_status_success().await?
+        } else {
+            false
+        };
 
         if more_chunks {
-            tw.bool(&TLVTag::Context(ReportDataTag::MoreChunkedMsgs as u8), true)?;
+            self.start_reply(wb)?;
+        }
+
+        Ok(cont)
+    }
+
+    /// Receive a status response from the peer
+    ///
+    /// If the response is not a status response, the method will fail with an `Invalid` error.
+    ///
+    /// Return `Ok(true)` if the response is a success response, `Ok(false)` if the response is not a success response.
+    async fn recv_status_success(&mut self) -> Result<bool, Error> {
+        let rx = self.invoker.exchange().recv().await?;
+        let opcode = rx.meta().proto_opcode;
+
+        if opcode != OpCode::StatusResponse as u8 {
+            warn!(
+                "Got opcode {:02x}, while expecting status code {:02x}",
+                opcode,
+                OpCode::StatusResponse as u8
+            );
+
+            return Err(ErrorCode::Invalid.into());
+        }
+
+        let resp = StatusResp::from_tlv(&get_root_node_struct(rx.payload())?)?;
+
+        if resp.status == IMStatusCode::Success {
+            Ok(true)
+        } else {
+            warn!(
+                "Got status response {:?}, aborting interaction",
+                resp.status
+            );
+
+            drop(rx);
+
+            self.invoker.exchange().acknowledge().await?;
+
+            Ok(false)
+        }
+    }
+
+    /// Start a reply by initializing the `WriteBuf` and writing the initial TLVs.
+    fn start_reply(&self, wb: &mut WriteBuf<'_>) -> Result<(), Error> {
+        wb.reset();
+        wb.shrink(Self::LONG_READS_TLV_RESERVE_SIZE)?;
+
+        wb.start_struct(&TLVTag::Anonymous)?;
+
+        if let Some(subscription_id) = self.subscription_id {
+            assert!(matches!(
+                self.req,
+                ReportDataReq::Subscribe(_) | ReportDataReq::SubscribeReport(_)
+            ));
+            wb.u32(
+                &TLVTag::Context(ReportDataTag::SubscriptionId as u8),
+                subscription_id,
+            )?;
+        } else {
+            assert!(matches!(self.req, ReportDataReq::Read(_)));
+        }
+
+        let has_requests = self.req.attr_requests()?.is_some();
+
+        if has_requests {
+            wb.start_array(&TLVTag::Context(ReportDataTag::AttributeReports as u8))?;
+        }
+
+        Ok(())
+    }
+
+    /// End a reply by writing the closing TLVs and potentially indicating that there are more chunks to send.
+    fn end_reply(
+        &self,
+        more_chunks: bool,
+        suppress_resp: bool,
+        wb: &mut WriteBuf<'_>,
+    ) -> Result<(), Error> {
+        wb.expand(Self::LONG_READS_TLV_RESERVE_SIZE)?;
+
+        let has_requests = self.req.attr_requests()?.is_some();
+
+        if has_requests {
+            wb.end_container()?;
+        }
+
+        if more_chunks {
+            wb.bool(&TLVTag::Context(ReportDataTag::MoreChunkedMsgs as u8), true)?;
         }
 
         if !more_chunks && suppress_resp {
-            tw.bool(&TLVTag::Context(ReportDataTag::SupressResponse as u8), true)?;
+            wb.bool(&TLVTag::Context(ReportDataTag::SupressResponse as u8), true)?;
         }
 
-        tw.end_container()?;
+        wb.end_container()?;
 
-        Ok(more_chunks)
+        Ok(())
     }
 }
 
-impl WriteReqRef<'_> {
-    async fn respond<T, B>(
-        &self,
-        handler: T,
-        buffers: B,
-        exchange: &Exchange<'_>,
-        node: &Node<'_>,
+/// This type responds to a `WriteReq` by invoking the
+/// corresponding handlers for each write attribute in the request.
+///
+/// The responser assumes that all response data can fit in a single Matter message,
+/// which is a fair assumption and as per the Matter spec, in that the response of a
+/// write request is always shorter than the write request itself, so given that the
+/// write request fits in a single Matter message, the write reponse should as well.
+///
+/// With that said, the write request might itself be just one out of many chunks that
+/// the other peers is sending, but processing all of those chunks is not done here,
+/// but is rather - a responsibility of the caller who should call in a loop `WriteResponder::respond`
+/// for all the chunks of the write request, until the `WriteReq::more_chunks()` returns `false`.
+struct WriteResponder<'a, 'b, 'c, D, B> {
+    req: &'a WriteReq<'a>,
+    node: &'a Node<'a>,
+    invoker: HandlerInvoker<'b, 'c, D, B>,
+}
+
+impl<'a, 'b, 'c, D, B> WriteResponder<'a, 'b, 'c, D, B>
+where
+    D: AsyncHandler,
+    B: BufferAccess<IMBuffer>,
+{
+    /// Create a new `WriteResponder`.
+    const fn new(
+        req: &'a WriteReq<'a>,
+        node: &'a Node<'a>,
+        invoker: HandlerInvoker<'b, 'c, D, B>,
+    ) -> Self {
+        Self { req, node, invoker }
+    }
+
+    /// Respond to the write request by processing each write attribute in the request
+    /// and sending a response back.
+    async fn respond(
+        &mut self,
         notify: &dyn ChangeNotify,
         wb: &mut WriteBuf<'_>,
-    ) -> Result<bool, Error>
-    where
-        T: DataModelHandler,
-        B: BufferAccess<IMBuffer>,
-    {
-        let accessor = exchange.accessor()?;
+    ) -> Result<(), Error> {
+        let accessor = self.invoker.exchange().accessor()?;
 
         wb.reset();
 
-        let mut tw = TLVWriter::new(wb);
-
-        tw.start_struct(&TLVTag::Anonymous)?;
-        tw.start_array(&TLVTag::Context(WriteRespTag::WriteResponses as u8))?;
+        wb.start_struct(&TLVTag::Anonymous)?;
+        wb.start_array(&TLVTag::Context(WriteRespTag::WriteResponses as u8))?;
 
         // The spec expects that a single write request like DeleteList + AddItem
         // should cause all ACLs of that fabric to be deleted and the new one to be added (Case 1).
@@ -1048,66 +1118,94 @@ impl WriteReqRef<'_> {
         // Thus we support the Case1 by doing this. It does come at the cost of maintaining an
         // additional list of expanded write requests as we start processing those.
         let write_attrs: heapless::Vec<_, MAX_WRITE_ATTRS_IN_ONE_TRANS> =
-            node.write(self, &accessor)?.collect();
+            self.node.write(self.req, &accessor)?.collect();
 
         for item in write_attrs {
-            ReadReplyInstance::handle_write(exchange, &item?, &handler, &buffers, &mut tw, notify)
-                .await?;
+            self.invoker.process_write(&item?, &mut *wb, notify).await?;
         }
 
-        tw.end_container()?;
-        tw.end_container()?;
+        wb.end_container()?;
+        wb.end_container()?;
 
-        self.more_chunked()
+        self.invoker
+            .exchange()
+            .send(OpCode::WriteResponse, wb.as_slice())
+            .await
     }
 }
 
-impl InvReqRef<'_> {
-    #[allow(clippy::too_many_arguments)]
-    async fn respond<T, B>(
-        &self,
-        handler: T,
-        buffers: B,
-        exchange: &Exchange<'_>,
-        node: &Node<'_>,
+/// This type responds to an `InvRequest` by invoking the
+/// corresponding handlers for each command in the invoke request.
+///
+/// NOTE: In future, this responder should support chunking in that
+/// if the reply to all the commands in the invoke request is too large to fit
+/// into a single Matter message, it should send the response in multiple chunks.
+///
+/// The simplest strategy for chunking would be to simply - and unconditionally - send each individual
+/// command response in a separate Matter message, i.e. if the invoke request contains 3 commands,
+/// the responder will send 3 Matter messages, each containing a single command response.
+struct InvokeResponder<'a, 'b, 'c, D, B> {
+    req: &'a InvReq<'a>,
+    node: &'a Node<'a>,
+    invoker: HandlerInvoker<'b, 'c, D, B>,
+}
+
+impl<'a, 'b, 'c, D, B> InvokeResponder<'a, 'b, 'c, D, B>
+where
+    D: AsyncHandler,
+    B: BufferAccess<IMBuffer>,
+{
+    /// Create a new `InvokeResponder`.
+    const fn new(
+        req: &'a InvReq<'a>,
+        node: &'a Node<'a>,
+        invoker: HandlerInvoker<'b, 'c, D, B>,
+    ) -> Self {
+        Self { req, node, invoker }
+    }
+
+    /// Respond to the invoke request by processing each command in the request
+    /// and sending one or more reponses back.
+    async fn respond(
+        &mut self,
         notify: &dyn ChangeNotify,
         wb: &mut WriteBuf<'_>,
         suppress_resp: bool,
-    ) -> Result<(), Error>
-    where
-        T: DataModelHandler,
-        B: BufferAccess<IMBuffer>,
-    {
+    ) -> Result<(), Error> {
         wb.reset();
 
-        let mut tw = TLVWriter::new(wb);
-
-        tw.start_struct(&TLVTag::Anonymous)?;
+        wb.start_struct(&TLVTag::Anonymous)?;
 
         // Suppress Response -> TODO: Need to revisit this for cases where we send a command back
-        tw.bool(
+        wb.bool(
             &TLVTag::Context(InvRespTag::SupressResponse as u8),
             suppress_resp,
         )?;
 
-        let has_requests = self.inv_requests()?.is_some();
+        let has_requests = self.req.inv_requests()?.is_some();
 
         if has_requests {
-            tw.start_array(&TLVTag::Context(InvRespTag::InvokeResponses as u8))?;
+            wb.start_array(&TLVTag::Context(InvRespTag::InvokeResponses as u8))?;
         }
 
-        let accessor = exchange.accessor()?;
+        let accessor = self.invoker.exchange().accessor()?;
 
-        for item in node.invoke(self, &accessor)? {
-            InvokeReplyInstance::handle(&item?, &handler, &buffers, &mut tw, exchange, notify)
+        for item in self.node.invoke(self.req, &accessor)? {
+            self.invoker
+                .process_invoke(&item?, &mut *wb, notify)
                 .await?;
         }
 
         if has_requests {
-            tw.end_container()?;
+            wb.end_container()?;
         }
 
-        tw.end_container()?;
+        wb.end_container()?;
+
+        self.invoker
+            .exchange()
+            .send(OpCode::InvokeResponse, wb.as_slice())
+            .await?;
 
         Ok(())
     }

--- a/rs-matter/src/dm/clusters/desc.rs
+++ b/rs-matter/src/dm/clusters/desc.rs
@@ -171,6 +171,7 @@ impl ClusterHandler for DescHandler<'_> {
                     .revision(dev_type.drev)?
                     .end()
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -196,6 +197,7 @@ impl ClusterHandler for DescHandler<'_> {
 
                 builder.set(&cluster.id)
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -210,6 +212,7 @@ impl ClusterHandler for DescHandler<'_> {
         match builder {
             ArrayAttributeRead::ReadAll(builder) => builder.end(),
             ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -241,6 +244,7 @@ impl ClusterHandler for DescHandler<'_> {
 
                 builder.set(&ep_id)
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 }

--- a/rs-matter/src/dm/clusters/gen_diag.rs
+++ b/rs-matter/src/dm/clusters/gen_diag.rs
@@ -244,6 +244,7 @@ impl ClusterHandler for GenDiagHandler<'_> {
                     ErrorCode::InvalidAction.into() // TODO
                 })
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 

--- a/rs-matter/src/dm/clusters/grp_key_mgmt.rs
+++ b/rs-matter/src/dm/clusters/grp_key_mgmt.rs
@@ -66,6 +66,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         match builder {
             ArrayAttributeRead::ReadAll(builder) => builder.end(),
             ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -80,6 +81,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         match builder {
             ArrayAttributeRead::ReadAll(builder) => builder.end(),
             ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 

--- a/rs-matter/src/dm/clusters/net_comm.rs
+++ b/rs-matter/src/dm/clusters/net_comm.rs
@@ -748,6 +748,7 @@ where
                     Err(ErrorCode::ConstraintError.into())
                 }
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -800,6 +801,7 @@ where
                     Err(ErrorCode::ConstraintError.into())
                 }
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -152,6 +152,7 @@ impl ClusterHandler for NocHandler {
                     Err(ErrorCode::ConstraintError.into())
                 }
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -204,6 +205,7 @@ impl ClusterHandler for NocHandler {
                     Err(ErrorCode::ConstraintError.into())
                 }
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -244,6 +246,7 @@ impl ClusterHandler for NocHandler {
                     Err(ErrorCode::ConstraintError.into())
                 }
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 

--- a/rs-matter/src/dm/clusters/thread_diag.rs
+++ b/rs-matter/src/dm/clusters/thread_diag.rs
@@ -492,6 +492,7 @@ impl ClusterHandler for ThreadDiagHandler<'_> {
                     Err(ErrorCode::InvalidAction.into())
                 }
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -533,6 +534,7 @@ impl ClusterHandler for ThreadDiagHandler<'_> {
                     Err(ErrorCode::InvalidAction.into())
                 }
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -656,6 +658,7 @@ impl ClusterHandler for ThreadDiagHandler<'_> {
                     Err(ErrorCode::InvalidAction.into())
                 }
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 

--- a/rs-matter/src/dm/clusters/unit_testing.rs
+++ b/rs-matter/src/dm/clusters/unit_testing.rs
@@ -338,7 +338,20 @@ impl UnitTestingHandlerData {
             range_restricted_int_8_s: -20,
             range_restricted_int_16_u: 200,
             range_restricted_int_16_s: -100,
-            list_long_octet_string <- Vec::init(),
+            list_long_octet_string <- Vec::init().chain(|vec| {
+                for _ in 0..4 {
+                    let item = Vec::init()
+                        .chain(|item| {
+                            unwrap!(item.extend_from_slice(b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"));
+
+                            Ok(())
+                        });
+
+                    unwrap!(vec.push_init_unchecked(item));
+                }
+
+                Ok(())
+            }),
             list_fabric_scoped <- Vec::init(),
             timed_write_boolean: false,
             nullable_boolean <- Nullable::init_none(),
@@ -541,6 +554,7 @@ impl ClusterHandler for UnitTestingHandler<'_> {
 
                 builder.end()
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -567,6 +581,7 @@ impl ClusterHandler for UnitTestingHandler<'_> {
 
                 builder.end()
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -605,6 +620,7 @@ impl ClusterHandler for UnitTestingHandler<'_> {
 
                 builder.end()
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -755,6 +771,7 @@ impl ClusterHandler for UnitTestingHandler<'_> {
 
                 builder.end()
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 
@@ -823,6 +840,7 @@ impl ClusterHandler for UnitTestingHandler<'_> {
 
                 builder.end()
             }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         }
     }
 

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -27,7 +27,7 @@ use super::{AttrDetails, ClusterId, CmdDetails, EndptId, InvokeReply, ReadReply}
 
 pub use asynch::*;
 
-pub(crate) trait ChangeNotify {
+pub trait ChangeNotify {
     fn notify(&self, endpt: EndptId, clust: ClusterId);
 }
 

--- a/rs-matter/src/dm/types/privilege.rs
+++ b/rs-matter/src/dm/types/privilege.rs
@@ -151,7 +151,7 @@ bitflags! {
         const FIXED = 0x04;      // Short: F
         const NULLABLE = 0x08;   // Short: X
         const OPTIONAL = 0x10;   // Short: O
-        const ARRAY = 0x20;     // Short: A
+        const ARRAY = 0x20;
 
         const SN = Self::SCENE.bits() | Self::PERSISTENT.bits();
         const S = Self::SCENE.bits();

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -177,8 +177,9 @@ impl GenericPath {
             _ => Err(ErrorCode::Invalid.into()),
         }
     }
+
     /// Returns true, if the path is wildcard
-    pub fn is_wildcard(&self) -> bool {
+    pub const fn is_wildcard(&self) -> bool {
         !matches!(
             *self,
             GenericPath {
@@ -195,9 +196,9 @@ impl GenericPath {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ReportDataReq<'a> {
-    Read(&'a ReadReqRef<'a>),
-    Subscribe(&'a SubscribeReqRef<'a>),
-    SubscribeReport(&'a SubscribeReqRef<'a>),
+    Read(&'a ReadReq<'a>),
+    Subscribe(&'a SubscribeReq<'a>),
+    SubscribeReport(&'a SubscribeReq<'a>),
 }
 
 impl<'a> ReportDataReq<'a> {
@@ -250,27 +251,11 @@ impl SubscribeResp {
     }
 }
 
-#[derive(Debug, Default, Clone, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub struct SubscribeReq<'a> {
-    pub keep_subs: bool,
-    pub min_int_floor: u16,
-    pub max_int_ceil: u16,
-    pub attr_requests: Option<TLVArray<'a, AttrPath>>,
-    pub event_requests: Option<TLVArray<'a, EventPath>>,
-    pub event_filters: Option<TLVArray<'a, EventFilter>>,
-    // The Context Tags are discontiguous for some reason
-    pub _dummy: Option<bool>,
-    pub fabric_filtered: bool,
-    pub dataver_filters: Option<TLVArray<'a, DataVersionFilter>>,
-}
-
 #[derive(FromTLV, ToTLV, Clone, PartialEq, Eq, Hash)]
 #[tlvargs(lifetime = "'a")]
-pub struct SubscribeReqRef<'a>(TLVElement<'a>);
+pub struct SubscribeReq<'a>(TLVElement<'a>);
 
-impl<'a> SubscribeReqRef<'a> {
+impl<'a> SubscribeReq<'a> {
     pub const fn new(element: TLVElement<'a>) -> Self {
         Self(element)
     }
@@ -308,7 +293,7 @@ impl<'a> SubscribeReqRef<'a> {
     }
 }
 
-impl fmt::Debug for SubscribeReqRef<'_> {
+impl fmt::Debug for SubscribeReq<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SubscribeReqRef")
             .field("keep_subs", &self.keep_subs())
@@ -324,7 +309,7 @@ impl fmt::Debug for SubscribeReqRef<'_> {
 }
 
 #[cfg(feature = "defmt")]
-impl defmt::Format for SubscribeReqRef<'_> {
+impl defmt::Format for SubscribeReq<'_> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f,
             "SubscribeReqRef {{\n  keep_subs: {:?},\n  min_int_floor: {:?},\n  max_int_ceil: {:?},\n  attr_requests: {:?},\n  event_requests: {:?},\n  event_filters: {:?},\n  fabric_filtered: {:?},\n  dataver_filters: {:?},\n}}",
@@ -377,20 +362,11 @@ pub enum InvReqTag {
     InvokeRequests = 2,
 }
 
-#[derive(Debug, Default, Clone, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub struct InvReq<'a> {
-    pub suppress_response: Option<bool>,
-    pub timed_request: Option<bool>,
-    pub inv_requests: Option<TLVArray<'a, CmdData<'a>>>,
-}
-
 #[derive(FromTLV, ToTLV, Clone, PartialEq, Eq, Hash)]
 #[tlvargs(lifetime = "'a")]
-pub struct InvReqRef<'a>(TLVElement<'a>);
+pub struct InvReq<'a>(TLVElement<'a>);
 
-impl<'a> InvReqRef<'a> {
+impl<'a> InvReq<'a> {
     pub const fn new(element: TLVElement<'a>) -> Self {
         Self(element)
     }
@@ -418,7 +394,7 @@ impl<'a> InvReqRef<'a> {
     }
 }
 
-impl fmt::Debug for InvReqRef<'_> {
+impl fmt::Debug for InvReq<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("InvReqRef")
             .field("suppress_response", &self.suppress_response())
@@ -429,7 +405,7 @@ impl fmt::Debug for InvReqRef<'_> {
 }
 
 #[cfg(feature = "defmt")]
-impl defmt::Format for InvReqRef<'_> {
+impl defmt::Format for InvReq<'_> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f,
             "InvReqRef {{\n  suppress_response: {:?},\n  timed_request: {:?},\n  inv_requests: {:?},\n}}",
@@ -458,22 +434,11 @@ pub enum InvRespTag {
     InvokeResponses = 1,
 }
 
-#[derive(Debug, Default, Clone, ToTLV, FromTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub struct ReadReq<'a> {
-    pub attr_requests: Option<TLVArray<'a, AttrPath>>,
-    pub event_requests: Option<TLVArray<'a, EventPath>>,
-    pub event_filters: Option<TLVArray<'a, EventFilter>>,
-    pub fabric_filtered: bool,
-    pub dataver_filters: Option<TLVArray<'a, DataVersionFilter>>,
-}
-
 #[derive(FromTLV, ToTLV, Clone, PartialEq, Eq, Hash)]
 #[tlvargs(lifetime = "'a")]
-pub struct ReadReqRef<'a>(TLVElement<'a>);
+pub struct ReadReq<'a>(TLVElement<'a>);
 
-impl<'a> ReadReqRef<'a> {
+impl<'a> ReadReq<'a> {
     pub const fn new(element: TLVElement<'a>) -> Self {
         Self(element)
     }
@@ -499,7 +464,7 @@ impl<'a> ReadReqRef<'a> {
     }
 }
 
-impl fmt::Debug for ReadReqRef<'_> {
+impl fmt::Debug for ReadReq<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ReadReqRef")
             .field("attr_requests", &self.attr_requests())
@@ -512,7 +477,7 @@ impl fmt::Debug for ReadReqRef<'_> {
 }
 
 #[cfg(feature = "defmt")]
-impl defmt::Format for ReadReqRef<'_> {
+impl defmt::Format for ReadReq<'_> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f,
             "ReadReqRef {{\n  attr_requests: {:?},\n  event_requests: {:?},\n  event_filters: {:?},\n  fabric_filtered: {:?},\n  dataver_filters: {:?},\n}}",
@@ -538,16 +503,6 @@ pub enum ReadReqTag {
     DataVersionFilters = 4,
 }
 
-#[derive(Debug, Clone, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub struct WriteReq<'a> {
-    pub supress_response: Option<bool>,
-    pub timed_request: Option<bool>,
-    pub write_requests: TLVArray<'a, AttrData<'a>>,
-    pub more_chunked: Option<bool>,
-}
-
 // This enum is helpful when we are constructing the request
 // step by step in incremental manner
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -562,9 +517,9 @@ pub enum WriteReqTag {
 
 #[derive(FromTLV, ToTLV, Clone, PartialEq, Eq, Hash)]
 #[tlvargs(lifetime = "'a")]
-pub struct WriteReqRef<'a>(TLVElement<'a>);
+pub struct WriteReq<'a>(TLVElement<'a>);
 
-impl<'a> WriteReqRef<'a> {
+impl<'a> WriteReq<'a> {
     pub const fn new(element: TLVElement<'a>) -> Self {
         Self(element)
     }
@@ -591,7 +546,7 @@ impl<'a> WriteReqRef<'a> {
         TLVArray::new(self.0.r#struct()?.find_ctx(2)?)
     }
 
-    pub fn more_chunked(&self) -> Result<bool, Error> {
+    pub fn more_chunks(&self) -> Result<bool, Error> {
         self.0
             .r#struct()?
             .find_ctx(3)?
@@ -601,26 +556,26 @@ impl<'a> WriteReqRef<'a> {
     }
 }
 
-impl fmt::Debug for WriteReqRef<'_> {
+impl fmt::Debug for WriteReq<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WriteReqRef")
             .field("supress_response", &self.supress_response())
             .field("timed_request", &self.timed_request())
             .field("write_requests", &self.write_requests())
-            .field("more_chunked", &self.more_chunked())
+            .field("more_chunks", &self.more_chunks())
             .finish()
     }
 }
 
 #[cfg(feature = "defmt")]
-impl defmt::Format for WriteReqRef<'_> {
+impl defmt::Format for WriteReq<'_> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f,
-            "WriteReqRef {{\n  supress_response: {:?},\n  timed_request: {:?},\n  write_requests: {:?},\n  more_chunked: {:?},\n}}",
+            "WriteReqRef {{\n  supress_response: {:?},\n  timed_request: {:?},\n  write_requests: {:?},\n  more_chunks: {:?},\n}}",
             self.supress_response(),
             self.timed_request(),
             self.write_requests(),
-            self.more_chunked(),
+            self.more_chunks(),
         )
     }
 }
@@ -668,7 +623,7 @@ pub enum CmdResp<'a> {
 }
 
 impl CmdResp<'_> {
-    pub fn status_new(
+    pub const fn status_new(
         cmd_path: CmdPath,
         status: IMStatusCode,
         cluster_status: Option<u16>,
@@ -705,7 +660,7 @@ pub struct CmdStatus {
 }
 
 impl CmdStatus {
-    pub fn new(path: CmdPath, status: IMStatusCode, cluster_status: Option<u16>) -> Self {
+    pub const fn new(path: CmdPath, status: IMStatusCode, cluster_status: Option<u16>) -> Self {
         Self {
             path,
             status: Status {
@@ -744,7 +699,7 @@ pub struct Status {
 }
 
 impl Status {
-    pub fn new(status: IMStatusCode, cluster_status: Option<u16>) -> Status {
+    pub const fn new(status: IMStatusCode, cluster_status: Option<u16>) -> Status {
         Status {
             status,
             cluster_status,
@@ -800,7 +755,7 @@ pub struct AttrData<'a> {
 }
 
 impl<'a> AttrData<'a> {
-    pub fn new(data_ver: Option<u32>, path: AttrPath, data: TLVElement<'a>) -> Self {
+    pub const fn new(data_ver: Option<u32>, path: AttrPath, data: TLVElement<'a>) -> Self {
         Self {
             data_ver,
             path,
@@ -867,7 +822,11 @@ pub struct AttrStatus {
 }
 
 impl AttrStatus {
-    pub fn new(path: &GenericPath, status: IMStatusCode, cluster_status: Option<u16>) -> Self {
+    pub const fn new(
+        path: &GenericPath,
+        status: IMStatusCode,
+        cluster_status: Option<u16>,
+    ) -> Self {
         Self {
             path: AttrPath::new(path),
             status: Status::new(status, cluster_status),
@@ -927,7 +886,7 @@ macro_rules! cmd_path_ib {
 }
 
 impl CmdPath {
-    pub fn new(
+    pub const fn new(
         endpoint: Option<EndptId>,
         cluster: Option<ClusterId>,
         command: Option<CmdId>,

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -222,7 +222,7 @@ mod tests {
 
     use rs_matter_macros::{FromTLV, ToTLV};
 
-    use crate::tlv::{Octets, TLVElement, TLVWriter, TLV};
+    use crate::tlv::{Octets, TLVElement, TLV};
     use crate::utils::init::InitMaybeUninit;
     use crate::utils::storage::WriteBuf;
 
@@ -244,27 +244,26 @@ mod tests {
 
     fn test_to_tlv<T: ToTLV>(t: T, expected: &[u8]) {
         let mut buf = [0; 20];
-        let mut writebuf = WriteBuf::new(&mut buf);
-        let mut tw = TLVWriter::new(&mut writebuf);
+        let mut tw = WriteBuf::new(&mut buf);
 
         t.to_tlv(&TLVTag::Anonymous, &mut tw).unwrap();
 
-        assert_eq!(writebuf.as_slice(), expected);
+        assert_eq!(tw.as_slice(), expected);
 
-        writebuf.reset();
+        tw.reset();
 
         let mut iter = t
             .tlv_iter(TLVTag::Anonymous)
             .flat_map(TLV::result_into_bytes_iter);
         loop {
             match iter.next() {
-                Some(Ok(byte)) => writebuf.append(&[byte]).unwrap(),
+                Some(Ok(byte)) => tw.append(&[byte]).unwrap(),
                 None => break,
                 _ => panic!("Error in iterator"),
             }
         }
 
-        ::core::assert_eq!(writebuf.as_slice(), expected);
+        ::core::assert_eq!(tw.as_slice(), expected);
     }
 
     #[derive(ToTLV, Debug)]

--- a/rs-matter/src/utils/maybe.rs
+++ b/rs-matter/src/utils/maybe.rs
@@ -96,11 +96,14 @@ impl<T, G> Maybe<T, G> {
     pub fn init<I: init::Init<T, E>, E>(value: Option<I>) -> impl init::Init<Self, E> {
         unsafe {
             init::init_from_closure(move |slot: *mut Self| {
-                addr_of_mut!((*slot).some).write(value.is_some());
+                let some = value.is_some();
 
                 if let Some(value) = value {
                     value.__init(addr_of_mut!((*slot).value) as _)?;
                 }
+
+                // Only set this once the value is initialized
+                addr_of_mut!((*slot).some).write(some);
 
                 Ok(())
             })

--- a/rs-matter/tests/common/e2e/im/commands.rs
+++ b/rs-matter/tests/common/e2e/im/commands.rs
@@ -18,7 +18,8 @@
 use rs_matter::dm::{AsyncHandler, AsyncMetadata};
 use rs_matter::error::Error;
 use rs_matter::im::{CmdPath, CmdStatus};
-use rs_matter::tlv::{TLVTag, TLVWrite, TLVWriter};
+use rs_matter::tlv::{TLVTag, TLVWrite};
+use rs_matter::utils::storage::WriteBuf;
 
 use crate::common::e2e::tlv::{TLVTest, TestToTLV};
 use crate::common::e2e::E2eRunner;
@@ -79,7 +80,7 @@ impl<'a> TestCmdData<'a> {
 }
 
 impl TestToTLV for TestCmdData<'_> {
-    fn test_to_tlv(&self, tag: &TLVTag, tw: &mut TLVWriter) -> Result<(), Error> {
+    fn test_to_tlv(&self, tag: &TLVTag, tw: &mut WriteBuf<'_>) -> Result<(), Error> {
         tw.start_struct(tag)?;
 
         self.path.test_to_tlv(&TLVTag::Context(0), tw)?;
@@ -103,7 +104,7 @@ pub enum TestCmdResp<'a> {
 }
 
 impl TestToTLV for TestCmdResp<'_> {
-    fn test_to_tlv(&self, tag: &TLVTag, tw: &mut TLVWriter) -> Result<(), Error> {
+    fn test_to_tlv(&self, tag: &TLVTag, tw: &mut WriteBuf<'_>) -> Result<(), Error> {
         tw.start_struct(tag)?;
 
         match self {

--- a/rs-matter/tests/common/e2e/im/echo_cluster.rs
+++ b/rs-matter/tests/common/e2e/im/echo_cluster.rs
@@ -160,7 +160,7 @@ impl EchoHandler {
 
         if let Some(mut writer) = reply.with_dataver(self.data_ver.get())? {
             if attr.is_system() {
-                CLUSTER.read(attr.attr_id, writer)
+                CLUSTER.read(attr, writer)
             } else {
                 match attr.attr_id.try_into()? {
                     Attributes::Att1 => writer.set(0x1234_u16),

--- a/rs-matter/tests/data_model/long_reads.rs
+++ b/rs-matter/tests/data_model/long_reads.rs
@@ -24,7 +24,6 @@ use rs_matter::im::GenericPath;
 use rs_matter::im::IMStatusCode;
 use rs_matter::im::{StatusResp, SubscribeResp};
 
-use crate::attr_data;
 use crate::common::e2e::im::attributes::TestAttrResp;
 use crate::common::e2e::im::{echo_cluster as echo, ReplyProcessor, TestSubscribeReq};
 use crate::common::e2e::im::{TestReadReq, TestReportDataMsg};
@@ -32,6 +31,7 @@ use crate::common::e2e::test::E2eTest;
 use crate::common::e2e::tlv::TLVTest;
 use crate::common::e2e::ImEngine;
 use crate::common::init_env_logger;
+use crate::{attr_data, attr_data_lel};
 
 static ATTR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(0, 29, desc::AttributeId::DeviceTypeList, None),
@@ -73,6 +73,27 @@ static ATTR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(0, 40, GlobalElements::AcceptedCmdList, None),
     attr_data!(0, 40, GlobalElements::EventList, None),
     attr_data!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
     attr_data!(0, 40, GlobalElements::FeatureMap, None),
     attr_data!(0, 40, GlobalElements::ClusterRevision, None),
     attr_data!(0, 48, gen_comm::AttributeId::Breadcrumb, None),
@@ -191,13 +212,196 @@ static ATTR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(1, echo::ID, GlobalElements::ClusterRevision, None),
 ];
 
+static ATTR_SUBSCR_RESPS: &[TestAttrResp<'static>] = &[
+    attr_data!(0, 29, desc::AttributeId::DeviceTypeList, None),
+    attr_data!(0, 29, desc::AttributeId::ServerList, None),
+    attr_data!(0, 29, desc::AttributeId::ClientList, None),
+    attr_data!(0, 29, desc::AttributeId::PartsList, None),
+    attr_data!(0, 29, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, 29, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, 29, GlobalElements::EventList, None),
+    attr_data!(0, 29, GlobalElements::AttributeList, None),
+    attr_data!(0, 29, GlobalElements::FeatureMap, None),
+    attr_data!(0, 29, GlobalElements::ClusterRevision, None),
+    attr_data!(0, 31, acl::AttributeId::Acl, None),
+    attr_data!(0, 31, acl::AttributeId::SubjectsPerAccessControlEntry, None),
+    attr_data!(0, 31, acl::AttributeId::TargetsPerAccessControlEntry, None),
+    attr_data!(0, 31, acl::AttributeId::AccessControlEntriesPerFabric, None),
+    attr_data!(0, 31, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, 31, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, 31, GlobalElements::EventList, None),
+    attr_data!(0, 31, GlobalElements::AttributeList, None),
+    attr_data!(0, 31, GlobalElements::FeatureMap, None),
+    attr_data!(0, 31, GlobalElements::ClusterRevision, None),
+    attr_data!(0, 40, basic_info::AttributeId::DataModelRevision, None),
+    attr_data!(0, 40, basic_info::AttributeId::VendorName, None),
+    attr_data!(0, 40, basic_info::AttributeId::VendorID, None),
+    attr_data!(0, 40, basic_info::AttributeId::ProductName, None),
+    attr_data!(0, 40, basic_info::AttributeId::ProductID, None),
+    attr_data!(0, 40, basic_info::AttributeId::NodeLabel, None),
+    attr_data!(0, 40, basic_info::AttributeId::Location, None),
+    attr_data!(0, 40, basic_info::AttributeId::HardwareVersion, None),
+    attr_data!(0, 40, basic_info::AttributeId::HardwareVersionString, None),
+    attr_data!(0, 40, basic_info::AttributeId::SoftwareVersion, None),
+    attr_data!(0, 40, basic_info::AttributeId::SoftwareVersionString, None),
+    attr_data!(0, 40, basic_info::AttributeId::SerialNumber, None),
+    attr_data!(0, 40, basic_info::AttributeId::CapabilityMinima, None),
+    attr_data!(0, 40, basic_info::AttributeId::SpecificationVersion, None),
+    attr_data!(0, 40, basic_info::AttributeId::MaxPathsPerInvoke, None),
+    attr_data!(0, 40, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, 40, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, 40, GlobalElements::EventList, None),
+    attr_data!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 40, GlobalElements::AttributeList, None),
+    attr_data!(0, 40, GlobalElements::FeatureMap, None),
+    attr_data!(0, 40, GlobalElements::ClusterRevision, None),
+    attr_data!(0, 48, gen_comm::AttributeId::Breadcrumb, None),
+    attr_data!(0, 48, gen_comm::AttributeId::BasicCommissioningInfo, None),
+    attr_data!(0, 48, gen_comm::AttributeId::RegulatoryConfig, None),
+    attr_data!(0, 48, gen_comm::AttributeId::LocationCapability, None),
+    attr_data!(
+        0,
+        48,
+        gen_comm::AttributeId::SupportsConcurrentConnection,
+        None
+    ),
+    attr_data!(0, 48, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, 48, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, 48, GlobalElements::EventList, None),
+    attr_data!(0, 48, GlobalElements::AttributeList, None),
+    attr_data!(0, 48, GlobalElements::FeatureMap, None),
+    attr_data!(0, 48, GlobalElements::ClusterRevision, None),
+    attr_data!(0, 51, gen_diag::AttributeId::NetworkInterfaces, None),
+    attr_data!(0, 51, gen_diag::AttributeId::RebootCount, None),
+    attr_data!(0, 51, gen_diag::AttributeId::TestEventTriggersEnabled, None),
+    attr_data!(0, 51, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, 51, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, 51, GlobalElements::EventList, None),
+    attr_data!(0, 51, GlobalElements::AttributeList, None),
+    attr_data!(0, 51, GlobalElements::FeatureMap, None),
+    attr_data!(0, 51, GlobalElements::ClusterRevision, None),
+    attr_data!(0, 60, adm_comm::AttributeId::WindowStatus, None),
+    attr_data!(0, 60, adm_comm::AttributeId::AdminFabricIndex, None),
+    attr_data!(0, 60, adm_comm::AttributeId::AdminVendorId, None),
+    attr_data!(0, 60, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, 60, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, 60, GlobalElements::EventList, None),
+    attr_data!(0, 60, GlobalElements::AttributeList, None),
+    attr_data!(0, 60, GlobalElements::FeatureMap, None),
+    attr_data!(0, 60, GlobalElements::ClusterRevision, None),
+    attr_data!(0, 62, noc::AttributeId::NOCs, None),
+    attr_data!(0, 62, noc::AttributeId::Fabrics, None),
+    attr_data!(0, 62, noc::AttributeId::SupportedFabrics, None),
+    attr_data!(0, 62, noc::AttributeId::CommissionedFabrics, None),
+    attr_data!(0, 62, noc::AttributeId::TrustedRootCertificates, None),
+    attr_data!(0, 62, noc::AttributeId::CurrentFabricIndex, None),
+    attr_data!(0, 62, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, 62, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, 62, GlobalElements::EventList, None),
+    attr_data!(0, 62, GlobalElements::AttributeList, None),
+    attr_data!(0, 62, GlobalElements::FeatureMap, None),
+    attr_data!(0, 62, GlobalElements::ClusterRevision, None),
+    attr_data!(0, 63, grp_key_mgmt::AttributeId::GroupKeyMap, None),
+    attr_data!(0, 63, grp_key_mgmt::AttributeId::GroupTable, None),
+    attr_data!(0, 63, grp_key_mgmt::AttributeId::MaxGroupsPerFabric, None),
+    attr_data!(
+        0,
+        63,
+        grp_key_mgmt::AttributeId::MaxGroupKeysPerFabric,
+        None
+    ),
+    attr_data!(0, 63, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, 63, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, 63, GlobalElements::EventList, None),
+    attr_data!(0, 63, GlobalElements::AttributeList, None),
+    attr_data!(0, 63, GlobalElements::FeatureMap, None),
+    attr_data!(0, 63, GlobalElements::ClusterRevision, None),
+    attr_data!(0, 49, net_comm::AttributeId::MaxNetworks, None),
+    attr_data!(0, 49, net_comm::AttributeId::Networks, None),
+    attr_data!(0, 49, net_comm::AttributeId::InterfaceEnabled, None),
+    attr_data!(0, 49, net_comm::AttributeId::LastNetworkingStatus, None),
+    attr_data!(0, 49, net_comm::AttributeId::LastNetworkID, None),
+    attr_data!(0, 49, net_comm::AttributeId::LastConnectErrorValue, None),
+    attr_data!(0, 49, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, 49, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, 49, GlobalElements::EventList, None),
+    attr_data!(0, 49, GlobalElements::AttributeList, None),
+    attr_data!(0, 49, GlobalElements::FeatureMap, None),
+    attr_data!(0, 49, GlobalElements::ClusterRevision, None),
+    attr_data!(0, 55, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, 55, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, 55, GlobalElements::EventList, None),
+    attr_data!(0, 55, GlobalElements::AttributeList, None),
+    attr_data!(0, 55, GlobalElements::FeatureMap, None),
+    attr_data!(0, 55, GlobalElements::ClusterRevision, None),
+    attr_data!(0, echo::ID, echo::AttributesDiscriminants::Att1, None),
+    attr_data!(0, echo::ID, echo::AttributesDiscriminants::Att2, None),
+    attr_data!(0, echo::ID, echo::AttributesDiscriminants::AttCustom, None),
+    attr_data!(0, echo::ID, GlobalElements::GeneratedCmdList, None),
+    attr_data!(0, echo::ID, GlobalElements::AcceptedCmdList, None),
+    attr_data!(0, echo::ID, GlobalElements::EventList, None),
+    attr_data!(0, echo::ID, GlobalElements::AttributeList, None),
+    attr_data!(0, echo::ID, GlobalElements::FeatureMap, None),
+    attr_data!(0, echo::ID, GlobalElements::ClusterRevision, None),
+    attr_data!(1, 29, desc::AttributeId::DeviceTypeList, None),
+    attr_data!(1, 29, desc::AttributeId::ServerList, None),
+    attr_data!(1, 29, desc::AttributeId::ClientList, None),
+    attr_data!(1, 29, desc::AttributeId::PartsList, None),
+    attr_data!(1, 29, GlobalElements::GeneratedCmdList, None),
+    attr_data!(1, 29, GlobalElements::AcceptedCmdList, None),
+    attr_data!(1, 29, GlobalElements::EventList, None),
+    attr_data!(1, 29, GlobalElements::AttributeList, None),
+    attr_data!(1, 29, GlobalElements::FeatureMap, None),
+    attr_data!(1, 29, GlobalElements::ClusterRevision, None),
+    attr_data!(1, 6, on_off::AttributeId::OnOff, None),
+    attr_data!(1, 6, GlobalElements::GeneratedCmdList, None),
+    attr_data!(1, 6, GlobalElements::AcceptedCmdList, None),
+    attr_data_lel!(1, 6, GlobalElements::AcceptedCmdList, None),
+    attr_data_lel!(1, 6, GlobalElements::AcceptedCmdList, None),
+    attr_data_lel!(1, 6, GlobalElements::AcceptedCmdList, None),
+    attr_data!(1, 6, GlobalElements::EventList, None),
+    attr_data!(1, 6, GlobalElements::AttributeList, None),
+    attr_data!(1, 6, GlobalElements::FeatureMap, None),
+    attr_data!(1, 6, GlobalElements::ClusterRevision, None),
+    attr_data!(1, echo::ID, echo::AttributesDiscriminants::Att1, None),
+    attr_data!(1, echo::ID, echo::AttributesDiscriminants::Att2, None),
+    attr_data!(1, echo::ID, echo::AttributesDiscriminants::AttCustom, None),
+    attr_data!(1, echo::ID, GlobalElements::GeneratedCmdList, None),
+    attr_data!(1, echo::ID, GlobalElements::AcceptedCmdList, None),
+    attr_data!(1, echo::ID, GlobalElements::EventList, None),
+    attr_data!(1, echo::ID, GlobalElements::AttributeList, None),
+    attr_data!(1, echo::ID, GlobalElements::FeatureMap, None),
+    attr_data!(1, echo::ID, GlobalElements::ClusterRevision, None),
+];
+
 #[test]
 fn test_long_read_success() {
     const PART_1: usize = 38;
-    const PART_2: usize = 37;
+    const PART_2: usize = 40;
     const PART_3: usize = 37;
+    const PART_4: usize = 38;
 
-    // Read the entire attribute database, which requires 3 reads to complete
+    // Read the entire attribute database, which requires multiple reads to complete
     init_env_logger();
 
     let im = ImEngine::new_default();
@@ -244,7 +448,18 @@ fn test_long_read_success() {
                     status: IMStatusCode::Success,
                 },
                 TestReportDataMsg {
-                    attr_reports: Some(&ATTR_RESPS[PART_1..][PART_2..][PART_3..]),
+                    attr_reports: Some(&ATTR_RESPS[PART_1..][PART_2..][PART_3..][..PART_4]),
+                    more_chunks: Some(true),
+                    ..Default::default()
+                },
+                ReplyProcessor::remove_attr_data,
+            ),
+            &TLVTest::continue_report(
+                StatusResp {
+                    status: IMStatusCode::Success,
+                },
+                TestReportDataMsg {
+                    attr_reports: Some(&ATTR_RESPS[PART_1..][PART_2..][PART_3..][PART_4..]),
                     suppress_response: Some(true),
                     ..Default::default()
                 },
@@ -257,10 +472,11 @@ fn test_long_read_success() {
 #[test]
 fn test_long_read_subscription_success() {
     const PART_1: usize = 38;
-    const PART_2: usize = 37;
+    const PART_2: usize = 40;
     const PART_3: usize = 37;
+    const PART_4: usize = 38;
 
-    // Subscribe to the entire attribute database, which requires 3 reads to complete
+    // Subscribe to the entire attribute database, which requires multiple reads to complete
     init_env_logger();
 
     let im = ImEngine::new_default();
@@ -279,7 +495,7 @@ fn test_long_read_subscription_success() {
                 },
                 TestReportDataMsg {
                     subscription_id: Some(1),
-                    attr_reports: Some(&ATTR_RESPS[..PART_1]),
+                    attr_reports: Some(&ATTR_SUBSCR_RESPS[..PART_1]),
                     more_chunks: Some(true),
                     ..Default::default()
                 },
@@ -291,7 +507,7 @@ fn test_long_read_subscription_success() {
                 },
                 TestReportDataMsg {
                     subscription_id: Some(1),
-                    attr_reports: Some(&ATTR_RESPS[PART_1..][..PART_2]),
+                    attr_reports: Some(&ATTR_SUBSCR_RESPS[PART_1..][..PART_2]),
                     more_chunks: Some(true),
                     ..Default::default()
                 },
@@ -303,7 +519,7 @@ fn test_long_read_subscription_success() {
                 },
                 TestReportDataMsg {
                     subscription_id: Some(1),
-                    attr_reports: Some(&ATTR_RESPS[PART_1..][PART_2..][..PART_3]),
+                    attr_reports: Some(&ATTR_SUBSCR_RESPS[PART_1..][PART_2..][..PART_3]),
                     more_chunks: Some(true),
                     ..Default::default()
                 },
@@ -315,7 +531,19 @@ fn test_long_read_subscription_success() {
                 },
                 TestReportDataMsg {
                     subscription_id: Some(1),
-                    attr_reports: Some(&ATTR_RESPS[PART_1..][PART_2..][PART_3..]),
+                    attr_reports: Some(&ATTR_SUBSCR_RESPS[PART_1..][PART_2..][PART_3..][..PART_4]),
+                    more_chunks: Some(true),
+                    ..Default::default()
+                },
+                ReplyProcessor::remove_attr_data,
+            ),
+            &TLVTest::continue_report(
+                StatusResp {
+                    status: IMStatusCode::Success,
+                },
+                TestReportDataMsg {
+                    subscription_id: Some(1),
+                    attr_reports: Some(&ATTR_SUBSCR_RESPS[PART_1..][PART_2..][PART_3..][PART_4..]),
                     ..Default::default()
                 },
                 ReplyProcessor::remove_attr_data,

--- a/rs-matter/tests/tlv_encoding.rs
+++ b/rs-matter/tests/tlv_encoding.rs
@@ -19,7 +19,7 @@ mod tlv_encoding_tests {
     use bitflags::bitflags;
     use rs_matter::bitflags_tlv;
     use rs_matter::error::Error;
-    use rs_matter::tlv::{FromTLV, TLVElement, TLVTag, TLVWriter, ToTLV};
+    use rs_matter::tlv::{FromTLV, TLVElement, TLVTag, ToTLV};
     use rs_matter::utils::storage::WriteBuf;
 
     #[derive(PartialEq, Debug, ToTLV, FromTLV)]
@@ -48,11 +48,10 @@ mod tlv_encoding_tests {
         const MAX_OUTPUT_SIZE: usize = 1024;
 
         let mut output_buffer = [0u8; MAX_OUTPUT_SIZE];
-        let mut write_buf = WriteBuf::new(&mut output_buffer);
-        let mut writer = TLVWriter::new(&mut write_buf);
+        let mut writer = WriteBuf::new(&mut output_buffer);
         what.to_tlv(&TLVTag::Anonymous, &mut writer)?;
 
-        Ok(Vec::from(write_buf.as_slice()))
+        Ok(Vec::from(writer.as_slice()))
     }
 
     fn decode_from_tlv<'a, T: FromTLV<'a>>(data: &'a [u8]) -> Result<T, Error> {

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -32,6 +32,7 @@ use log::{debug, info, warn};
 const DEFAULT_TESTS: &[&str] = &[
     "TestAttributesById",
     "TestCommandsById",
+    "TestCluster",
     // "TestBasicInformation",
     // "TestAccessControlCluster",
 ];


### PR DESCRIPTION
This is fixing `rs-matter` attribute reads' reporting so that the remaining failing 3 tests in Matter C++'s `TestCluster` test suite complete successfully.

The `TestCluster` test suite is therefore appended to our nightly tests with this PR.

===

The real changes are in two modules: `dm.rs` and `reply.rs`. Everything else is either a regexp change, or a side effect of the removal of `TLVWriter` (see below), or enabling array chunking for the system or app array attributes we support (array chunking for stuff imported via the `import!` macro comes almost for free - there is just a new variant - `ArrayAttributeRead::ReadNone` where the user should just return the passed builder as-is. Magic!)

#### Changes to the Data Model impl (`dm.rs`)

Yes, these changes are quite obtrusive!
The main reason was, the existing code was simply **not** written in mind with the expectation that we might have to 
send a "here's a chunk of data" Matter message **in the middle of reading from an attribute**. The previous code did allow sending such message chunks in-between two attributes, but _not_ in the middle of an (array) attribute.

The "heart" of the change is the `ReportDataResponder::send_array_items` method. Everything else is enablier for this method.

Yet - the external API of the `DataModel` / `dm` module remains the same. Only the internal "guts" of it were reshuffled, so to say. Other than that and thanks to async, we can in principle generate and send such messages over the IO layer just fine, without any state machines.

While at it, I also took the effort to actually document the Data Model code, which was not extensively documented before.
Note that a similar data documentation excercise is coming for the data structures of the `im` module as well, with a following PR.

#### Changes to the Reply impl (`reply.rs`)

These were not strictly necessary. But these make the API a bit more ergonomic which in turn made the total code size in `dm.rs` a bit smaller.
Also a large portion of the changes here is documenting everything.

#### `TLVWriter` removed

This was long overdue and I just did it at the few remaining places. 98% of the code uses the `TLVWrite` trait anyway since > 1 year, so I just fixed the remaining 2% which were forgotten.
And they were primarily in the `dm.rs` / `reply.rs` code anyway.
