### PR TITLE
Document the IM model; split the im.rs file into sub-modules

### DIFF
--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -25,8 +25,9 @@ use embassy_time::{Instant, Timer};
 
 use crate::error::{Error, ErrorCode};
 use crate::im::{
-    IMStatusCode, InvReq, InvRespTag, OpCode, ReadReq, ReportDataReq, ReportDataTag, StatusResp,
-    SubscribeReq, SubscribeResp, TimedReq, WriteReq, WriteRespTag, PROTO_ID_INTERACTION_MODEL,
+    IMStatusCode, InvReq, InvRespTag, OpCode, ReadReq, ReportDataReq, ReportDataRespTag,
+    StatusResp, SubscribeReq, SubscribeResp, TimedReq, WriteReq, WriteRespTag,
+    PROTO_ID_INTERACTION_MODEL,
 };
 use crate::respond::ExchangeHandler;
 use crate::tlv::{get_root_node_struct, FromTLV, Nullable, TLVElement, TLVTag, TLVWrite};
@@ -1016,7 +1017,7 @@ where
                 ReportDataReq::Subscribe(_) | ReportDataReq::SubscribeReport(_)
             ));
             wb.u32(
-                &TLVTag::Context(ReportDataTag::SubscriptionId as u8),
+                &TLVTag::Context(ReportDataRespTag::SubscriptionId as u8),
                 subscription_id,
             )?;
         } else {
@@ -1026,7 +1027,7 @@ where
         let has_requests = self.req.attr_requests()?.is_some();
 
         if has_requests {
-            wb.start_array(&TLVTag::Context(ReportDataTag::AttributeReports as u8))?;
+            wb.start_array(&TLVTag::Context(ReportDataRespTag::AttributeReports as u8))?;
         }
 
         Ok(())
@@ -1048,11 +1049,17 @@ where
         }
 
         if more_chunks {
-            wb.bool(&TLVTag::Context(ReportDataTag::MoreChunkedMsgs as u8), true)?;
+            wb.bool(
+                &TLVTag::Context(ReportDataRespTag::MoreChunkedMsgs as u8),
+                true,
+            )?;
         }
 
         if !more_chunks && suppress_resp {
-            wb.bool(&TLVTag::Context(ReportDataTag::SupressResponse as u8), true)?;
+            wb.bool(
+                &TLVTag::Context(ReportDataRespTag::SupressResponse as u8),
+                true,
+            )?;
         }
 
         wb.end_container()?;

--- a/rs-matter/src/dm/types.rs
+++ b/rs-matter/src/dm/types.rs
@@ -39,10 +39,10 @@ mod node;
 mod privilege;
 mod reply;
 
-pub type EndptId = u16;
-pub type ClusterId = u32;
-pub type AttrId = u32;
-pub type CmdId = u32;
+pub type EndptId = crate::im::EndptId;
+pub type ClusterId = crate::im::ClusterId;
+pub type AttrId = crate::im::AttrId;
+pub type CmdId = crate::im::CmdId;
 
 #[derive(Debug, ToTLV, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/rs-matter/src/dm/types/attribute.rs
+++ b/rs-matter/src/dm/types/attribute.rs
@@ -22,7 +22,7 @@ use strum::FromRepr;
 
 use crate::attribute_enum;
 use crate::error::{Error, ErrorCode};
-use crate::im::{AttrPath, AttrStatus, GenericPath, IMStatusCode};
+use crate::im::{AttrPath, AttrStatus, IMStatusCode};
 use crate::tlv::{AsNullable, FromTLV, Nullable, TLVBuilder, TLVBuilderParent, TLVElement, TLVTag};
 use crate::utils::maybe::Maybe;
 
@@ -310,17 +310,9 @@ impl AttrDetails<'_> {
             })
     }
 
-    pub const fn status(&self, status: IMStatusCode) -> Option<AttrStatus> {
+    pub fn status(&self, status: IMStatusCode) -> Option<AttrStatus> {
         if self.should_report(status) {
-            Some(AttrStatus::new(
-                &GenericPath {
-                    endpoint: Some(self.endpoint_id),
-                    cluster: Some(self.cluster_id),
-                    leaf: Some(self.attr_id as _),
-                },
-                status,
-                None,
-            ))
+            Some(AttrStatus::new(self.reply_path(), status, None))
         } else {
             None
         }

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -281,7 +281,7 @@ impl<'a> PathExpansionItem<'a> for AttrReadPath<'a> {
     }
 
     fn into_status(self, status: IMStatusCode) -> Self::Status {
-        AttrStatus::new(&self.path.to_gp(), status, None)
+        AttrStatus::new(self.path, status, None)
     }
 }
 
@@ -324,7 +324,7 @@ impl<'a> PathExpansionItem<'a> for AttrData<'a> {
     }
 
     fn into_status(self, status: IMStatusCode) -> Self::Status {
-        AttrStatus::new(&self.path.to_gp(), status, None)
+        AttrStatus::new(self.path, status, None)
     }
 }
 
@@ -336,7 +336,7 @@ impl<'a> PathExpansionItem<'a> for CmdData<'a> {
     type Status = CmdStatus;
 
     fn path(&self) -> GenericPath {
-        self.path.path.clone()
+        self.path.to_gp()
     }
 
     fn expand(

--- a/rs-matter/src/dm/types/reply.rs
+++ b/rs-matter/src/dm/types/reply.rs
@@ -435,7 +435,7 @@ where
         tw.start_struct(&TLVTag::Anonymous)?;
         tw.start_struct(&TLVTag::Context(CmdRespTag::Cmd as _))?;
 
-        self.path.path.leaf = Some(cmd as _);
+        self.path.cmd = Some(cmd as _);
         self.path
             .to_tlv(&TagType::Context(CmdDataTag::Path as _), tw)?;
 

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -15,20 +15,34 @@
  *    limitations under the License.
  */
 
-use core::fmt;
-use core::time::Duration;
+//! This module contains the TLV-serde types as defined by the Interaction Model.
+//!
+//! Additionally, it contains a very simple IM implementation - busy - which always
+//! returns a busy status code, to all incoming IM requests.
 
 use num::FromPrimitive;
 use num_derive::FromPrimitive;
 
-use crate::dm::{AttrDetails, AttrId, ClusterId, CmdId, EndptId};
-use crate::error::*;
-use crate::tlv::{FromTLV, Nullable, TLVArray, TLVElement, TLVTag, TLVWrite, TagType, ToTLV, TLV};
+use crate::error::{Error, ErrorCode};
+use crate::tlv::{FromTLV, TLVElement, TLVTag, TLVWrite, ToTLV, TLV};
 use crate::transport::exchange::MessageMeta;
-use crate::utils::{epoch::Epoch, storage::WriteBuf};
+
+pub use attr::*;
+pub use invoke::*;
+pub use status::*;
+pub use timed::*;
 
 pub mod busy;
 
+mod attr;
+mod invoke;
+mod status;
+mod timed;
+
+/// Interaction Model ID as per the Matter Core spec
+pub const PROTO_ID_INTERACTION_MODEL: u16 = 0x01;
+
+/// An enumeration of all possible error codes that can be returned by the Interaction Model.
 #[derive(FromPrimitive, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum IMStatusCode {
@@ -103,6 +117,7 @@ impl ToTLV for IMStatusCode {
     }
 }
 
+/// An enumeration of all possible opcodes used in the Interaction Model.
 #[derive(FromPrimitive, Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum OpCode {
@@ -120,7 +135,11 @@ pub enum OpCode {
 }
 
 impl OpCode {
-    pub fn meta(&self) -> MessageMeta {
+    /// Return the opcode as a `MessageMeta` structure, which contains
+    /// the protocol ID, opcode, and reliability information.
+    ///
+    /// Reliability is set to `true` as all IM messages are reliable.
+    pub const fn meta(&self) -> MessageMeta {
         MessageMeta {
             proto_id: PROTO_ID_INTERACTION_MODEL,
             proto_opcode: *self as u8,
@@ -128,7 +147,10 @@ impl OpCode {
         }
     }
 
-    pub fn is_tlv(&self) -> bool {
+    /// Return `true` if the opcode payload is in TLV format.
+    ///
+    /// Currently, the payload of all IM opcodes except `Reserved` is in TLV format.
+    pub const fn is_tlv(&self) -> bool {
         !matches!(self, Self::Reserved)
     }
 }
@@ -139,21 +161,39 @@ impl From<OpCode> for MessageMeta {
     }
 }
 
-/* Interaction Model ID as per the Matter Spec */
-pub const PROTO_ID_INTERACTION_MODEL: u16 = 0x01;
+/// A type alias for endpoint ID, which is a 16-bit unsigned integer.
+pub type EndptId = u16;
+/// A type alias for cluster ID, which is a 32-bit unsigned integer.
+pub type ClusterId = u32;
+/// A type alias for attribute ID, which is a 32-bit unsigned integer.
+pub type AttrId = u32;
+/// A type alias for command ID, which is a 32-bit unsigned integer.
+pub type CmdId = u32;
 
-// A generic path with endpoint, clusters, and a leaf
-// The leaf could be command, attribute, event
-#[derive(Default, Clone, Debug, PartialEq, FromTLV, ToTLV)]
+/// A generic (possibly a wildcard) path with endpoint, clusters, and a leaf
+///
+/// The leaf could be a command, an attribute, or an event
+///
+/// Note that this type does not implement `FromTLV` / `ToTLV` because it does not correspond
+/// to a specific TLV structure in the Interaction Model.
+///
+/// Note also that it only captures a _subset_ of the fields of `AttrPath`, and as such, it should be used with care!
+///
+/// Look at `AttrPath`, `CmdPath`, and `EventPath` for specific TLV structures, which
+/// can be turned into `GenericPath` using their `to_gp()` method.
+#[derive(Default, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(datatype = "list")]
 pub struct GenericPath {
+    /// The endpoint ID, if specified, otherwise `None` for wildcard
     pub endpoint: Option<EndptId>,
+    /// The cluster ID, if specified, otherwise `None` for wildcard
     pub cluster: Option<ClusterId>,
+    /// The leaf ID, if specified, otherwise `None` for wildcard
     pub leaf: Option<u32>,
 }
 
 impl GenericPath {
+    /// Create a new `GenericPath` with the given endpoint, cluster, and leaf.
     pub const fn new(
         endpoint: Option<EndptId>,
         cluster: Option<ClusterId>,
@@ -166,7 +206,7 @@ impl GenericPath {
         }
     }
 
-    /// Returns Ok, if the path is non wildcard, otherwise returns an error
+    /// Return Ok, if the path is non wildcard, otherwise returns an error
     pub fn not_wildcard(&self) -> Result<(EndptId, ClusterId, u32), Error> {
         match *self {
             GenericPath {
@@ -178,7 +218,7 @@ impl GenericPath {
         }
     }
 
-    /// Returns true, if the path is wildcard
+    /// Return true, if the path is wildcard
     pub const fn is_wildcard(&self) -> bool {
         !matches!(
             *self,
@@ -189,772 +229,4 @@ impl GenericPath {
             }
         )
     }
-}
-
-/// A wrapper enum for `ReadReq` and `SubscribeReq` that allows downstream code to
-/// treat the two in a unified manner with regards to `OpCode::ReportDataResp` type responses.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum ReportDataReq<'a> {
-    Read(&'a ReadReq<'a>),
-    Subscribe(&'a SubscribeReq<'a>),
-    SubscribeReport(&'a SubscribeReq<'a>),
-}
-
-impl<'a> ReportDataReq<'a> {
-    pub fn attr_requests(&self) -> Result<Option<TLVArray<'a, AttrPath>>, Error> {
-        match self {
-            Self::Read(req) => req.attr_requests(),
-            Self::Subscribe(req) | Self::SubscribeReport(req) => req.attr_requests(),
-        }
-    }
-
-    pub fn dataver_filters(&self) -> Result<Option<TLVArray<'_, DataVersionFilter>>, Error> {
-        match self {
-            Self::Read(req) => req.dataver_filters(),
-            Self::Subscribe(req) => req.dataver_filters(),
-            Self::SubscribeReport(_) => Ok(None),
-        }
-    }
-
-    pub fn fabric_filtered(&self) -> Result<bool, Error> {
-        match self {
-            Self::Read(req) => req.fabric_filtered(),
-            Self::Subscribe(req) | Self::SubscribeReport(req) => req.fabric_filtered(),
-        }
-    }
-}
-
-impl StatusResp {
-    pub fn write(wb: &mut WriteBuf, status: IMStatusCode) -> Result<(), Error> {
-        let status = Self { status };
-        status.to_tlv(&TagType::Anonymous, wb)
-    }
-}
-
-impl TimedReq {
-    pub fn timeout_instant(&self, epoch: Epoch) -> Duration {
-        unwrap!(epoch().checked_add(Duration::from_millis(self.timeout as _)))
-    }
-}
-
-impl SubscribeResp {
-    pub fn write<'a>(
-        wb: &'a mut WriteBuf,
-        subscription_id: u32,
-        max_int: u16,
-    ) -> Result<&'a [u8], Error> {
-        let resp = Self::new(subscription_id, max_int);
-        resp.to_tlv(&TagType::Anonymous, &mut *wb)?;
-
-        Ok(wb.as_slice())
-    }
-}
-
-#[derive(FromTLV, ToTLV, Clone, PartialEq, Eq, Hash)]
-#[tlvargs(lifetime = "'a")]
-pub struct SubscribeReq<'a>(TLVElement<'a>);
-
-impl<'a> SubscribeReq<'a> {
-    pub const fn new(element: TLVElement<'a>) -> Self {
-        Self(element)
-    }
-
-    pub fn keep_subs(&self) -> Result<bool, Error> {
-        self.0.r#struct()?.find_ctx(0)?.bool()
-    }
-
-    pub fn min_int_floor(&self) -> Result<u16, Error> {
-        self.0.r#struct()?.find_ctx(1)?.u16()
-    }
-
-    pub fn max_int_ceil(&self) -> Result<u16, Error> {
-        self.0.r#struct()?.find_ctx(2)?.u16()
-    }
-
-    pub fn attr_requests(&self) -> Result<Option<TLVArray<'a, AttrPath>>, Error> {
-        Option::from_tlv(&self.0.r#struct()?.find_ctx(3)?)
-    }
-
-    pub fn event_requests(&self) -> Result<Option<TLVArray<'a, EventPath>>, Error> {
-        Option::from_tlv(&self.0.r#struct()?.find_ctx(4)?)
-    }
-
-    pub fn event_filters(&self) -> Result<Option<TLVArray<'a, EventFilter>>, Error> {
-        Option::from_tlv(&self.0.r#struct()?.find_ctx(5)?)
-    }
-
-    pub fn fabric_filtered(&self) -> Result<bool, Error> {
-        self.0.r#struct()?.find_ctx(7)?.bool()
-    }
-
-    pub fn dataver_filters(&self) -> Result<Option<TLVArray<'a, DataVersionFilter>>, Error> {
-        Option::from_tlv(&self.0.r#struct()?.find_ctx(8)?)
-    }
-}
-
-impl fmt::Debug for SubscribeReq<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SubscribeReqRef")
-            .field("keep_subs", &self.keep_subs())
-            .field("min_int_floor", &self.min_int_floor())
-            .field("max_int_ceil", &self.max_int_ceil())
-            .field("attr_requests", &self.attr_requests())
-            .field("event_requests", &self.event_requests())
-            .field("event_filters", &self.event_filters())
-            .field("fabric_filtered", &self.fabric_filtered())
-            .field("dataver_filters", &self.dataver_filters())
-            .finish()
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for SubscribeReq<'_> {
-    fn format(&self, f: defmt::Formatter<'_>) {
-        defmt::write!(f,
-            "SubscribeReqRef {{\n  keep_subs: {:?},\n  min_int_floor: {:?},\n  max_int_ceil: {:?},\n  attr_requests: {:?},\n  event_requests: {:?},\n  event_filters: {:?},\n  fabric_filtered: {:?},\n  dataver_filters: {:?},\n}}",
-            self.keep_subs(),
-            self.min_int_floor(),
-            self.max_int_ceil(),
-            self.attr_requests(),
-            self.event_requests(),
-            self.event_filters(),
-            self.fabric_filtered(),
-            self.dataver_filters(),
-        )
-    }
-}
-
-#[derive(Debug, Default, Clone, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct SubscribeResp {
-    pub subs_id: u32,
-    // The Context Tags are discontiguous for some reason
-    pub _dummy: Option<u32>,
-    pub max_int: u16,
-}
-
-impl SubscribeResp {
-    pub fn new(subs_id: u32, max_int: u16) -> Self {
-        Self {
-            subs_id,
-            _dummy: None,
-            max_int,
-        }
-    }
-}
-
-#[derive(Debug, Clone, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TimedReq {
-    pub timeout: u16,
-}
-
-#[derive(Debug, Clone, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct StatusResp {
-    pub status: IMStatusCode,
-}
-
-pub enum InvReqTag {
-    SupressResponse = 0,
-    TimedReq = 1,
-    InvokeRequests = 2,
-}
-
-#[derive(FromTLV, ToTLV, Clone, PartialEq, Eq, Hash)]
-#[tlvargs(lifetime = "'a")]
-pub struct InvReq<'a>(TLVElement<'a>);
-
-impl<'a> InvReq<'a> {
-    pub const fn new(element: TLVElement<'a>) -> Self {
-        Self(element)
-    }
-
-    pub fn suppress_response(&self) -> Result<bool, Error> {
-        self.0
-            .r#struct()?
-            .find_ctx(0)?
-            .non_empty()
-            .map(|t| t.bool())
-            .unwrap_or(Ok(false))
-    }
-
-    pub fn timed_request(&self) -> Result<bool, Error> {
-        self.0
-            .r#struct()?
-            .find_ctx(1)?
-            .non_empty()
-            .map(|t| t.bool())
-            .unwrap_or(Ok(false))
-    }
-
-    pub fn inv_requests(&self) -> Result<Option<TLVArray<'a, CmdData<'a>>>, Error> {
-        Option::from_tlv(&self.0.r#struct()?.find_ctx(2)?)
-    }
-}
-
-impl fmt::Debug for InvReq<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InvReqRef")
-            .field("suppress_response", &self.suppress_response())
-            .field("timed_request", &self.timed_request())
-            .field("inv_requests", &self.inv_requests())
-            .finish()
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for InvReq<'_> {
-    fn format(&self, f: defmt::Formatter<'_>) {
-        defmt::write!(f,
-            "InvReqRef {{\n  suppress_response: {:?},\n  timed_request: {:?},\n  inv_requests: {:?},\n}}",
-            self.suppress_response(),
-            self.timed_request(),
-            self.inv_requests(),
-        )
-    }
-}
-
-#[derive(FromTLV, ToTLV, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub struct InvResp<'a> {
-    pub suppress_response: Option<bool>,
-    pub inv_responses: Option<TLVArray<'a, CmdResp<'a>>>,
-}
-
-// This enum is helpful when we are constructing the response
-// step by step in incremental manner
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[repr(u8)]
-pub enum InvRespTag {
-    SupressResponse = 0,
-    InvokeResponses = 1,
-}
-
-#[derive(FromTLV, ToTLV, Clone, PartialEq, Eq, Hash)]
-#[tlvargs(lifetime = "'a")]
-pub struct ReadReq<'a>(TLVElement<'a>);
-
-impl<'a> ReadReq<'a> {
-    pub const fn new(element: TLVElement<'a>) -> Self {
-        Self(element)
-    }
-
-    pub fn attr_requests(&self) -> Result<Option<TLVArray<'a, AttrPath>>, Error> {
-        Option::from_tlv(&self.0.r#struct()?.find_ctx(0)?)
-    }
-
-    pub fn event_requests(&self) -> Result<Option<TLVArray<'a, EventPath>>, Error> {
-        Option::from_tlv(&self.0.r#struct()?.find_ctx(1)?)
-    }
-
-    pub fn event_filters(&self) -> Result<Option<TLVArray<'a, EventFilter>>, Error> {
-        Option::from_tlv(&self.0.r#struct()?.find_ctx(2)?)
-    }
-
-    pub fn fabric_filtered(&self) -> Result<bool, Error> {
-        self.0.r#struct()?.find_ctx(3)?.bool()
-    }
-
-    pub fn dataver_filters(&self) -> Result<Option<TLVArray<'a, DataVersionFilter>>, Error> {
-        Option::from_tlv(&self.0.r#struct()?.find_ctx(4)?)
-    }
-}
-
-impl fmt::Debug for ReadReq<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ReadReqRef")
-            .field("attr_requests", &self.attr_requests())
-            .field("event_requests", &self.event_requests())
-            .field("event_filters", &self.event_filters())
-            .field("fabric_filtered", &self.fabric_filtered())
-            .field("dataver_filters", &self.dataver_filters())
-            .finish()
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for ReadReq<'_> {
-    fn format(&self, f: defmt::Formatter<'_>) {
-        defmt::write!(f,
-            "ReadReqRef {{\n  attr_requests: {:?},\n  event_requests: {:?},\n  event_filters: {:?},\n  fabric_filtered: {:?},\n  dataver_filters: {:?},\n}}",
-            self.attr_requests(),
-            self.event_requests(),
-            self.event_filters(),
-            self.fabric_filtered(),
-            self.dataver_filters(),
-        )
-    }
-}
-
-// This enum is helpful when we are constructing the request
-// step by step in incremental manner
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[repr(u8)]
-pub enum ReadReqTag {
-    AttrRequests = 0,
-    EventRequests = 1,
-    EventFilters = 2,
-    FabricFiltered = 3,
-    DataVersionFilters = 4,
-}
-
-// This enum is helpful when we are constructing the request
-// step by step in incremental manner
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[repr(u8)]
-pub enum WriteReqTag {
-    SuppressResponse = 0,
-    TimedRequest = 1,
-    WriteRequests = 2,
-    MoreChunked = 3,
-}
-
-#[derive(FromTLV, ToTLV, Clone, PartialEq, Eq, Hash)]
-#[tlvargs(lifetime = "'a")]
-pub struct WriteReq<'a>(TLVElement<'a>);
-
-impl<'a> WriteReq<'a> {
-    pub const fn new(element: TLVElement<'a>) -> Self {
-        Self(element)
-    }
-
-    pub fn supress_response(&self) -> Result<bool, Error> {
-        self.0
-            .r#struct()?
-            .find_ctx(0)?
-            .non_empty()
-            .map(|t| t.bool())
-            .unwrap_or(Ok(false))
-    }
-
-    pub fn timed_request(&self) -> Result<bool, Error> {
-        self.0
-            .r#struct()?
-            .find_ctx(1)?
-            .non_empty()
-            .map(|t| t.bool())
-            .unwrap_or(Ok(false))
-    }
-
-    pub fn write_requests(&self) -> Result<TLVArray<'a, AttrData<'_>>, Error> {
-        TLVArray::new(self.0.r#struct()?.find_ctx(2)?)
-    }
-
-    pub fn more_chunks(&self) -> Result<bool, Error> {
-        self.0
-            .r#struct()?
-            .find_ctx(3)?
-            .non_empty()
-            .map(|t| t.bool())
-            .unwrap_or(Ok(false))
-    }
-}
-
-impl fmt::Debug for WriteReq<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("WriteReqRef")
-            .field("supress_response", &self.supress_response())
-            .field("timed_request", &self.timed_request())
-            .field("write_requests", &self.write_requests())
-            .field("more_chunks", &self.more_chunks())
-            .finish()
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for WriteReq<'_> {
-    fn format(&self, f: defmt::Formatter<'_>) {
-        defmt::write!(f,
-            "WriteReqRef {{\n  supress_response: {:?},\n  timed_request: {:?},\n  write_requests: {:?},\n  more_chunks: {:?},\n}}",
-            self.supress_response(),
-            self.timed_request(),
-            self.write_requests(),
-            self.more_chunks(),
-        )
-    }
-}
-
-// Report Data
-#[derive(FromTLV, ToTLV, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub struct ReportDataMsg<'a> {
-    pub subscription_id: Option<u32>,
-    pub attr_reports: Option<TLVArray<'a, AttrResp<'a>>>,
-    // TODO
-    pub event_reports: Option<bool>,
-    pub more_chunks: Option<bool>,
-    pub suppress_response: Option<bool>,
-}
-
-pub enum ReportDataTag {
-    SubscriptionId = 0,
-    AttributeReports = 1,
-    _EventReport = 2,
-    MoreChunkedMsgs = 3,
-    SupressResponse = 4,
-}
-
-// Write Response
-#[derive(ToTLV, FromTLV, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub struct WriteResp<'a> {
-    pub write_responses: TLVArray<'a, AttrStatus>,
-}
-
-pub enum WriteRespTag {
-    WriteResponses = 0,
-}
-
-// Command Response
-#[derive(Clone, FromTLV, ToTLV, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub enum CmdResp<'a> {
-    Cmd(CmdData<'a>),
-    Status(CmdStatus),
-}
-
-impl CmdResp<'_> {
-    pub const fn status_new(
-        cmd_path: CmdPath,
-        status: IMStatusCode,
-        cluster_status: Option<u16>,
-    ) -> Self {
-        Self::Status(CmdStatus {
-            path: cmd_path,
-            status: Status::new(status, cluster_status),
-        })
-    }
-}
-
-impl<'a> From<CmdData<'a>> for CmdResp<'a> {
-    fn from(value: CmdData<'a>) -> Self {
-        Self::Cmd(value)
-    }
-}
-
-pub enum CmdRespTag {
-    Cmd = 0,
-    Status = 1,
-}
-
-impl From<CmdStatus> for CmdResp<'_> {
-    fn from(value: CmdStatus) -> Self {
-        Self::Status(value)
-    }
-}
-
-#[derive(FromTLV, ToTLV, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct CmdStatus {
-    pub path: CmdPath,
-    pub status: Status,
-}
-
-impl CmdStatus {
-    pub const fn new(path: CmdPath, status: IMStatusCode, cluster_status: Option<u16>) -> Self {
-        Self {
-            path,
-            status: Status {
-                status,
-                cluster_status,
-            },
-        }
-    }
-}
-
-#[derive(Debug, Clone, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub struct CmdData<'a> {
-    pub path: CmdPath,
-    pub data: TLVElement<'a>,
-}
-
-impl<'a> CmdData<'a> {
-    pub const fn new(path: CmdPath, data: TLVElement<'a>) -> Self {
-        Self { path, data }
-    }
-}
-
-pub enum CmdDataTag {
-    Path = 0,
-    Data = 1,
-}
-
-// Status
-#[derive(Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Status {
-    pub status: IMStatusCode,
-    pub cluster_status: Option<u16>,
-}
-
-impl Status {
-    pub const fn new(status: IMStatusCode, cluster_status: Option<u16>) -> Status {
-        Status {
-            status,
-            cluster_status,
-        }
-    }
-}
-
-// Attribute Response
-#[derive(Clone, FromTLV, ToTLV, PartialEq, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub enum AttrResp<'a> {
-    Status(AttrStatus),
-    Data(AttrData<'a>),
-}
-
-impl<'a> AttrResp<'a> {
-    pub fn unwrap_data(self) -> AttrData<'a> {
-        match self {
-            AttrResp::Data(d) => d,
-            _ => {
-                panic!("No data exists");
-            }
-        }
-    }
-}
-
-impl<'a> From<AttrData<'a>> for AttrResp<'a> {
-    fn from(value: AttrData<'a>) -> Self {
-        Self::Data(value)
-    }
-}
-
-impl From<AttrStatus> for AttrResp<'_> {
-    fn from(value: AttrStatus) -> Self {
-        Self::Status(value)
-    }
-}
-
-pub enum AttrRespTag {
-    Status = 0,
-    Data = 1,
-}
-
-// Attribute Data
-#[derive(Debug, Clone, PartialEq, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a")]
-pub struct AttrData<'a> {
-    pub data_ver: Option<u32>,
-    pub path: AttrPath,
-    pub data: TLVElement<'a>,
-}
-
-impl<'a> AttrData<'a> {
-    pub const fn new(data_ver: Option<u32>, path: AttrPath, data: TLVElement<'a>) -> Self {
-        Self {
-            data_ver,
-            path,
-            data,
-        }
-    }
-}
-
-pub enum AttrDataTag {
-    DataVer = 0,
-    Path = 1,
-    Data = 2,
-}
-
-#[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-/// Operations on an Interaction Model List
-pub enum ListOperation {
-    /// Add (append) an item to the list
-    AddItem,
-    /// Edit an item from the list
-    EditItem(u16),
-    /// Delete item from the list
-    DeleteItem(u16),
-    /// Delete the whole list
-    DeleteList,
-}
-
-/// Attribute Lists in Attribute Data are special. Infer the correct meaning using this function
-pub fn attr_list_write<F>(attr: &AttrDetails, data: &TLVElement, mut f: F) -> Result<(), Error>
-where
-    F: FnMut(ListOperation, &TLVElement) -> Result<(), Error>,
-{
-    if let Some(Some(index)) = attr.list_index.clone().map(Into::into) {
-        // If list index is valid,
-        //    - this is a modify item or delete item operation
-        if data.null().is_ok() {
-            // If data is NULL, delete item
-            f(ListOperation::DeleteItem(index), data)
-        } else {
-            f(ListOperation::EditItem(index), data)
-        }
-    } else if let Ok(array) = data.array() {
-        // If data is list, this is either Delete List or OverWrite List operation
-        // in either case, we have to first delete the whole list
-        f(ListOperation::DeleteList, data)?;
-        // Now the data must be a list, that should be added item by item
-
-        for d in array.iter() {
-            f(ListOperation::AddItem, &d?)?;
-        }
-        Ok(())
-    } else {
-        // If data is not a list, this must be an add operation
-        f(ListOperation::AddItem, data)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct AttrStatus {
-    pub path: AttrPath,
-    pub status: Status,
-}
-
-impl AttrStatus {
-    pub const fn new(
-        path: &GenericPath,
-        status: IMStatusCode,
-        cluster_status: Option<u16>,
-    ) -> Self {
-        Self {
-            path: AttrPath::new(path),
-            status: Status::new(status, cluster_status),
-        }
-    }
-}
-
-// Attribute Path
-#[derive(Default, Clone, Debug, PartialEq, Eq, Hash, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(datatype = "list")]
-pub struct AttrPath {
-    pub tag_compression: Option<bool>,
-    pub node: Option<u64>,
-    pub endpoint: Option<EndptId>,
-    pub cluster: Option<ClusterId>,
-    pub attr: Option<AttrId>,
-    pub list_index: Option<Nullable<u16>>,
-}
-
-impl AttrPath {
-    pub const fn new(path: &GenericPath) -> Self {
-        Self {
-            endpoint: path.endpoint,
-            cluster: path.cluster,
-            attr: path.leaf,
-            tag_compression: None,
-            node: None,
-            list_index: None,
-        }
-    }
-
-    pub fn to_gp(&self) -> GenericPath {
-        GenericPath::new(self.endpoint, self.cluster, self.attr)
-    }
-}
-
-// Command Path
-#[derive(Default, Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct CmdPath {
-    pub path: GenericPath,
-}
-
-#[macro_export]
-macro_rules! cmd_path_ib {
-    ($endpoint:literal,$cluster:ident,$command:expr) => {{
-        use $crate::im::{ib::CmdPath, GenericPath};
-        CmdPath {
-            path: GenericPath {
-                endpoint: Some($endpoint),
-                cluster: Some($cluster),
-                leaf: Some($command as u32),
-            },
-        }
-    }};
-}
-
-impl CmdPath {
-    pub const fn new(
-        endpoint: Option<EndptId>,
-        cluster: Option<ClusterId>,
-        command: Option<CmdId>,
-    ) -> Self {
-        Self {
-            path: GenericPath {
-                endpoint,
-                cluster,
-                leaf: command,
-            },
-        }
-    }
-}
-
-impl FromTLV<'_> for CmdPath {
-    fn from_tlv(cmd_path: &TLVElement) -> Result<Self, Error> {
-        let c = CmdPath {
-            path: GenericPath::from_tlv(cmd_path)?,
-        };
-
-        if c.path.leaf.is_none() {
-            error!("Wildcard command parameter not supported");
-            Err(ErrorCode::CommandNotFound.into())
-        } else {
-            Ok(c)
-        }
-    }
-}
-
-impl ToTLV for CmdPath {
-    fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, tw: W) -> Result<(), Error> {
-        self.path.to_tlv(tag, tw)
-    }
-
-    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
-        self.path.tlv_iter(tag)
-    }
-}
-
-#[derive(FromTLV, ToTLV, Clone, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct ClusterPath {
-    pub node: Option<u64>,
-    pub endpoint: EndptId,
-    pub cluster: ClusterId,
-}
-
-#[derive(FromTLV, ToTLV, Clone, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct DataVersionFilter {
-    pub path: ClusterPath,
-    pub data_ver: u32,
-}
-
-#[derive(FromTLV, ToTLV, Clone, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(datatype = "list")]
-pub struct EventPath {
-    pub node: Option<u64>,
-    pub endpoint: Option<EndptId>,
-    pub cluster: Option<ClusterId>,
-    pub event: Option<u32>,
-    pub is_urgent: Option<bool>,
-}
-
-#[derive(FromTLV, ToTLV, Clone, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct EventFilter {
-    pub node: Option<u64>,
-    pub event_min: Option<u64>,
 }

--- a/rs-matter/src/im/attr.rs
+++ b/rs-matter/src/im/attr.rs
@@ -1,0 +1,305 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use crate::error::Error;
+use crate::tlv::{FromTLV, Nullable, TLVArray, TLVElement, ToTLV};
+
+use super::{AttrId, ClusterId, EndptId, GenericPath, IMStatusCode, Status};
+
+pub use read::*;
+pub use subscribe::*;
+pub use write::*;
+
+mod read;
+mod subscribe;
+mod write;
+
+/// A path to an attribute in the Interaction Model.
+///
+/// Corresponds to the `AttrPathIB` TLV structure in the Interaction Model.
+#[derive(Default, Clone, Debug, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(datatype = "list")]
+pub struct AttrPath {
+    pub tag_compression: Option<bool>,
+    pub node: Option<u64>,
+    pub endpoint: Option<EndptId>,
+    pub cluster: Option<ClusterId>,
+    pub attr: Option<AttrId>,
+    pub list_index: Option<Nullable<u16>>,
+}
+
+impl AttrPath {
+    /// Create a new `AttrPath` from the provided `GenericPath`,
+    /// filling all fields which are not provided with their default values.
+    pub const fn from_gp(path: &GenericPath) -> Self {
+        Self {
+            endpoint: path.endpoint,
+            cluster: path.cluster,
+            attr: path.leaf,
+            tag_compression: None,
+            node: None,
+            list_index: None,
+        }
+    }
+
+    /// Convert this `AttrPath` to a `GenericPath`.
+    pub const fn to_gp(&self) -> GenericPath {
+        GenericPath::new(self.endpoint, self.cluster, self.attr)
+    }
+}
+
+/// A status response for an attribute in the Interaction Model.
+///
+/// Corresponds to the `AttrStatusIB` TLV structure in the Interaction Model.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct AttrStatus {
+    /// The path to the attribute.
+    pub path: AttrPath,
+    /// The status of the attribute operation.
+    pub status: Status,
+}
+
+impl AttrStatus {
+    /// Create a new `AttrStatus` with the given path, status code, and optional cluster status.
+    pub const fn new(path: AttrPath, status: IMStatusCode, cluster_status: Option<u16>) -> Self {
+        Self {
+            path,
+            status: Status::new(status, cluster_status),
+        }
+    }
+
+    /// Create a new `AttrStatus` from a `GenericPath`, status code, and optional cluster status.
+    ///
+    /// ATTENTION: the actual reply `AttrPath` will be filled with the `GenericPath` values,
+    /// however these are not necessarily expressing the full path of the incoming data as `AttrPath` does.
+    ///
+    /// Hence, this method is primarily useful for unit tests.
+    pub const fn from_gp(
+        path: &GenericPath,
+        status: IMStatusCode,
+        cluster_status: Option<u16>,
+    ) -> Self {
+        Self::new(AttrPath::from_gp(path), status, cluster_status)
+    }
+}
+
+/// A data response for an attribute in the Interaction Model.
+///
+/// Corresponds to the `AttrDataIB` TLV structure in the Interaction Model.
+#[derive(Debug, Clone, PartialEq, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(lifetime = "'a")]
+pub struct AttrData<'a> {
+    /// The cluster dataver
+    pub data_ver: Option<u32>,
+    /// The path to the attribute.
+    pub path: AttrPath,
+    /// The data for the attribute, represented as a TLV element.
+    pub data: TLVElement<'a>,
+}
+
+impl<'a> AttrData<'a> {
+    /// Create a new `AttrData` with the given data version, path, and data.
+    pub const fn new(data_ver: Option<u32>, path: AttrPath, data: TLVElement<'a>) -> Self {
+        Self {
+            data_ver,
+            path,
+            data,
+        }
+    }
+}
+
+/// Tags corresponding to the fields in the `AttrDataIB` TLV structure.
+///
+/// Used when there is a need to perform low-level TLV serde on
+/// 1AttrDataIB` structures.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum AttrDataTag {
+    DataVer = 0,
+    Path = 1,
+    Data = 2,
+}
+
+/// Attribute Response
+///
+/// Corresponds to the `AttributeReportIB` TLV structure in the Interaction Model.
+#[derive(Clone, FromTLV, ToTLV, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(lifetime = "'a")]
+pub enum AttrResp<'a> {
+    Status(AttrStatus),
+    Data(AttrData<'a>),
+}
+
+impl<'a> From<AttrData<'a>> for AttrResp<'a> {
+    fn from(value: AttrData<'a>) -> Self {
+        Self::Data(value)
+    }
+}
+
+impl From<AttrStatus> for AttrResp<'_> {
+    fn from(value: AttrStatus) -> Self {
+        Self::Status(value)
+    }
+}
+
+/// Tags corresponding to the fields in the `AttributeReportIB` TLV structure.
+///
+/// Used when there is a need to perform low-level TLV serde on
+/// `AttributeReportIB` structures.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum AttrRespTag {
+    Status = 0,
+    Data = 1,
+}
+
+/// Cluster Path
+///
+/// Corresponds to the `ClusterPathIB` TLV structure in the Interaction Model.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[tlvargs(datatype = "list")]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ClusterPath {
+    pub node: Option<u64>,
+    pub endpoint: EndptId,
+    pub cluster: ClusterId,
+}
+
+/// Event Filter
+///
+/// Corresponds to the `EventFilterIB` TLV structure in the Interaction Model.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct EventFilter {
+    pub node: Option<u64>,
+    pub event_min: Option<u64>,
+}
+
+/// Data Version Filter
+///
+/// Corresponds to the `DataVersionFilterIB` TLV structure in the Interaction Model.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DataVersionFilter {
+    pub path: ClusterPath,
+    pub data_ver: u32,
+}
+
+/// Event Path
+///
+/// Corresponds to the `EventPathIB` TLV structure in the Interaction Model.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(datatype = "list")]
+pub struct EventPath {
+    pub node: Option<u64>,
+    pub endpoint: Option<EndptId>,
+    pub cluster: Option<ClusterId>,
+    pub event: Option<u32>,
+    pub is_urgent: Option<bool>,
+}
+
+impl EventPath {
+    /// Create a new `EventPath` from the provided `GenericPath`,
+    /// filling all fields which are not provided with their default values.
+    pub const fn from_gp(path: &GenericPath) -> Self {
+        Self {
+            node: None,
+            endpoint: path.endpoint,
+            cluster: path.cluster,
+            event: path.leaf,
+            is_urgent: None,
+        }
+    }
+
+    /// Convert this `EventPath` to a `GenericPath`.
+    pub const fn to_gp(&self) -> GenericPath {
+        GenericPath::new(self.endpoint, self.cluster, self.event)
+    }
+}
+
+/// A wrapper enum for `ReadReq` and `SubscribeReq` that allows downstream code to
+/// treat the two in a unified manner with regards to `OpCode::ReportDataResp` type responses.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ReportDataReq<'a> {
+    Read(&'a ReadReq<'a>),
+    Subscribe(&'a SubscribeReq<'a>),
+    SubscribeReport(&'a SubscribeReq<'a>),
+}
+
+impl<'a> ReportDataReq<'a> {
+    pub fn attr_requests(&self) -> Result<Option<TLVArray<'a, AttrPath>>, Error> {
+        match self {
+            Self::Read(req) => req.attr_requests(),
+            Self::Subscribe(req) | Self::SubscribeReport(req) => req.attr_requests(),
+        }
+    }
+
+    pub fn dataver_filters(&self) -> Result<Option<TLVArray<'_, DataVersionFilter>>, Error> {
+        match self {
+            Self::Read(req) => req.dataver_filters(),
+            Self::Subscribe(req) => req.dataver_filters(),
+            Self::SubscribeReport(_) => Ok(None),
+        }
+    }
+
+    pub fn fabric_filtered(&self) -> Result<bool, Error> {
+        match self {
+            Self::Read(req) => req.fabric_filtered(),
+            Self::Subscribe(req) | Self::SubscribeReport(req) => req.fabric_filtered(),
+        }
+    }
+}
+
+/// Report Data Message
+///
+/// Corresponds to the `ReportDataMessage` TLV structure in the Interaction Model.
+///
+/// Only used in unitand integration tests. The Data Model layer in `rs-matter` does not
+/// use this structure directly, utilizing on-the-fly serialization via `ReportDataTag` instead.
+#[derive(FromTLV, ToTLV, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(lifetime = "'a")]
+pub struct ReportDataResp<'a> {
+    pub subscription_id: Option<u32>,
+    pub attr_reports: Option<TLVArray<'a, AttrResp<'a>>>,
+    pub event_reports: Option<bool>,
+    pub more_chunks: Option<bool>,
+    pub suppress_response: Option<bool>,
+}
+
+/// Tags corresponding to the fields in the `ReportDataMessage` TLV structure.
+///
+/// Used when there is a need to perform low-level TLV serde on
+/// `ReportDataMessage` structures.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum ReportDataRespTag {
+    SubscriptionId = 0,
+    AttributeReports = 1,
+    _EventReport = 2,
+    MoreChunkedMsgs = 3,
+    SupressResponse = 4,
+}

--- a/rs-matter/src/im/attr/read.rs
+++ b/rs-matter/src/im/attr/read.rs
@@ -1,0 +1,102 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use core::fmt;
+
+use crate::error::Error;
+use crate::im::{AttrPath, DataVersionFilter, EventFilter, EventPath};
+use crate::tlv::{FromTLV, TLVArray, TLVElement, ToTLV};
+
+/// A request to read attributes and events from a Matter device.
+///
+/// Corresponds to the `ReadRequestMessage` TLV structure in the Interaction Model.
+#[derive(Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[tlvargs(lifetime = "'a")]
+pub struct ReadReq<'a>(TLVElement<'a>);
+
+impl<'a> ReadReq<'a> {
+    /// Create a new `ReadReq` from a `TLVElement`.
+    pub const fn new(element: TLVElement<'a>) -> Self {
+        Self(element)
+    }
+
+    /// Return the attribute requests in this read request, if any.
+    pub fn attr_requests(&self) -> Result<Option<TLVArray<'a, AttrPath>>, Error> {
+        Option::from_tlv(&self.0.r#struct()?.find_ctx(0)?)
+    }
+
+    /// Return the event requests in this read request, if any.
+    pub fn event_requests(&self) -> Result<Option<TLVArray<'a, EventPath>>, Error> {
+        Option::from_tlv(&self.0.r#struct()?.find_ctx(1)?)
+    }
+
+    /// Return the event filters in this read request, if any.
+    pub fn event_filters(&self) -> Result<Option<TLVArray<'a, EventFilter>>, Error> {
+        Option::from_tlv(&self.0.r#struct()?.find_ctx(2)?)
+    }
+
+    /// Return Ok(`true`) if this read request is fabric-filtered.
+    pub fn fabric_filtered(&self) -> Result<bool, Error> {
+        self.0.r#struct()?.find_ctx(3)?.bool()
+    }
+
+    /// Return the data version filters in this read request, if any.
+    pub fn dataver_filters(&self) -> Result<Option<TLVArray<'a, DataVersionFilter>>, Error> {
+        Option::from_tlv(&self.0.r#struct()?.find_ctx(4)?)
+    }
+}
+
+impl fmt::Debug for ReadReq<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadReqRef")
+            .field("attr_requests", &self.attr_requests())
+            .field("event_requests", &self.event_requests())
+            .field("event_filters", &self.event_filters())
+            .field("fabric_filtered", &self.fabric_filtered())
+            .field("dataver_filters", &self.dataver_filters())
+            .finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for ReadReq<'_> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(f,
+            "ReadReqRef {{\n  attr_requests: {:?},\n  event_requests: {:?},\n  event_filters: {:?},\n  fabric_filtered: {:?},\n  dataver_filters: {:?},\n}}",
+            self.attr_requests(),
+            self.event_requests(),
+            self.event_filters(),
+            self.fabric_filtered(),
+            self.dataver_filters(),
+        )
+    }
+}
+
+/// Tags corresponding to the fields in the `ReadReq` TLV structure.
+///
+/// Used when there is a need to perform low-level TLV serde on
+/// `ReadReq` structures.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum ReadReqTag {
+    AttrRequests = 0,
+    EventRequests = 1,
+    EventFilters = 2,
+    FabricFiltered = 3,
+    DataVersionFilters = 4,
+}

--- a/rs-matter/src/im/attr/subscribe.rs
+++ b/rs-matter/src/im/attr/subscribe.rs
@@ -1,0 +1,151 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use core::fmt;
+
+use crate::error::Error;
+use crate::im::{AttrPath, DataVersionFilter, EventFilter, EventPath};
+use crate::tlv::{FromTLV, TLVArray, TLVElement, TagType, ToTLV};
+use crate::utils::storage::WriteBuf;
+
+/// A request to subscribe to attributes and events from a Matter device.
+///
+/// Corresponds to the `SubscribeRequestMessage` TLV structure in the Interaction Model.
+#[derive(Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[tlvargs(lifetime = "'a")]
+pub struct SubscribeReq<'a>(TLVElement<'a>);
+
+impl<'a> SubscribeReq<'a> {
+    /// Create a new `SubscribeReq` from a `TLVElement`.
+    pub const fn new(element: TLVElement<'a>) -> Self {
+        Self(element)
+    }
+
+    /// Return `Ok(true)` if this subscription request should keep existing subscriptions.
+    pub fn keep_subs(&self) -> Result<bool, Error> {
+        self.0.r#struct()?.find_ctx(0)?.bool()
+    }
+
+    /// Return the minimum interval floor for this subscription request.
+    pub fn min_int_floor(&self) -> Result<u16, Error> {
+        self.0.r#struct()?.find_ctx(1)?.u16()
+    }
+
+    /// Return the maximum interval ceiling for this subscription request.
+    pub fn max_int_ceil(&self) -> Result<u16, Error> {
+        self.0.r#struct()?.find_ctx(2)?.u16()
+    }
+
+    /// Return the attribute requests in this subscription request, if any.
+    pub fn attr_requests(&self) -> Result<Option<TLVArray<'a, AttrPath>>, Error> {
+        Option::from_tlv(&self.0.r#struct()?.find_ctx(3)?)
+    }
+
+    /// Return the event requests in this subscription request, if any.
+    pub fn event_requests(&self) -> Result<Option<TLVArray<'a, EventPath>>, Error> {
+        Option::from_tlv(&self.0.r#struct()?.find_ctx(4)?)
+    }
+
+    /// Return the event filters in this subscription request, if any.
+    pub fn event_filters(&self) -> Result<Option<TLVArray<'a, EventFilter>>, Error> {
+        Option::from_tlv(&self.0.r#struct()?.find_ctx(5)?)
+    }
+
+    /// Return `Ok(true)` if this subscription request is fabric-filtered.
+    pub fn fabric_filtered(&self) -> Result<bool, Error> {
+        self.0.r#struct()?.find_ctx(7)?.bool()
+    }
+
+    /// Return the data version filters in this subscription request, if any.
+    pub fn dataver_filters(&self) -> Result<Option<TLVArray<'a, DataVersionFilter>>, Error> {
+        Option::from_tlv(&self.0.r#struct()?.find_ctx(8)?)
+    }
+}
+
+impl fmt::Debug for SubscribeReq<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SubscribeReqRef")
+            .field("keep_subs", &self.keep_subs())
+            .field("min_int_floor", &self.min_int_floor())
+            .field("max_int_ceil", &self.max_int_ceil())
+            .field("attr_requests", &self.attr_requests())
+            .field("event_requests", &self.event_requests())
+            .field("event_filters", &self.event_filters())
+            .field("fabric_filtered", &self.fabric_filtered())
+            .field("dataver_filters", &self.dataver_filters())
+            .finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for SubscribeReq<'_> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(f,
+            "SubscribeReqRef {{\n  keep_subs: {:?},\n  min_int_floor: {:?},\n  max_int_ceil: {:?},\n  attr_requests: {:?},\n  event_requests: {:?},\n  event_filters: {:?},\n  fabric_filtered: {:?},\n  dataver_filters: {:?},\n}}",
+            self.keep_subs(),
+            self.min_int_floor(),
+            self.max_int_ceil(),
+            self.attr_requests(),
+            self.event_requests(),
+            self.event_filters(),
+            self.fabric_filtered(),
+            self.dataver_filters(),
+        )
+    }
+}
+
+/// A response to a subscription request.
+///
+/// Corresponds to the `SubscribeResponseMessage` TLV structure in the Interaction Model.
+#[derive(Debug, Default, Clone, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SubscribeResp {
+    pub subs_id: u32,
+    // The Context Tags are discontiguous for some reason
+    pub _dummy: Option<u32>,
+    pub max_int: u16,
+}
+
+impl SubscribeResp {
+    /// Create a new `SubscribeResp` with the given subscription ID and maximum interval.
+    pub fn new(subs_id: u32, max_int: u16) -> Self {
+        Self {
+            subs_id,
+            _dummy: None,
+            max_int,
+        }
+    }
+
+    /// Write a `SubscribeResp` message to the provided `WriteBuf`.
+    ///
+    /// Returns a slice of the buffer containing the serialized response.
+    ///
+    /// Arguments:
+    /// - `wb`: A mutable reference to a `WriteBuf` where the response will be written.
+    /// - `subscription_id`: The subscription ID to include in the response.
+    /// - `max_int`: The maximum interval for the subscription to include in the response.
+    pub fn write<'a>(
+        wb: &'a mut WriteBuf,
+        subscription_id: u32,
+        max_int: u16,
+    ) -> Result<&'a [u8], Error> {
+        let resp = Self::new(subscription_id, max_int);
+        resp.to_tlv(&TagType::Anonymous, &mut *wb)?;
+
+        Ok(wb.as_slice())
+    }
+}

--- a/rs-matter/src/im/attr/write.rs
+++ b/rs-matter/src/im/attr/write.rs
@@ -1,0 +1,131 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use core::fmt;
+
+use crate::error::Error;
+use crate::im::{AttrData, AttrStatus};
+use crate::tlv::{FromTLV, TLVArray, TLVElement, ToTLV};
+
+/// A request to write attributes to a Matter device.
+///
+/// Corresponds to the `WriteRequestMessage` TLV structure in the Interaction Model.
+#[derive(Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[tlvargs(lifetime = "'a")]
+pub struct WriteReq<'a>(TLVElement<'a>);
+
+impl<'a> WriteReq<'a> {
+    /// Create a new `WriteReq` from a `TLVElement`.
+    pub const fn new(element: TLVElement<'a>) -> Self {
+        Self(element)
+    }
+
+    /// Return `Ok(true)` if this write request should suppress the response.
+    pub fn supress_response(&self) -> Result<bool, Error> {
+        self.0
+            .r#struct()?
+            .find_ctx(0)?
+            .non_empty()
+            .map(|t| t.bool())
+            .unwrap_or(Ok(false))
+    }
+
+    /// Return `Ok(true)` if this write request is a timed request.
+    pub fn timed_request(&self) -> Result<bool, Error> {
+        self.0
+            .r#struct()?
+            .find_ctx(1)?
+            .non_empty()
+            .map(|t| t.bool())
+            .unwrap_or(Ok(false))
+    }
+
+    /// Return the attribute data to write in this write request.
+    pub fn write_requests(&self) -> Result<TLVArray<'a, AttrData<'_>>, Error> {
+        TLVArray::new(self.0.r#struct()?.find_ctx(2)?)
+    }
+
+    /// Return `Ok(true)` if this write request has more chunks
+    /// (i.e. more write requests coming after this one, which are for the same exchange/transaction).
+    pub fn more_chunks(&self) -> Result<bool, Error> {
+        self.0
+            .r#struct()?
+            .find_ctx(3)?
+            .non_empty()
+            .map(|t| t.bool())
+            .unwrap_or(Ok(false))
+    }
+}
+
+impl fmt::Debug for WriteReq<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WriteReqRef")
+            .field("supress_response", &self.supress_response())
+            .field("timed_request", &self.timed_request())
+            .field("write_requests", &self.write_requests())
+            .field("more_chunks", &self.more_chunks())
+            .finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for WriteReq<'_> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(f,
+            "WriteReqRef {{\n  supress_response: {:?},\n  timed_request: {:?},\n  write_requests: {:?},\n  more_chunks: {:?},\n}}",
+            self.supress_response(),
+            self.timed_request(),
+            self.write_requests(),
+            self.more_chunks(),
+        )
+    }
+}
+
+/// Tags corresponding to the fields in the `WriteReq` TLV structure.
+///
+/// Used when there is a need to perform low-level TLV serde on
+/// `WriteReq` structures.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum WriteReqTag {
+    SuppressResponse = 0,
+    TimedRequest = 1,
+    WriteRequests = 2,
+    MoreChunked = 3,
+}
+
+/// A response to a write request.
+///
+/// Corresponds to the `WriteResponseMessage` TLV structure in the Interaction Model.
+#[derive(ToTLV, FromTLV, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(lifetime = "'a")]
+pub struct WriteResp<'a> {
+    pub write_responses: TLVArray<'a, AttrStatus>,
+}
+
+/// Create a new `WriteResp` from a `TLVElement`.
+///
+/// Used when there is a need to perform low-level TLV serde on
+/// `WriteResp` structures.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum WriteRespTag {
+    WriteResponses = 0,
+}

--- a/rs-matter/src/im/invoke.rs
+++ b/rs-matter/src/im/invoke.rs
@@ -1,0 +1,261 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! This module contains types related to command invocations in the Interaction Model.
+
+use core::fmt;
+
+use crate::error::Error;
+use crate::tlv::{FromTLV, TLVArray, TLVElement, ToTLV};
+
+use super::{ClusterId, CmdId, EndptId, GenericPath, IMStatusCode, Status};
+
+/// A path to a command in the Interaction Model.
+///
+/// Corresponds to the `CommandPathIB` block in the Matter Core spec.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[tlvargs(datatype = "list")]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct CmdPath {
+    /// The endpoint ID, if specified, otherwise `None` for wildcard
+    pub endpoint: Option<EndptId>,
+    /// The cluster ID, if specified, otherwise `None` for wildcard
+    pub cluster: Option<ClusterId>,
+    /// The command ID, if specified, otherwise `None` for wildcard
+    pub cmd: Option<CmdId>,
+}
+
+impl CmdPath {
+    /// Create a new instance from the given IDs.
+    pub const fn new(
+        endpoint: Option<EndptId>,
+        cluster: Option<ClusterId>,
+        cmd: Option<CmdId>,
+    ) -> Self {
+        Self {
+            endpoint,
+            cluster,
+            cmd,
+        }
+    }
+
+    /// Create a new instance from the given `GenericPath`.
+    pub const fn from_gp(path: &GenericPath) -> Self {
+        Self {
+            endpoint: path.endpoint,
+            cluster: path.cluster,
+            cmd: path.leaf,
+        }
+    }
+
+    /// Convert this command path to a `GenericPath`.
+    pub const fn to_gp(&self) -> GenericPath {
+        GenericPath::new(self.endpoint, self.cluster, self.cmd)
+    }
+}
+
+/// Status of a command invocation.
+///
+/// Returned when a command invocation does not have a specific generated-command
+/// response.
+///
+/// Corresponds to the `CommandStatusIB` block in the Matter Core spec.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct CmdStatus {
+    /// The command path associated with this status.
+    pub path: CmdPath,
+    /// The status of the command invocation.
+    pub status: Status,
+}
+
+impl CmdStatus {
+    /// Create a new command status with the given path, status code, and optional cluster status.
+    pub const fn new(path: CmdPath, status: IMStatusCode, cluster_status: Option<u16>) -> Self {
+        Self {
+            path,
+            status: Status {
+                status,
+                cluster_status,
+            },
+        }
+    }
+}
+
+/// Data associated with a command invocation.
+///
+/// Corresponds to the `CommandDataIB` struct in the Matter Core spec.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(lifetime = "'a")]
+pub struct CmdData<'a> {
+    pub path: CmdPath,
+    pub data: TLVElement<'a>,
+}
+
+impl<'a> CmdData<'a> {
+    /// Create a new command data instance with the specified path and data.
+    pub const fn new(path: CmdPath, data: TLVElement<'a>) -> Self {
+        Self { path, data }
+    }
+}
+
+/// Tags corresponding to the fields in the `CmdData` struct.
+///
+/// Used when there is a need to perform low-level TLV serde on
+/// `CmdData` data.
+pub enum CmdDataTag {
+    Path = 0,
+    Data = 1,
+}
+
+/// Response to a command invocation.
+///
+/// Corresponds to the `InvokeResponseIB` struct in the Matter Core spec.
+#[derive(Clone, FromTLV, ToTLV, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(lifetime = "'a")]
+pub enum CmdResp<'a> {
+    Cmd(CmdData<'a>),
+    Status(CmdStatus),
+}
+
+impl CmdResp<'_> {
+    /// Create the `Status` variant of a command response
+    /// with the given command path, status code, and optional cluster status.
+    pub const fn status_new(
+        cmd_path: CmdPath,
+        status: IMStatusCode,
+        cluster_status: Option<u16>,
+    ) -> Self {
+        Self::Status(CmdStatus {
+            path: cmd_path,
+            status: Status::new(status, cluster_status),
+        })
+    }
+}
+
+impl<'a> From<CmdData<'a>> for CmdResp<'a> {
+    fn from(value: CmdData<'a>) -> Self {
+        Self::Cmd(value)
+    }
+}
+
+/// Tags corresponding to the fields in the `CmdResp` enum.
+///
+/// Used when there is a need to perform low-level TLV serde on
+/// `CmdResp` data.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum CmdRespTag {
+    Cmd = 0,
+    Status = 1,
+}
+
+impl From<CmdStatus> for CmdResp<'_> {
+    fn from(value: CmdStatus) -> Self {
+        Self::Status(value)
+    }
+}
+
+/// A request to invoke commands in the Interaction Model.
+///
+/// Corresponds to the `InvokeRequestMessage` struct in the Matter Core spec.
+#[derive(Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[tlvargs(lifetime = "'a")]
+pub struct InvReq<'a>(TLVElement<'a>);
+
+impl<'a> InvReq<'a> {
+    /// Create a new `InvReq` instance from the given TLV element.
+    pub const fn new(element: TLVElement<'a>) -> Self {
+        Self(element)
+    }
+
+    /// Return `true` if the request indicates that the response should be suppressed.
+    pub fn suppress_response(&self) -> Result<bool, Error> {
+        self.0
+            .r#struct()?
+            .find_ctx(0)?
+            .non_empty()
+            .map(|t| t.bool())
+            .unwrap_or(Ok(false))
+    }
+
+    /// Return `true` if the request indicates that it is a timed request.
+    pub fn timed_request(&self) -> Result<bool, Error> {
+        self.0
+            .r#struct()?
+            .find_ctx(1)?
+            .non_empty()
+            .map(|t| t.bool())
+            .unwrap_or(Ok(false))
+    }
+
+    /// Return the invocation requests contained in this request.
+    pub fn inv_requests(&self) -> Result<Option<TLVArray<'a, CmdData<'a>>>, Error> {
+        Option::from_tlv(&self.0.r#struct()?.find_ctx(2)?)
+    }
+}
+
+impl fmt::Debug for InvReq<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InvReqRef")
+            .field("suppress_response", &self.suppress_response())
+            .field("timed_request", &self.timed_request())
+            .field("inv_requests", &self.inv_requests())
+            .finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for InvReq<'_> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(f,
+            "InvReqRef {{\n  suppress_response: {:?},\n  timed_request: {:?},\n  inv_requests: {:?},\n}}",
+            self.suppress_response(),
+            self.timed_request(),
+            self.inv_requests(),
+        )
+    }
+}
+
+/// Tags corresponding to the fields in the `InvReq` struct.
+///
+/// Used when there is a need to perform low-level TLV serde on
+/// `InvReq` data.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum InvReqTag {
+    SupressResponse = 0,
+    TimedReq = 1,
+    InvokeRequests = 2,
+}
+
+/// Tags corresponding to the fields in the `InvokeResponseMessage`
+/// IM struct.
+///
+/// Used when there is a need to perform low-level TLV serde on
+/// `InvokeResponseMessage` data.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum InvRespTag {
+    SupressResponse = 0,
+    InvokeResponses = 1,
+}

--- a/rs-matter/src/im/status.rs
+++ b/rs-matter/src/im/status.rs
@@ -1,0 +1,62 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! This module defines the `Status` and `StatusResp` structures used in the Interaction Model.
+
+use crate::error::Error;
+use crate::tlv::{FromTLV, TagType, ToTLV};
+use crate::utils::storage::WriteBuf;
+
+use super::IMStatusCode;
+
+/// An IM status structure that contains an `IMStatusCode` and an optional cluster status code.
+///
+/// Corresponds to the `StatusIB` block in the Matter Interaction Model.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Status {
+    /// The status code of the IM operation.
+    pub status: IMStatusCode,
+    /// An optional cluster status code, which is used for cluster-specific status codes.
+    pub cluster_status: Option<u16>,
+}
+
+impl Status {
+    /// Create a new `Status` instance with the given `IMStatusCode` and an optional cluster status code.
+    pub const fn new(status: IMStatusCode, cluster_status: Option<u16>) -> Status {
+        Status {
+            status,
+            cluster_status,
+        }
+    }
+}
+
+/// An IM status response structure used for sending/receiving status responses in the Interaction Model.
+///
+/// Corresponds to the `StatusResponseMessage` struct in the Matter Interaction Model.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct StatusResp {
+    pub status: IMStatusCode,
+}
+
+impl StatusResp {
+    pub fn write(wb: &mut WriteBuf, status: IMStatusCode) -> Result<(), Error> {
+        let status = Self { status };
+        status.to_tlv(&TagType::Anonymous, wb)
+    }
+}

--- a/rs-matter/src/im/timed.rs
+++ b/rs-matter/src/im/timed.rs
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! This module contains types related to the Timed Request feature in the Matter Interaction Model.
+
+use core::time::Duration;
+
+use crate::tlv::{FromTLV, ToTLV};
+use crate::utils::epoch::Epoch;
+
+/// A structure representing a timed request in the Interaction Model.
+///
+/// Corresponds to the `TimedRequestMessage` struct in the Interaction Model.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TimedReq {
+    /// The timeout duration in milliseconds for the request.
+    pub timeout: u16,
+}
+
+impl TimedReq {
+    /// Returns the moment in time - since the system epoch - when the request
+    /// following this timed request should be considered expired.
+    pub fn timeout_instant(&self, epoch: Epoch) -> Duration {
+        unwrap!(epoch().checked_add(Duration::from_millis(self.timeout as _)))
+    }
+}

--- a/rs-matter/tests/common/e2e/im.rs
+++ b/rs-matter/tests/common/e2e/im.rs
@@ -20,7 +20,7 @@ use bitflags::bitflags;
 use rs_matter::error::Error;
 use rs_matter::im::{AttrPath, AttrResp, AttrStatus, DataVersionFilter, EventFilter, EventPath};
 use rs_matter::im::{OpCode, PROTO_ID_INTERACTION_MODEL};
-use rs_matter::im::{ReportDataMsg, WriteReqTag};
+use rs_matter::im::{ReportDataResp, WriteReqTag};
 use rs_matter::tlv::{FromTLV, Slice, TLVElement, TLVTag, TLVWrite, ToTLV};
 use rs_matter::transport::exchange::MessageMeta;
 use rs_matter::utils::storage::WriteBuf;
@@ -398,7 +398,7 @@ impl ReplyProcessor {
             return Ok(wb.get_tail());
         }
 
-        let report_data = ReportDataMsg::from_tlv(element)?;
+        let report_data = ReportDataResp::from_tlv(element)?;
 
         wb.start_struct(&TLVTag::Anonymous)?;
 

--- a/rs-matter/tests/common/e2e/im/attributes.rs
+++ b/rs-matter/tests/common/e2e/im/attributes.rs
@@ -25,13 +25,74 @@ use rs_matter::utils::storage::WriteBuf;
 use crate::common::e2e::tlv::{TLVTest, TestToTLV};
 use crate::common::e2e::E2eRunner;
 
-/// A macro for creating a `TestAttrResp` instance of variant `Status`.
+/// A macro for creating an `AttrStatus` instance for the provided generic path and `IMStatusCode``
 #[macro_export]
 macro_rules! attr_status {
     ($path:expr, $status:expr) => {
-        $crate::common::e2e::im::attributes::TestAttrResp::AttrStatus(
-            rs_matter::im::AttrStatus::new($path, $status, None),
+        rs_matter::im::AttrStatus::from_gp($path, $status, None)
+    };
+}
+
+/// A macro for creating an `AttrStatus` instance for the provided generic path and `IMStatusCode``,
+/// where the path is for one concrete array element in an array attribute
+#[macro_export]
+macro_rules! attr_status_lel {
+    ($path:expr, $status:expr) => {
+        rs_matter::im::AttrStatus::new(
+            rs_matter::im::AttrPath {
+                tag_compression: None,
+                node: None,
+                endpoint: $path.endpoint,
+                cluster: $path.cluster,
+                attr: $path.leaf,
+                list_index: Some(rs_matter::tlv::Nullable::none()),
+            },
+            $status,
+            None,
         )
+    };
+}
+
+/// A macro for creating a `TestAttrResp` instance of variant `Status`.
+#[macro_export]
+macro_rules! attr_read_status_resp {
+    ($path:expr, $status:expr) => {
+        $crate::common::e2e::im::attributes::TestAttrResp::AttrStatus($crate::attr_status!(
+            $path, $status
+        ))
+    };
+}
+
+/// A macro for creating a `TestAttrData` instance of variant `AttrData` taking
+/// a `GenericPath` instance and data.
+#[macro_export]
+macro_rules! attr_data_req {
+    ($path:expr, $data:expr) => {
+        $crate::common::e2e::im::attributes::TestAttrData {
+            data_ver: None,
+            path: rs_matter::im::AttrPath::from_gp(&$path),
+            data: $data,
+        }
+    };
+}
+
+/// Same as `attr_data_req!`, but generates a path for one concrete
+/// array element in an array attribute
+#[macro_export]
+macro_rules! attr_data_req_lel {
+    ($path:expr, $data:expr) => {
+        $crate::common::e2e::im::attributes::TestAttrData {
+            data_ver: None,
+            path: rs_matter::im::AttrPath {
+                tag_compression: None,
+                node: None,
+                endpoint: $path.endpoint,
+                cluster: $path.cluster,
+                attr: $path.leaf,
+                list_index: Some(rs_matter::tlv::Nullable::none()),
+            },
+            data: $data,
+        }
     };
 }
 
@@ -40,13 +101,9 @@ macro_rules! attr_status {
 #[macro_export]
 macro_rules! attr_data_path {
     ($path:expr, $data:expr) => {
-        $crate::common::e2e::im::attributes::TestAttrResp::AttrData(
-            $crate::common::e2e::im::attributes::TestAttrData {
-                data_ver: None,
-                path: rs_matter::im::AttrPath::new(&$path),
-                data: $data,
-            },
-        )
+        $crate::common::e2e::im::attributes::TestAttrResp::AttrData($crate::attr_data_req!(
+            $path, $data
+        ))
     };
 }
 
@@ -55,20 +112,9 @@ macro_rules! attr_data_path {
 #[macro_export]
 macro_rules! attr_data_lel_path {
     ($path:expr, $data:expr) => {
-        $crate::common::e2e::im::attributes::TestAttrResp::AttrData(
-            $crate::common::e2e::im::attributes::TestAttrData {
-                data_ver: None,
-                path: rs_matter::im::AttrPath {
-                    tag_compression: None,
-                    node: None,
-                    endpoint: $path.endpoint,
-                    cluster: $path.cluster,
-                    attr: $path.leaf,
-                    list_index: Some(rs_matter::tlv::Nullable::none()),
-                },
-                data: $data,
-            },
-        )
+        $crate::common::e2e::im::attributes::TestAttrResp::AttrData($crate::attr_data_req_lel!(
+            $path, $data
+        ))
     };
 }
 
@@ -160,7 +206,7 @@ pub enum TestAttrResp<'a> {
 impl<'a> TestAttrResp<'a> {
     /// Create a new `TestAttrResp` instance with an `AttrData` value.
     pub fn data(path: &GenericPath, data: &'a dyn TestToTLV) -> Self {
-        Self::AttrData(TestAttrData::new(None, AttrPath::new(path), data))
+        Self::AttrData(TestAttrData::new(None, AttrPath::from_gp(path), data))
     }
 }
 

--- a/rs-matter/tests/data_model/long_reads.rs
+++ b/rs-matter/tests/data_model/long_reads.rs
@@ -413,7 +413,7 @@ fn test_long_read_success() {
         &handler,
         [
             &TLVTest::read(
-                TestReadReq::reqs(&[AttrPath::new(&GenericPath::new(None, None, None))]),
+                TestReadReq::reqs(&[AttrPath::from_gp(&GenericPath::new(None, None, None))]),
                 TestReportDataMsg {
                     attr_reports: Some(&ATTR_RESPS[..PART_1]),
                     more_chunks: Some(true),
@@ -491,7 +491,9 @@ fn test_long_read_subscription_success() {
                 TestSubscribeReq {
                     min_int_floor: 1,
                     max_int_ceil: 10,
-                    ..TestSubscribeReq::reqs(&[AttrPath::new(&GenericPath::new(None, None, None))])
+                    ..TestSubscribeReq::reqs(&[AttrPath::from_gp(&GenericPath::new(
+                        None, None, None,
+                    ))])
                 },
                 TestReportDataMsg {
                     subscription_id: Some(1),

--- a/rs-matter/tests/data_model/timed_requests.rs
+++ b/rs-matter/tests/data_model/timed_requests.rs
@@ -44,7 +44,11 @@ fn test_timed_write_fail_and_success() {
         Some(echo_cluster::ID),
         Some(echo_cluster::AttributesDiscriminants::AttWrite as u32),
     );
-    let input = &[TestAttrData::new(None, AttrPath::new(&ep_att), &val0 as _)];
+    let input = &[TestAttrData::new(
+        None,
+        AttrPath::from_gp(&ep_att),
+        &val0 as _,
+    )];
 
     let ep0_att = GenericPath::new(
         Some(0),
@@ -58,8 +62,8 @@ fn test_timed_write_fail_and_success() {
         Some(echo_cluster::AttributesDiscriminants::AttWrite as u32),
     );
     let expected = &[
-        AttrStatus::new(&ep0_att, IMStatusCode::Success, None),
-        AttrStatus::new(&ep1_att, IMStatusCode::Success, None),
+        AttrStatus::from_gp(&ep0_att, IMStatusCode::Success, None),
+        AttrStatus::from_gp(&ep1_att, IMStatusCode::Success, None),
     ];
 
     let im = ImEngine::new_default();


### PR DESCRIPTION
This PR is documenting all structures in the Interaction Model (`im.rs`) and is also splitting the large `im.rs` file into private submodules to improve readability.

To the outside world, the private modules are invisible as they are re-exported with `pub use::*` under the `rs_matter::im` namespace, as we do for many other private modules as well.

====

While this change was supposed to have **zero** impact on code outside `rs_mater::im`, while doing it I uncovered two bugs, which resulted in two changes (and one rename):

1. **The method `AttrStatus::new(GenericPath, ...)` should NOT be used in anything but unit tests**
The reason is, the `GenericPath` utility (now documented) is capturing only a subset of the fields of the actual `AttrPath`. In particular, it is not capturing the `list_index` field of the original `AttrPath`, and as such it should not be used in non-unit-test `rs-matter` code.

Therefore, the signature of `AttrStatus::new` is now changed to take a proper `AttrPath`, and the old signature is renamed to `AttrStatus::from_gp` and documented as unreliable. It is only now used in unit tests which is OK. BTW, we have to clean those up a bit as they are unnecessarily verbose at many places by not utilizing enough the `*path!` / `*data!` uni-test / integration-test macros we have, but that's for another day.

2. **`ListOperation` / `attr_list_write` removed**

This type and accompanying method are the old (and wrong) way of interpreting incoming array-attribute modification operations. They should've been removed long ago, but I forgot them and turns out they were still used in the "array attribute write" unit test (`attribute_lists.rs`) which was itself wrongly testing and I had to fix it.

The TL;DR is that `ListOperation` / `attr_list_write` assume that individual operations on attribute arrays (deleting an individual array item; replacing an individual array item etc.) are possible, while in reality these are not (yet) possible, as per section 10.6.4.3.1 "Lists" of the Matter Core spec.

The new `ArrayAttributeWrite` type which was introduced months ago does preserve forward compatibility with possible future Matter spec that would allow individual operations, but interpret the incoming `list_index` value correctly as per the latest Matter spec and makes sure those future individual array item operations are in fact disabled and generate `InvalidAction` errors (which the Matter tests check for!).

3. **`ReportDataMsg` / `ReportDataMsgTag` were renamed to `ReportDataResp` / `ReportDataRespTag`**

This is just for consistency with all other IM types which do have the `Resp` rather than the `Msg` suffix.
