### PR TITLE
TestClusterComplexTypes

### DIFF
--- a/rs-matter-macros/src/idl.rs
+++ b/rs-matter-macros/src/idl.rs
@@ -20557,7 +20557,7 @@ pub mod unit_testing {
                 rs_matter_crate::dm::Command::new(
                     CommandId::TimedInvokeRequest as _,
                     None,
-                    rs_matter_crate::dm::Access::WO,
+                    rs_matter_crate::dm::Access::WO.union(rs_matter_crate::dm::Access::TIMED_ONLY),
                 ),
                 rs_matter_crate::dm::Command::new(
                     CommandId::TestSimpleOptionalArgumentRequest as _,

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -583,7 +583,7 @@ where
                 .map(|timeout_instant| (exchange.matter().epoch())() > timeout_instant)
                 .unwrap_or(false)
             {
-                Some(IMStatusCode::Timeout)
+                Some(IMStatusCode::UnsupportedAccess)
             } else {
                 None
             }

--- a/rs-matter/src/dm/clusters/unit_testing.rs
+++ b/rs-matter/src/dm/clusters/unit_testing.rs
@@ -853,7 +853,7 @@ impl ClusterHandler for UnitTestingHandler<'_> {
     }
 
     fn timed_write_boolean(&self, _ctx: impl ReadContext) -> Result<bool, Error> {
-        todo!()
+        Ok(self.data.borrow().timed_write_boolean)
     }
 
     fn general_error_boolean(&self, _ctx: impl ReadContext) -> Result<bool, Error> {
@@ -1636,8 +1636,9 @@ impl ClusterHandler for UnitTestingHandler<'_> {
         todo!()
     }
 
-    fn set_timed_write_boolean(&self, _ctx: impl WriteContext, _value: bool) -> Result<(), Error> {
-        todo!()
+    fn set_timed_write_boolean(&self, _ctx: impl WriteContext, value: bool) -> Result<(), Error> {
+        self.data.borrow_mut().timed_write_boolean = value;
+        Ok(())
     }
 
     fn set_general_error_boolean(
@@ -2543,7 +2544,7 @@ impl ClusterHandler for UnitTestingHandler<'_> {
     }
 
     fn handle_timed_invoke_request(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 
     fn handle_test_simple_optional_argument_request(

--- a/rs-matter/tests/data_model/timed_requests.rs
+++ b/rs-matter/tests/data_model/timed_requests.rs
@@ -162,7 +162,7 @@ fn test_timed_write_fail_and_success() {
                     reliable: true,
                 },
                 expected_payload: StatusResp {
-                    status: IMStatusCode::Timeout,
+                    status: IMStatusCode::UnsupportedAccess,
                 },
                 process_reply: ReplyProcessor::none,
             },
@@ -276,7 +276,7 @@ fn test_timed_cmd_timeout() {
                     reliable: true,
                 },
                 expected_payload: StatusResp {
-                    status: IMStatusCode::Timeout,
+                    status: IMStatusCode::UnsupportedAccess,
                 },
                 process_reply: ReplyProcessor::none,
             },

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -33,6 +33,7 @@ const DEFAULT_TESTS: &[&str] = &[
     "TestAttributesById",
     "TestCommandsById",
     "TestCluster",
+    "TestClusterComplexTypes",
     "TestBasicInformation",
     // "TestAccessControlCluster",
 ];


### PR DESCRIPTION
Turns out the timed command invokes and timed attribute writes of `TestCluster` are in a separate test suite - `TestClusterComplexTypes` - for, hm, reasons.

Anyway.

The `TestClusterComplexTypes` suite now also executes successfully, after the usual round of bug-fixes. This time, much smaller change-set, for a change:
- I had to push the "timed" and "fabric_scoped" attributes of the commands from the IDL down to the `Command::access` member, as I had forgotten that.
- I had to implement a small chunk of code that actually does use those access types and checks that the attribute-write or the command invocation of a timed-only attribute and/or command really **does** come from a timed request. Otherwise we should fail. Also, when a timed attr-write or invoke has timed out we should fail with "UnsupportedAccess" and not with "Timeout" as it was wrongly coded in our own unit tests and the code.