### PR TITLE
Fix embassy_futures::select_slice

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -44,7 +44,7 @@ safemem = { version = "0.3", default-features = false }
 owo-colors = "4"
 time = { version = "0.3", default-features = false }
 verhoeff = { version = "1", default-features = false }
-embassy-futures = "0.1"
+embassy-futures = "0.1.2"
 embassy-time = "0.4"
 embassy-time-queue-utils = "0.1"
 embassy-sync = "0.7"

--- a/rs-matter/src/respond.rs
+++ b/rs-matter/src/respond.rs
@@ -159,7 +159,10 @@ where
             unwrap!(handlers.push(self.handle(handler_id)).map_err(|_| ())); // Cannot fail because the vector has size N
         }
 
-        select_slice(&mut handlers).await.0
+        let handlers = pin!(handlers);
+        let handlers = unsafe { handlers.map_unchecked_mut(|handlers| handlers.as_mut_slice()) };
+
+        select_slice(handlers).await.0
     }
 
     #[inline(always)]


### PR DESCRIPTION
The just released `embassy-futures`  patch (0.1.2) contains a breaking change in `select_slice`. It was released as a patch release, because Rust semver checks do not apply when a soundness issue is found.

This PR is updating `rs-matter` to be compatible with the new signature of `select_slice` which requires pinning.