### PR TITLE
Add target flag to itest

### DIFF
--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -43,9 +43,6 @@ pub const CHIP_DEFAULT_GITREF: &str = "v1.3.0.0"; //"master";
 /// The directory where the Chip repository will be cloned
 const CHIP_DIR: &str = ".build/itest/connectedhomeip";
 
-/// The name of the tested `rs-matter` executable's PICS file
-const TEST_EXE_PICS_NAME: &str = "chip_tool_tests.pics";
-
 /// The tooling that is checked for presence in the command line
 const REQUIRED_TOOLING: &[&str] = &[
     "bash",
@@ -303,7 +300,13 @@ impl ITests {
         Ok(())
     }
 
-    fn run_test(&self, test_name: &str, timeout_secs: u32, profile: &str, target: &str) -> anyhow::Result<()> {
+    fn run_test(
+        &self,
+        test_name: &str,
+        timeout_secs: u32,
+        profile: &str,
+        target: &str,
+    ) -> anyhow::Result<()> {
         // TODO: Running test-by-test is slow. Turn this into a run-multiple-tests function.
 
         info!("=> Running test `{test_name}` with timeout {timeout_secs}s...");
@@ -313,10 +316,10 @@ impl ITests {
         let test_suite_path = chip_dir.join("scripts/tests/run_test_suite.py");
         let chip_tool_path = chip_dir.join("out/host/chip-tool");
         let test_exe_path = self.test_exe_path(profile, target);
-        let test_pics_path = self.test_pics_path();
+        let test_pics_path = self.test_pics_path(target);
 
         let test_command = format!(
-            "{} --log-level debug --target {} --runner chip_tool_python --chip-tool {} run --iterations 1 --test-timeout-seconds {} --all-clusters-app {} --pics-file {}",
+            "{} --log-level warn --target {} --runner chip_tool_python --chip-tool {} run --iterations 1 --test-timeout-seconds {} --all-clusters-app {} --pics-file {}",
             test_suite_path.display(),
             test_name,
             chip_tool_path.display(),
@@ -506,18 +509,15 @@ impl ITests {
     }
 
     fn test_exe_path(&self, profile: &str, target: &str) -> PathBuf {
-        self.workspace_dir
-            .join("target")
-            .join(profile)
-            .join(target)
+        self.workspace_dir.join("target").join(profile).join(target)
     }
 
-    fn test_pics_path(&self) -> PathBuf {
+    fn test_pics_path(&self, target: &str) -> PathBuf {
         self.workspace_dir
             .join("examples")
             .join("src")
             .join("bin")
-            .join(TEST_EXE_PICS_NAME)
+            .join(format!("{target}.pics"))
     }
 
     fn chip_dir(&self) -> PathBuf {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -98,6 +98,7 @@ impl Command {
                 .setup(Some(&args.gitref), args.force_setup),
             Command::ItestExe(args) => ITests::new(workspace_dir(), print_cmd_output).build(
                 &args.profile,
+                &args.target,
                 &args.features,
                 args.force_rebuild,
             ),
@@ -121,6 +122,7 @@ impl Command {
                     tests,
                     *timeout,
                     &build_args.profile,
+                    &build_args.target,
                 )
             }
             Command::Tlv {
@@ -183,6 +185,9 @@ struct BuildArgs {
     /// Build profile (debug or release)
     #[arg(long, default_value = "debug")]
     profile: String,
+    /// Build target application name
+    #[arg(long, default_value = "chip_tool_tests")]
+    target: String,
     /// Additional cargo features
     #[arg(long)]
     features: Vec<String>,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -185,7 +185,7 @@ struct BuildArgs {
     /// Build profile (debug or release)
     #[arg(long, default_value = "debug")]
     profile: String,
-    /// Build target application name
+    /// Build target application name (`chip_tool_tests` by default)
     #[arg(long, default_value = "chip_tool_tests")]
     target: String,
     /// Additional cargo features


### PR DESCRIPTION
This PR adds the `--target` flag to the `itest` xtask, allowing the caller to run tests against any example application. `itest` expects a `.pics` file with the same name of the target in the same location of the target main.

The default value for `--target` is the same as the previous hard-coded value, `chip_tool_tests`.


