### PR TITLE
Adds shell.nix providing a standard Linux filesystem layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ There are two different environments for different use-cases.
 ### `devenv.nix`
 
 This is used for normal development of applications.
-To set this up run `devenv shell` in the project root.
+To enter this shell, run `devenv shell` in the project root.
 You can optionally follow this with your preferred shell e.g. `devenv shell zsh`.
 
 This requires [devenv](https://devenv.sh/) to be installed on your system.
@@ -82,6 +82,7 @@ For nix managed systems, add `pkgs.devenv` to `environment.systemPackages`.
 
 This is for cases where tools expect a standard Linux filesystem layout (FHS).
 Use this shell when running `cargo xtask itest` as it sets up `connectedhomeip` which expects a FHS layout.
+To enter this shell, run `nix-shell` in the project root.
 
 ## How does it look like?
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ Also look at all [open issues](https://github.com/project-chip/rs-matter/issues)
   - Automated nightly CI execution
   - Iterative test enablement workflow for developers
 
+## Nix support
+
+`rs-matter` provides nix files for setting up reproducible shells on systems using the nix package manager.
+There are two different environments for different use-cases.
+
+### `devenv.nix`
+
+This is used for normal development of applications.
+To set this up run `devenv shell` in the project root.
+You can optionally follow this with your preferred shell e.g. `devenv shell zsh`.
+
+This requires [devenv](https://devenv.sh/) to be installed on your system.
+For nix managed systems, add `pkgs.devenv` to `environment.systemPackages`.
+
+### `shell.nix`
+
+This is for cases where tools expect a standard Linux filesystem layout (FHS).
+Use this shell when running `cargo xtask itest` as it sets up `connectedhomeip` which expects a FHS layout.
+
 ## How does it look like?
 
 See the [examples](examples).

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,46 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+
+(pkgs.buildFHSEnv {
+	name = "rs-matter-test-env";
+	runScript = "zsh";
+
+    targetPkgs = pkgs: with pkgs; [
+        # rust support
+        rustc
+        cargo
+        rustfmt
+        clippy
+
+        # Provide non-privileged execution of `ip` commands
+        iproute2
+        iptables
+
+        # connectedhomeip requirements
+        git
+        gcc
+        glib
+        glib.dev
+        pkg-config
+        cmake
+        ninja
+        gn
+        gobject-introspection.dev
+        gobject-introspection.out
+        openssl.dev
+        dbus.dev
+        avahi.dev
+        unzip
+        cairo.dev
+        readline.dev
+        jre
+        libffi.dev
+        zap-chip
+
+        ## python support
+        # Note: python 3.11 is required due to the deprecation of the `imp` module in newer versions of python.
+        python311Full
+        python311Packages.pip
+        python311Packages.virtualenv
+    ];
+}).env

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,8 @@
 { pkgs ? import <nixpkgs> {} }:
 
-
 (pkgs.buildFHSEnv {
 	name = "rs-matter-test-env";
-	runScript = "zsh";
+    runScript = builtins.getEnv "SHELL";
 
     targetPkgs = pkgs: with pkgs; [
         # rust support
@@ -17,6 +16,7 @@
         iptables
 
         # connectedhomeip requirements
+        bash
         git
         gcc
         glib
@@ -40,7 +40,6 @@
         ## python support
         # Note: python 3.11 is required due to the deprecation of the `imp` module in newer versions of python.
         python311Full
-        python311Packages.pip
-        python311Packages.virtualenv
     ];
+
 }).env


### PR DESCRIPTION
This PR adds `shell.nix`, providing a standard Linux filesystem layout. A standard Linux filesystem layout is required when calling `cargo xtask itest` as this sets up `connectedhomeip` which expects such a layout.

This PR adds documentation to the main README explaining the different uses of `devenv.nix` and `shell.nix`.