### PR TITLE
Configurable memory

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -14,6 +14,78 @@ rust-version = "1.83"
 [features]
 default = ["os", "rustcrypto", "log"]
 #default = ["os", "mbedtls", "log"] mbedtls is broken since several months - check the root cause
+
+# Sizing
+
+# Number of fabrics
+max-fabrics-32 = []
+max-fabrics-16 = []
+max-fabrics-8 = []
+max-fabrics-7 = []
+max-fabrics-6 = []
+max-fabrics-5 = []
+max-fabrics-4 = []
+max-fabrics-3 = [] # default
+max-fabrics-2 = []
+max-fabrics-1 = []
+
+# Number of ACL entries per fabric
+max-acls-per-fabric-32 = []
+max-acls-per-fabric-16 = []
+max-acls-per-fabric-8 = []
+max-acls-per-fabric-7 = []
+max-acls-per-fabric-6 = []
+max-acls-per-fabric-5 = []
+max-acls-per-fabric-4 = [] # default
+max-acls-per-fabric-3 = []
+max-acls-per-fabric-2 = []
+max-acls-per-fabric-1 = []
+
+# Number of subjects per ACL entry
+max-subjects-per-acl-32 = []
+max-subjects-per-acl-16 = []
+max-subjects-per-acl-8 = []
+max-subjects-per-acl-7 = []
+max-subjects-per-acl-6 = []
+max-subjects-per-acl-5 = []
+max-subjects-per-acl-4 = [] # default
+max-subjects-per-acl-3 = []
+max-subjects-per-acl-2 = []
+max-subjects-per-acl-1 = []
+
+# Number of targets per ACL entry
+max-targets-per-acl-32 = []
+max-targets-per-acl-16 = []
+max-targets-per-acl-8 = []
+max-targets-per-acl-7 = []
+max-targets-per-acl-6 = []
+max-targets-per-acl-5 = []
+max-targets-per-acl-4 = []
+max-targets-per-acl-3 = [] # default
+max-targets-per-acl-2 = []
+max-targets-per-acl-1 = []
+
+# Number of sessions
+max-sessions-64 = []
+max-sessions-32 = []
+max-sessions-16 = [] # default
+max-sessions-8 = []
+max-sessions-7 = []
+max-sessions-6 = []
+max-sessions-5 = []
+max-sessions-4 = []
+max-sessions-3 = []
+
+# Number of exchanges per session
+max-exchanges-per-session-16 = []
+max-exchanges-per-session-8 = []
+max-exchanges-per-session-7 = []
+max-exchanges-per-session-6 = []
+max-exchanges-per-session-5 = [] # default
+max-exchanges-per-session-4 = []
+max-exchanges-per-session-3 = []
+
+# General
 astro-dnssd = ["os", "dep:astro-dnssd"]
 zeroconf = ["os", "dep:zeroconf"]
 zbus = ["dep:zbus", "os", "futures-lite", "libc", "uuid", "async-io"]
@@ -30,6 +102,7 @@ large-buffers = [] # TCP support
 
 [dependencies]
 rs-matter-macros = { version = "0.1", path = "../rs-matter-macros" }
+cfg-if = "1"
 bitflags = { version =  "2.5", default-features = false }
 byteorder = { version = "1.5", default-features = false }
 heapless = "0.8"

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -21,6 +21,7 @@ use core::fmt::Display;
 use core::num::NonZeroU8;
 use core::ops::RangeInclusive;
 
+use cfg_if::cfg_if;
 use num_derive::FromPrimitive;
 
 use crate::dm::clusters::acl::{
@@ -37,17 +38,116 @@ use crate::utils::cell::RefCell;
 use crate::utils::init::{init, Init, IntoFallibleInit};
 use crate::utils::storage::Vec;
 
-/// Max subjects per ACL entry
-// TODO: Make this configurable via a cargo feature
-pub const SUBJECTS_PER_ENTRY: usize = 4;
+cfg_if! {
+    if #[cfg(feature = "max-subjects-per-acl-32")] {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 32;
+    } else if #[cfg(feature = "max-subjects-per-acl-16")] {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 16;
+    } else if #[cfg(feature = "max-subjects-per-acl-8")] {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 8;
+    } else if #[cfg(feature = "max-subjects-per-acl-7")] {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 7;
+    } else if #[cfg(feature = "max-subjects-per-acl-6")] {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 6;
+    } else if #[cfg(feature = "max-subjects-per-acl-5")] {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 5;
+    } else if #[cfg(feature = "max-subjects-per-acl-4")] {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 4;
+    } else if #[cfg(feature = "max-subjects-per-acl-3")] {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 3;
+    } else if #[cfg(feature = "max-subjects-per-acl-2")] {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 2;
+    } else if #[cfg(feature = "max-subjects-per-acl-1")] {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 1;
+    } else {
+        /// Max subjects per ACL entry
+        pub const MAX_SUBJECTS_PER_ACL_ENTRY: usize = 4;
+    }
+}
 
-/// Max targets per ACL entry
-// TODO: Make this configurable via a cargo feature
-pub const TARGETS_PER_ENTRY: usize = 3;
+cfg_if! {
+    if #[cfg(feature = "max-targets-per-acl-32")] {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 32;
+    } else if #[cfg(feature = "max-targets-per-acl-16")] {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 16;
+    } else if #[cfg(feature = "max-targets-per-acl-8")] {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 8;
+    } else if #[cfg(feature = "max-targets-per-acl-7")] {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 7;
+    } else if #[cfg(feature = "max-targets-per-acl-6")] {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 6;
+    } else if #[cfg(feature = "max-targets-per-acl-5")] {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 5;
+    } else if #[cfg(feature = "max-targets-per-acl-4")] {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 4;
+    } else if #[cfg(feature = "max-targets-per-acl-3")] {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 3;
+    } else if #[cfg(feature = "max-targets-per-acl-2")] {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 2;
+    } else if #[cfg(feature = "max-targets-per-acl-1")] {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 1;
+    } else {
+        /// Max targets per ACL entry
+        pub const MAX_TARGETS_PER_ACL_ENTRY: usize = 3;
+    }
+}
 
-/// Max ACL entries per fabric
-// TODO: Make this configurable via a cargo feature
-pub const ENTRIES_PER_FABRIC: usize = 4;
+cfg_if! {
+    if #[cfg(feature = "max-acls-per-fabric-32")] {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 32;
+    } else if #[cfg(feature = "max-acls-per-fabric-16")] {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 16;
+    } else if #[cfg(feature = "max-acls-per-fabric-8")] {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 8;
+    } else if #[cfg(feature = "max-acls-per-fabric-7")] {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 7;
+    } else if #[cfg(feature = "max-acls-per-fabric-6")] {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 6;
+    } else if #[cfg(feature = "max-acls-per-fabric-5")] {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 5;
+    } else if #[cfg(feature = "max-acls-per-fabric-4")] {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 4;
+    } else if #[cfg(feature = "max-acls-per-fabric-3")] {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 3;
+    } else if #[cfg(feature = "max-acls-per-fabric-2")] {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 2;
+    } else if #[cfg(feature = "max-acls-per-fabric-1")] {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 1;
+    } else {
+        /// Max ACL entries per fabric
+        pub const MAX_ACL_ENTRIES_PER_FABRIC: usize = 4;
+    }
+}
 
 /// An enum modeling the different authentication modes
 // TODO: Check if this and the SessionMode can be combined into some generic data structure
@@ -387,9 +487,9 @@ pub struct AclEntry {
     /// The auth mode of the entry
     auth_mode: AuthMode,
     /// The subjects of the entry
-    subjects: Nullable<Vec<u64, SUBJECTS_PER_ENTRY>>,
+    subjects: Nullable<Vec<u64, MAX_SUBJECTS_PER_ACL_ENTRY>>,
     /// The targets of the entry
-    targets: Nullable<Vec<Target, TARGETS_PER_ENTRY>>,
+    targets: Nullable<Vec<Target, MAX_TARGETS_PER_ACL_ENTRY>>,
     // TODO: Instead of the direct value, we should consider GlobalElements::FabricIndex
     // Note that this field will always be `Some(NN)` when the entry is persisted in storage,
     // however, it will be `None` when the entry is coming from the other peer

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -103,7 +103,7 @@ impl AclHandler {
                     let entry = entry?;
                     entry.check()?;
                 }
-                if list.iter().count() > acl::ENTRIES_PER_FABRIC {
+                if list.iter().count() > acl::MAX_ACL_ENTRIES_PER_FABRIC {
                     Err(ErrorCode::ConstraintError)?;
                 }
 
@@ -165,15 +165,15 @@ impl ClusterHandler for AclHandler {
     }
 
     fn subjects_per_access_control_entry(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
-        Ok(acl::SUBJECTS_PER_ENTRY as _)
+        Ok(acl::MAX_SUBJECTS_PER_ACL_ENTRY as _)
     }
 
     fn targets_per_access_control_entry(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
-        Ok(acl::TARGETS_PER_ENTRY as _)
+        Ok(acl::MAX_TARGETS_PER_ACL_ENTRY as _)
     }
 
     fn access_control_entries_per_fabric(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
-        Ok(acl::ENTRIES_PER_FABRIC as _)
+        Ok(acl::MAX_ACL_ENTRIES_PER_FABRIC as _)
     }
 
     fn set_acl(

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -26,7 +26,7 @@ use crate::crypto::{self, KeyPair};
 use crate::dm::clusters::dev_att;
 use crate::dm::{ArrayAttributeRead, Cluster, Dataver, InvokeContext, ReadContext};
 use crate::error::{Error, ErrorCode};
-use crate::fabric::{Fabric, MAX_SUPPORTED_FABRICS};
+use crate::fabric::{Fabric, MAX_FABRICS};
 use crate::tlv::{
     Nullable, Octets, OctetsArrayBuilder, OctetsBuilder, TLVBuilder, TLVBuilderParent, TLVElement,
     TLVTag, TLVWrite,
@@ -213,7 +213,7 @@ impl ClusterHandler for NocHandler {
     }
 
     fn supported_fabrics(&self, _ctx: impl ReadContext) -> Result<u8, Error> {
-        Ok(MAX_SUPPORTED_FABRICS as u8)
+        Ok(MAX_FABRICS as u8)
     }
 
     fn commissioned_fabrics(&self, ctx: impl ReadContext) -> Result<u8, Error> {

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -18,6 +18,7 @@
 use core::mem::MaybeUninit;
 use core::num::NonZeroU8;
 
+use cfg_if::cfg_if;
 use heapless::String;
 
 use crate::acl::{self, AccessReq, AclEntry, AuthMode};
@@ -67,7 +68,7 @@ pub struct Fabric {
     /// Fabric label; unique accross all fabrics on the device
     label: String<32>,
     /// Access Control List
-    acl: Vec<AclEntry, { acl::ENTRIES_PER_FABRIC }>,
+    acl: Vec<AclEntry, { acl::MAX_ACL_ENTRIES_PER_FABRIC }>,
 }
 
 impl Fabric {
@@ -394,13 +395,46 @@ impl Fabric {
     }
 }
 
-/// Max number of supported fabrics
-// TODO: Make this configurable via a cargo feature
-pub const MAX_SUPPORTED_FABRICS: usize = 3;
+cfg_if! {
+    if #[cfg(feature = "max-fabrics-32")] {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 32;
+    } else if #[cfg(feature = "max-fabrics-16")] {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 16;
+    } else if #[cfg(feature = "max-fabrics-8")] {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 8;
+    } else if #[cfg(feature = "max-fabrics-7")] {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 7;
+    } else if #[cfg(feature = "max-fabrics-6")] {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 6;
+    } else if #[cfg(feature = "max-fabrics-5")] {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 5;
+    } else if #[cfg(feature = "max-fabrics-4")] {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 4;
+    } else if #[cfg(feature = "max-fabrics-3")] {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 3;
+    } else if #[cfg(feature = "max-fabrics-2")] {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 2;
+    } else if #[cfg(feature = "max-fabrics-1")] {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 1;
+    } else {
+        /// Max number of supported fabrics
+        pub const MAX_FABRICS: usize = 3;
+    }
+}
 
 /// Fabric manager type
 pub struct FabricMgr {
-    fabrics: Vec<Fabric, MAX_SUPPORTED_FABRICS>,
+    fabrics: Vec<Fabric, MAX_FABRICS>,
     changed: bool,
 }
 

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -19,6 +19,8 @@ use core::fmt;
 use core::num::NonZeroU8;
 use core::time::Duration;
 
+use cfg_if::cfg_if;
+
 use crate::error::*;
 use crate::transport::exchange::ExchangeId;
 use crate::transport::mrp::ReliableMessage;
@@ -559,8 +561,67 @@ impl Drop for ReservedSession<'_> {
     }
 }
 
-const MAX_SESSIONS: usize = 16;
-const MAX_EXCHANGES: usize = 5;
+cfg_if! {
+    if #[cfg(feature = "max-sessions-64")] {
+        /// Max number of supported sessions
+        pub const MAX_SESSIONS: usize = 64;
+    } else if #[cfg(feature = "max-sessions-32")] {
+        /// Max number of supported sessions
+        pub const MAX_SESSIONS: usize = 32;
+    } else if #[cfg(feature = "max-sessions-16")] {
+        /// Max number of supported sessions
+        pub const MAX_SESSIONS: usize = 16;
+    } else if #[cfg(feature = "max-sessions-8")] {
+        /// Max number of supported sessions
+        pub const MAX_SESSIONS: usize = 8;
+    } else if #[cfg(feature = "max-sessions-7")] {
+        /// Max number of supported sessions
+        pub const MAX_SESSIONS: usize = 7;
+    } else if #[cfg(feature = "max-sessions-6")] {
+        /// Max number of supported sessions
+        pub const MAX_SESSIONS: usize = 6;
+    } else if #[cfg(feature = "max-sessions-5")] {
+        /// Max number of supported sessions
+        pub const MAX_SESSIONS: usize = 5;
+    } else if #[cfg(feature = "max-sessions-4")] {
+        /// Max number of supported sessions
+        pub const MAX_SESSIONS: usize = 4;
+    } else if #[cfg(feature = "max-sessions-3")] {
+        /// Max number of supported sessions
+        pub const MAX_SESSIONS: usize = 3;
+    } else {
+        /// Max number of supported sessions
+        pub const MAX_SESSIONS: usize = 16;
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "max-exchanges-per-session-16")] {
+        /// Max number of supported exchanges per session
+        pub const MAX_EXCHANGES: usize = 16;
+    } else if #[cfg(feature = "max-exchanges-per-session-8")] {
+        /// Max number of supported exchanges per session
+        pub const MAX_EXCHANGES: usize = 8;
+    } else if #[cfg(feature = "max-exchanges-per-session-7")] {
+        /// Max number of supported exchanges per session
+        pub const MAX_EXCHANGES: usize = 7;
+    } else if #[cfg(feature = "max-exchanges-per-session-6")] {
+        /// Max number of supported exchanges per session
+        pub const MAX_EXCHANGES: usize = 6;
+    } else if #[cfg(feature = "max-exchanges-per-session-5")] {
+        /// Max number of supported exchanges per session
+        pub const MAX_EXCHANGES: usize = 5;
+    } else if #[cfg(feature = "max-exchanges-per-session-4")] {
+        /// Max number of supported exchanges per session
+        pub const MAX_EXCHANGES: usize = 4;
+    } else if #[cfg(feature = "max-exchanges-per-session-3")] {
+        /// Max number of supported exchanges per session
+        pub const MAX_EXCHANGES: usize = 3;
+    } else {
+        /// Max number of supported exchanges per session
+        pub const MAX_EXCHANGES: usize = 5;
+    }
+}
 
 const MATTER_MSG_CTR_RANGE: u32 = 0x0fffffff;
 


### PR DESCRIPTION
This is a minimal PR that addresses #252 in the simplest possible way outlined in #252's description - using features.

===

As much as I would like to utilize [the "resources" pattern alternative mentioned later in that issue](https://github.com/project-chip/rs-matter/issues/252#issuecomment-3193646529), it is not trivial at all because `rs-matter` has **nested** structures. :(  As in, `FabricMgr` has a `Vec` of `Fabric`s, but then each `Fabric` **in turn** has a `Vec` of `AclEntry`s.

Say, I rework FabricMgr to use my [`SliceVec`](https://github.com/sysgrok/rs-matter/blob/737ac46215f41b1921a25bae2eba0d98ccf6a735/rs-matter/src/utils/storage/slice_vec.rs#L77) variant instead of the current "heapless like" `Vec`. That would make `MAX_FABRICS` a generic on a future `MatterResources<MAX_FABRICS>` struct (after a lof of juggling with unsafe that is, and turning non-`'static` lifetimes into `'static` ones, as we did in `openthread`). But fine.

**However**: what to do with the `Fabric` itself, which contains a `Vec<MAX_ACL_ENTRIES_PER_FABRIC>`??
Not trivial at all.