### PR TITLE
Fix a regression for Google Home

### DIFF
--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -245,7 +245,6 @@ impl BridgedHandler {
 
 impl bridged_device_basic_information::ClusterHandler for BridgedHandler {
     const CLUSTER: Cluster<'static> = bridged_device_basic_information::FULL_CLUSTER
-        .with_revision(1)
         .with_features(0)
         .with_attrs(with!(required))
         .with_cmds(with!());

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -16,6 +16,8 @@
  */
 
 //! An example Matter device that implements the On/Off and LevelControl cluster over Ethernet.
+#![allow(clippy::uninlined_format_args)]
+
 use core::pin::pin;
 
 use std::net::UdpSocket;
@@ -298,7 +300,6 @@ impl LevelControlHooks for LevelControlDeviceLogic {
     const MAX_LEVEL: u8 = 254;
     const FASTEST_RATE: u8 = 50;
     const CLUSTER: Cluster<'static> = LEVEL_CONTROL_FULL_CLUSTER
-        .with_revision(5)
         .with_features(
             level_control::Feature::LIGHTING.bits() | level_control::Feature::ON_OFF.bits(),
         )

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -229,7 +229,6 @@ impl MediaHandler {
 impl media_playback::ClusterAsyncHandler for MediaHandler {
     /// The metadata cluster definition corresponding to the handler
     const CLUSTER: Cluster<'static> = media_playback::FULL_CLUSTER
-        .with_revision(1)
         .with_attrs(with!(required))
         .with_cmds(with!(
             media_playback::CommandId::Play
@@ -407,7 +406,6 @@ impl ContentHandler {
 
 impl content_launcher::ClusterAsyncHandler for ContentHandler {
     const CLUSTER: Cluster<'static> = content_launcher::FULL_CLUSTER
-        .with_revision(1)
         .with_features(0b11)
         .with_attrs(
             with!(required; content_launcher::AttributeId::AcceptHeader | content_launcher::AttributeId::SupportedStreamingProtocols),
@@ -519,7 +517,6 @@ impl KeypadInputHandler {
 
 impl keypad_input::ClusterAsyncHandler for KeypadInputHandler {
     const CLUSTER: Cluster<'static> = keypad_input::FULL_CLUSTER
-        .with_revision(1)
         .with_attrs(with!(required))
         .with_cmds(with!(keypad_input::CommandId::SendKey));
 

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -208,7 +208,6 @@ impl LevelControlHandler {
 impl level_control::ClusterAsyncHandler for LevelControlHandler {
     /// The metadata cluster definition corresponding to the handler
     const CLUSTER: Cluster<'static> = level_control::FULL_CLUSTER
-        .with_revision(1)
         .with_attrs(with!(required))
         .with_cmds(with!(
             level_control::CommandId::MoveToLevel

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -136,10 +136,7 @@ impl AclHandler {
 }
 
 impl ClusterHandler for AclHandler {
-    const CLUSTER: Cluster<'static> = FULL_CLUSTER
-        .with_revision(1)
-        .with_attrs(with!(required))
-        .with_cmds(with!());
+    const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required)).with_cmds(with!());
 
     fn dataver(&self) -> u32 {
         self.dataver.get()

--- a/rs-matter/src/dm/clusters/basic_info.rs
+++ b/rs-matter/src/dm/clusters/basic_info.rs
@@ -157,11 +157,11 @@ pub struct CapabilityMinima {
 
 impl CapabilityMinima {
     /// Create a default instance of `CapabilityMinima`,
-    /// with CASE sessions per fabric and `DEFAULT_MAX_SUBSCRIPTIONS` subscriptions per fabric.
+    /// with actual CASE sessions per fabric and subscriptions per fabric based on `DEFAULT_MAX_SUBSCRIPTIONS`.
     pub const fn new() -> Self {
         Self {
             case_sessions_per_fabric: (MAX_SESSIONS / MAX_FABRICS) as _,
-            subscriptions_per_fabric: DEFAULT_MAX_SUBSCRIPTIONS as _,
+            subscriptions_per_fabric: (DEFAULT_MAX_SUBSCRIPTIONS / MAX_FABRICS) as _,
         }
     }
 }

--- a/rs-matter/src/dm/clusters/desc.rs
+++ b/rs-matter/src/dm/clusters/desc.rs
@@ -129,10 +129,7 @@ impl<'a> DescHandler<'a> {
 }
 
 impl ClusterHandler for DescHandler<'_> {
-    const CLUSTER: Cluster<'static> = FULL_CLUSTER
-        .with_revision(1)
-        .with_attrs(with!(required))
-        .with_cmds(with!());
+    const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required)).with_cmds(with!());
 
     fn dataver(&self) -> u32 {
         self.dataver.get()

--- a/rs-matter/src/dm/clusters/eth_diag.rs
+++ b/rs-matter/src/dm/clusters/eth_diag.rs
@@ -43,10 +43,7 @@ impl EthDiagHandler {
 }
 
 impl ClusterHandler for EthDiagHandler {
-    const CLUSTER: Cluster<'static> = FULL_CLUSTER
-        .with_revision(1)
-        .with_attrs(with!(required))
-        .with_cmds(with!());
+    const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required)).with_cmds(with!());
 
     fn dataver(&self) -> u32 {
         self.dataver.get()

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -129,7 +129,7 @@ impl<'a> GenCommHandler<'a> {
 }
 
 impl ClusterHandler for GenCommHandler<'_> {
-    const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_revision(1).with_attrs(with!(required));
+    const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
 
     fn dataver(&self) -> u32 {
         self.dataver.get()

--- a/rs-matter/src/dm/clusters/net_comm.rs
+++ b/rs-matter/src/dm/clusters/net_comm.rs
@@ -44,17 +44,14 @@ impl NetworkType {
     pub const fn cluster(&self) -> Cluster<'static> {
         match self {
             Self::Ethernet => FULL_CLUSTER
-                .with_revision(1)
                 .with_features(Feature::ETHERNET_NETWORK_INTERFACE.bits())
                 .with_attrs(with!(required))
                 .with_cmds(with!()),
             Self::Wifi => FULL_CLUSTER
-                .with_revision(1)
                 .with_features(Feature::WI_FI_NETWORK_INTERFACE.bits())
                 .with_attrs(with!(required; AttributeId::ScanMaxTimeSeconds | AttributeId::ConnectMaxTimeSeconds | AttributeId::SupportedWiFiBands))
                 .with_cmds(with!(CommandId::AddOrUpdateWiFiNetwork | CommandId::ScanNetworks | CommandId::RemoveNetwork | CommandId::ConnectNetwork | CommandId::ReorderNetwork)),
             Self::Thread => FULL_CLUSTER
-                .with_revision(1)
                 .with_features(Feature::THREAD_NETWORK_INTERFACE.bits())
                 .with_attrs(with!(required; AttributeId::ScanMaxTimeSeconds | AttributeId::ConnectMaxTimeSeconds | AttributeId::ThreadVersion | AttributeId::SupportedThreadFeatures))
                 .with_cmds(with!(CommandId::AddOrUpdateThreadNetwork | CommandId::ScanNetworks | CommandId::RemoveNetwork | CommandId::ConnectNetwork | CommandId::ReorderNetwork)),

--- a/rs-matter/src/dm/clusters/on_off.rs
+++ b/rs-matter/src/dm/clusters/on_off.rs
@@ -84,7 +84,6 @@ impl OnOffHandler {
 
 impl ClusterHandler for OnOffHandler {
     const CLUSTER: Cluster<'static> = FULL_CLUSTER
-        .with_revision(1)
         .with_attrs(with!(required))
         .with_cmds(with!(CommandId::On | CommandId::Off | CommandId::Toggle));
 

--- a/rs-matter/src/dm/clusters/thread_diag.rs
+++ b/rs-matter/src/dm/clusters/thread_diag.rs
@@ -376,10 +376,8 @@ impl<'a> ThreadDiagHandler<'a> {
 }
 
 impl ClusterHandler for ThreadDiagHandler<'_> {
-    const CLUSTER: crate::dm::Cluster<'static> = FULL_CLUSTER
-        .with_revision(1)
-        .with_attrs(with!(required))
-        .with_cmds(with!());
+    const CLUSTER: crate::dm::Cluster<'static> =
+        FULL_CLUSTER.with_attrs(with!(required)).with_cmds(with!());
 
     fn dataver(&self) -> u32 {
         self.dataver.get()

--- a/rs-matter/src/dm/clusters/wifi_diag.rs
+++ b/rs-matter/src/dm/clusters/wifi_diag.rs
@@ -118,10 +118,7 @@ impl<'a> WifiDiagHandler<'a> {
 }
 
 impl ClusterHandler for WifiDiagHandler<'_> {
-    const CLUSTER: Cluster<'static> = FULL_CLUSTER
-        .with_revision(1)
-        .with_attrs(with!(required))
-        .with_cmds(with!());
+    const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required)).with_cmds(with!());
 
     fn dataver(&self) -> u32 {
         self.dataver.get()

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -22,14 +22,15 @@ use embassy_time::Instant;
 
 use portable_atomic::{AtomicU32, Ordering};
 
+use crate::fabric::MAX_FABRICS;
 use crate::utils::cell::RefCell;
 use crate::utils::init::{init, Init};
 use crate::utils::sync::Notification;
 
 /// The maximum number of subscriptions that can be tracked at the same time by default.
 ///
-/// Currently set to 3.
-pub const DEFAULT_MAX_SUBSCRIPTIONS: usize = 3;
+/// According to the Matter spec, at least 3 subscriptions per fabric should be supported.
+pub const DEFAULT_MAX_SUBSCRIPTIONS: usize = MAX_FABRICS * 3;
 
 /// A type alias for `Subscriptions` with the default maximum number of subscriptions.
 pub type DefaultSubscriptions = Subscriptions<DEFAULT_MAX_SUBSCRIPTIONS>;

--- a/rs-matter/src/dm/types/cluster.rs
+++ b/rs-matter/src/dm/types/cluster.rs
@@ -273,8 +273,8 @@ impl<'a> Cluster<'a> {
         mut tw: W,
     ) -> Result<(), Error> {
         debug!(
-            "Endpt(0x??)::Cluster(:04x)::Attr::AttributeIDs(0xNN)::Read{{{:?}}} -> Ok([",
-            index
+            "Endpt(0x??)::Cluster(0x{:04x})::Attr::AttributeIDs(0xffffb)::Read{{{:?}}} -> Ok([",
+            self.id, index
         );
 
         if let Some(Some(index)) = index {

--- a/rs-matter/tests/data_model/long_reads.rs
+++ b/rs-matter/tests/data_model/long_reads.rs
@@ -24,6 +24,7 @@ use rs_matter::im::GenericPath;
 use rs_matter::im::IMStatusCode;
 use rs_matter::im::{StatusResp, SubscribeResp};
 
+use crate::attr_data;
 use crate::common::e2e::im::attributes::TestAttrResp;
 use crate::common::e2e::im::{echo_cluster as echo, ReplyProcessor, TestSubscribeReq};
 use crate::common::e2e::im::{TestReadReq, TestReportDataMsg};
@@ -31,7 +32,6 @@ use crate::common::e2e::test::E2eTest;
 use crate::common::e2e::tlv::TLVTest;
 use crate::common::e2e::ImEngine;
 use crate::common::init_env_logger;
-use crate::{attr_data, attr_data_lel};
 
 static ATTR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(0, 29, desc::AttributeId::DeviceTypeList, None),
@@ -114,15 +114,6 @@ static ATTR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(0, 60, GlobalElements::AcceptedCmdList, None),
     attr_data!(0, 60, GlobalElements::EventList, None),
     attr_data!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
     attr_data!(0, 60, GlobalElements::FeatureMap, None),
     attr_data!(0, 60, GlobalElements::ClusterRevision, None),
     attr_data!(0, 62, noc::AttributeId::NOCs, None),
@@ -288,15 +279,6 @@ static ATTR_SUBSCR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(0, 60, GlobalElements::AcceptedCmdList, None),
     attr_data!(0, 60, GlobalElements::EventList, None),
     attr_data!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
-    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
     attr_data!(0, 60, GlobalElements::FeatureMap, None),
     attr_data!(0, 60, GlobalElements::ClusterRevision, None),
     attr_data!(0, 62, noc::AttributeId::NOCs, None),
@@ -368,13 +350,6 @@ static ATTR_SUBSCR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(1, 6, GlobalElements::AcceptedCmdList, None),
     attr_data!(1, 6, GlobalElements::EventList, None),
     attr_data!(1, 6, GlobalElements::AttributeList, None),
-    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
-    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
-    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
-    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
-    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
-    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
-    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
     attr_data!(1, 6, GlobalElements::FeatureMap, None),
     attr_data!(1, 6, GlobalElements::ClusterRevision, None),
     attr_data!(1, echo::ID, echo::AttributesDiscriminants::Att1, None),
@@ -391,9 +366,9 @@ static ATTR_SUBSCR_RESPS: &[TestAttrResp<'static>] = &[
 #[test]
 fn test_long_read_success() {
     const PART_1: usize = 38;
-    const PART_2: usize = 37;
-    const PART_3: usize = 39;
-    const PART_4: usize = 36;
+    const PART_2: usize = 36;
+    const PART_3: usize = 37;
+    const PART_4: usize = 37;
 
     // Read the entire attribute database, which requires multiple reads to complete
     init_env_logger();
@@ -466,8 +441,8 @@ fn test_long_read_success() {
 #[test]
 fn test_long_read_subscription_success() {
     const PART_1: usize = 38;
-    const PART_2: usize = 37;
-    const PART_3: usize = 38;
+    const PART_2: usize = 36;
+    const PART_3: usize = 37;
     const PART_4: usize = 37;
 
     // Subscribe to the entire attribute database, which requires multiple reads to complete


### PR DESCRIPTION
PR #291 enabled proper serialization of very long array attributes which do not fit into a single Matter message.

Turns out however, that the **system** array attributes - at least in Google Home - are not compatible with this scheme (Google Home returns InvalidAction err for those) so specifically for system array attributes (where each such attribute does fit in a single Matter message chunk) I've restored the old serialization approach, where these are serialized as a single attribute.

This PR contains two commits (UPDATE - 3 commits after some testing):

##### Commit 1

Large but repetitive and a bit unrelated to this change. It removes all explicit `cluster_revision` declarations because they are just noise. The `import!` macro generates the `FULL_CLUSTER` with the correct (latest) cluster revision anyway.

It also reports correct subscriptions-per-fabric and sessions-per-fabric in the Basic Info cluster, now that the max-subscriptions and max-fabrics are configurable.

##### Commit 2

This is the actual change.
A single "if" actually.

##### Commit 3 

A small fix for Commit 1 after testing.