### PR TITLE
A feature to enable TLV dumps in debug level

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -98,6 +98,7 @@ mbedtls = ["alloc", "dep:mbedtls"]
 rustcrypto = ["alloc", "sha2", "hmac", "pbkdf2", "hkdf", "aes", "ccm", "p256", "sec1", "elliptic-curve", "crypto-bigint", "x509-cert", "rand_core"]
 defmt = ["dep:defmt", "heapless/defmt-03", "embassy-time/defmt"]
 log = ["dep:log", "embassy-time/log"]
+debug-tlv-payload = []
 large-buffers = [] # TCP support
 
 [dependencies]

--- a/rs-matter/src/dm/types/cluster.rs
+++ b/rs-matter/src/dm/types/cluster.rs
@@ -273,7 +273,7 @@ impl<'a> Cluster<'a> {
         mut tw: W,
     ) -> Result<(), Error> {
         debug!(
-            "Endpt(0x??)::Cluster(0x{:04x})::Attr::AttributeIDs(0xffffb)::Read{{{:?}}} -> Ok([",
+            "Endpt(0x??)::Cluster(0x{:04x})::Attr::AttributeIDs(0xfffb)::Read{{{:?}}} -> Ok([",
             self.id, index
         );
 

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -680,6 +680,17 @@ impl TxMessage<'_> {
             },
         );
 
+        #[cfg(feature = "debug-tlv-payload")]
+        debug!(
+            "{}",
+            Packet::<0>::display_payload(
+                &self.packet.header.proto,
+                &self.packet.buf
+                    [PacketHdr::HDR_RESERVE + payload_start..PacketHdr::HDR_RESERVE + payload_end]
+            )
+        );
+
+        #[cfg(not(feature = "debug-tlv-payload"))]
         trace!(
             "{}",
             Packet::<0>::display_payload(


### PR DESCRIPTION
TLV dumps are currently logged with `trace!` but enabling `trace!` is a bit OMG (lost in the noise).

This PR introduces a small feature so that TLV dumps can be enabled and dumped with `debug!` rather than `trace!`.

Related:
- #308 
- https://github.com/project-chip/connectedhomeip/issues/41033#issuecomment-3304803108