### PR TITLE
Fix global attributes' TLV serialization

### DIFF
--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -855,15 +855,7 @@ where
                                     .endpoint(attr.endpoint_id)
                                     .and_then(|e| e.cluster(attr.cluster_id))
                                     .and_then(|c| c.attribute(attr.attr_id))
-                                    .map(|a| {
-                                        a.quality.contains(Quality::ARRAY)
-                                        // Google Home (or maybe the Matter SDK itself?) chokes when we send a system array attribute as individual items
-                                        // If we do that, we receive an InvalidAction
-                                        // 
-                                        // Reason is yet unknown, but sending system array attributes as a whole is a valid workaround,
-                                        // because we do know that every system array attribute fits in single Matter message
-                                        && !a.is_system()
-                                    })
+                                    .map(|a| a.quality.contains(Quality::ARRAY))
                                     .unwrap_or(false)
                         });
 

--- a/rs-matter/src/dm/types/cluster.rs
+++ b/rs-matter/src/dm/types/cluster.rs
@@ -283,7 +283,7 @@ impl<'a> Cluster<'a> {
                 .nth(index)
                 .ok_or(ErrorCode::ConstraintError)?;
 
-            tw.u32(&TLVTag::Anonymous, attr.id)?;
+            tw.u32(tag, attr.id)?;
             debug!("    Attr: 0x{:02x},", attr.id);
         } else {
             tw.start_array(tag)?;
@@ -320,7 +320,7 @@ impl<'a> Cluster<'a> {
                 .nth(index)
                 .ok_or(ErrorCode::ConstraintError)?;
 
-            tw.u32(&TLVTag::Anonymous, cmd.id)?;
+            tw.u32(tag, cmd.id)?;
             debug!("    Cmd: 0x{:02x}, ", cmd.id);
         } else {
             tw.start_array(tag)?;
@@ -371,7 +371,10 @@ impl<'a> Cluster<'a> {
             })
             .min()
         {
-            if index == Some(Some(count)) || index.is_none() {
+            if index == Some(Some(count)) {
+                tw.u32(tag, next_cmd)?;
+                debug!("    Cmd: 0x{:02x}, ", next_cmd);
+            } else if index.is_none() {
                 tw.u32(&TLVTag::Anonymous, next_cmd)?;
                 debug!("    Cmd: 0x{:02x}, ", next_cmd);
             }

--- a/rs-matter/tests/data_model/long_reads.rs
+++ b/rs-matter/tests/data_model/long_reads.rs
@@ -24,7 +24,6 @@ use rs_matter::im::GenericPath;
 use rs_matter::im::IMStatusCode;
 use rs_matter::im::{StatusResp, SubscribeResp};
 
-use crate::attr_data;
 use crate::common::e2e::im::attributes::TestAttrResp;
 use crate::common::e2e::im::{echo_cluster as echo, ReplyProcessor, TestSubscribeReq};
 use crate::common::e2e::im::{TestReadReq, TestReportDataMsg};
@@ -32,6 +31,7 @@ use crate::common::e2e::test::E2eTest;
 use crate::common::e2e::tlv::TLVTest;
 use crate::common::e2e::ImEngine;
 use crate::common::init_env_logger;
+use crate::{attr_data, attr_data_lel};
 
 static ATTR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(0, 29, desc::AttributeId::DeviceTypeList, None),
@@ -114,6 +114,15 @@ static ATTR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(0, 60, GlobalElements::AcceptedCmdList, None),
     attr_data!(0, 60, GlobalElements::EventList, None),
     attr_data!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
     attr_data!(0, 60, GlobalElements::FeatureMap, None),
     attr_data!(0, 60, GlobalElements::ClusterRevision, None),
     attr_data!(0, 62, noc::AttributeId::NOCs, None),
@@ -279,6 +288,15 @@ static ATTR_SUBSCR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(0, 60, GlobalElements::AcceptedCmdList, None),
     attr_data!(0, 60, GlobalElements::EventList, None),
     attr_data!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
+    attr_data_lel!(0, 60, GlobalElements::AttributeList, None),
     attr_data!(0, 60, GlobalElements::FeatureMap, None),
     attr_data!(0, 60, GlobalElements::ClusterRevision, None),
     attr_data!(0, 62, noc::AttributeId::NOCs, None),
@@ -350,6 +368,13 @@ static ATTR_SUBSCR_RESPS: &[TestAttrResp<'static>] = &[
     attr_data!(1, 6, GlobalElements::AcceptedCmdList, None),
     attr_data!(1, 6, GlobalElements::EventList, None),
     attr_data!(1, 6, GlobalElements::AttributeList, None),
+    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
+    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
+    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
+    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
+    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
+    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
+    attr_data_lel!(1, 6, GlobalElements::AttributeList, None),
     attr_data!(1, 6, GlobalElements::FeatureMap, None),
     attr_data!(1, 6, GlobalElements::ClusterRevision, None),
     attr_data!(1, echo::ID, echo::AttributesDiscriminants::Att1, None),
@@ -366,8 +391,8 @@ static ATTR_SUBSCR_RESPS: &[TestAttrResp<'static>] = &[
 #[test]
 fn test_long_read_success() {
     const PART_1: usize = 38;
-    const PART_2: usize = 36;
-    const PART_3: usize = 37;
+    const PART_2: usize = 37;
+    const PART_3: usize = 38;
     const PART_4: usize = 37;
 
     // Read the entire attribute database, which requires multiple reads to complete
@@ -441,8 +466,8 @@ fn test_long_read_success() {
 #[test]
 fn test_long_read_subscription_success() {
     const PART_1: usize = 38;
-    const PART_2: usize = 36;
-    const PART_3: usize = 37;
+    const PART_2: usize = 37;
+    const PART_3: usize = 38;
     const PART_4: usize = 37;
 
     // Subscribe to the entire attribute database, which requires multiple reads to complete


### PR DESCRIPTION
This PR is reverting the work done in #308 because - as it turns out - the (only) "manual" TLV serde in `rs-matter` - the one for the global attributes - did have a small bug.

The actual bugfix is 3 lines in `cluster.rs`. The rest is just the #308 reverting work.

More details [here](https://github.com/project-chip/connectedhomeip/issues/41033#issuecomment-3306001646).
