### PR TITLE
Memory optimization changes

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -122,6 +122,7 @@ embassy-futures = "0.1.2"
 embassy-time = "0.4"
 embassy-time-queue-utils = "0.1"
 embassy-sync = "0.7"
+either = "1"
 critical-section = "1.1"
 domain = { version = "0.10", default-features = false, features = ["heapless"] }
 portable-atomic = "1"

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -85,6 +85,12 @@ max-exchanges-per-session-5 = [] # default
 max-exchanges-per-session-4 = []
 max-exchanges-per-session-3 = []
 
+# Number of BTP sessions
+max-btp-sessions-8 = []
+max-btp-sessions-4 = []
+max-btp-sessions-2 = []
+max-btp-sessions-1 = [] # default
+
 # General
 astro-dnssd = ["os", "dep:astro-dnssd"]
 zeroconf = ["os", "dep:zeroconf"]

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -16,6 +16,7 @@
  */
 
 use core::cell::{Cell, RefCell};
+use core::future::Future;
 use core::num::NonZeroU8;
 use core::pin::pin;
 use core::time::Duration;
@@ -765,8 +766,8 @@ where
     T: DataModelHandler,
     B: BufferAccess<IMBuffer>,
 {
-    async fn handle(&self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
-        DataModel::handle(self, exchange).await
+    fn handle(&self, exchange: &mut Exchange<'_>) -> impl Future<Output = Result<(), Error>> {
+        DataModel::handle(self, exchange)
     }
 }
 

--- a/rs-matter/src/dm/networks.rs
+++ b/rs-matter/src/dm/networks.rs
@@ -17,6 +17,8 @@
 
 //! A module containing various types for managing Ethernet, Thread and Wifi networks.
 
+use core::future::Future;
+
 pub mod eth;
 #[cfg(all(unix, feature = "os", not(target_os = "espidf")))]
 pub mod unix;
@@ -32,7 +34,7 @@ impl<T> NetChangeNotif for &T
 where
     T: NetChangeNotif,
 {
-    async fn wait_changed(&self) {
-        (*self).wait_changed().await
+    fn wait_changed(&self) -> impl Future<Output = ()> {
+        (*self).wait_changed()
     }
 }

--- a/rs-matter/src/dm/types/metadata.rs
+++ b/rs-matter/src/dm/types/metadata.rs
@@ -131,6 +131,8 @@ where
 }
 
 mod asynch {
+    use core::future::Future;
+
     use crate::dm::{Async, Node};
 
     use super::{Metadata, MetadataGuard};
@@ -152,8 +154,8 @@ mod asynch {
         where
             Self: 'a;
 
-        async fn lock(&self) -> Self::MetadataGuard<'_> {
-            (**self).lock().await
+        fn lock(&self) -> impl Future<Output = Self::MetadataGuard<'_>> {
+            (**self).lock()
         }
     }
 
@@ -166,8 +168,8 @@ mod asynch {
         where
             Self: 'a;
 
-        async fn lock(&self) -> Self::MetadataGuard<'_> {
-            (**self).lock().await
+        fn lock(&self) -> impl Future<Output = Self::MetadataGuard<'_>> {
+            (**self).lock()
         }
     }
 
@@ -194,8 +196,8 @@ mod asynch {
         where
             Self: 'a;
 
-        async fn lock(&self) -> Self::MetadataGuard<'_> {
-            self.0.lock().await
+        fn lock(&self) -> impl Future<Output = Self::MetadataGuard<'_>> {
+            self.0.lock()
         }
     }
 

--- a/rs-matter/src/im/busy.rs
+++ b/rs-matter/src/im/busy.rs
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+use core::future::Future;
+
 use crate::error::*;
 use crate::respond::ExchangeHandler;
 use crate::transport::exchange::Exchange;
@@ -75,7 +77,7 @@ impl BusyInteractionModel {
 }
 
 impl ExchangeHandler for BusyInteractionModel {
-    async fn handle(&self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
-        BusyInteractionModel::handle(self, exchange).await
+    fn handle(&self, exchange: &mut Exchange<'_>) -> impl Future<Output = Result<(), Error>> {
+        BusyInteractionModel::handle(self, exchange)
     }
 }

--- a/rs-matter/src/respond.rs
+++ b/rs-matter/src/respond.rs
@@ -16,6 +16,7 @@
  */
 
 use core::fmt::Display;
+use core::future::Future;
 use core::pin::pin;
 
 use embassy_futures::select::{select3, select_slice};
@@ -46,8 +47,8 @@ impl<T> ExchangeHandler for &T
 where
     T: ExchangeHandler,
 {
-    async fn handle(&self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
-        (*self).handle(exchange).await
+    fn handle(&self, exchange: &mut Exchange<'_>) -> impl Future<Output = Result<(), Error>> {
+        (*self).handle(exchange)
     }
 }
 

--- a/rs-matter/src/respond.rs
+++ b/rs-matter/src/respond.rs
@@ -140,6 +140,11 @@ where
         }
     }
 
+    /// Get the name of this responder
+    pub const fn name(&self) -> &str {
+        self.name
+    }
+
     /// Get a reference to the `ExchangeHandler` instance used by this responder
     pub fn handler(&self) -> &T {
         &self.handler
@@ -166,8 +171,9 @@ where
         select_slice(handlers).await.0
     }
 
+    /// A handler for one exchange.
     #[inline(always)]
-    async fn handle(&self, handler_id: impl Display) -> Result<(), Error> {
+    pub async fn handle(&self, handler_id: impl Display) -> Result<(), Error> {
         loop {
             // Ignore the error as it had been logged already
             let _ = self.respond_once(&handler_id).await;
@@ -314,12 +320,39 @@ where
     pub async fn run<const A: usize, const O: usize>(&self) -> Result<(), Error> {
         let mut actual = pin!(self.responder.run::<A>());
         let mut busy = pin!(self.busy_responder.run::<O>());
-        let mut sub = pin!(self
+        let mut sub = pin!(self.process_subscriptions());
+
+        select3(&mut actual, &mut busy, &mut sub).coalesce().await
+    }
+
+    /// Get a reference to the main responder.
+    ///
+    /// Useful when the user would like to organize its own herd of responders rather than using the `run` method.
+    pub const fn responder(
+        &self,
+    ) -> &Responder<'a, ChainedExchangeHandler<DataModel<'a, N, B, T>, SecureChannel>> {
+        &self.responder
+    }
+
+    /// Get a reference to the busy responder.
+    ///
+    /// Useful when the user would like to organize its own herd of busy responders rather than using the `run` method.
+    pub const fn busy_responder(
+        &self,
+    ) -> &Responder<'a, ChainedExchangeHandler<BusyInteractionModel, BusySecureChannel>> {
+        &self.busy_responder
+    }
+
+    /// Process subscriptions.
+    ///
+    /// Useful when the user would like to call `process_subscriptions` manually rather than using the `run` method.
+    pub async fn process_subscriptions(&self) -> Result<(), Error> {
+        let mut process = pin!(self
             .responder
             .handler()
             .handler
             .process_subscriptions(self.responder.matter));
 
-        select3(&mut actual, &mut busy, &mut sub).coalesce().await
+        (&mut process).await
     }
 }

--- a/rs-matter/src/sc.rs
+++ b/rs-matter/src/sc.rs
@@ -16,6 +16,7 @@
  */
 
 use core::borrow::Borrow;
+use core::future::Future;
 use core::mem::MaybeUninit;
 
 use num_derive::FromPrimitive;
@@ -266,8 +267,8 @@ impl Default for SecureChannel {
 }
 
 impl ExchangeHandler for SecureChannel {
-    async fn handle(&self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
-        SecureChannel::handle(self, exchange).await
+    fn handle(&self, exchange: &mut Exchange<'_>) -> impl Future<Output = Result<(), Error>> {
+        SecureChannel::handle(self, exchange)
     }
 }
 

--- a/rs-matter/src/sc/busy.rs
+++ b/rs-matter/src/sc/busy.rs
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+use core::future::Future;
+
 use crate::error::*;
 use crate::respond::ExchangeHandler;
 use crate::transport::exchange::Exchange;
@@ -79,7 +81,7 @@ impl BusySecureChannel {
 }
 
 impl ExchangeHandler for BusySecureChannel {
-    async fn handle(&self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
-        BusySecureChannel::handle(self, exchange).await
+    fn handle(&self, exchange: &mut Exchange<'_>) -> impl Future<Output = Result<(), Error>> {
+        BusySecureChannel::handle(self, exchange)
     }
 }

--- a/rs-matter/src/transport/network.rs
+++ b/rs-matter/src/transport/network.rs
@@ -16,6 +16,7 @@
  */
 
 use core::fmt::{self, Debug, Display};
+use core::future::Future;
 use core::pin::pin;
 
 pub use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
@@ -177,8 +178,8 @@ impl<T> NetworkSend for &mut T
 where
     T: NetworkSend,
 {
-    async fn send_to(&mut self, data: &[u8], addr: Address) -> Result<(), Error> {
-        (*self).send_to(data, addr).await
+    fn send_to(&mut self, data: &[u8], addr: Address) -> impl Future<Output = Result<(), Error>> {
+        (*self).send_to(data, addr)
     }
 }
 
@@ -207,12 +208,15 @@ impl<T> NetworkReceive for &mut T
 where
     T: NetworkReceive,
 {
-    async fn wait_available(&mut self) -> Result<(), Error> {
-        (*self).wait_available().await
+    fn wait_available(&mut self) -> impl Future<Output = Result<(), Error>> {
+        (*self).wait_available()
     }
 
-    async fn recv_from(&mut self, buffer: &mut [u8]) -> Result<(usize, Address), Error> {
-        (*self).recv_from(buffer).await
+    fn recv_from(
+        &mut self,
+        buffer: &mut [u8],
+    ) -> impl Future<Output = Result<(usize, Address), Error>> {
+        (*self).recv_from(buffer)
     }
 }
 

--- a/rs-matter/src/transport/network/btp/context.rs
+++ b/rs-matter/src/transport/network/btp/context.rs
@@ -17,7 +17,10 @@
 
 use core::sync::atomic::Ordering;
 
+use cfg_if::cfg_if;
+
 use embassy_sync::blocking_mutex::raw::RawMutex;
+
 use portable_atomic::AtomicUsize;
 
 use crate::error::{Error, ErrorCode};
@@ -30,12 +33,44 @@ use crate::utils::sync::Notification;
 
 use super::{session::Session, GattPeripheralEvent};
 
-/// The maximum number of BTP sessions that can be active at any given time.
-/// This is an `rs-matter` specific limit, and is not a requirement of the Matter BTP spec, and which in future should be configurable.
-///
-/// The `GattPeripheral` implementation is expected to enforce this limit as well,
-/// i.e. it should not allow more than `MAX_BTP_SESSIONS` active subscriptions to characteristic `C2`.
-pub const MAX_BTP_SESSIONS: usize = 2;
+cfg_if! {
+    if #[cfg(feature = "max-btp-sessions-8")] {
+        /// The maximum number of BTP sessions that can be active at any given time.
+        /// This is an `rs-matter` specific limit, and is not a requirement of the Matter BTP spec.
+        ///
+        /// The `GattPeripheral` implementation is expected to enforce this limit as well,
+        /// i.e. it should not allow more than `MAX_BTP_SESSIONS` active subscriptions to characteristic `C2`.
+        pub const MAX_BTP_SESSIONS: usize = 8;
+    } else if #[cfg(feature = "max-btp-sessions-4")] {
+        /// The maximum number of BTP sessions that can be active at any given time.
+        /// This is an `rs-matter` specific limit, and is not a requirement of the Matter BTP spec.
+        ///
+        /// The `GattPeripheral` implementation is expected to enforce this limit as well,
+        /// i.e. it should not allow more than `MAX_BTP_SESSIONS` active subscriptions to characteristic `C2`.
+        pub const MAX_BTP_SESSIONS: usize = 4;
+    } else if #[cfg(feature = "max-btp-sessions-2")] {
+        /// The maximum number of BTP sessions that can be active at any given time.
+        /// This is an `rs-matter` specific limit, and is not a requirement of the Matter BTP spec.
+        ///
+        /// The `GattPeripheral` implementation is expected to enforce this limit as well,
+        /// i.e. it should not allow more than `MAX_BTP_SESSIONS` active subscriptions to characteristic `C2`.
+        pub const MAX_BTP_SESSIONS: usize = 2;
+    } else if #[cfg(feature = "max-btp-sessions-1")] {
+        /// The maximum number of BTP sessions that can be active at any given time.
+        /// This is an `rs-matter` specific limit, and is not a requirement of the Matter BTP spec.
+        ///
+        /// The `GattPeripheral` implementation is expected to enforce this limit as well,
+        /// i.e. it should not allow more than `MAX_BTP_SESSIONS` active subscriptions to characteristic `C2`.
+        pub const MAX_BTP_SESSIONS: usize = 1;
+    } else {
+        /// The maximum number of BTP sessions that can be active at any given time.
+        /// This is an `rs-matter` specific limit, and is not a requirement of the Matter BTP spec.
+        ///
+        /// The `GattPeripheral` implementation is expected to enforce this limit as well,
+        /// i.e. it should not allow more than `MAX_BTP_SESSIONS` active subscriptions to characteristic `C2`.
+        pub const MAX_BTP_SESSIONS: usize = 1;
+    }
+}
 
 /// Represents an error that occurred while trying to lock a session for sending.
 #[derive(Debug)]

--- a/rs-matter/src/transport/network/btp/gatt.rs
+++ b/rs-matter/src/transport/network/btp/gatt.rs
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+use core::future::Future;
 use core::iter::{empty, once};
 
 use crate::dm::clusters::basic_info::BasicInfoConfig;
@@ -221,15 +222,15 @@ where
         service_name: &str,
         adv_data: &AdvData,
         callback: F,
-    ) -> impl core::future::Future<Output = Result<(), Error>>
+    ) -> impl Future<Output = Result<(), Error>>
     where
         F: Fn(GattPeripheralEvent) + Send + Sync + Clone + 'static,
     {
         (*self).run(service_name, adv_data, callback)
     }
 
-    async fn indicate(&self, data: &[u8], address: BtAddr) -> Result<(), Error> {
-        (*self).indicate(data, address).await
+    fn indicate(&self, data: &[u8], address: BtAddr) -> impl Future<Output = Result<(), Error>> {
+        (*self).indicate(data, address)
     }
 }
 
@@ -242,14 +243,14 @@ where
         service_name: &str,
         adv_data: &AdvData,
         callback: F,
-    ) -> impl core::future::Future<Output = Result<(), Error>>
+    ) -> impl Future<Output = Result<(), Error>>
     where
         F: Fn(GattPeripheralEvent) + Send + Sync + Clone + 'static,
     {
         (**self).run(service_name, adv_data, callback)
     }
 
-    async fn indicate(&self, data: &[u8], address: BtAddr) -> Result<(), Error> {
-        (**self).indicate(data, address).await
+    fn indicate(&self, data: &[u8], address: BtAddr) -> impl Future<Output = Result<(), Error>> {
+        (**self).indicate(data, address)
     }
 }

--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -363,7 +363,7 @@ impl RecvWindow {
     }
 }
 
-/// Represents a BTP Session, as per the MAtter Core spec.
+/// Represents a BTP Session, as per the Matter Core spec.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Session {

--- a/rs-matter/src/transport/network/mdns.rs
+++ b/rs-matter/src/transport/network/mdns.rs
@@ -16,6 +16,7 @@
  */
 
 use core::fmt::Write;
+use core::future::Future;
 use core::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
 
 use crate::dm::clusters::basic_info::BasicInfoConfig;
@@ -63,12 +64,12 @@ impl<T> MdnsResolver for &mut T
 where
     T: MdnsResolver,
 {
-    async fn resolve(
+    fn resolve(
         &mut self,
         compressed_fabric_id: u64,
         node_id: u64,
-    ) -> Result<SocketAddr, Error> {
-        (*self).resolve(compressed_fabric_id, node_id).await
+    ) -> impl Future<Output = Result<SocketAddr, Error>> {
+        (*self).resolve(compressed_fabric_id, node_id)
     }
 }
 

--- a/rs-matter/src/utils/storage/pooled.rs
+++ b/rs-matter/src/utils/storage/pooled.rs
@@ -16,6 +16,7 @@
  */
 
 use core::cell::UnsafeCell;
+use core::future::Future;
 use core::ops::{Deref, DerefMut};
 use core::pin::pin;
 
@@ -54,8 +55,8 @@ where
     where
         Self: 'a;
 
-    async fn get(&self) -> Option<Self::Buffer<'_>> {
-        (*self).get().await
+    fn get(&self) -> impl Future<Output = Option<Self::Buffer<'_>>> {
+        (*self).get()
     }
 }
 


### PR DESCRIPTION
Currently, `rs-matter` needs an enormous stack by MCU standards. ~ **100KB**.

_The_ major reason for that is that our futures end up being very large - which - in turn - is primarily because of long-standing bugs in rustc or rather - suboptimal generation of the futures' memory layout.

As much as so far we've pulled all sorts of buffers _outside_ of our futures, our futures themselves keep growing.

This effort is significantly reducing the memory consumption of the `rs-matter` futures, by implementing a few very simple backwards-compatible optimizations, where each such one is a separate commit.

The outcome of this work is that the 100KB+ stack went down for me **to ~ 13.5KB for the futures and then < 20KB for the true thread stack**. There is one more thing being implemented downstream in `rs-matter-stack` for that (a simple bump "allocator"), but that's a separate topic.

Commits in details:

#### [Use impl Future syntax for delegating methods to reduce future sizes](https://github.com/project-chip/rs-matter/commit/82c3aaeb40f5d32760b21bc3ca951a10837ed080) 

This commit changes all async delegation I was able to find from:
```rust
async fn foo(&self, arg: Arg) -> Output {
    self.delegate.foo(arg).await
}
```

into:
```rust
fn foo(&self, arg: Arg) -> impl Future<Output = Output> {
    self.delegate.foo(arg)
}
```

This change is a workaround for [this long standing bug](https://github.com/rust-lang/rust/issues/62958).

#### [Introduce Either to handle even more cases where we can avoid .await](https://github.com/project-chip/rs-matter/commit/88f632204d2b978b58b569753132c4f88654981d)

This commit is a continuation of the delegation pattern from above. It changes all async "either or" conditional delegation I was able to find from:
```rust
async fn foo(&self, arg: Arg) -> Output {
    if self.whatever() {
        self.delegate1.foo(arg).await
    } else {
        self.delegate2.foo(arg).await
    }
}
```

into:
```rust
fn foo(&self, arg: Arg) -> impl Future<Output = Output> {
    if self.whatever() {
        Either::Left(self.delegate1.foo(arg))
    } else {
        Either::Right(self.delegate2.foo(arg))
    }
}
```

#### [Make num of BTP sessions configurable; set default to 1](https://github.com/project-chip/rs-matter/pull/312/commits/b5f351750a503d4f4425957b6a32c9ace2b255b4)

This change is unrelated to the others, and more related to #306 in that it exposes features to configure the max number of BTP/BLE connections, and reduces this number from 2 to 1, as I don't think BTP/BLE is used for anything than commissioning, and the commissioner<->commissionee is always 1:1.

#### Expose responder details in case user would like to arrange the responders in a different way downstream

This is a trivial change that makes some methods in `Responder` / `DefaultResponder` public, so that the user downstream has the flexibility to arrange its own herd of responders.