### PR TITLE
Fix: the new either dep is bringing STD

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -128,7 +128,7 @@ embassy-futures = "0.1.2"
 embassy-time = "0.4"
 embassy-time-queue-utils = "0.1"
 embassy-sync = "0.7"
-either = "1"
+either = { version = "1", default-features = false }
 critical-section = "1.1"
 domain = { version = "0.10", default-features = false, features = ["heapless"] }
 portable-atomic = "1"

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -121,7 +121,6 @@ log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true, features = ["ip_in_core"] }
 subtle = { version = "2.5", default-features = false }
 safemem = { version = "0.3", default-features = false }
-owo-colors = "4"
 time = { version = "0.3", default-features = false }
 verhoeff = { version = "1", default-features = false }
 embassy-futures = "0.1.2"


### PR DESCRIPTION
The new dependency on the `either` crate was bringing STD as a dependency even in `no_std` builds. (Introduced in #312.)

Apparently we could not catch it as `either` does not use the STD prelude and uses `extern crate std` instead, which builds fine under `#[no_std]` as long as STD is "around" (And our CI only builds for the x86 target with rustc stable, where STD "is around").

===

EDIT: I also removed the `owo-colors` dependency because the AI correctly noticed it has the same issue. This did not hit us because we don't actually use `owo-colors` in the code since a long time.

===

EDIT 2: https://github.com/project-chip/rs-matter/issues/314