### PR TITLE
Introduce minimal `HandlerContext` to `AsyncHandler::run`

### DIFF
--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -35,8 +35,8 @@ use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::unix::UnixNetifs;
 use rs_matter::dm::subscriptions::DefaultSubscriptions;
 use rs_matter::dm::{
-    Async, AsyncHandler, AsyncMetadata, Cluster, Dataver, EmptyHandler, Endpoint, EpClMatcher,
-    Node, ReadContext,
+    Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver, EmptyHandler, Endpoint,
+    EpClMatcher, Node, ReadContext,
 };
 use rs_matter::error::Error;
 use rs_matter::pairing::DiscoveryCapabilities;
@@ -71,19 +71,19 @@ fn main() -> Result<(), Error> {
     // Create the subscriptions
     let subscriptions = DefaultSubscriptions::new();
 
-    // Assemble our Data Model handler by composing the predefined Root Endpoint handler with our custom Speaker handler
-    let dm_handler = dm_handler(&matter);
+    // Create the Data Model instance
+    let dm = DataModel::new(&matter, &buffers, &subscriptions, dm_handler(&matter));
 
     // Create a default responder capable of handling up to 3 subscriptions
     // All other subscription requests will be turned down with "resource exhausted"
-    let responder = DefaultResponder::new(&matter, &buffers, &subscriptions, &dm_handler);
+    let responder = DefaultResponder::new(&dm);
 
     // Run the responder with up to 4 handlers (i.e. 4 exchanges can be handled simultaneously)
     // Clients trying to open more exchanges than the ones currently running will get "I'm busy, please try again later"
     let mut respond = pin!(responder.run::<4, 4>());
 
-    // Run the background job the handler might be having
-    let mut dm_handler_job = pin!(dm_handler.run());
+    // Run the background job of the data model
+    let mut dm_job = pin!(dm.run());
 
     // Create the Matter UDP socket
     let socket = async_io::Async::<UdpSocket>::bind(MATTER_SOCKET_BIND_ADDR)?;
@@ -105,7 +105,7 @@ fn main() -> Result<(), Error> {
         &mut transport,
         &mut mdns,
         &mut persist,
-        select(&mut respond, &mut dm_handler_job).coalesce(),
+        select(&mut respond, &mut dm_job).coalesce(),
     );
 
     // Run with a simple `block_on`. Any local executor would do.

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -54,8 +54,8 @@ use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::unix::UnixNetifs;
 use rs_matter::dm::subscriptions::DefaultSubscriptions;
 use rs_matter::dm::{
-    ArrayAttributeRead, Async, AsyncHandler, AsyncMetadata, Cluster, Dataver, EmptyHandler,
-    Endpoint, EpClMatcher, InvokeContext, Node, ReadContext,
+    ArrayAttributeRead, Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver,
+    EmptyHandler, Endpoint, EpClMatcher, InvokeContext, Node, ReadContext,
 };
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::pairing::DiscoveryCapabilities;
@@ -96,19 +96,19 @@ fn main() -> Result<(), Error> {
     // Create the subscriptions
     let subscriptions = DefaultSubscriptions::new();
 
-    // Assemble our Data Model handler by composing the predefined Root Endpoint handler with our custom Speaker handler
-    let dm_handler = dm_handler(&matter);
+    // Create the Data Model instance
+    let dm = DataModel::new(&matter, &buffers, &subscriptions, dm_handler(&matter));
 
     // Create a default responder capable of handling up to 3 subscriptions
     // All other subscription requests will be turned down with "resource exhausted"
-    let responder = DefaultResponder::new(&matter, &buffers, &subscriptions, &dm_handler);
+    let responder = DefaultResponder::new(&dm);
 
     // Run the responder with up to 4 handlers (i.e. 4 exchanges can be handled simultaneously)
     // Clients trying to open more exchanges than the ones currently running will get "I'm busy, please try again later"
     let mut respond = pin!(responder.run::<4, 4>());
 
-    // Run the background job the handler might be having
-    let mut dm_handler_job = pin!(dm_handler.run());
+    // Run the background job of the data model
+    let mut dm_job = pin!(dm.run());
 
     // Create the Matter UDP socket
     let socket = async_io::Async::<UdpSocket>::bind(MATTER_SOCKET_BIND_ADDR)?;
@@ -130,7 +130,7 @@ fn main() -> Result<(), Error> {
         &mut transport,
         &mut mdns,
         &mut persist,
-        select(&mut respond, &mut dm_handler_job).coalesce(),
+        select(&mut respond, &mut dm_job).coalesce(),
     );
 
     // Run with a simple `block_on`. Any local executor would do.

--- a/rs-matter-macros/src/idl/handler.rs
+++ b/rs-matter-macros/src/idl/handler.rs
@@ -78,8 +78,8 @@ pub fn handler(
     if delegate {
         let run = if asynch {
             quote!(
-                async fn run(&self) -> Result<(), #krate::error::Error> {
-                    (**self).run().await
+                fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                    (**self).run(ctx)
                 }
             )
         } else {
@@ -108,8 +108,8 @@ pub fn handler(
     } else {
         let run = if asynch {
             quote!(
-                async fn run(&self) -> Result<(), #krate::error::Error> {
-                    core::future::pending::<Result::<(), #krate::error::Error>>().await
+                fn run(&self, _ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                    core::future::pending::<Result::<(), #krate::error::Error>>()
                 }
             )
         } else {
@@ -270,8 +270,8 @@ pub fn handler_adaptor(
 
     let run = if asynch {
         quote!(
-            async fn run(&self) -> Result<(), #krate::error::Error> {
-                self.0.run().await
+            fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                self.0.run(ctx)
             }
         )
     } else {

--- a/rs-matter/src/dm/clusters/level_control.rs
+++ b/rs-matter/src/dm/clusters/level_control.rs
@@ -36,7 +36,7 @@ use embassy_time::{Duration, Instant};
 
 pub use crate::dm::clusters::decl::level_control::*;
 use crate::dm::clusters::{level_control, on_off::OnOffHandler};
-use crate::dm::{Cluster, Dataver, InvokeContext, ReadContext, WriteContext};
+use crate::dm::{Cluster, Dataver, HandlerContext, InvokeContext, ReadContext, WriteContext};
 use crate::error::{Error, ErrorCode};
 use crate::tlv::Nullable;
 
@@ -790,7 +790,7 @@ impl<'a, H: LevelControlHooks> ClusterAsyncHandler for LevelControlHandler<'a, H
     const CLUSTER: Cluster<'static> = H::CLUSTER;
 
     // Runs an async task manager for the cluster handler.
-    async fn run(&self) -> Result<(), Error> {
+    async fn run(&self, _ctx: impl HandlerContext) -> Result<(), Error> {
         loop {
             let mut task = self.task_signal.wait().await;
 

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -22,6 +22,7 @@ use embassy_time::Instant;
 
 use portable_atomic::{AtomicU32, Ordering};
 
+use crate::dm::{ClusterId, EndptId};
 use crate::fabric::MAX_FABRICS;
 use crate::utils::cell::RefCell;
 use crate::utils::init::{init, Init};
@@ -99,11 +100,18 @@ impl<const N: usize> Subscriptions<N> {
         })
     }
 
-    /// Notify the instance that some data in the data model has changed and that it should re-evaluate the subscriptions
-    /// and report on those that concern the changed data.
+    /// Notify the instance that the data of a specific cluster had changed and that it should re-evaluate the subscriptions
+    /// and report on those that are interested in the changed data.
     ///
-    /// This method is supposed to be called by the application code whenever it changes the data model.
-    pub fn notify_changed(&self) {
+    /// This method is supposed to be called by the application code whenever it changes the data of a cluster.
+    ///
+    /// # Arguments
+    /// - `endpoint_id`: The endpoint ID of the cluster that had changed.
+    /// - `cluster_id`: The cluster ID of the cluster that had changed.
+    pub fn notify_cluster_changed(&self, _endpoint_id: EndptId, _cluster_id: ClusterId) {
+        // TODO: Make use of the endpoint_id and cluster_id parameters
+        // to implement more intelligent reporting on subscriptions
+
         for sub in self.subscriptions.borrow_mut().iter_mut() {
             sub.changed = true;
         }

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -47,6 +47,10 @@ impl ChangeNotify for () {
     }
 }
 
+/// A context super-type that is passed to the `AsyncHandler::run` method.
+///
+/// It provides access to the Matter instance and to Data Model-related objects,
+/// which could be useful in the context of executing background tasks specific for the concrete handler.
 pub trait HandlerContext {
     /// Return the Matter object that is associated with this handler
     fn matter(&self) -> &Matter<'_>;

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -1041,6 +1041,10 @@ mod asynch {
         ) -> impl Future<Output = Result<(), Error>> {
             self.1.invoke(ctx, reply)
         }
+
+        fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
+            self.1.run(ctx)
+        }
     }
 
     impl<T> AsyncHandler for Async<T>

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -22,6 +22,7 @@ use crate::error::{Error, ErrorCode};
 use crate::tlv::TLVElement;
 use crate::transport::exchange::Exchange;
 use crate::utils::storage::pooled::{BufferAccess, PooledBuffers};
+use crate::Matter;
 
 use super::{AttrDetails, ClusterId, CmdDetails, EndptId, InvokeReply, ReadReply};
 
@@ -46,42 +47,89 @@ impl ChangeNotify for () {
     }
 }
 
-/// A context super-type that is passed to the handler when processing an attribute read/write or a command invoke operation.
-pub trait Context {
-    /// Return the exchange object that is associated with this operation.
-    fn exchange(&self) -> &Exchange<'_>;
+pub trait HandlerContext {
+    /// Return the Matter object that is associated with this handler
+    fn matter(&self) -> &Matter<'_>;
 
-    /// Return the global handler that is associated with this operation.
+    /// Return the global handler that this handler is part of.
     ///
     /// Useful in case a concrete cluster handler (say, the Scenes one) needs to
     /// access the global handler so as to invoke read/write/invoke operations on other clusters.
     fn handler(&self) -> impl AsyncHandler + '_;
 
-    /// Return the buffer pool of the Data Model, in of the that are associated with this operation.
+    /// Return the buffer pool of the Data Model.
     ///
-    /// Useful in case a concrete cluster handler needs to invoke read/write/invoke operations on
+    /// Useful in case e.g. a concrete cluster handler needs to invoke read/write/invoke operations on
     /// other clusters, and the TLV input/output data for those operations is non-trivial in size.
     fn buffers(&self) -> impl BufferAccess<IMBuffer> + '_;
 
-    /// Notify that the state of the cluster has changed.
-    fn notify_changed(&self);
+    /// Notify that the state of a cluster has changed.
+    ///
+    /// # Arguments
+    /// - `endpoint_id`: The endpoint ID of the cluster that has changed.
+    /// - `cluster_id`: The cluster ID of the cluster that has changed.
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId);
+}
+
+impl<T> HandlerContext for &T
+where
+    T: HandlerContext,
+{
+    fn matter(&self) -> &Matter<'_> {
+        (**self).matter()
+    }
+
+    fn handler(&self) -> impl AsyncHandler + '_ {
+        (**self).handler()
+    }
+
+    fn buffers(&self) -> impl BufferAccess<IMBuffer> + '_ {
+        (**self).buffers()
+    }
+
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        (**self).notify_cluster_changed(endpoint_id, cluster_id);
+    }
+}
+
+/// A context super-type that is passed to the handler when processing an attribute read/write or a command invoke operation.
+pub trait Context: HandlerContext {
+    /// Return the exchange object that is associated with this operation.
+    fn exchange(&self) -> &Exchange<'_>;
+
+    /// Notify that the state of the cluster whose read/write/invoke operation is processed has changed.
+    fn notify_changed(&self) {
+        if let Some(ctx) = self.as_read_ctx() {
+            self.notify_cluster_changed(ctx.attr().endpoint_id, ctx.attr().cluster_id);
+        } else if let Some(ctx) = self.as_write_ctx() {
+            self.notify_cluster_changed(ctx.attr().endpoint_id, ctx.attr().cluster_id);
+        } else if let Some(ctx) = self.as_invoke_ctx() {
+            self.notify_cluster_changed(ctx.cmd().endpoint_id, ctx.cmd().cluster_id);
+        } else {
+            unreachable!()
+        }
+    }
 
     /// Try to upcast the context to a read context.
     /// The operation will return `Some` only if the underlying context represents a read operation.
     fn as_read_ctx(&self) -> Option<impl ReadContext> {
-        Option::<ReadContextInstance<EmptyHandler, PooledBuffers<0, NoopRawMutex, IMBuffer>>>::None
+        Option::<&'static ReadContextInstance<EmptyHandler, PooledBuffers<0, NoopRawMutex, IMBuffer>>>::None
     }
 
     /// Try to upcast the context to a write context.
     /// The operation will return `Some` only if the underlying context represents a write operation.
     fn as_write_ctx(&self) -> Option<impl WriteContext> {
-        Option::<WriteContextInstance<EmptyHandler, PooledBuffers<0, NoopRawMutex, IMBuffer>>>::None
+        Option::<
+            &'static WriteContextInstance<EmptyHandler, PooledBuffers<0, NoopRawMutex, IMBuffer>>,
+        >::None
     }
 
     /// Try to upcast the context to an invoke context.
     /// The operation will return `Some` only if the underlying context represents an invoke operation.
     fn as_invoke_ctx(&self) -> Option<impl InvokeContext> {
-        Option::<InvokeContextInstance<EmptyHandler, PooledBuffers<0, NoopRawMutex, IMBuffer>>>::None
+        Option::<
+            &'static InvokeContextInstance<EmptyHandler, PooledBuffers<0, NoopRawMutex, IMBuffer>>,
+        >::None
     }
 }
 
@@ -91,14 +139,6 @@ where
 {
     fn exchange(&self) -> &Exchange<'_> {
         (**self).exchange()
-    }
-
-    fn handler(&self) -> impl AsyncHandler + '_ {
-        (**self).handler()
-    }
-
-    fn buffers(&self) -> impl BufferAccess<IMBuffer> + '_ {
-        (**self).buffers()
     }
 
     fn notify_changed(&self) {
@@ -176,12 +216,65 @@ where
     }
 }
 
+/// A concrete implementation of the `HandlerContext` trait
+pub(crate) struct HandlerContextInstance<'a, T, B> {
+    matter: &'a Matter<'a>,
+    handler: T,
+    buffers: B,
+    pub(crate) notify: &'a dyn ChangeNotify,
+}
+
+impl<'a, T, B> HandlerContextInstance<'a, T, B>
+where
+    T: AsyncHandler,
+    B: BufferAccess<IMBuffer>,
+{
+    /// Construct a new instance.
+    #[inline(always)]
+    pub(crate) const fn new(
+        matter: &'a Matter<'a>,
+        handler: T,
+        buffers: B,
+        notify: &'a dyn ChangeNotify,
+    ) -> Self {
+        Self {
+            matter,
+            handler,
+            buffers,
+            notify,
+        }
+    }
+}
+
+impl<T, B> HandlerContext for HandlerContextInstance<'_, T, B>
+where
+    T: AsyncHandler,
+    B: BufferAccess<IMBuffer>,
+{
+    fn matter(&self) -> &Matter<'_> {
+        self.matter
+    }
+
+    fn handler(&self) -> impl AsyncHandler + '_ {
+        &self.handler
+    }
+
+    fn buffers(&self) -> impl BufferAccess<IMBuffer> + '_ {
+        &self.buffers
+    }
+
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        self.notify.notify(endpoint_id, cluster_id);
+    }
+}
+
 /// A concrete implementation of the `ReadContext` trait
 pub(crate) struct ReadContextInstance<'a, T, B> {
     exchange: &'a Exchange<'a>,
     handler: T,
     buffers: B,
     attr: &'a AttrDetails<'a>,
+    pub(crate) notify: &'a dyn ChangeNotify,
 }
 
 impl<'a, T, B> ReadContextInstance<'a, T, B>
@@ -196,23 +289,25 @@ where
         handler: T,
         buffers: B,
         attr: &'a AttrDetails<'a>,
+        notify: &'a dyn ChangeNotify,
     ) -> Self {
         Self {
             exchange,
             handler,
             buffers,
             attr,
+            notify,
         }
     }
 }
 
-impl<T, B> Context for ReadContextInstance<'_, T, B>
+impl<T, B> HandlerContext for ReadContextInstance<'_, T, B>
 where
     T: AsyncHandler,
     B: BufferAccess<IMBuffer>,
 {
-    fn exchange(&self) -> &Exchange<'_> {
-        self.exchange
+    fn matter(&self) -> &Matter<'_> {
+        self.exchange().matter()
     }
 
     fn handler(&self) -> impl AsyncHandler + '_ {
@@ -223,8 +318,18 @@ where
         &self.buffers
     }
 
-    fn notify_changed(&self) {
-        // no-op
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        self.notify.notify(endpoint_id, cluster_id);
+    }
+}
+
+impl<T, B> Context for ReadContextInstance<'_, T, B>
+where
+    T: AsyncHandler,
+    B: BufferAccess<IMBuffer>,
+{
+    fn exchange(&self) -> &Exchange<'_> {
+        self.exchange
     }
 
     fn as_read_ctx(&self) -> Option<impl ReadContext> {
@@ -278,13 +383,13 @@ where
     }
 }
 
-impl<T, B> Context for WriteContextInstance<'_, T, B>
+impl<T, B> HandlerContext for WriteContextInstance<'_, T, B>
 where
     T: AsyncHandler,
     B: BufferAccess<IMBuffer>,
 {
-    fn exchange(&self) -> &Exchange<'_> {
-        self.exchange
+    fn matter(&self) -> &Matter<'_> {
+        self.exchange().matter()
     }
 
     fn handler(&self) -> impl AsyncHandler + '_ {
@@ -295,9 +400,18 @@ where
         &self.buffers
     }
 
-    fn notify_changed(&self) {
-        self.notify
-            .notify(self.attr.endpoint_id, self.attr.cluster_id);
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        self.notify.notify(endpoint_id, cluster_id);
+    }
+}
+
+impl<T, B> Context for WriteContextInstance<'_, T, B>
+where
+    T: AsyncHandler,
+    B: BufferAccess<IMBuffer>,
+{
+    fn exchange(&self) -> &Exchange<'_> {
+        self.exchange
     }
 
     fn as_write_ctx(&self) -> Option<impl WriteContext> {
@@ -355,13 +469,13 @@ where
     }
 }
 
-impl<T, B> Context for InvokeContextInstance<'_, T, B>
+impl<T, B> HandlerContext for InvokeContextInstance<'_, T, B>
 where
     T: AsyncHandler,
     B: BufferAccess<IMBuffer>,
 {
-    fn exchange(&self) -> &Exchange<'_> {
-        self.exchange
+    fn matter(&self) -> &Matter<'_> {
+        self.exchange().matter()
     }
 
     fn handler(&self) -> impl AsyncHandler + '_ {
@@ -372,9 +486,18 @@ where
         &self.buffers
     }
 
-    fn notify_changed(&self) {
-        self.notify
-            .notify(self.cmd.endpoint_id, self.cmd.cluster_id);
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        self.notify.notify(endpoint_id, cluster_id);
+    }
+}
+
+impl<T, B> Context for InvokeContextInstance<'_, T, B>
+where
+    T: AsyncHandler,
+    B: BufferAccess<IMBuffer>,
+{
+    fn exchange(&self) -> &Exchange<'_> {
+        self.exchange
     }
 
     fn as_invoke_ctx(&self) -> Option<impl InvokeContext> {
@@ -713,7 +836,7 @@ mod asynch {
     use either::Either;
     use embassy_futures::select::select;
 
-    use crate::dm::{InvokeReply, Matcher, ReadReply};
+    use crate::dm::{HandlerContext, InvokeReply, Matcher, ReadReply};
     use crate::error::{Error, ErrorCode};
     use crate::utils::select::Coalesce;
 
@@ -794,7 +917,7 @@ mod asynch {
 
         /// A hook (a scheduling facility) for placing handler-impl-specific code that needs to run
         /// asynchronously - forever and in the "background".
-        fn run(&self) -> impl Future<Output = Result<(), Error>> {
+        fn run(&self, _ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
             // Default implementation pends forever.
             // This is useful for handlers that do not need to run any async operations in the background.
             core::future::pending::<Result<(), Error>>()
@@ -837,8 +960,8 @@ mod asynch {
             (**self).invoke(ctx, reply)
         }
 
-        fn run(&self) -> impl Future<Output = Result<(), Error>> {
-            (**self).run()
+        fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
+            (**self).run(ctx)
         }
     }
 
@@ -878,8 +1001,8 @@ mod asynch {
             (**self).invoke(ctx, reply)
         }
 
-        fn run(&self) -> impl Future<Output = Result<(), Error>> {
-            (**self).run()
+        fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
+            (**self).run(ctx)
         }
     }
 
@@ -1033,9 +1156,9 @@ mod asynch {
             }
         }
 
-        async fn run(&self) -> Result<(), Error> {
-            let mut handler = pin!(self.handler.run());
-            let mut next = pin!(self.next.run());
+        async fn run(&self, ctx: impl HandlerContext) -> Result<(), Error> {
+            let mut handler = pin!(self.handler.run(&ctx));
+            let mut next = pin!(self.next.run(&ctx));
 
             select(&mut handler, &mut next).coalesce().await
         }

--- a/rs-matter/src/dm/types/reply.rs
+++ b/rs-matter/src/dm/types/reply.rs
@@ -97,10 +97,11 @@ where
         &mut self,
         item: &Result<AttrDetails<'_>, AttrStatus>,
         mut tw: T,
+        notify: &dyn ChangeNotify,
     ) -> Result<(), Error> {
         let tail = tw.get_tail();
 
-        let result = self.do_process_read(item, &mut tw).await;
+        let result = self.do_process_read(item, &mut tw, notify).await;
 
         if result.is_err() {
             // If there was an error, rewind to the tail so we don't write any data.
@@ -114,12 +115,13 @@ where
         &mut self,
         item: &Result<AttrDetails<'_>, AttrStatus>,
         mut tw: T,
+        notify: &dyn ChangeNotify,
     ) -> Result<(), Error> {
         let result = match item {
             Ok(attr) => {
                 let pos = tw.get_tail();
 
-                let result = self.read(attr, &mut tw).await;
+                let result = self.read(attr, &mut tw, notify).await;
 
                 match result {
                     Ok(()) => Ok(None),
@@ -150,9 +152,10 @@ where
         &'t mut self,
         attr: &'t AttrDetails<'_>,
         tw: T,
+        notify: &'t dyn ChangeNotify,
     ) -> impl Future<Output = Result<(), Error>> + 't {
         self.handler.read(
-            ReadContextInstance::new(self.exchange, &self.handler, &self.buffers, attr),
+            ReadContextInstance::new(self.exchange, &self.handler, &self.buffers, attr, notify),
             ReadReplyInstance::new(attr, tw),
         )
     }

--- a/rs-matter/tests/common/e2e.rs
+++ b/rs-matter/tests/common/e2e.rs
@@ -165,7 +165,7 @@ impl E2eRunner {
 
         let responder = Responder::new(
             "Default",
-            DataModel::new(&self.buffers, &self.subscriptions, handler),
+            DataModel::new(&self.matter, &self.buffers, &self.subscriptions, handler),
             &self.matter,
             0,
         );


### PR DESCRIPTION
This PR addresses some TODOs in #316 but is useful in general.

Turns out, the `AsyncHandler::run` method we introduced some time ago needs at least some minimal Matter-related context which otherwise the user has to manually "push"  inside it. Specifically:
- Access to the `Matter` instance
- Capability to inform Matter, that the data related to _some_ cluster did change
- Access to the Data Model buffers (just in case)

The already existing `Context` and its `ReadContext`, `WriteContext` and `InvokeContext` sub-traits cannot do, as they contain data which is related to the _concrete_ operation handled by the handler (as in - the current Exchange, the processed attribute and/or command and so on). Since `AsyncHandler::run` runs in the background (it is just a convenience for the user so that she can easily schedule handler-related operations "in the background"), it cannot make use of the current `Context`, and it needs a more basic one.

This PR is therefore defining a `HandlerContext` which contains the above basics, and makes it a super-trait of `Context` and its operation-specific sub-traits. And defines its implementation.

Additionally, the PR is meticulously threading the changed cluster ID and its endpoint ID all the way down to the `Subscriptions` instance, which brings us one step closer to solving #166.

The re-shuffling of code related to the Responders was necessary, so as to make it as ergonomic as possible for the users to call the "run" method with a proper HandlerContext (this is done now by exposing a new `DataModel::run` method which does the magic).

====

The second, one-liner commit in this PR is addressing a bug @hicklin noticed - due to a missing delegation impl, the `AsyncHandler::run` was actually not really called.
