### PR TITLE
Provide blanket impls for the OnOff and LevelControl Hooks' traits; fix the BT example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Examples
         if: matrix.features == 'os' && matrix.crypto-backend == 'rustcrypto'
-        run: cargo build --examples --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},log
+        run: cargo build --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},log,zbus
 
       - name: Xtask Fmt
         if: matrix.features == 'os' && matrix.crypto-backend == 'rustcrypto'

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -29,9 +29,7 @@ use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::level_control::LevelControlHooks;
 use rs_matter::dm::clusters::net_comm::NetworkType;
-use rs_matter::dm::clusters::on_off::{
-    self, test::TestOnOffDeviceLogic, NoLevelControl, OnOffHandler, OnOffHooks,
-};
+use rs_matter::dm::clusters::on_off::{self, test::TestOnOffDeviceLogic, OnOffHooks};
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::{DEV_TYPE_AGGREGATOR, DEV_TYPE_BRIDGED_NODE, DEV_TYPE_ON_OFF_LIGHT};
 use rs_matter::dm::endpoints;
@@ -75,23 +73,16 @@ fn main() -> Result<(), Error> {
     let subscriptions = DefaultSubscriptions::new();
 
     // Our on-off clusters
-    let on_off_device_logic_ep2 = TestOnOffDeviceLogic::new();
-    let on_off_handler_ep2: OnOffHandler<TestOnOffDeviceLogic, NoLevelControl> =
-        on_off::OnOffHandler::new(
-            Dataver::new_rand(matter.rand()),
-            2,
-            &on_off_device_logic_ep2,
-        );
-    on_off_handler_ep2.init(None);
-
-    let on_off_device_logic_ep3 = TestOnOffDeviceLogic::new();
-    let on_off_handler_ep3: OnOffHandler<TestOnOffDeviceLogic, NoLevelControl> =
-        on_off::OnOffHandler::new(
-            Dataver::new_rand(matter.rand()),
-            3,
-            &on_off_device_logic_ep3,
-        );
-    on_off_handler_ep3.init(None);
+    let on_off_handler_ep2 = on_off::OnOffHandler::new_standalone(
+        Dataver::new_rand(matter.rand()),
+        2,
+        TestOnOffDeviceLogic::new(),
+    );
+    let on_off_handler_ep3 = on_off::OnOffHandler::new_standalone(
+        Dataver::new_rand(matter.rand()),
+        3,
+        TestOnOffDeviceLogic::new(),
+    );
 
     // Create the Data Model instance
     let dm = DataModel::new(

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -41,7 +41,7 @@ use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::level_control::LevelControlHooks;
 use rs_matter::dm::clusters::net_comm::NetworkType;
 use rs_matter::dm::clusters::on_off::{
-    self, EffectVariantEnum, NoLevelControl, OnOffHandler, OnOffHooks, StartUpOnOffEnum,
+    self, EffectVariantEnum, OnOffHandler, OnOffHooks, StartUpOnOffEnum,
 };
 use rs_matter::dm::clusters::unit_testing::{
     ClusterHandler as _, UnitTestingHandler, UnitTestingHandlerData,
@@ -136,10 +136,8 @@ fn main() -> Result<(), Error> {
         .init_with(DefaultSubscriptions::init());
 
     // Our on-off cluster
-    let on_off_device_logic = OnOffDeviceLogic::new();
-    let on_off_handler: OnOffHandler<OnOffDeviceLogic, NoLevelControl> =
-        OnOffHandler::new(Dataver::new_rand(matter.rand()), 1, &on_off_device_logic);
-    on_off_handler.init(None);
+    let on_off_handler =
+        OnOffHandler::new_standalone(Dataver::new_rand(matter.rand()), 1, OnOffDeviceLogic::new());
 
     // Our unit testing cluster data
     let unit_testing_data = UNIT_TESTING_DATA

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -139,25 +139,22 @@ fn run() -> Result<(), Error> {
         .init_with(DefaultSubscriptions::init());
 
     // OnOff cluster setup
-    let on_off_device_logic = OnOffDeviceLogic::new();
     let on_off_handler =
-        on_off::OnOffHandler::new(Dataver::new_rand(matter.rand()), 1, &on_off_device_logic);
+        on_off::OnOffHandler::new(Dataver::new_rand(matter.rand()), 1, OnOffDeviceLogic::new());
 
     // LevelControl cluster setup
-    let level_control_device_logic = LevelControlDeviceLogic::new();
-    let level_control_defaults = level_control::AttributeDefaults {
-        on_level: Nullable::some(42),
-        options: OptionsBitmap::from_bits(OptionsBitmap::EXECUTE_IF_OFF.bits()).unwrap(),
-        on_off_transition_time: 0,
-        on_transition_time: Nullable::none(),
-        off_transition_time: Nullable::none(),
-        default_move_rate: Nullable::none(),
-    };
     let level_control_handler = level_control::LevelControlHandler::new(
         Dataver::new_rand(matter.rand()),
         1,
-        &level_control_device_logic,
-        level_control_defaults,
+        LevelControlDeviceLogic::new(),
+        level_control::AttributeDefaults {
+            on_level: Nullable::some(42),
+            options: OptionsBitmap::from_bits(OptionsBitmap::EXECUTE_IF_OFF.bits()).unwrap(),
+            on_off_transition_time: 0,
+            on_transition_time: Nullable::none(),
+            off_transition_time: Nullable::none(),
+            default_move_rate: Nullable::none(),
+        },
     );
 
     // Cluster wiring, validation and initialisation

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -48,9 +48,7 @@ use media_playback::{
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::level_control::LevelControlHooks;
 use rs_matter::dm::clusters::net_comm::NetworkType;
-use rs_matter::dm::clusters::on_off::{
-    self, test::TestOnOffDeviceLogic, NoLevelControl, OnOffHandler, OnOffHooks,
-};
+use rs_matter::dm::clusters::on_off::{self, test::TestOnOffDeviceLogic, OnOffHooks};
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_CASTING_VIDEO_PLAYER;
 use rs_matter::dm::endpoints;
@@ -100,10 +98,11 @@ fn main() -> Result<(), Error> {
     let subscriptions = DefaultSubscriptions::new();
 
     // Assemble our Data Model handler by composing the predefined Root Endpoint handler with our custom Speaker handler
-    let on_off_device_logic = TestOnOffDeviceLogic::new();
-    let on_off_handler: OnOffHandler<TestOnOffDeviceLogic, NoLevelControl> =
-        on_off::OnOffHandler::new(Dataver::new_rand(matter.rand()), 1, &on_off_device_logic);
-    on_off_handler.init(None);
+    let on_off_handler = on_off::OnOffHandler::new_standalone(
+        Dataver::new_rand(matter.rand()),
+        1,
+        TestOnOffDeviceLogic::new(),
+    );
 
     // Create the Data Model instance
     let dm = DataModel::new(

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -72,25 +72,25 @@ fn main() -> Result<(), Error> {
     let subscriptions = DefaultSubscriptions::new();
 
     // OnOff cluster setup
-    let on_off_device_logic = TestOnOffDeviceLogic::new();
-    let on_off_handler =
-        on_off::OnOffHandler::new(Dataver::new_rand(matter.rand()), 1, &on_off_device_logic);
+    let on_off_handler = on_off::OnOffHandler::new(
+        Dataver::new_rand(matter.rand()),
+        1,
+        TestOnOffDeviceLogic::new(),
+    );
 
     // LevelControl cluster setup
-    let level_control_device_logic = LevelControlDeviceLogic::new();
-    let level_control_defaults = AttributeDefaults {
-        on_level: Nullable::some(42),
-        options: OptionsBitmap::from_bits(OptionsBitmap::EXECUTE_IF_OFF.bits()).unwrap(),
-        on_off_transition_time: 0,
-        on_transition_time: Nullable::none(),
-        off_transition_time: Nullable::none(),
-        default_move_rate: Nullable::none(),
-    };
     let level_control_handler = LevelControlHandler::new(
         Dataver::new_rand(matter.rand()),
         1,
-        &level_control_device_logic,
-        level_control_defaults,
+        LevelControlDeviceLogic::new(),
+        AttributeDefaults {
+            on_level: Nullable::some(42),
+            options: OptionsBitmap::from_bits(OptionsBitmap::EXECUTE_IF_OFF.bits()).unwrap(),
+            on_off_transition_time: 0,
+            on_transition_time: Nullable::none(),
+            off_transition_time: Nullable::none(),
+            default_move_rate: Nullable::none(),
+        },
     );
 
     // Cluster wiring, validation and initialisation

--- a/rs-matter/src/dm/clusters/level_control.rs
+++ b/rs-matter/src/dm/clusters/level_control.rs
@@ -107,6 +107,8 @@ pub struct AttributeDefaults {
 impl<'a, H: LevelControlHooks> LevelControlHandler<'a, H, NoOnOff> {
     /// Creates a new `LevelControlHandler` with the given hooks which is **not** coupled to an OnOff cluster.
     ///
+    /// NOTE: This constructor automatically calls `init` with no coupled `OnOff` handler.
+    ///
     /// # Arguments
     /// - `hooks` - A reference to the struct implementing the device-specific level control logic.
     pub fn new_standalone(

--- a/rs-matter/src/dm/clusters/level_control.rs
+++ b/rs-matter/src/dm/clusters/level_control.rs
@@ -78,7 +78,7 @@ enum Task {
 pub struct LevelControlHandler<'a, H: LevelControlHooks, OH: OnOffHooks> {
     dataver: Dataver,
     endpoint_id: EndptId,
-    hooks: &'a H,
+    hooks: H,
     on_off_handler: Cell<Option<&'a OnOffHandler<'a, OH, H>>>,
     task_signal: Signal<NoopRawMutex, Task>,
     on_level: Cell<Nullable<u8>>,
@@ -104,23 +104,45 @@ pub struct AttributeDefaults {
     pub default_move_rate: Nullable<u8>,
 }
 
+impl<'a, H: LevelControlHooks> LevelControlHandler<'a, H, NoOnOff> {
+    /// Creates a new `LevelControlHandler` with the given hooks which is **not** coupled to an OnOff cluster.
+    ///
+    /// # Arguments
+    /// - `hooks` - A reference to the struct implementing the device-specific level control logic.
+    pub fn new_standalone(
+        dataver: Dataver,
+        endpoint_id: EndptId,
+        hooks: H,
+        attribute_defaults: AttributeDefaults,
+    ) -> Self {
+        let this = Self::new(dataver, endpoint_id, hooks, attribute_defaults);
+
+        this.init(None);
+
+        this
+    }
+}
+
 impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
     const MAXIMUM_LEVEL: u8 = 254;
 
     /// Creates a new `LevelControlHandler` with the given hooks.
     ///
     /// # Arguments
-    /// - `level_control_hooks` - A reference to the struct implementing the device-specific level control logic.
+    /// - `hooks` - A reference to the struct implementing the device-specific level control logic.
+    ///
+    /// # Usage
+    /// - Initialise and optionally couple with an OnOff handler via `init`.
     pub fn new(
         dataver: Dataver,
         endpoint_id: EndptId,
-        level_control_hooks: &'a H,
+        hooks: H,
         attribute_defaults: AttributeDefaults,
     ) -> Self {
         Self {
             dataver,
             endpoint_id,
-            hooks: level_control_hooks,
+            hooks,
             on_off_handler: Cell::new(None),
             task_signal: Signal::new(),
             on_level: Cell::new(attribute_defaults.on_level),
@@ -388,7 +410,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
             }
         };
 
-        if on_off_state.on_off()? {
+        if on_off_state.on_off() {
             return Ok(true);
         }
 
@@ -557,7 +579,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
 
         // The `validate` method ensures that the on_off_handler is set if this function is called.
         if let Some(on_off) = self.on_off_handler.get() {
-            let current_on_off = on_off.on_off()?;
+            let current_on_off = on_off.on_off();
             if current_on_off != new_on_off_value {
                 info!(
                     "Updating the OnOff cluster with on_off = {}",
@@ -1262,6 +1284,36 @@ pub trait LevelControlHooks {
     /// This value should persist across reboots.
     fn set_start_up_current_level(&self, _value: Option<u8>) -> Result<(), Error> {
         Err(ErrorCode::InvalidAction.into())
+    }
+}
+
+impl<T> LevelControlHooks for &T
+where
+    T: LevelControlHooks,
+{
+    const MIN_LEVEL: u8 = T::MIN_LEVEL;
+    const MAX_LEVEL: u8 = T::MAX_LEVEL;
+    const FASTEST_RATE: u8 = T::FASTEST_RATE;
+    const CLUSTER: Cluster<'static> = T::CLUSTER;
+
+    fn set_device_level(&self, level: u8) -> Result<Option<u8>, ()> {
+        (*self).set_device_level(level)
+    }
+
+    fn current_level(&self) -> Option<u8> {
+        (*self).current_level()
+    }
+
+    fn set_current_level(&self, level: Option<u8>) {
+        (*self).set_current_level(level)
+    }
+
+    fn start_up_current_level(&self) -> Result<Option<u8>, Error> {
+        (*self).start_up_current_level()
+    }
+
+    fn set_start_up_current_level(&self, value: Option<u8>) -> Result<(), Error> {
+        (*self).set_start_up_current_level(value)
     }
 }
 

--- a/rs-matter/src/dm/clusters/on_off.rs
+++ b/rs-matter/src/dm/clusters/on_off.rs
@@ -103,6 +103,8 @@ pub struct OnOffHandler<'a, H: OnOffHooks, LH: LevelControlHooks> {
 impl<'a, H: OnOffHooks> OnOffHandler<'a, H, NoLevelControl> {
     /// Creates a new `OnOffHandler` with the given hooks which is **not** coupled with a `LevelControl` handler.
     ///
+    /// NOTE: This constructor automatically calls `init` with no coupled `LevelControl` handler.
+    ///
     /// # Arguments
     /// - `hooks` - A reference to the struct implementing the device-specific on/off logic.
     pub fn new_standalone(dataver: Dataver, endpoint_id: EndptId, hooks: H) -> Self {

--- a/rs-matter/src/dm/clusters/on_off.rs
+++ b/rs-matter/src/dm/clusters/on_off.rs
@@ -29,6 +29,7 @@
 //! - The attribute and logic related to the Scenes cluster are not fully implemented since the Scenes cluster is not yet implemented.
 
 use core::cell::Cell;
+use core::future::Future;
 
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::signal::Signal;
@@ -90,7 +91,7 @@ enum OnOffCommand {
 pub struct OnOffHandler<'a, H: OnOffHooks, LH: LevelControlHooks> {
     dataver: Dataver,
     endpoint_id: EndptId,
-    hooks: &'a H,
+    hooks: H,
     level_control_handler: Cell<Option<&'a LevelControlHandler<'a, LH, H>>>,
     state_change_signal: Signal<NoopRawMutex, OnOffCommand>,
     state: Cell<OnOffClusterState>,
@@ -99,17 +100,30 @@ pub struct OnOffHandler<'a, H: OnOffHooks, LH: LevelControlHooks> {
     off_wait_time: Cell<u16>,
 }
 
+impl<'a, H: OnOffHooks> OnOffHandler<'a, H, NoLevelControl> {
+    /// Creates a new `OnOffHandler` with the given hooks which is **not** coupled with a `LevelControl` handler.
+    ///
+    /// # Arguments
+    /// - `hooks` - A reference to the struct implementing the device-specific on/off logic.
+    pub fn new_standalone(dataver: Dataver, endpoint_id: EndptId, hooks: H) -> Self {
+        let this = Self::new(dataver, endpoint_id, hooks);
+
+        this.init(None);
+
+        this
+    }
+}
+
 impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
     /// Creates a new `OnOffHandler` with the given hooks.
     ///
     /// # Arguments
-    /// - `on_off_hooks` - A reference to the struct implementing the device-specific on/off logic.
+    /// - `hooks` - A reference to the struct implementing the device-specific on/off logic.
     ///
     /// # Usage
-    /// - Initialise and optionally couple with a LevelControl cluster via `init`.
-    /// - Use the async `run` method to run the OnOff server.
-    pub fn new(dataver: Dataver, endpoint_id: EndptId, on_off_hooks: &'a H) -> Self {
-        let state = match on_off_hooks.on_off() {
+    /// - Initialise and optionally couple with a LevelControl handler via `init`.
+    pub fn new(dataver: Dataver, endpoint_id: EndptId, hooks: H) -> Self {
+        let state = match hooks.on_off() {
             true => OnOffClusterState::On,
             false => OnOffClusterState::Off,
         };
@@ -117,7 +131,7 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
         Self {
             dataver,
             endpoint_id,
-            hooks: on_off_hooks,
+            hooks,
             level_control_handler: Cell::new(None),
             state_change_signal: Signal::new(),
             state: Cell::new(state),
@@ -244,9 +258,9 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
         }
     }
 
-    // Allows coupled clusters to get the on_off state.
-    pub(crate) fn on_off(&self) -> Result<bool, Error> {
-        Ok(self.hooks.on_off())
+    // Allows coupled clusters or user code to get the on_off state.
+    pub fn on_off(&self) -> bool {
+        self.hooks.on_off()
     }
 
     /// Sets the on_off state to true and updates the off_wait_time and global_scene_control accordingly.
@@ -734,6 +748,33 @@ pub trait OnOffHooks {
     fn set_start_up_on_off(&self, value: Nullable<StartUpOnOffEnum>) -> Result<(), Error>;
 
     async fn handle_off_with_effect(&self, effect: EffectVariantEnum);
+}
+
+impl<T> OnOffHooks for &T
+where
+    T: OnOffHooks,
+{
+    const CLUSTER: Cluster<'static> = T::CLUSTER;
+
+    fn on_off(&self) -> bool {
+        (*self).on_off()
+    }
+
+    fn set_on_off(&self, on: bool) {
+        (*self).set_on_off(on)
+    }
+
+    fn start_up_on_off(&self) -> Nullable<StartUpOnOffEnum> {
+        (*self).start_up_on_off()
+    }
+
+    fn set_start_up_on_off(&self, value: Nullable<StartUpOnOffEnum>) -> Result<(), Error> {
+        (*self).set_start_up_on_off(value)
+    }
+
+    fn handle_off_with_effect(&self, effect: EffectVariantEnum) -> impl Future<Output = ()> {
+        (*self).handle_off_with_effect(effect)
+    }
 }
 
 /// This is a phantom type for when the OnOff cluster is not coupled with a LevelControl cluster.

--- a/rs-matter/tests/common/e2e.rs
+++ b/rs-matter/tests/common/e2e.rs
@@ -26,7 +26,6 @@ use embassy_sync::{
 
 use rs_matter::acl::{AclEntry, AuthMode};
 use rs_matter::crypto::KeyPair;
-use rs_matter::dm::clusters::on_off::test::TestOnOffDeviceLogic;
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{AsyncHandler, AsyncMetadata, Privilege};
@@ -67,7 +66,6 @@ pub struct E2eRunner {
     buffers: PooledBuffers<10, NoopRawMutex, IMBuffer>,
     subscriptions: Subscriptions<1>,
     cat_ids: NocCatIds,
-    on_off_hooks: TestOnOffDeviceLogic,
 }
 
 impl E2eRunner {
@@ -92,7 +90,6 @@ impl E2eRunner {
             buffers: PooledBuffers::new(0),
             subscriptions: Subscriptions::new(),
             cat_ids,
-            on_off_hooks: TestOnOffDeviceLogic::new(),
         }
     }
 

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -144,9 +144,11 @@ impl<'a, OH: OnOffHooks, LH: LevelControlHooks> AsyncMetadata for E2eTestHandler
 impl<'a> E2eRunner {
     // For backwards compatibility
     pub fn handler(&self) -> E2eTestHandler<'_, TestOnOffDeviceLogic, NoLevelControl> {
-        let on_off_handler: OnOffHandler<'_, TestOnOffDeviceLogic, NoLevelControl> =
-            on_off::OnOffHandler::new(Dataver::new_rand(self.matter.rand()), 1, &self.on_off_hooks);
-        on_off_handler.init(None);
+        let on_off_handler = on_off::OnOffHandler::new_standalone(
+            Dataver::new_rand(self.matter.rand()),
+            1,
+            TestOnOffDeviceLogic::new(),
+        );
 
         E2eTestHandler::new(&self.matter, on_off_handler)
     }


### PR DESCRIPTION
We should always add [blanket impls](https://www.judy.co.uk/blog/rust-traits-and-references/) for all public traits defined by `rs-matter` and expected to be implemented by the user.

This allows her:
- To pass her trait impl to us by move
- To pass her trait impl to us by reference (`&` or `&mut` - depending whether the trait has `&mut self` methods or not)

The rule should be:
```rust
impl<T> TheTrait for &T where T: TheTrait { ... }
```
... if the trait has only `&self` methods. (Adding the below `&mut T` impl can also be done, but there is no much use for it, as every `&mut T` can be trivially re-cast as `&T` by just `&*t`.)

```rust
impl<T> TheTrait for &mut T where T: TheTrait { ... }
```
... if the trait has at least one `&mut self` method.

The outcome of adding blanket trait impls for the OnOff and LevelControl hooks can be seen in the examples (and in the e2e test) where we can now pass the hook impl by moving it into the handler (in addition to borrowing it).

====

To further lower the boilerplate, I've added `new_standalone` methods to `OnOffHandler` and `LevelControlHandler` that do the "new + init" dance in a single pass.

====

This PR also fixes the `onoff_light_bt` example as it did not compile.
Turns out our GH CI action was not updated to properly build the examples! Now fixed.

