### PR TITLE
Suppress generic-array deprecation warnings

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -150,7 +150,7 @@ ccm = { version = "0.5", default-features = false, features = ["alloc"], optiona
 p256 = { version = "0.13", default-features = false, features = ["arithmetic", "ecdh", "ecdsa"], optional = true }
 sec1 = { version = "0.7", default-features = false, optional = true }
 elliptic-curve = { version = "0.13", optional = true }
-crypto-bigint = { version = "0.5", default-features = false, optional = true }
+crypto-bigint = { version = "0.6", default-features = false, optional = true }
 rand_core = { version = "0.6", default-features = false, optional = true }
 x509-cert = { version = "0.2", default-features = false, features = ["pem"], optional = true } # TODO: requires `alloc`
 

--- a/rs-matter/src/crypto/openssl.rs
+++ b/rs-matter/src/crypto/openssl.rs
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#![allow(deprecated)] // Remove this once `hmac` updates to `generic-array` 1.x
+
 use core::fmt::{self, Debug};
 
 use crate::error::{Error, ErrorCode};

--- a/rs-matter/src/crypto/rustcrypto.rs
+++ b/rs-matter/src/crypto/rustcrypto.rs
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#![allow(deprecated)] // Remove this once `ccm` and `elliptic_curve` update to `generic-array` 1.x
+
 use core::convert::{TryFrom, TryInto};
 use core::mem::MaybeUninit;
 

--- a/rs-matter/src/sc/crypto/rustcrypto.rs
+++ b/rs-matter/src/sc/crypto/rustcrypto.rs
@@ -15,7 +15,8 @@
  *    limitations under the License.
  */
 
-use crypto_bigint::Encoding;
+#![allow(deprecated)] // Remove this once `ccm` and `elliptic_curve` update to `generic-array` 1.x
+
 use crypto_bigint::NonZero;
 use crypto_bigint::U384;
 use elliptic_curve::ops::*;


### PR DESCRIPTION
A few RustCrypto crates (`ccm` and `elliptic_curve`) still depend on and re-export `generic-array` < 1.0, however the last 0.x `generic-array` release just got deprecated a couple of hours ago.

Until the above crates migrate to `generic-array` 1.x I think it is fair to suppress the warnings generated by them, as `generic-array` 0.14 is actually _pub-re-exported_ from them (i.e. it is part of their API) so we don't have a better move in the meantime.

EDIT 1: Also the same warnings' suppression in `openssl.rs` which uses the `hmac` RustCrypto module, which has the same issue.

===

EDIT 2: Also updated crypto-bigint to 0.6 as it was still on 0.5.