### PR TITLE
Switch to embassy-time 0.5

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -41,8 +41,8 @@ log = "0.4"
 env_logger = "0.11"
 embassy-futures = "0.1"
 embassy-sync = "0.7"
-embassy-time = { version = "0.4", features = ["std"] }
-embassy-time-queue-utils = { version = "0.1", features = ["generic-queue-64"] }
+embassy-time = { version = "0.5", features = ["std"] }
+embassy-time-queue-utils = { version = "0.3", features = ["generic-queue-64"] }
 static_cell = "1"
 nix = { version = "0.27", features = ["net"] }
 async-io = "2"

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -124,8 +124,7 @@ safemem = { version = "0.3", default-features = false }
 time = { version = "0.3", default-features = false }
 verhoeff = { version = "1", default-features = false }
 embassy-futures = "0.1.2"
-embassy-time = "0.4"
-embassy-time-queue-utils = "0.1"
+embassy-time = "0.5"
 embassy-sync = "0.7"
 either = { version = "1", default-features = false }
 critical-section = "1.1"
@@ -184,5 +183,5 @@ futures-lite = "2"
 async-channel = "2"
 static_cell = "2"
 similar = "2.6"
-embassy-time-queue-utils = { version = "0.1", features = ["generic-queue-64"] }
+embassy-time-queue-utils = { version = "0.3", features = ["generic-queue-64"] }
 trybuild = "1"


### PR DESCRIPTION
Given that `esp-hal` RC1 is out, I think there is nothing stopping us from finally upgrading to `embassy-time` 0.5.
