### PR TITLE
Extend TestDeviceLogic with functionality to toggle the cluster state out of band

### DIFF
--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -76,12 +76,12 @@ fn main() -> Result<(), Error> {
     let on_off_handler_ep2 = on_off::OnOffHandler::new_standalone(
         Dataver::new_rand(matter.rand()),
         2,
-        TestOnOffDeviceLogic::new(),
+        TestOnOffDeviceLogic::new(false),
     );
     let on_off_handler_ep3 = on_off::OnOffHandler::new_standalone(
         Dataver::new_rand(matter.rand()),
         3,
-        TestOnOffDeviceLogic::new(),
+        TestOnOffDeviceLogic::new(false),
     );
 
     // Create the Data Model instance

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -28,8 +28,6 @@ use std::path::PathBuf;
 
 use embassy_futures::select::{select3, select4};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-#[cfg(not(feature = "chip-test"))]
-use embassy_time::{Duration, Timer};
 
 use async_signal::{Signal, Signals};
 use log::{error, info, trace};
@@ -43,8 +41,6 @@ use rs_matter::dm::clusters::decl::on_off as on_off_cluster;
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::level_control::{self, LevelControlHooks};
 use rs_matter::dm::clusters::net_comm::NetworkType;
-#[cfg(not(feature = "chip-test"))]
-use rs_matter::dm::clusters::on_off::OutOfBandMessage;
 use rs_matter::dm::clusters::on_off::{self, OnOffHooks, StartUpOnOffEnum};
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_DIMMABLE_LIGHT;
@@ -535,17 +531,5 @@ impl OnOffHooks for OnOffDeviceLogic {
 
     async fn handle_off_with_effect(&self, _effect: on_off::EffectVariantEnum) {
         // no effect
-    }
-
-    #[cfg(not(feature = "chip-test"))]
-    async fn run<F: Fn(OutOfBandMessage)>(&self, notify: F) {
-        loop {
-            // In a real example we wait for physical interaction.
-            Timer::after(Duration::from_secs(5)).await;
-            match self.on_off() {
-                true => notify(OutOfBandMessage::Off),
-                false => notify(OutOfBandMessage::On),
-            }
-        }
     }
 }

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -101,7 +101,7 @@ fn main() -> Result<(), Error> {
     let on_off_handler = on_off::OnOffHandler::new_standalone(
         Dataver::new_rand(matter.rand()),
         1,
-        TestOnOffDeviceLogic::new(),
+        TestOnOffDeviceLogic::new(false),
     );
 
     // Create the Data Model instance

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -34,10 +34,9 @@ use core::pin::pin;
 
 use std::net::UdpSocket;
 
-use embassy_futures::select::{select, select3, select4};
+use embassy_futures::select::{select, select4};
 
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_time::{Duration, Timer};
 use log::{info, warn};
 
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
@@ -135,7 +134,7 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
     let on_off_handler = on_off::OnOffHandler::new_standalone(
         Dataver::new_rand(matter.rand()),
         1,
-        TestOnOffDeviceLogic::new(),
+        TestOnOffDeviceLogic::new(true),
     );
 
     // A storage for the Wifi networks
@@ -164,19 +163,6 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
 
     // Run the background job of the data model
     let mut dm_job = pin!(dm.run());
-
-    // This is a sample code that simulates state changes triggered by the HAL
-    // Changes will be properly communicated to the Matter controllers and other Matter apps (i.e. Google Home, Alexa), thanks to subscriptions
-    let mut device = pin!(async {
-        loop {
-            Timer::after(Duration::from_secs(5)).await;
-
-            on_off_handler.set_on_off(!on_off_handler.on_off());
-            subscriptions.notify_cluster_changed(1, TestOnOffDeviceLogic::CLUSTER.id);
-
-            info!("Lamp toggled");
-        }
-    });
 
     // Create, load and run the persister
     let mut psm: Psm<4096> = Psm::new();
@@ -207,7 +193,7 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
             &mut transport,
             &mut bluetooth,
             select(&mut wifi_prov_task, &mut persist).coalesce(),
-            select3(&mut respond, &mut device, &mut dm_job).coalesce(),
+            select(&mut respond, &mut dm_job).coalesce(),
         );
 
         // Run with a simple `block_on`. Any local executor would do.
@@ -227,7 +213,7 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
         &mut transport,
         &mut mdns,
         &mut persist,
-        select3(&mut respond, &mut device, &mut dm_job).coalesce(),
+        select(&mut respond, &mut dm_job).coalesce(),
     );
 
     // Run with a simple `block_on`. Any local executor would do.

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -75,7 +75,7 @@ fn main() -> Result<(), Error> {
     let on_off_handler = on_off::OnOffHandler::new(
         Dataver::new_rand(matter.rand()),
         1,
-        TestOnOffDeviceLogic::new(),
+        TestOnOffDeviceLogic::new(true),
     );
 
     // LevelControl cluster setup

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -147,7 +147,7 @@ impl<'a> E2eRunner {
         let on_off_handler = on_off::OnOffHandler::new_standalone(
             Dataver::new_rand(self.matter.rand()),
             1,
-            TestOnOffDeviceLogic::new(),
+            TestOnOffDeviceLogic::new(false),
         );
 
         E2eTestHandler::new(&self.matter, on_off_handler)


### PR DESCRIPTION
We have this piece of code which toggles the on-off cluster state on and off every 5 seconds repeated throughout all examples of `rs-matter`, `rs-matter-stack`, `rs-matter-embassy` and `esp-idf-matter`.

Therefore, I think it makes sense to move it into the `TestOnOffDeviceLogic` struct rather than copy-pasting it everywhere.