### PR TITLE
More tests

### DIFF
--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -80,7 +80,7 @@ use rs_matter::error::Error;
 use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::respond::DefaultResponder;
-use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
+use rs_matter::sc::pake::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use rs_matter::tlv::Nullable;
 use rs_matter::transport::network::btp::{
     AdvData, Btp, BtpContext, GattPeripheral, GattPeripheralEvent,
@@ -419,7 +419,7 @@ fn main() -> ! {
 
         unwrap!(stack
             .matter
-            .enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS));
+            .open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS));
     }
 
     executor.run(|spawner| {

--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -77,8 +77,10 @@ use rs_matter::dm::subscriptions::{Subscriptions, DEFAULT_MAX_SUBSCRIPTIONS};
 use rs_matter::dm::{endpoints, IMBuffer};
 use rs_matter::dm::{Async, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node};
 use rs_matter::error::Error;
+use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::respond::DefaultResponder;
+use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
 use rs_matter::tlv::Nullable;
 use rs_matter::transport::network::btp::{
     AdvData, Btp, BtpContext, GattPeripheral, GattPeripheralEvent,
@@ -404,14 +406,23 @@ fn main() -> ! {
 
     info!("===================================================");
 
-    executor.run(|spawner| {
-        unwrap!(embassy_futures::block_on(
-            stack.matter.enable_basic_commissioning(
-                DiscoveryCapabilities::BLE,
-                TEST_DEV_COMM.discriminator
-            )
-        ));
+    if !stack.matter.is_commissioned() {
+        // If the device is not commissioned yet, print the QR text and code to the console
+        // and enable basic commissioning
 
+        unwrap!(stack
+            .matter
+            .print_standard_qr_text(DiscoveryCapabilities::IP));
+        unwrap!(stack
+            .matter
+            .print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP));
+
+        unwrap!(stack
+            .matter
+            .enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS));
+    }
+
+    executor.run(|spawner| {
         unwrap!(spawner.spawn(respond_task(responder)));
         unwrap!(spawner.spawn(dm_task(dm)));
         unwrap!(spawner.spawn(mdns_task(mdns)));

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -44,7 +44,7 @@ use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
-use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
+use rs_matter::sc::pake::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::select::Coalesce;
 use rs_matter::utils::storage::pooled::PooledBuffers;
@@ -125,7 +125,7 @@ fn main() -> Result<(), Error> {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS)?;
     }
 
     let mut persist = pin!(psm.run(&path, &matter, NO_NETWORKS));

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -40,9 +40,11 @@ use rs_matter::dm::{
     EpClMatcher, Node, ReadContext,
 };
 use rs_matter::error::Error;
+use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
+use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::select::Coalesce;
 use rs_matter::utils::storage::pooled::PooledBuffers;
@@ -108,13 +110,23 @@ fn main() -> Result<(), Error> {
 
     // Run the Matter and mDNS transports
     let mut mdns = pin!(mdns::run_mdns(&matter));
-    let mut transport = pin!(matter.run(&socket, &socket, DiscoveryCapabilities::IP));
+    let mut transport = pin!(matter.run(&socket, &socket));
 
     // Create, load and run the persister
     let mut psm: Psm<4096> = Psm::new();
     let path = std::env::temp_dir().join("rs-matter");
 
     psm.load(&path, &matter, NO_NETWORKS)?;
+
+    if !matter.is_commissioned() {
+        // If the device is not commissioned yet, print the QR text and code to the console
+        // and enable basic commissioning
+
+        matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
+        matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
+
+        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+    }
 
     let mut persist = pin!(psm.run(&path, &matter, NO_NETWORKS));
 

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -53,10 +53,11 @@ use rs_matter::dm::{
     Node,
 };
 use rs_matter::error::Error;
+use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
-use rs_matter::sc::pake::MAX_COMMISSIONING_TIMEOUT_SECS;
+use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::cell::RefCell;
 use rs_matter::utils::init::InitMaybeUninit;
@@ -172,28 +173,13 @@ fn main() -> Result<(), Error> {
 
     info!(
         "Transport memory: Transport fut (stack)={}B, mDNS fut (stack)={}B",
-        core::mem::size_of_val(&matter.run(&socket, &socket, DiscoveryCapabilities::IP)),
+        core::mem::size_of_val(&matter.run(&socket, &socket)),
         core::mem::size_of_val(&mdns::run_mdns(matter))
     );
 
     // Run the Matter and mDNS transports
     let mut mdns = pin!(mdns::run_mdns(matter));
-    let mut transport = pin!(async {
-        if matter.is_commissioned() {
-            matter
-                .print_pairing_code_and_qr(DiscoveryCapabilities::IP)
-                .await?;
-        } else {
-            matter
-                .enable_basic_commissioning(
-                    DiscoveryCapabilities::IP,
-                    MAX_COMMISSIONING_TIMEOUT_SECS,
-                )
-                .await?;
-        }
-
-        matter.run_transport(&socket, &socket).await
-    });
+    let mut transport = pin!(matter.run_transport(&socket, &socket));
 
     // Create, load and run the persister
     let psm = PSM.uninit().init_with(Psm::init());
@@ -206,6 +192,19 @@ fn main() -> Result<(), Error> {
     );
 
     psm.load(&path, matter, NO_NETWORKS)?;
+
+    // We need to always print the QR text, because the test runner expects it to be printed
+    // even if the device is already commissioned
+    matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
+
+    if !matter.is_commissioned() {
+        // If the device is not commissioned yet, print the QR code to the console
+        // and enable basic commissioning
+
+        matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
+
+        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+    }
 
     let mut persist = pin!(psm.run(&path, matter, NO_NETWORKS));
 

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -57,7 +57,7 @@ use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
-use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
+use rs_matter::sc::pake::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::cell::RefCell;
 use rs_matter::utils::init::InitMaybeUninit;
@@ -203,7 +203,7 @@ fn main() -> Result<(), Error> {
 
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS)?;
     }
 
     let mut persist = pin!(psm.run(&path, matter, NO_NETWORKS));

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -57,7 +57,7 @@ use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
-use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
+use rs_matter::sc::pake::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use rs_matter::tlv::Nullable;
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::init::InitMaybeUninit;
@@ -222,7 +222,7 @@ fn run() -> Result<(), Error> {
 
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS)?;
     }
 
     let mut persist = pin!(psm.run(&path, matter, NO_NETWORKS));

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -63,7 +63,7 @@ use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
-use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
+use rs_matter::sc::pake::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use rs_matter::tlv::{TLVBuilderParent, Utf8StrArrayBuilder, Utf8StrBuilder};
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::select::Coalesce;
@@ -145,7 +145,7 @@ fn main() -> Result<(), Error> {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS)?;
     }
 
     let mut persist = pin!(psm.run(&path, &matter, NO_NETWORKS));

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -59,9 +59,11 @@ use rs_matter::dm::{
     EmptyHandler, Endpoint, EpClMatcher, InvokeContext, Node, ReadContext,
 };
 use rs_matter::error::{Error, ErrorCode};
+use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
+use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
 use rs_matter::tlv::{TLVBuilderParent, Utf8StrArrayBuilder, Utf8StrBuilder};
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::select::Coalesce;
@@ -128,13 +130,23 @@ fn main() -> Result<(), Error> {
 
     // Run the Matter and mDNS transports
     let mut mdns = pin!(mdns::run_mdns(&matter));
-    let mut transport = pin!(matter.run(&socket, &socket, DiscoveryCapabilities::IP));
+    let mut transport = pin!(matter.run(&socket, &socket));
 
     // Create, load and run the persister
     let mut psm: Psm<4096> = Psm::new();
     let path = std::env::temp_dir().join("rs-matter");
 
     psm.load(&path, &matter, NO_NETWORKS)?;
+
+    if !matter.is_commissioned() {
+        // If the device is not commissioned yet, print the QR text and code to the console
+        // and enable basic commissioning
+
+        matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
+        matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
+
+        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+    }
 
     let mut persist = pin!(psm.run(&path, &matter, NO_NETWORKS));
 

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -45,7 +45,7 @@ use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
-use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
+use rs_matter::sc::pake::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::init::InitMaybeUninit;
 use rs_matter::utils::select::Coalesce;
@@ -176,7 +176,7 @@ fn run() -> Result<(), Error> {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS)?;
     }
 
     let mut persist = pin!(psm.run(&path, matter, NO_NETWORKS));

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -41,9 +41,11 @@ use rs_matter::dm::{
     Node,
 };
 use rs_matter::error::Error;
+use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
+use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::init::InitMaybeUninit;
 use rs_matter::utils::select::Coalesce;
@@ -147,13 +149,13 @@ fn run() -> Result<(), Error> {
 
     info!(
         "Transport memory: Transport fut (stack)={}B, mDNS fut (stack)={}B",
-        core::mem::size_of_val(&matter.run(&socket, &socket, DiscoveryCapabilities::IP)),
+        core::mem::size_of_val(&matter.run(&socket, &socket)),
         core::mem::size_of_val(&mdns::run_mdns(matter))
     );
 
     // Run the Matter and mDNS transports
     let mut mdns = pin!(mdns::run_mdns(matter));
-    let mut transport = pin!(matter.run(&socket, &socket, DiscoveryCapabilities::IP));
+    let mut transport = pin!(matter.run(&socket, &socket));
 
     // Create, load and run the persister
     let psm = PSM.uninit().init_with(Psm::init());
@@ -166,6 +168,16 @@ fn run() -> Result<(), Error> {
     );
 
     psm.load(&path, matter, NO_NETWORKS)?;
+
+    if !matter.is_commissioned() {
+        // If the device is not commissioned yet, print the QR text and code to the console
+        // and enable basic commissioning
+
+        matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
+        matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
+
+        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+    }
 
     let mut persist = pin!(psm.run(&path, matter, NO_NETWORKS));
 

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -59,7 +59,7 @@ use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::Psm;
 use rs_matter::respond::DefaultResponder;
-use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
+use rs_matter::sc::pake::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use rs_matter::transport::network::btp::bluez::BluezGattPeripheral;
 use rs_matter::transport::network::btp::{Btp, BtpContext};
 use rs_matter::transport::network::wifi::nm::NetMgrCtl;
@@ -186,7 +186,7 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS)?;
 
         // The BTP transport impl
         let btp = Btp::new(BluezGattPeripheral::new(None, connection), &BTP_CONTEXT);

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -42,9 +42,11 @@ use rs_matter::dm::{
     Node,
 };
 use rs_matter::error::Error;
+use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
+use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
 use rs_matter::tlv::Nullable;
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::select::Coalesce;
@@ -121,13 +123,23 @@ fn main() -> Result<(), Error> {
 
     // Run the Matter and mDNS transports
     let mut mdns = pin!(mdns::run_mdns(&matter));
-    let mut transport = pin!(matter.run(&socket, &socket, DiscoveryCapabilities::IP));
+    let mut transport = pin!(matter.run(&socket, &socket));
 
     // Create, load and run the persister
     let mut psm: Psm<4096> = Psm::new();
     let path = std::env::temp_dir().join("rs-matter");
 
     psm.load(&path, &matter, NO_NETWORKS)?;
+
+    if !matter.is_commissioned() {
+        // If the device is not commissioned yet, print the QR text and code to the console
+        // and enable basic commissioning
+
+        matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
+        matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
+
+        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+    }
 
     let mut persist = pin!(psm.run(&path, &matter, NO_NETWORKS));
 

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -46,7 +46,7 @@ use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{Psm, NO_NETWORKS};
 use rs_matter::respond::DefaultResponder;
-use rs_matter::sc::pake::MAX_COMM_TIMEOUT_SECS;
+use rs_matter::sc::pake::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use rs_matter::tlv::Nullable;
 use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
 use rs_matter::utils::select::Coalesce;
@@ -138,7 +138,7 @@ fn main() -> Result<(), Error> {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.enable_basic_commissioning(MAX_COMM_TIMEOUT_SECS)?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS)?;
     }
 
     let mut persist = pin!(psm.run(&path, &matter, NO_NETWORKS));

--- a/examples/src/common/mdns.rs
+++ b/examples/src/common/mdns.rs
@@ -136,7 +136,7 @@ async fn run_builtin_mdns(matter: &Matter<'_>) -> Result<(), Error> {
             &socket,
             &Host {
                 id: 0,
-                hostname: "rs-matter-demo",
+                hostname: "001122334455", //"rs-matter-demo",
                 ip: ipv4_addr,
                 ipv6: ipv6_addr,
             },

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -226,7 +226,7 @@ impl ClusterHandler for GenCommHandler<'_> {
                 .matter()
                 .pase_mgr
                 .borrow_mut()
-                .disable_pase_session(&mut || ctx.exchange().matter().notify_mdns())?;
+                .close_comm_window(&mut || ctx.exchange().matter().notify_mdns())?;
         }
 
         response.error_code(status)?.debug_text("")?.end()

--- a/rs-matter/src/pairing.rs
+++ b/rs-matter/src/pairing.rs
@@ -17,15 +17,10 @@
 
 //! This module contains the logic for generating the pairing code and the QR code for easy pairing.
 
-use qr::no_optional_data;
-
 use crate::dm::clusters::basic_info::BasicInfoConfig;
 use crate::error::Error;
 use crate::utils::bitflags::bitflags;
 use crate::BasicCommData;
-
-use self::code::{compute_pairing_code, pretty_print_pairing_code};
-use self::qr::{compute_qr_code_text, print_qr_code};
 
 pub mod code;
 pub mod qr;
@@ -44,39 +39,4 @@ impl Default for DiscoveryCapabilities {
     fn default() -> Self {
         Self::IP
     }
-}
-
-/// Prepares and prints the pairing code and the QR code for easy pairing.
-pub fn print_pairing_code_and_qr(
-    dev_det: &BasicInfoConfig,
-    comm_data: &BasicCommData,
-    discovery_capabilities: DiscoveryCapabilities,
-    buf: &mut [u8],
-) -> Result<(), Error> {
-    let pairing_code = compute_pairing_code(comm_data);
-
-    pretty_print_pairing_code(&pairing_code);
-
-    let (qr_code, remaining_buf) = compute_qr_code_text(
-        dev_det,
-        comm_data,
-        discovery_capabilities,
-        no_optional_data,
-        buf,
-    )?;
-
-    print_qr_code(qr_code, remaining_buf)?;
-
-    Ok(())
-}
-
-#[repr(u16)]
-pub enum VendorId {
-    CommonOrUnspecified = 0x0000,
-    TestVendor4 = 0xFFF4,
-}
-
-pub fn is_vendor_id_valid_operationally(vendor_id: u16) -> bool {
-    (vendor_id != VendorId::CommonOrUnspecified as u16)
-        && (vendor_id <= VendorId::TestVendor4 as u16)
 }

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -270,7 +270,9 @@ where
             wb.le_u8(ch? as u8)?;
         }
 
-        let str = unsafe { core::str::from_utf8_unchecked(str_buf) };
+        // Can't fail as `emit_chars` generates a valid UTF-8 string
+        let str = unwrap!(core::str::from_utf8(str_buf));
+
         Ok((str, remaining_buf))
     }
 
@@ -491,10 +493,10 @@ impl<'a> Qr<'a> {
 
         let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
 
-        Ok((
-            unsafe { core::str::from_utf8_unchecked(str_buf) },
-            remaining_buf,
-        ))
+        // Can't fail as `emit_chars` generates a valid UTF-8 string
+        let str = unwrap!(core::str::from_utf8(str_buf));
+
+        Ok((str, remaining_buf))
     }
 
     /// Encode a single line of the QR as a string into the provided buffer
@@ -535,10 +537,10 @@ impl<'a> Qr<'a> {
 
         let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
 
-        Ok((
-            unsafe { core::str::from_utf8_unchecked(str_buf) },
-            remaining_buf,
-        ))
+        // Can't fail as `emit_chars` generates a valid UTF-8 string
+        let str = unwrap!(core::str::from_utf8(str_buf));
+
+        Ok((str, remaining_buf))
     }
 
     /// Get an iterator over the indexes of the lines of the QR code including borders
@@ -718,10 +720,10 @@ impl<'a> QrTextRenderer<'a> {
 
         let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
 
-        Ok((
-            unsafe { core::str::from_utf8_unchecked(str_buf) },
-            remaining_buf,
-        ))
+        // Can't fail as `emit_chars` generates a valid UTF-8 string
+        let str = unwrap!(core::str::from_utf8(str_buf));
+
+        Ok((str, remaining_buf))
     }
 
     /// Render a single line of the QR code as a string into the provided buffer
@@ -760,10 +762,10 @@ impl<'a> QrTextRenderer<'a> {
 
         let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
 
-        Ok((
-            unsafe { core::str::from_utf8_unchecked(str_buf) },
-            remaining_buf,
-        ))
+        // Can't fail as `emit_chars` generates a valid UTF-8 string
+        let str = unwrap!(core::str::from_utf8(str_buf));
+
+        Ok((str, remaining_buf))
     }
 
     /// Get an iterator over the indexes of the lines of the QR code including borders

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -54,40 +54,121 @@ pub const BPKFSALT_TAG: u8 = 0x02;
 pub const NUMBER_OFDEVICES_TAG: u8 = 0x03;
 pub const COMMISSIONING_TIMEOUT_TAG: u8 = 0x04;
 
-pub struct QrSetupPayload<'data, T> {
+/// Commissioning flow type as per the Matter Core spec
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CommFlowType {
+    /// Standard commissioning flow
+    Standard = 0,
+    /// Enhanced commissioning flow with user intent
+    UserIntent = 1,
+    /// Custom commissioning flow
+    Custom = 2,
+}
+
+/// Type alias for no optional data function for the QR payload
+pub type NoOptionalData = fn() -> Empty<Result<u8, Error>>;
+
+/// Function that provides no optional data for the QR payload
+pub fn no_optional_data() -> Empty<Result<u8, Error>> {
+    core::iter::empty()
+}
+
+/// QR Code payload type
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct QrPayload<'a, T> {
+    /// Payload version. Always 0
     version: u8,
-    flow_type: CommissionningFlowType,
+    /// Discovery capabilities of the device
     discovery_capabilities: DiscoveryCapabilities,
-    dev_det: &'data BasicInfoConfig<'data>,
-    comm_data: &'data BasicCommData,
-    // The data written by the optional data provider must be ordered by the tag of each TLV element in ascending order.
+    /// Commissioning flow type
+    comm_flow: CommFlowType,
+    /// Basic commissioning data
+    comm_data: BasicCommData,
+    /// Vendor ID
+    vid: u16,
+    /// Product ID
+    pid: u16,
+    /// Serial number of the device
+    serial_no: &'a str,
+    /// Optional extra data
+    /// The data must be ordered by the tag of each TLV element in ascending order.
     optional_data: T,
 }
 
-impl<'data, T, I> QrSetupPayload<'data, T>
+impl<'a, T, I> QrPayload<'a, T>
 where
     T: Fn() -> I,
-    I: Iterator<Item = Result<u8, Error>> + 'data,
+    I: Iterator<Item = Result<u8, Error>> + 'a,
 {
-    /// `optional_data` should be ordered by tag number in ascending order.
-    pub fn new(
-        dev_det: &'data BasicInfoConfig,
-        comm_data: &'data BasicCommData,
+    /// Create a new QR payload from the device basic info config
+    ///
+    /// # Arguments
+    /// - `discovery_capabilities` - Discovery capabilities of the device
+    /// - `comm_flow` - Commissioning flow type
+    /// - `comm_data` - Basic commissioning data
+    /// - `dev_det` - Device basic info config
+    /// - `optional_data` - Function that provides an iterator over optional TLV data bytes.
+    ///   NOTE: Should be ordered by tag number in ascending order.
+    pub const fn new_from_basic_info(
         discovery_capabilities: DiscoveryCapabilities,
+        comm_flow: CommFlowType,
+        comm_data: BasicCommData,
+        dev_det: &'a BasicInfoConfig,
+        optional_data: T,
+    ) -> Self {
+        Self::new(
+            discovery_capabilities,
+            comm_flow,
+            comm_data,
+            dev_det.vid,
+            dev_det.pid,
+            dev_det.serial_no,
+            optional_data,
+        )
+    }
+
+    /// Create a new QR payload
+    ///
+    /// # Arguments
+    /// - `discovery_capabilities` - Discovery capabilities of the device
+    /// - `comm_flow` - Commissioning flow type
+    /// - `comm_data` - Basic commissioning data
+    /// - `vid` - Vendor ID
+    /// - `pid` - Product ID
+    /// - `serial_no` - Serial number of the device
+    /// - `optional_data` - Function that provides an iterator over optional TLV data bytes.
+    ///   NOTE: Should be ordered by tag number in ascending order.
+    pub const fn new(
+        discovery_capabilities: DiscoveryCapabilities,
+        comm_flow: CommFlowType,
+        comm_data: BasicCommData,
+        vid: u16,
+        pid: u16,
+        serial_no: &'a str,
         optional_data: T,
     ) -> Self {
         const DEFAULT_VERSION: u8 = 0;
 
         Self {
             version: DEFAULT_VERSION,
-            flow_type: CommissionningFlowType::Standard,
             discovery_capabilities,
-            dev_det,
+            comm_flow,
             comm_data,
+            vid,
+            pid,
+            serial_no,
             optional_data,
         }
     }
 
+    /// Check if the QR payload is valid
+    ///
+    /// # Returns
+    /// - `true` if the payload is valid
+    /// - `false` otherwise
     pub fn is_valid(&self) -> bool {
         // 3-bit value specifying the QR code payload version.
         if self.version >= 1 << VERSION_FIELD_LENGTH_IN_BITS {
@@ -106,6 +187,19 @@ where
     }
 
     fn check_payload_common_constraints(&self) -> bool {
+        #[repr(u16)]
+        enum VendorId {
+            CommonOrUnspecified = 0x0000,
+            TestVendor4 = 0xFFF4,
+        }
+
+        impl VendorId {
+            fn is_valid_operationally(vendor_id: u16) -> bool {
+                (vendor_id != Self::CommonOrUnspecified as u16)
+                    && (vendor_id <= Self::TestVendor4 as u16)
+            }
+        }
+
         // A version not equal to 0 would be invalid for v1 and would indicate new format (e.g. version 2)
         if self.version != 0 {
             return false;
@@ -116,8 +210,8 @@ where
         }
 
         // VendorID must be unspecified (0) or in valid range expected.
-        if !is_vendor_id_valid_operationally(self.dev_det.vid)
-            && (self.dev_det.vid != VendorId::CommonOrUnspecified as u16)
+        if VendorId::is_valid_operationally(self.vid)
+            && (self.vid != VendorId::CommonOrUnspecified as u16)
         {
             return false;
         }
@@ -126,7 +220,7 @@ where
         //  * To announce an anonymized Product ID as part of device discovery
         //  * To indicate an OTA software update file applies to multiple Product IDs equally.
         //  * To avoid confusion when presenting the Onboarding Payload for ECM with multiple nodes
-        if self.dev_det.pid == 0 && self.dev_det.vid != VendorId::CommonOrUnspecified as u16 {
+        if self.pid == 0 && self.vid != VendorId::CommonOrUnspecified as u16 {
             return false;
         }
 
@@ -158,7 +252,15 @@ where
         true
     }
 
-    pub fn try_as_str<'a>(&self, buf: &'a mut [u8]) -> Result<(&'a str, &'a mut [u8]), Error> {
+    /// Encode the QR text of this payload as a string into the provided buffer
+    ///
+    /// # Arguments
+    /// - `buf` - Buffer to store the QR code string
+    ///
+    /// # Returns
+    /// - On success, returns a tuple containing the QR code string and the remaining buffer
+    /// - On failure, returns an error
+    pub fn as_str<'b>(&self, buf: &'b mut [u8]) -> Result<(&'b str, &'b mut [u8]), Error> {
         let str_len = self.emit_chars().count();
 
         let (str_buf, remaining_buf) = buf.split_at_mut(str_len);
@@ -172,6 +274,7 @@ where
         Ok((str, remaining_buf))
     }
 
+    /// Emit the QR text of this payload as an iterator of characters
     pub fn emit_chars(&self) -> impl Iterator<Item = Result<char, Error>> + '_ {
         struct PackedBitsIterator<I>(I);
 
@@ -226,15 +329,15 @@ where
     fn emit_all_bits(&self) -> impl Iterator<Item = Result<bool, Error>> + '_ {
         Self::emit_bits(self.version as _, VERSION_FIELD_LENGTH_IN_BITS)
             .chain(Self::emit_bits(
-                self.dev_det.vid as _,
+                self.vid as _,
                 VENDOR_IDFIELD_LENGTH_IN_BITS,
             ))
             .chain(Self::emit_bits(
-                self.dev_det.pid as _,
+                self.pid as _,
                 PRODUCT_IDFIELD_LENGTH_IN_BITS,
             ))
             .chain(Self::emit_bits(
-                self.flow_type as _,
+                self.comm_flow as _,
                 COMMISSIONING_FLOW_FIELD_LENGTH_IN_BITS,
             ))
             .chain(Self::emit_bits(
@@ -270,16 +373,15 @@ where
     }
 
     fn emit_optional_tlv_data(&self) -> impl Iterator<Item = Result<u8, Error>> + '_ {
-        if self.dev_det.serial_no.is_empty() && (self.optional_data)().next().is_none() {
+        if self.serial_no.is_empty() && (self.optional_data)().next().is_none() {
             return EitherIter::First(core::iter::empty());
         }
 
-        let serial_no = if self.dev_det.serial_no.is_empty() {
+        let serial_no = if self.serial_no.is_empty() {
             EitherIter::First(core::iter::empty())
         } else {
             EitherIter::Second(
-                TLV::utf8(TLVTag::Context(SERIAL_NUMBER_TAG), self.dev_det.serial_no)
-                    .into_tlv_iter(),
+                TLV::utf8(TLVTag::Context(SERIAL_NUMBER_TAG), self.serial_no).into_tlv_iter(),
             )
         };
 
@@ -298,54 +400,84 @@ where
     }
 }
 
-#[repr(u8)]
-#[derive(Clone, Copy)]
-pub enum CommissionningFlowType {
-    Standard = 0,
-    UserIntent = 1,
-    Custom = 2,
-}
-
-pub fn print_qr_code(qr_code_text: &str, buf: &mut [u8]) -> Result<(), Error> {
-    // Do not remove this logging line or change its formatting.
-    // C++ E2E tests rely on this log line to grep the QR code
-    info!("SetupQRCode: [{}]", qr_code_text);
-
-    let (tmp_buf, out_buf) = buf.split_at_mut(buf.len() / 2);
-
-    let qr_code = compute_qr_code(qr_code_text, tmp_buf, out_buf)?;
-
-    let text_image = TextImage::Unicode;
-
-    for y in text_image.lines_range(&qr_code, 4) {
-        info!(
-            "{}",
-            text_image.render_line(&qr_code, 4, false, false, y, tmp_buf)?
-        );
-    }
-
-    Ok(())
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+/// QR Code text type
+///
+/// Used when emitting the QR code in different text formats
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum TextImage {
+pub enum QrTextType {
+    /// Pure ASCII text
+    /// Compatible with all consoles
     Ascii,
+    /// ANSI
     Ansi,
+    /// Unicode
     Unicode,
 }
 
-impl TextImage {
-    pub fn render<'a>(
+/// QR Code representation
+pub struct Qr<'a>(QrCode<'a>);
+
+impl<'a> Qr<'a> {
+    /// Create a new QR code from the given text
+    ///
+    /// # Arguments
+    /// - `text` - Text to encode in the QR code
+    /// - `tmp_buf` - Temporary buffer for QR code generation
+    /// - `out_buf` - Output buffer for the QR code
+    ///
+    /// # Returns
+    /// - On success, returns the generated QR code
+    /// - On failure, returns an error
+    pub fn compute(text: &str, tmp_buf: &mut [u8], out_buf: &'a mut [u8]) -> Result<Self, Error> {
+        let needed_version = Version::new(Self::version(text));
+
+        let qr = QrCode::encode_text(
+            text,
+            tmp_buf,
+            out_buf,
+            QrCodeEcc::Medium,
+            needed_version,
+            needed_version,
+            None,
+            false,
+        )
+        .map_err(|_| ErrorCode::BufferTooSmall)?;
+
+        Ok(Self(qr))
+    }
+
+    /// Get the size of the QR code
+    pub fn size(&self) -> u32 {
+        self.0.size() as _
+    }
+
+    /// Get the module value at the given coordinates
+    pub fn get_module(&self, x: i32, y: i32) -> bool {
+        self.0.get_module(x, y)
+    }
+
+    /// Encode the QR as a string into the provided buffer
+    ///
+    /// # Arguments
+    /// - `text_type` - Type of text to return (ASCII, ANSI, Unicode)
+    /// - `border` - Border size
+    /// - `invert` - Whether to invert the colors (black on a white background)
+    /// - `out_buf` - Output buffer for the rendered string
+    ///
+    /// # Returns
+    /// - On success, returns a tuple containing the rendered string and the remaining buffer
+    /// - On failure, returns an error
+    pub fn as_str<'b>(
         &self,
-        qr_code: &QrCode,
+        text_type: QrTextType,
         border: u8,
         invert: bool,
-        out_buf: &'a mut [u8],
-    ) -> Result<&'a str, Error> {
+        out_buf: &'b mut [u8],
+    ) -> Result<(&'b str, &'b mut [u8]), Error> {
         let mut offset = 0;
 
-        for c in self.render_iter(qr_code, border, invert) {
+        for c in self.emit_chars(text_type, border, invert) {
             let mut dst = [0; 4];
             let bytes = c.encode_utf8(&mut dst).as_bytes();
 
@@ -357,21 +489,39 @@ impl TextImage {
             }
         }
 
-        Ok(unsafe { core::str::from_utf8_unchecked(&out_buf[..offset]) })
+        let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
+
+        Ok((
+            unsafe { core::str::from_utf8_unchecked(str_buf) },
+            remaining_buf,
+        ))
     }
 
-    pub fn render_line<'a>(
+    /// Encode a single line of the QR as a string into the provided buffer
+    ///
+    /// # Arguments
+    /// - `text_type` - Type of text to return (ASCII, ANSI, Unicode)
+    /// - `border` - Border size
+    /// - `invert` - Whether to invert the colors (black on a white background)
+    /// - `nl` - Whether to add a newline at the end of the line
+    /// - `y` - Y coordinate of the line to render
+    /// - `out_buf` - Output buffer for the rendered string
+    ///
+    /// # Returns
+    /// - On success, returns a tuple containing the rendered string and the remaining buffer
+    /// - On failure, returns an error
+    pub fn line_as_str<'b>(
         &self,
-        qr_code: &QrCode,
+        text_type: QrTextType,
         border: u8,
         invert: bool,
         nl: bool,
         y: i32,
-        out_buf: &'a mut [u8],
-    ) -> Result<&'a str, Error> {
+        out_buf: &'b mut [u8],
+    ) -> Result<(&'b str, &'b mut [u8]), Error> {
         let mut offset = 0;
 
-        for c in self.render_line_iter(qr_code, border, invert, nl, y) {
+        for c in self.emit_line_chars(text_type, border, invert, nl, y) {
             let mut dst = [0; 4];
             let bytes = c.encode_utf8(&mut dst).as_bytes();
 
@@ -383,57 +533,87 @@ impl TextImage {
             }
         }
 
-        Ok(unsafe { core::str::from_utf8_unchecked(&out_buf[..offset]) })
+        let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
+
+        Ok((
+            unsafe { core::str::from_utf8_unchecked(str_buf) },
+            remaining_buf,
+        ))
     }
 
-    pub fn render_iter<'a>(
+    /// Get an iterator over the indexes of the lines of the QR code including borders
+    ///
+    /// # Arguments
+    /// - `text_type` - Type of text to return (ASCII, ANSI, Unicode)
+    /// - `border` - Border size
+    pub fn lines_range(
         &self,
-        qr_code: &'a QrCode<'a>,
+        text_type: QrTextType,
         border: u8,
-        invert: bool,
-    ) -> impl Iterator<Item = char> + 'a {
-        let console_type = *self;
-
-        self.lines_range(qr_code, border)
-            .flat_map(move |y| console_type.render_line_iter(qr_code, border, invert, true, y))
-    }
-
-    pub fn lines_range(&self, qr_code: &QrCode, border: u8) -> impl Iterator<Item = i32> {
+    ) -> impl Iterator<Item = i32> + '_ + 'a {
         let iborder: i32 = border as _;
-        let console_type = *self;
 
-        (-iborder..qr_code.size() + iborder)
-            .filter(move |y| console_type != Self::Unicode || (y - -iborder) % 2 == 0)
+        (-iborder..self.size() as i32 + iborder)
+            .filter(move |y| !matches!(text_type, QrTextType::Unicode) || (*y - -iborder) % 2 == 0)
     }
 
-    pub fn render_line_iter<'a>(
+    /// Get an iterator over the characters of the rendered QR code
+    ///
+    /// # Arguments
+    /// - `text_type` - Type of text to return (ASCII, ANSI, Unicode)
+    /// - `border` - Border size
+    /// - `invert` - Whether to invert the colors (black on a white background)
+    ///
+    /// # Returns
+    /// - An iterator over the characters of the rendered QR code
+    pub fn emit_chars(
         &self,
-        qr_code: &'a QrCode<'a>,
+        text_type: QrTextType,
+        border: u8,
+        invert: bool,
+    ) -> impl Iterator<Item = char> + use<'_, 'a> {
+        self.lines_range(text_type, border)
+            .flat_map(move |y| self.emit_line_chars(text_type, border, invert, true, y))
+    }
+
+    /// Get an iterator over the characters of a single line of the rendered QR code
+    ///
+    /// # Arguments
+    /// - `text_type` - Type of text to return (ASCII, ANSI, Unicode)
+    /// - `border` - Border size
+    /// - `invert` - Whether to invert the colors (black on a white background)
+    /// - `nl` - Whether to add a newline at the end of the line
+    /// - `y` - Y coordinate of the line to render
+    ///
+    /// # Returns
+    /// - An iterator over the characters of the rendered line
+    pub fn emit_line_chars(
+        &self,
+        text_type: QrTextType,
         border: u8,
         invert: bool,
         nl: bool,
         y: i32,
-    ) -> impl Iterator<Item = char> + 'a {
+    ) -> impl Iterator<Item = char> + use<'_, 'a> {
         let border: i32 = border as _;
-        let console_type = *self;
 
-        (-border..qr_code.size() + border + 1)
+        (-border..self.size() as i32 + border + 1)
             .map(move |x| (x, y))
             .map(move |(x, y)| {
-                if x < qr_code.size() + border {
-                    let white = !qr_code.get_module(x, y) ^ invert;
+                if x < self.size() as i32 + border {
+                    let white = !self.get_module(x, y) ^ invert;
 
-                    match console_type {
-                        Self::Ascii => {
+                    match text_type {
+                        QrTextType::Ascii => {
                             if white {
                                 "#"
                             } else {
                                 " "
                             }
                         }
-                        Self::Ansi => {
+                        QrTextType::Ansi => {
                             let prev_white = if x > -border {
-                                Some(qr_code.get_module(x - 1, y))
+                                Some(self.get_module(x - 1, y))
                             } else {
                                 None
                             }
@@ -449,8 +629,8 @@ impl TextImage {
                                 " "
                             }
                         }
-                        Self::Unicode => {
-                            if white == !qr_code.get_module(x, y + 1) ^ invert {
+                        QrTextType::Unicode => {
+                            if white == !self.get_module(x, y + 1) ^ invert {
                                 if white {
                                     "\u{2588}"
                                 } else {
@@ -464,15 +644,15 @@ impl TextImage {
                         }
                     }
                 } else {
-                    match console_type {
-                        TextImage::Ascii => {
+                    match text_type {
+                        QrTextType::Ascii => {
                             if nl {
                                 "\n"
                             } else {
                                 ""
                             }
                         }
-                        TextImage::Ansi | TextImage::Unicode => {
+                        _ => {
                             if nl {
                                 "\x1b[0m\n"
                             } else {
@@ -484,58 +664,232 @@ impl TextImage {
             })
             .flat_map(str::chars)
     }
-}
 
-pub fn compute_qr_code<'a>(
-    qr_code_text: &str,
-    tmp_buf: &mut [u8],
-    out_buf: &'a mut [u8],
-) -> Result<QrCode<'a>, Error> {
-    let needed_version = Version::new(compute_qr_code_version(qr_code_text));
-
-    QrCode::encode_text(
-        qr_code_text,
-        tmp_buf,
-        out_buf,
-        QrCodeEcc::Medium,
-        needed_version,
-        needed_version,
-        None,
-        false,
-    )
-    .map_err(|_| ErrorCode::BufferTooSmall.into())
-}
-
-pub fn compute_qr_code_version(qr_code_text: &str) -> u8 {
-    match qr_code_text.len() {
-        0..=38 => 2,
-        39..=61 => 3,
-        62..=90 => 4,
-        _ => 5,
+    fn version(qr_code_text: &str) -> u8 {
+        match qr_code_text.len() {
+            0..=38 => 2,
+            39..=61 => 3,
+            62..=90 => 4,
+            _ => 5,
+        }
     }
 }
 
-pub fn compute_qr_code_text<'a, T, I>(
-    dev_det: &BasicInfoConfig,
-    comm_data: &BasicCommData,
-    discovery_capabilities: DiscoveryCapabilities,
-    optional_data: T,
-    buf: &'a mut [u8],
-) -> Result<(&'a str, &'a mut [u8]), Error>
-where
-    T: Fn() -> I,
-    I: Iterator<Item = Result<u8, Error>>,
-{
-    let qr_code_data =
-        QrSetupPayload::new(dev_det, comm_data, discovery_capabilities, optional_data);
-
-    qr_code_data.try_as_str(buf)
+/// QR Code text renderer
+pub enum QrTextRenderer<'a> {
+    /// ASCII renderer
+    Ascii(Qr<'a>),
+    /// ANSI renderer
+    Ansi(Qr<'a>),
+    /// Unicode renderer
+    Unicode(Qr<'a>),
 }
 
-pub type NoOptionalData = fn() -> Empty<Result<u8, Error>>;
+impl<'a> QrTextRenderer<'a> {
+    /// Render the complete QR code as a string into the provided buffer
+    ///
+    /// # Arguments
+    /// - `border` - Border size
+    /// - `invert` - Whether to invert the colors (black on a white background)
+    /// - `out_buf` - Output buffer for the rendered string
+    ///
+    /// # Returns
+    /// - On success, returns a tuple containing the rendered string and the remaining buffer
+    /// - On failure, returns an error
+    pub fn render<'b>(
+        &self,
+        border: u8,
+        invert: bool,
+        out_buf: &'b mut [u8],
+    ) -> Result<(&'b str, &'b mut [u8]), Error> {
+        let mut offset = 0;
 
-pub fn no_optional_data() -> Empty<Result<u8, Error>> {
-    core::iter::empty()
+        for c in self.render_iter(border, invert) {
+            let mut dst = [0; 4];
+            let bytes = c.encode_utf8(&mut dst).as_bytes();
+
+            if offset + bytes.len() > out_buf.len() {
+                return Err(ErrorCode::BufferTooSmall)?;
+            } else {
+                out_buf[offset..offset + bytes.len()].copy_from_slice(bytes);
+                offset += bytes.len();
+            }
+        }
+
+        let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
+
+        Ok((
+            unsafe { core::str::from_utf8_unchecked(str_buf) },
+            remaining_buf,
+        ))
+    }
+
+    /// Render a single line of the QR code as a string into the provided buffer
+    ///
+    /// # Arguments
+    /// - `border` - Border size
+    /// - `invert` - Whether to invert the colors (black on a white background)
+    /// - `nl` - Whether to add a newline at the end of the line
+    /// - `y` - Y coordinate of the line to render
+    /// - `out_buf` - Output buffer for the rendered string
+    ///
+    /// # Returns
+    /// - On success, returns a tuple containing the rendered string and the remaining buffer
+    /// - On failure, returns an error
+    pub fn render_line<'b>(
+        &self,
+        border: u8,
+        invert: bool,
+        nl: bool,
+        y: i32,
+        out_buf: &'b mut [u8],
+    ) -> Result<(&'b str, &'b mut [u8]), Error> {
+        let mut offset = 0;
+
+        for c in self.render_line_iter(border, invert, nl, y) {
+            let mut dst = [0; 4];
+            let bytes = c.encode_utf8(&mut dst).as_bytes();
+
+            if offset + bytes.len() > out_buf.len() {
+                return Err(ErrorCode::BufferTooSmall)?;
+            } else {
+                out_buf[offset..offset + bytes.len()].copy_from_slice(bytes);
+                offset += bytes.len();
+            }
+        }
+
+        let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
+
+        Ok((
+            unsafe { core::str::from_utf8_unchecked(str_buf) },
+            remaining_buf,
+        ))
+    }
+
+    /// Get an iterator over the indexes of the lines of the QR code including borders
+    ///
+    /// # Arguments
+    /// - `border` - Border size
+    pub fn lines_range(&self, border: u8) -> impl Iterator<Item = i32> + '_ + 'a {
+        let unicode = matches!(self, Self::Unicode(_));
+        let iborder: i32 = border as _;
+
+        (-iborder..self.qr().size() as i32 + iborder)
+            .filter(move |y| !unicode || (*y - -iborder) % 2 == 0)
+    }
+
+    /// Get an iterator over the characters of the rendered QR code
+    ///
+    /// # Arguments
+    /// - `border` - Border size
+    /// - `invert` - Whether to invert the colors (black on a white background)
+    ///
+    /// # Returns
+    /// - An iterator over the characters of the rendered QR code
+    pub fn render_iter(
+        &self,
+        border: u8,
+        invert: bool,
+    ) -> impl Iterator<Item = char> + use<'_, 'a> {
+        self.lines_range(border)
+            .flat_map(move |y| self.render_line_iter(border, invert, true, y))
+    }
+
+    /// Get an iterator over the characters of a single line of the rendered QR code
+    ///
+    /// # Arguments
+    /// - `border` - Border size
+    /// - `invert` - Whether to invert the colors (black on a white background)
+    /// - `nl` - Whether to add a newline at the end of the line
+    /// - `y` - Y coordinate of the line to render
+    ///
+    /// # Returns
+    /// - An iterator over the characters of the rendered line
+    pub fn render_line_iter(
+        &self,
+        border: u8,
+        invert: bool,
+        nl: bool,
+        y: i32,
+    ) -> impl Iterator<Item = char> + use<'_, 'a> {
+        let border: i32 = border as _;
+
+        (-border..self.qr().size() as i32 + border + 1)
+            .map(move |x| (x, y))
+            .map(move |(x, y)| {
+                if x < self.qr().size() as i32 + border {
+                    let white = !self.qr().get_module(x, y) ^ invert;
+
+                    match self {
+                        Self::Ascii(_) => {
+                            if white {
+                                "#"
+                            } else {
+                                " "
+                            }
+                        }
+                        Self::Ansi(_) => {
+                            let prev_white = if x > -border {
+                                Some(self.qr().get_module(x - 1, y))
+                            } else {
+                                None
+                            }
+                            .map(|prev_white| !prev_white ^ invert);
+
+                            if prev_white != Some(white) {
+                                if white {
+                                    "\x1b[47m "
+                                } else {
+                                    "\x1b[40m "
+                                }
+                            } else {
+                                " "
+                            }
+                        }
+                        Self::Unicode(_) => {
+                            if white == !self.qr().get_module(x, y + 1) ^ invert {
+                                if white {
+                                    "\u{2588}"
+                                } else {
+                                    " "
+                                }
+                            } else if white {
+                                "\u{2580}"
+                            } else {
+                                "\u{2584}"
+                            }
+                        }
+                    }
+                } else {
+                    match self {
+                        Self::Ascii(_) => {
+                            if nl {
+                                "\n"
+                            } else {
+                                ""
+                            }
+                        }
+                        _ => {
+                            if nl {
+                                "\x1b[0m\n"
+                            } else {
+                                "\x1b[0m"
+                            }
+                        }
+                    }
+                }
+            })
+            .flat_map(str::chars)
+    }
+
+    #[inline(always)]
+    pub fn qr(&self) -> &Qr<'a> {
+        match self {
+            Self::Ascii(qr) => qr,
+            Self::Ansi(qr) => qr,
+            Self::Unicode(qr) => qr,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -557,10 +911,15 @@ mod tests {
         };
 
         let disc_cap = DiscoveryCapabilities::BLE;
-        let qr_code_data =
-            QrSetupPayload::<NoOptionalData>::new(&dev_det, &comm_data, disc_cap, no_optional_data);
+        let qr_code_data = QrPayload::new_from_basic_info(
+            disc_cap,
+            CommFlowType::Standard,
+            comm_data,
+            &dev_det,
+            no_optional_data,
+        );
         let mut buf = [0; 1024];
-        let data_str = unwrap!(qr_code_data.try_as_str(&mut buf), "Failed to encode").0;
+        let data_str = unwrap!(qr_code_data.as_str(&mut buf), "Failed to encode").0;
         assert_eq!(data_str, QR_CODE)
     }
 
@@ -580,10 +939,15 @@ mod tests {
         };
 
         let disc_cap = DiscoveryCapabilities::IP;
-        let qr_code_data =
-            QrSetupPayload::<NoOptionalData>::new(&dev_det, &comm_data, disc_cap, no_optional_data);
+        let qr_code_data = QrPayload::new_from_basic_info(
+            disc_cap,
+            CommFlowType::Standard,
+            comm_data,
+            &dev_det,
+            no_optional_data,
+        );
         let mut buf = [0; 1024];
-        let data_str = unwrap!(qr_code_data.try_as_str(&mut buf), "Failed to encode").0;
+        let data_str = unwrap!(qr_code_data.as_str(&mut buf), "Failed to encode").0;
         assert_eq!(data_str, QR_CODE)
     }
 
@@ -625,10 +989,16 @@ mod tests {
             .flat_map(TLV::result_into_bytes_iter)
         };
 
-        let qr_code_data = QrSetupPayload::new(&dev_det, &comm_data, disc_cap, optional_data);
+        let qr_code_data = QrPayload::new_from_basic_info(
+            disc_cap,
+            CommFlowType::Standard,
+            comm_data,
+            &dev_det,
+            optional_data,
+        );
 
         let mut buf = [0; 1024];
-        let data_str = unwrap!(qr_code_data.try_as_str(&mut buf), "Failed to encode").0;
+        let data_str = unwrap!(qr_code_data.as_str(&mut buf), "Failed to encode").0;
         assert_eq!(data_str, QR_CODE)
     }
 }

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -271,7 +271,7 @@ where
         }
 
         // Can't fail as `emit_chars` generates a valid UTF-8 string
-        let str = unwrap!(core::str::from_utf8(str_buf));
+        let str = unwrap!(core::str::from_utf8(str_buf).map_err(|_| ErrorCode::InvalidData));
 
         Ok((str, remaining_buf))
     }
@@ -494,7 +494,7 @@ impl<'a> Qr<'a> {
         let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
 
         // Can't fail as `emit_chars` generates a valid UTF-8 string
-        let str = unwrap!(core::str::from_utf8(str_buf));
+        let str = unwrap!(core::str::from_utf8(str_buf).map_err(|_| ErrorCode::InvalidData));
 
         Ok((str, remaining_buf))
     }
@@ -538,7 +538,7 @@ impl<'a> Qr<'a> {
         let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
 
         // Can't fail as `emit_chars` generates a valid UTF-8 string
-        let str = unwrap!(core::str::from_utf8(str_buf));
+        let str = unwrap!(core::str::from_utf8(str_buf).map_err(|_| ErrorCode::InvalidData));
 
         Ok((str, remaining_buf))
     }
@@ -721,7 +721,7 @@ impl<'a> QrTextRenderer<'a> {
         let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
 
         // Can't fail as `emit_chars` generates a valid UTF-8 string
-        let str = unwrap!(core::str::from_utf8(str_buf));
+        let str = unwrap!(core::str::from_utf8(str_buf).map_err(|_| ErrorCode::InvalidData));
 
         Ok((str, remaining_buf))
     }
@@ -763,7 +763,7 @@ impl<'a> QrTextRenderer<'a> {
         let (str_buf, remaining_buf) = out_buf.split_at_mut(offset);
 
         // Can't fail as `emit_chars` generates a valid UTF-8 string
-        let str = unwrap!(core::str::from_utf8(str_buf));
+        let str = unwrap!(core::str::from_utf8(str_buf).map_err(|_| ErrorCode::InvalidData));
 
         Ok((str, remaining_buf))
     }

--- a/rs-matter/src/sc.rs
+++ b/rs-matter/src/sc.rs
@@ -28,15 +28,13 @@ use crate::transport::exchange::{Exchange, MessageMeta};
 use crate::utils::init::InitMaybeUninit;
 use crate::utils::storage::{ReadBuf, WriteBuf};
 
-use case::{Case, CaseSession};
+use case::Case;
 use pake::Pake;
-use spake2p::Spake2P;
 
 pub mod busy;
 pub mod case;
 pub mod crypto;
 pub mod pake;
-pub mod spake2p;
 
 /* Interaction Model ID as per the Matter Spec */
 pub const PROTO_ID_SECURE_CHANNEL: u16 = 0x00;
@@ -243,14 +241,12 @@ impl SecureChannel {
 
         match meta.opcode()? {
             OpCode::PBKDFParamRequest => {
-                let mut spake2p = MaybeUninit::uninit(); // TODO LARGE BUFFER
-                let spake2p = spake2p.init_with(Spake2P::init());
-                Pake::new().handle(exchange, spake2p).await
+                let mut pake = MaybeUninit::uninit(); // TODO LARGE BUFFER
+                pake.init_with(Pake::init()).handle(exchange).await
             }
             OpCode::CASESigma1 => {
-                let mut case_session = MaybeUninit::uninit(); // TODO LARGE BUFFER
-                let case_session = case_session.init_with(CaseSession::init());
-                Case::new().handle(exchange, case_session).await
+                let mut case = MaybeUninit::uninit(); // TODO LARGE BUFFER
+                case.init_with(Case::init()).handle(exchange).await
             }
             opcode => {
                 error!("Invalid opcode: {:?}", opcode);

--- a/rs-matter/src/sc/case.rs
+++ b/rs-matter/src/sc/case.rs
@@ -31,25 +31,28 @@ use crate::transport::session::{NocCatIds, ReservedSession, SessionMode};
 use crate::utils::init::{init, zeroed, Init, InitMaybeUninit};
 use crate::utils::storage::WriteBuf;
 
+/// The CASE Session type used during the CASE handshake
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct CaseSession {
+struct CaseSession {
+    /// The peer's session ID
     peer_sessid: u16,
+    /// The local session ID
     local_sessid: u16,
+    /// The Transcript Hash
     tt_hash: Option<Sha256>,
+    /// The ECDH Shared Secret
     shared_secret: [u8; crypto::ECDH_SHARED_SECRET_LEN_BYTES],
+    /// Our ephemeral public key
     our_pub_key: [u8; crypto::EC_POINT_LEN_BYTES],
+    /// The peer's ephemeral public key
     peer_pub_key: [u8; crypto::EC_POINT_LEN_BYTES],
+    /// The local fabric index for this session
     local_fabric_idx: u8,
 }
 
-impl Default for CaseSession {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl CaseSession {
+    /// Create a new `CaseSession` instance
     #[inline(always)]
     pub const fn new() -> Self {
         Self {
@@ -63,6 +66,7 @@ impl CaseSession {
         }
     }
 
+    /// Return an in-place initializer for `CaseSession`
     pub fn init() -> impl Init<Self> {
         init!(Self {
             peer_sessid: 0,
@@ -74,444 +78,32 @@ impl CaseSession {
             local_fabric_idx: 0,
         })
     }
-}
 
-pub struct Case(());
-
-impl Case {
-    #[inline(always)]
-    pub const fn new() -> Self {
-        Self(())
-    }
-
-    pub async fn handle(
-        &mut self,
-        exchange: &mut Exchange<'_>,
-        case_session: &mut CaseSession,
-    ) -> Result<(), Error> {
-        let session = ReservedSession::reserve(exchange.matter()).await?;
-
-        self.handle_casesigma1(exchange, case_session).await?;
-
-        exchange.recv_fetch().await?;
-
-        self.handle_casesigma3(exchange, case_session, session)
-            .await?;
-
-        exchange.acknowledge().await?;
-        exchange.matter().notify_persist();
-
-        Ok(())
-    }
-
-    async fn handle_casesigma3(
-        &mut self,
-        exchange: &mut Exchange<'_>,
-        case_session: &mut CaseSession,
-        mut session: ReservedSession<'_>,
-    ) -> Result<(), Error> {
-        check_opcode(exchange, OpCode::CASESigma3)?;
-
-        let status = {
-            let fabric_mgr = exchange.matter().fabric_mgr.borrow();
-
-            let fabric = NonZeroU8::new(case_session.local_fabric_idx)
-                .and_then(|fabric_idx| fabric_mgr.get(fabric_idx));
-            if let Some(fabric) = fabric {
-                let root = get_root_node_struct(exchange.rx()?.payload())?;
-                let encrypted = root.structure()?.ctx(1)?.str()?;
-
-                let mut decrypted = alloc!([0; 800]); // TODO LARGE BUFFER
-                if encrypted.len() > decrypted.len() {
-                    error!("Encrypted data too large");
-                    Err(ErrorCode::BufferTooSmall)?;
-                }
-                let decrypted = &mut decrypted[..encrypted.len()];
-                decrypted.copy_from_slice(encrypted);
-
-                let len =
-                    Case::get_sigma3_decryption(fabric.ipk().op_key(), case_session, decrypted)?;
-                let decrypted = &decrypted[..len];
-
-                let root = get_root_node_struct(decrypted)?;
-                let d = Sigma3Decrypt::from_tlv(&root)?;
-
-                let initiator_noc = CertRef::new(TLVElement::new(d.initiator_noc.0));
-                let initiator_icac = d
-                    .initiator_icac
-                    .map(|icac| CertRef::new(TLVElement::new(icac.0)));
-
-                let mut buf = alloc!([0; 800]); // TODO LARGE BUFFER
-                let buf = &mut buf[..];
-                if let Err(e) =
-                    Case::validate_certs(fabric, &initiator_noc, initiator_icac.as_ref(), buf)
-                {
-                    error!("Certificate Chain doesn't match: {}", e);
-                    SCStatusCodes::InvalidParameter
-                } else if let Err(e) = Case::validate_sigma3_sign(
-                    d.initiator_noc.0,
-                    d.initiator_icac.map(|a| a.0),
-                    &initiator_noc,
-                    d.signature.0,
-                    case_session,
-                    buf,
-                ) {
-                    error!("Sigma3 Signature doesn't match: {}", e);
-                    SCStatusCodes::InvalidParameter
-                } else {
-                    // Only now do we add this message to the TT Hash
-                    let mut peer_catids: NocCatIds = Default::default();
-                    initiator_noc.get_cat_ids(&mut peer_catids)?;
-                    unwrap!(case_session.tt_hash.as_mut()).update(exchange.rx()?.payload())?;
-
-                    let mut session_keys =
-                        MaybeUninit::<[u8; 3 * crypto::SYMM_KEY_LEN_BYTES]>::uninit(); // TODO MEDIM BUFFER
-                    let session_keys = session_keys.init_zeroed();
-                    Case::get_session_keys(
-                        fabric.ipk().op_key(),
-                        unwrap!(case_session.tt_hash.as_ref()),
-                        &case_session.shared_secret,
-                        session_keys,
-                    )?;
-
-                    let peer_addr = exchange.with_session(|sess| Ok(sess.get_peer_addr()))?;
-
-                    session.update(
-                        fabric.node_id(),
-                        initiator_noc.get_node_id()?,
-                        case_session.peer_sessid,
-                        case_session.local_sessid,
-                        peer_addr,
-                        SessionMode::Case {
-                            // Unwrapping is safe, because if the fabric index was 0, we would not be in here
-                            fab_idx: unwrap!(NonZeroU8::new(case_session.local_fabric_idx)),
-                            cat_ids: peer_catids,
-                        },
-                        Some(&session_keys[0..16]),
-                        Some(&session_keys[16..32]),
-                        Some(&session_keys[32..48]),
-                    )?;
-
-                    // Complete the reserved session and thus make the `Session` instance
-                    // immediately available for use by the system.
-                    //
-                    // We need to do this _before_ we send the response to the peer, or else we risk missing
-                    // (dropping) the first messages the peer would send us on the newly-established session,
-                    // as it might start using it right after it receives the response, while it is still marked
-                    // as reserved.
-                    session.complete();
-
-                    SCStatusCodes::SessionEstablishmentSuccess
-                }
-            } else {
-                SCStatusCodes::NoSharedTrustRoots
-            }
-        };
-
-        complete_with_status(exchange, status, &[]).await
-    }
-
-    async fn handle_casesigma1(
-        &mut self,
-        exchange: &mut Exchange<'_>,
-        case_session: &mut CaseSession,
-    ) -> Result<(), Error> {
-        check_opcode(exchange, OpCode::CASESigma1)?;
-
-        let root = get_root_node_struct(exchange.rx()?.payload())?;
-        let r = Sigma1Req::from_tlv(&root)?;
-
-        let local_fabric_idx = exchange
-            .matter()
-            .fabric_mgr
-            .borrow()
-            .get_by_dest_id(r.initiator_random.0, r.dest_id.0)
-            .map(|fabric| fabric.fab_idx());
-        if local_fabric_idx.is_none() {
-            error!("Fabric Index mismatch");
-            complete_with_status(exchange, SCStatusCodes::NoSharedTrustRoots, &[]).await?;
-
-            return Ok(());
-        }
-
-        let local_sessid = exchange
-            .matter()
-            .transport_mgr
-            .session_mgr
-            .borrow_mut()
-            .get_next_sess_id();
-        case_session.peer_sessid = r.initiator_sessid;
-        case_session.local_sessid = local_sessid;
-        case_session.tt_hash = Some(Sha256::new()?);
-        unwrap!(case_session.tt_hash.as_mut()).update(exchange.rx()?.payload())?;
-        case_session.local_fabric_idx = unwrap!(local_fabric_idx).get();
-        if r.peer_pub_key.0.len() != crypto::EC_POINT_LEN_BYTES {
-            error!("Invalid public key length");
-            Err(ErrorCode::Invalid)?;
-        }
-        case_session.peer_pub_key.copy_from_slice(r.peer_pub_key.0);
-        trace!(
-            "Destination ID matched to fabric index {}",
-            case_session.local_fabric_idx
-        );
-
-        // Create an ephemeral Key Pair
-        let key_pair = KeyPair::new(exchange.matter().rand())?;
-        let _ = key_pair.get_public_key(&mut case_session.our_pub_key)?;
-
-        // Derive the Shared Secret
-        let len = key_pair.derive_secret(r.peer_pub_key.0, &mut case_session.shared_secret)?;
-        if len != 32 {
-            error!("Derived secret length incorrect");
-            Err(ErrorCode::Invalid)?;
-        }
-        //        println!("Derived secret: {:x?} len: {}", secret, len);
-
-        let mut our_random = MaybeUninit::<[u8; 32]>::uninit(); // TODO MEDIUM BUFFER
-        let our_random = our_random.init_zeroed();
-        (exchange.matter().rand())(our_random);
-
-        let mut resumption_id = MaybeUninit::<[u8; 16]>::uninit(); // TODO MEDIUM BUFFER
-        let resumption_id = resumption_id.init_zeroed();
-        (exchange.matter().rand())(resumption_id);
-
-        let mut tt_hash = MaybeUninit::<[u8; crypto::SHA256_HASH_LEN_BYTES]>::uninit(); // TODO MEDIUM BUFFER
-        let tt_hash = tt_hash.init_zeroed();
-        unwrap!(case_session.tt_hash.as_ref())
-            .clone()
-            .finish(tt_hash)?;
-
-        let mut hash_updated = false;
-        exchange
-            .send_with(|exchange, tw| {
-                let fabric_mgr = exchange.matter().fabric_mgr.borrow();
-
-                let fabric = NonZeroU8::new(case_session.local_fabric_idx)
-                    .and_then(|fabric_idx| fabric_mgr.get(fabric_idx));
-
-                let Some(fabric) = fabric else {
-                    return sc_write(tw, SCStatusCodes::NoSharedTrustRoots, &[]);
-                };
-
-                let mut signature = MaybeUninit::<[u8; crypto::EC_SIGNATURE_LEN_BYTES]>::uninit(); // TODO MEDIUM BUFFER
-                let signature = signature.init_zeroed();
-
-                // Use the remainder of the TX buffer as scratch space for computing the signature
-                let sign_buf = tw.empty_as_mut_slice();
-
-                let sign_len = Case::get_sigma2_sign(
-                    fabric,
-                    &case_session.our_pub_key,
-                    &case_session.peer_pub_key,
-                    sign_buf,
-                    signature,
-                )?;
-
-                let signature = &signature[..sign_len];
-
-                tw.start_struct(&TLVTag::Anonymous)?;
-                tw.str(&TLVTag::Context(1), &*our_random)?;
-                tw.u16(&TLVTag::Context(2), local_sessid)?;
-                tw.str(&TLVTag::Context(3), &case_session.our_pub_key)?;
-
-                tw.str_cb(&TLVTag::Context(4), |buf| {
-                    Case::get_sigma2_encryption(
-                        fabric,
-                        &*our_random,
-                        &case_session.our_pub_key,
-                        tt_hash,
-                        &case_session.shared_secret,
-                        signature,
-                        resumption_id,
-                        buf,
-                    )
-                })?;
-                tw.end_container()?;
-
-                if !hash_updated {
-                    unwrap!(case_session.tt_hash.as_mut()).update(tw.as_slice())?;
-                    hash_updated = true;
-                }
-
-                Ok(Some(OpCode::CASESigma2.into()))
-            })
-            .await
-    }
-
-    fn validate_sigma3_sign(
-        initiator_noc: &[u8],
-        initiator_icac: Option<&[u8]>,
-        initiator_noc_cert: &CertRef,
-        sign: &[u8],
-        case_session: &CaseSession,
-        buf: &mut [u8],
-    ) -> Result<(), Error> {
-        let mut write_buf = WriteBuf::new(buf);
-        let tw = &mut write_buf;
-        tw.start_struct(&TLVTag::Anonymous)?;
-        tw.str(&TLVTag::Context(1), initiator_noc)?;
-        if let Some(icac) = initiator_icac {
-            tw.str(&TLVTag::Context(2), icac)?;
-        }
-        tw.str(&TLVTag::Context(3), &case_session.peer_pub_key)?;
-        tw.str(&TLVTag::Context(4), &case_session.our_pub_key)?;
-        tw.end_container()?;
-
-        let key = KeyPair::new_from_public(initiator_noc_cert.pubkey()?)?;
-        key.verify_msg(write_buf.as_slice(), sign)?;
-        Ok(())
-    }
-
-    fn validate_certs(
-        fabric: &Fabric,
-        noc: &CertRef,
-        icac: Option<&CertRef>,
-        buf: &mut [u8],
-    ) -> Result<(), Error> {
-        let mut verifier = noc.verify_chain_start();
-
-        if fabric.fabric_id() != noc.get_fabric_id()? {
-            Err(ErrorCode::Invalid)?;
-        }
-
-        if let Some(icac) = icac {
-            // If ICAC is present handle it
-            if let Ok(fid) = icac.get_fabric_id() {
-                if fid != fabric.fabric_id() {
-                    Err(ErrorCode::Invalid)?;
-                }
-            }
-            verifier = verifier.add_cert(icac, buf)?;
-        }
-
-        verifier
-            .add_cert(&CertRef::new(TLVElement::new(fabric.root_ca())), buf)?
-            .finalise(buf)?;
-        Ok(())
-    }
-
-    fn get_session_keys(
-        ipk: &[u8],
-        tt: &Sha256,
-        shared_secret: &[u8],
-        key: &mut [u8],
-    ) -> Result<(), Error> {
-        const SEKEYS_INFO: [u8; 11] = [
-            0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x4b, 0x65, 0x79, 0x73,
-        ];
-        if key.len() < 48 {
-            Err(ErrorCode::InvalidData)?;
-        }
-        let mut salt = heapless::Vec::<u8, 256>::new();
-        unwrap!(salt.extend_from_slice(ipk));
-        let tt = tt.clone();
-        let mut tt_hash = [0u8; crypto::SHA256_HASH_LEN_BYTES];
-        tt.finish(&mut tt_hash)?;
-        unwrap!(salt.extend_from_slice(&tt_hash));
-        //        println!("Session Key: salt: {:x?}, len: {}", salt, salt.len());
-
-        crypto::hkdf_sha256(salt.as_slice(), shared_secret, &SEKEYS_INFO, key)
-            .map_err(|_x| ErrorCode::InvalidData)?;
-        //        println!("Session Key: key: {:x?}", key);
-
-        Ok(())
-    }
-
-    fn get_sigma3_decryption(
-        ipk: &[u8],
-        case_session: &CaseSession,
-        encrypted: &mut [u8],
-    ) -> Result<usize, Error> {
-        let mut sigma3_key = [0_u8; crypto::SYMM_KEY_LEN_BYTES];
-        Case::get_sigma3_key(
-            ipk,
-            unwrap!(case_session.tt_hash.as_ref()),
-            &case_session.shared_secret,
-            &mut sigma3_key,
-        )?;
-        // println!("Sigma3 Key: {:x?}", sigma3_key);
-
-        let nonce: [u8; 13] = [
-            0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x33, 0x4e,
-        ];
-
-        let encrypted_len = encrypted.len();
-        crypto::decrypt_in_place(&sigma3_key, &nonce, &[], encrypted)?;
-        Ok(encrypted_len - crypto::AEAD_MIC_LEN_BYTES)
-    }
-
-    fn get_sigma3_key(
-        ipk: &[u8],
-        tt: &Sha256,
-        shared_secret: &[u8],
-        key: &mut [u8],
-    ) -> Result<(), Error> {
-        const S3K_INFO: [u8; 6] = [0x53, 0x69, 0x67, 0x6d, 0x61, 0x33];
-        if key.len() < 16 {
-            Err(ErrorCode::InvalidData)?;
-        }
-        let mut salt = heapless::Vec::<u8, 256>::new();
-        unwrap!(salt.extend_from_slice(ipk));
-
-        let tt = tt.clone();
-
-        let mut tt_hash = [0u8; crypto::SHA256_HASH_LEN_BYTES];
-        tt.finish(&mut tt_hash)?;
-        unwrap!(salt.extend_from_slice(&tt_hash));
-        //        println!("Sigma3Key: salt: {:x?}, len: {}", salt, salt.len());
-
-        crypto::hkdf_sha256(salt.as_slice(), shared_secret, &S3K_INFO, key)
-            .map_err(|_x| ErrorCode::InvalidData)?;
-        //        println!("Sigma3Key: key: {:x?}", key);
-
-        Ok(())
-    }
-
-    fn get_sigma2_key(
-        ipk: &[u8],
-        our_random: &[u8],
-        our_pub_key: &[u8],
-        our_hash: &[u8],
-        shared_secret: &[u8],
-        key: &mut [u8],
-    ) -> Result<(), Error> {
-        const S2K_INFO: [u8; 6] = [0x53, 0x69, 0x67, 0x6d, 0x61, 0x32];
-        if key.len() < 16 {
-            Err(ErrorCode::InvalidData)?;
-        }
-        let mut salt = heapless::Vec::<u8, 256>::new();
-        unwrap!(salt.extend_from_slice(ipk));
-        unwrap!(salt.extend_from_slice(our_random));
-        unwrap!(salt.extend_from_slice(our_pub_key));
-        unwrap!(salt.extend_from_slice(our_hash));
-
-        crypto::hkdf_sha256(salt.as_slice(), shared_secret, &S2K_INFO, key)
-            .map_err(|_x| ErrorCode::InvalidData)?;
-        //        println!("Sigma2Key: key: {:x?}", key);
-
-        Ok(())
-    }
-
+    /// Get the Sigma2 encrypted data
+    ///
+    /// # Arguments
+    /// - `fabric` - The local fabric
+    /// - `our_random` - Our random value
+    /// - `our_hash` - Our transcript hash
+    /// - `signature` - Our signature
+    /// - `resumption_id` - The resumption ID
+    /// - `out` - The output buffer to write the encrypted data to
+    ///
+    /// # Returns
+    /// - `Ok(usize)` - The length of the encrypted data written to `out`
+    /// - `Err(Error)` - If an error occurred during the process
     #[allow(clippy::too_many_arguments)]
     fn get_sigma2_encryption(
+        &self,
         fabric: &Fabric,
         our_random: &[u8],
-        our_pub_key: &[u8],
         our_hash: &[u8],
-        shared_secret: &[u8],
         signature: &[u8],
         resumption_id: &[u8],
         out: &mut [u8],
     ) -> Result<usize, Error> {
         let mut sigma2_key = [0_u8; crypto::SYMM_KEY_LEN_BYTES];
-        Case::get_sigma2_key(
-            fabric.ipk().op_key(),
-            our_random,
-            our_pub_key,
-            our_hash,
-            shared_secret,
-            &mut sigma2_key,
-        )?;
+        self.get_sigma2_key(fabric.ipk().op_key(), our_random, our_hash, &mut sigma2_key)?;
 
         let mut write_buf = WriteBuf::new(out);
         let tw = &mut write_buf;
@@ -546,14 +138,26 @@ impl Case {
         Ok(write_buf.as_slice().len())
     }
 
+    /// Get the Sigma2 signature
+    ///
+    /// # Arguments
+    /// - `fabric` - The local fabric
+    /// - `tmp_buf` - A temporary buffer for constructing the signature
+    /// - `signature` - The output buffer to write the signature to
+    ///
+    /// # Returns
+    /// - `Ok(usize)` - The length of the signature written to `signature`
+    /// - `Err(Error)` - If an error occurred during the process
     fn get_sigma2_sign(
+        &self,
         fabric: &Fabric,
-        our_pub_key: &[u8],
-        peer_pub_key: &[u8],
-        buf: &mut [u8],
+        tmp_buf: &mut [u8],
         signature: &mut [u8],
     ) -> Result<usize, Error> {
-        let mut write_buf = WriteBuf::new(buf);
+        let our_pub_key = &self.our_pub_key;
+        let peer_pub_key = &self.peer_pub_key;
+
+        let mut write_buf = WriteBuf::new(tmp_buf);
         let tw = &mut write_buf;
         tw.start_struct(&TLVTag::Anonymous)?;
         tw.str(&TLVTag::Context(1), fabric.noc())?;
@@ -566,32 +170,526 @@ impl Case {
         //println!("TBS is {:x?}", write_buf.as_borrow_slice());
         fabric.sign_msg(write_buf.as_slice(), signature)
     }
+
+    /// Get the Sigma2 key
+    ///
+    /// # Arguments
+    /// - `ipk` - The IPK
+    /// - `our_random` - Our random value
+    /// - `our_pub_key` - Our public key
+    /// - `our_hash` - Our transcript hash
+    /// - `key` - The output buffer to write the Sigma2 key to
+    ///
+    /// # Returns
+    /// - `Ok(())` - If the Sigma2 key was successfully derived
+    /// - `Err(Error)` - If an error occurred during the process
+    fn get_sigma2_key(
+        &self,
+        ipk: &[u8],
+        our_random: &[u8],
+        our_hash: &[u8],
+        key: &mut [u8],
+    ) -> Result<(), Error> {
+        let our_pub_key = &self.our_pub_key;
+        let shared_secret = &self.shared_secret;
+
+        const S2K_INFO: [u8; 6] = [0x53, 0x69, 0x67, 0x6d, 0x61, 0x32];
+        if key.len() < 16 {
+            Err(ErrorCode::InvalidData)?;
+        }
+        let mut salt = heapless::Vec::<u8, 256>::new();
+        unwrap!(salt.extend_from_slice(ipk));
+        unwrap!(salt.extend_from_slice(our_random));
+        unwrap!(salt.extend_from_slice(our_pub_key));
+        unwrap!(salt.extend_from_slice(our_hash));
+
+        crypto::hkdf_sha256(salt.as_slice(), shared_secret, &S2K_INFO, key)
+            .map_err(|_x| ErrorCode::InvalidData)?;
+        //        println!("Sigma2Key: key: {:x?}", key);
+
+        Ok(())
+    }
+
+    /// Validate the certificate chain
+    ///
+    /// # Arguments
+    /// - `fabric` - The local fabric
+    /// - `noc` - The Node Operational Certificate
+    /// - `icac` - The Intermediate Certificate Authority Certificate (optional)
+    /// - `tmp_buf` - A temporary buffer for certificate validation
+    ///
+    /// # Returns
+    /// - `Ok(())` - If the certificate chain is valid
+    /// - `Err(Error)` - If the certificate chain is invalid
+    fn validate_certs(
+        fabric: &Fabric,
+        noc: &CertRef,
+        icac: Option<&CertRef>,
+        tmp_buf: &mut [u8],
+    ) -> Result<(), Error> {
+        let mut verifier = noc.verify_chain_start();
+
+        if fabric.fabric_id() != noc.get_fabric_id()? {
+            Err(ErrorCode::Invalid)?;
+        }
+
+        if let Some(icac) = icac {
+            // If ICAC is present handle it
+            if let Ok(fid) = icac.get_fabric_id() {
+                if fid != fabric.fabric_id() {
+                    Err(ErrorCode::Invalid)?;
+                }
+            }
+            verifier = verifier.add_cert(icac, tmp_buf)?;
+        }
+
+        verifier
+            .add_cert(&CertRef::new(TLVElement::new(fabric.root_ca())), tmp_buf)?
+            .finalise(tmp_buf)?;
+        Ok(())
+    }
+
+    /// Validate the Sigma3 signature
+    ///
+    /// # Arguments
+    /// - `initiator_noc` - The initiator's Node Operational Certificate
+    /// - `initiator_icac` - The initiator's Intermediate Certificate Authority Certificate (optional)
+    /// - `initiator_noc_cert` - The initiator's Node Operational Certificate reference
+    /// - `sign` - The signature to validate
+    /// - `tmp_buf` - A temporary buffer for signature validation
+    ///
+    /// # Returns
+    /// - `Ok(())` - If the signature is valid
+    /// - `Err(Error)` - If the signature is invalid
+    fn validate_sigma3_sign(
+        &self,
+        initiator_noc: &[u8],
+        initiator_icac: Option<&[u8]>,
+        initiator_noc_cert: &CertRef,
+        sign: &[u8],
+        tmp_buf: &mut [u8],
+    ) -> Result<(), Error> {
+        let mut write_buf = WriteBuf::new(tmp_buf);
+        let tw = &mut write_buf;
+        tw.start_struct(&TLVTag::Anonymous)?;
+        tw.str(&TLVTag::Context(1), initiator_noc)?;
+        if let Some(icac) = initiator_icac {
+            tw.str(&TLVTag::Context(2), icac)?;
+        }
+        tw.str(&TLVTag::Context(3), &self.peer_pub_key)?;
+        tw.str(&TLVTag::Context(4), &self.our_pub_key)?;
+        tw.end_container()?;
+
+        let key = KeyPair::new_from_public(initiator_noc_cert.pubkey()?)?;
+        key.verify_msg(write_buf.as_slice(), sign)?;
+        Ok(())
+    }
+
+    /// Get the session keys
+    ///
+    /// # Arguments
+    /// - `ipk` - The IPK
+    /// - `key` - The output buffer to write the session keys to
+    ///
+    /// # Returns
+    /// - `Ok(())` - If the session keys were successfully derived
+    /// - `Err(Error)` - If an error occurred during the process
+    fn get_session_keys(&self, ipk: &[u8], key: &mut [u8]) -> Result<(), Error> {
+        let tt = unwrap!(self.tt_hash.as_ref());
+        let shared_secret = &self.shared_secret;
+
+        const SEKEYS_INFO: [u8; 11] = [
+            0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x4b, 0x65, 0x79, 0x73,
+        ];
+        if key.len() < 48 {
+            Err(ErrorCode::InvalidData)?;
+        }
+        let mut salt = heapless::Vec::<u8, 256>::new();
+        unwrap!(salt.extend_from_slice(ipk));
+        let tt = tt.clone();
+        let mut tt_hash = [0u8; crypto::SHA256_HASH_LEN_BYTES];
+        tt.finish(&mut tt_hash)?;
+        unwrap!(salt.extend_from_slice(&tt_hash));
+        //        println!("Session Key: salt: {:x?}, len: {}", salt, salt.len());
+
+        crypto::hkdf_sha256(salt.as_slice(), shared_secret, &SEKEYS_INFO, key)
+            .map_err(|_x| ErrorCode::InvalidData)?;
+        //        println!("Session Key: key: {:x?}", key);
+
+        Ok(())
+    }
+
+    /// Get the Sigma3 decrypted data
+    ///
+    /// # Arguments
+    /// - `ipk` - The IPK
+    /// - `encrypted` - The encrypted data to decrypt
+    ///
+    /// # Returns
+    /// - `Ok(usize)` - The length of the decrypted data
+    /// - `Err(Error)` - If an error occurred during the process
+    fn get_sigma3_decryption(&self, ipk: &[u8], encrypted: &mut [u8]) -> Result<usize, Error> {
+        let mut sigma3_key = [0_u8; crypto::SYMM_KEY_LEN_BYTES];
+        self.get_sigma3_key(ipk, &mut sigma3_key)?;
+        // println!("Sigma3 Key: {:x?}", sigma3_key);
+
+        let nonce: [u8; 13] = [
+            0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x33, 0x4e,
+        ];
+
+        let encrypted_len = encrypted.len();
+        crypto::decrypt_in_place(&sigma3_key, &nonce, &[], encrypted)?;
+        Ok(encrypted_len - crypto::AEAD_MIC_LEN_BYTES)
+    }
+
+    /// Get the Sigma3 key
+    ///
+    /// # Arguments
+    /// - `ipk` - The IPK
+    /// - `key` - The output buffer to write the Sigma3 key to
+    ///
+    /// # Returns
+    /// - `Ok(())` - If the Sigma3 key was successfully derived
+    /// - `Err(Error)` - If an error occurred during the process
+    fn get_sigma3_key(&self, ipk: &[u8], key: &mut [u8]) -> Result<(), Error> {
+        let tt = unwrap!(self.tt_hash.as_ref());
+        let shared_secret = &self.shared_secret;
+
+        const S3K_INFO: [u8; 6] = [0x53, 0x69, 0x67, 0x6d, 0x61, 0x33];
+        if key.len() < 16 {
+            Err(ErrorCode::InvalidData)?;
+        }
+        let mut salt = heapless::Vec::<u8, 256>::new();
+        unwrap!(salt.extend_from_slice(ipk));
+
+        let tt = tt.clone();
+
+        let mut tt_hash = [0u8; crypto::SHA256_HASH_LEN_BYTES];
+        tt.finish(&mut tt_hash)?;
+        unwrap!(salt.extend_from_slice(&tt_hash));
+        //        println!("Sigma3Key: salt: {:x?}, len: {}", salt, salt.len());
+
+        crypto::hkdf_sha256(salt.as_slice(), shared_secret, &S3K_INFO, key)
+            .map_err(|_x| ErrorCode::InvalidData)?;
+        //        println!("Sigma3Key: key: {:x?}", key);
+
+        Ok(())
+    }
+}
+
+impl Default for CaseSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Sigma1 Request structure
+#[derive(FromTLV, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(start = 1, lifetime = "'a")]
+struct Sigma1Req<'a> {
+    /// The initiator's random value
+    initiator_random: OctetStr<'a>,
+    /// The initiator's session ID
+    initiator_sessid: u16,
+    /// The destination ID
+    dest_id: OctetStr<'a>,
+    /// The peer's public key
+    peer_pub_key: OctetStr<'a>,
+    /// Session parameters (optional)
+    session_parameters: Option<SessionParameters>,
+    /// Resumption ID (optional)
+    resumption_id: Option<OctetStr<'a>>,
+    /// Initiator Resume MIC (optional)
+    initiator_resume_mic: Option<OctetStr<'a>>,
+}
+
+/// Sigma3 Decrypt structure
+#[derive(FromTLV, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(start = 1, lifetime = "'a")]
+struct Sigma3Decrypt<'a> {
+    /// The initiator's Node Operational Certificate
+    initiator_noc: OctetStr<'a>,
+    /// The initiator's Intermediate Certificate Authority Certificate (optional)
+    initiator_icac: Option<OctetStr<'a>>,
+    /// The signature
+    signature: OctetStr<'a>,
+}
+
+/// The CASE protocol handler
+pub struct Case {
+    /// The CASE session state
+    session: CaseSession,
+}
+
+impl Case {
+    /// Create a new `Case` instance
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self {
+            session: CaseSession::new(),
+        }
+    }
+
+    /// Return an in-place initializer for `Case`
+    pub fn init() -> impl Init<Self> {
+        init!(Self {
+            session <- CaseSession::init(),
+        })
+    }
+
+    /// Handle the CASE protocol exchange, where the other peer is the exchange initiator
+    ///
+    /// # Arguments
+    /// - `exchange` - The exchange to handle the CASE protocol on
+    pub async fn handle(&mut self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
+        let session = ReservedSession::reserve(exchange.matter()).await?;
+
+        self.handle_casesigma1(exchange).await?;
+
+        exchange.recv_fetch().await?;
+
+        self.handle_casesigma3(exchange, session).await?;
+
+        exchange.acknowledge().await?;
+        exchange.matter().notify_persist();
+
+        Ok(())
+    }
+
+    /// Handle the CASE Sigma1 message
+    ///
+    /// # Arguments
+    /// - `exchange` - The exchange to handle the CASE Sigma1 message on
+    async fn handle_casesigma1(&mut self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
+        check_opcode(exchange, OpCode::CASESigma1)?;
+
+        let root = get_root_node_struct(exchange.rx()?.payload())?;
+        let r = Sigma1Req::from_tlv(&root)?;
+
+        let local_fabric_idx = exchange
+            .matter()
+            .fabric_mgr
+            .borrow()
+            .get_by_dest_id(r.initiator_random.0, r.dest_id.0)
+            .map(|fabric| fabric.fab_idx());
+        if local_fabric_idx.is_none() {
+            error!("Fabric Index mismatch");
+            complete_with_status(exchange, SCStatusCodes::NoSharedTrustRoots, &[]).await?;
+
+            return Ok(());
+        }
+
+        let local_sessid = exchange
+            .matter()
+            .transport_mgr
+            .session_mgr
+            .borrow_mut()
+            .get_next_sess_id();
+        self.session.peer_sessid = r.initiator_sessid;
+        self.session.local_sessid = local_sessid;
+        self.session.tt_hash = Some(Sha256::new()?);
+        unwrap!(self.session.tt_hash.as_mut()).update(exchange.rx()?.payload())?;
+        self.session.local_fabric_idx = unwrap!(local_fabric_idx).get();
+        if r.peer_pub_key.0.len() != crypto::EC_POINT_LEN_BYTES {
+            error!("Invalid public key length");
+            Err(ErrorCode::Invalid)?;
+        }
+        self.session.peer_pub_key.copy_from_slice(r.peer_pub_key.0);
+        trace!(
+            "Destination ID matched to fabric index {}",
+            self.session.local_fabric_idx
+        );
+
+        // Create an ephemeral Key Pair
+        let key_pair = KeyPair::new(exchange.matter().rand())?;
+        let _ = key_pair.get_public_key(&mut self.session.our_pub_key)?;
+
+        // Derive the Shared Secret
+        let len = key_pair.derive_secret(r.peer_pub_key.0, &mut self.session.shared_secret)?;
+        if len != 32 {
+            error!("Derived secret length incorrect");
+            Err(ErrorCode::Invalid)?;
+        }
+        //        println!("Derived secret: {:x?} len: {}", secret, len);
+
+        let mut our_random = MaybeUninit::<[u8; 32]>::uninit(); // TODO MEDIUM BUFFER
+        let our_random = our_random.init_zeroed();
+        (exchange.matter().rand())(our_random);
+
+        let mut resumption_id = MaybeUninit::<[u8; 16]>::uninit(); // TODO MEDIUM BUFFER
+        let resumption_id = resumption_id.init_zeroed();
+        (exchange.matter().rand())(resumption_id);
+
+        let mut tt_hash = MaybeUninit::<[u8; crypto::SHA256_HASH_LEN_BYTES]>::uninit(); // TODO MEDIUM BUFFER
+        let tt_hash = tt_hash.init_zeroed();
+        unwrap!(self.session.tt_hash.as_ref())
+            .clone()
+            .finish(tt_hash)?;
+
+        let mut hash_updated = false;
+        exchange
+            .send_with(|exchange, tw| {
+                let fabric_mgr = exchange.matter().fabric_mgr.borrow();
+
+                let fabric = NonZeroU8::new(self.session.local_fabric_idx)
+                    .and_then(|fabric_idx| fabric_mgr.get(fabric_idx));
+
+                let Some(fabric) = fabric else {
+                    return sc_write(tw, SCStatusCodes::NoSharedTrustRoots, &[]);
+                };
+
+                let mut signature = MaybeUninit::<[u8; crypto::EC_SIGNATURE_LEN_BYTES]>::uninit(); // TODO MEDIUM BUFFER
+                let signature = signature.init_zeroed();
+
+                // Use the remainder of the TX buffer as scratch space for computing the signature
+                let sign_buf = tw.empty_as_mut_slice();
+
+                let sign_len = self.session.get_sigma2_sign(fabric, sign_buf, signature)?;
+
+                let signature = &signature[..sign_len];
+
+                tw.start_struct(&TLVTag::Anonymous)?;
+                tw.str(&TLVTag::Context(1), &*our_random)?;
+                tw.u16(&TLVTag::Context(2), local_sessid)?;
+                tw.str(&TLVTag::Context(3), &self.session.our_pub_key)?;
+
+                tw.str_cb(&TLVTag::Context(4), |buf| {
+                    self.session.get_sigma2_encryption(
+                        fabric,
+                        &*our_random,
+                        &*tt_hash,
+                        signature,
+                        resumption_id,
+                        buf,
+                    )
+                })?;
+                tw.end_container()?;
+
+                if !hash_updated {
+                    unwrap!(self.session.tt_hash.as_mut()).update(tw.as_slice())?;
+                    hash_updated = true;
+                }
+
+                Ok(Some(OpCode::CASESigma2.into()))
+            })
+            .await
+    }
+
+    /// Handle the CASE Sigma3 message
+    ///
+    /// # Arguments
+    /// - `exchange` - The exchange to handle the CASE Sigma3 message on
+    /// - `session` - The reserved session to complete upon successful CASE handshake
+    async fn handle_casesigma3(
+        &mut self,
+        exchange: &mut Exchange<'_>,
+        mut session: ReservedSession<'_>,
+    ) -> Result<(), Error> {
+        check_opcode(exchange, OpCode::CASESigma3)?;
+
+        let status = {
+            let fabric_mgr = exchange.matter().fabric_mgr.borrow();
+
+            let fabric = NonZeroU8::new(self.session.local_fabric_idx)
+                .and_then(|fabric_idx| fabric_mgr.get(fabric_idx));
+            if let Some(fabric) = fabric {
+                let root = get_root_node_struct(exchange.rx()?.payload())?;
+                let encrypted = root.structure()?.ctx(1)?.str()?;
+
+                let mut decrypted = alloc!([0; 800]); // TODO LARGE BUFFER
+                if encrypted.len() > decrypted.len() {
+                    error!("Encrypted data too large");
+                    Err(ErrorCode::BufferTooSmall)?;
+                }
+                let decrypted = &mut decrypted[..encrypted.len()];
+                decrypted.copy_from_slice(encrypted);
+
+                let len = self
+                    .session
+                    .get_sigma3_decryption(fabric.ipk().op_key(), decrypted)?;
+                let decrypted = &decrypted[..len];
+
+                let root = get_root_node_struct(decrypted)?;
+                let d = Sigma3Decrypt::from_tlv(&root)?;
+
+                let initiator_noc = CertRef::new(TLVElement::new(d.initiator_noc.0));
+                let initiator_icac = d
+                    .initiator_icac
+                    .map(|icac| CertRef::new(TLVElement::new(icac.0)));
+
+                let mut buf = alloc!([0; 800]); // TODO LARGE BUFFER
+                let buf = &mut buf[..];
+                if let Err(e) = CaseSession::validate_certs(
+                    fabric,
+                    &initiator_noc,
+                    initiator_icac.as_ref(),
+                    buf,
+                ) {
+                    error!("Certificate Chain doesn't match: {}", e);
+                    SCStatusCodes::InvalidParameter
+                } else if let Err(e) = self.session.validate_sigma3_sign(
+                    d.initiator_noc.0,
+                    d.initiator_icac.map(|a| a.0),
+                    &initiator_noc,
+                    d.signature.0,
+                    buf,
+                ) {
+                    error!("Sigma3 Signature doesn't match: {}", e);
+                    SCStatusCodes::InvalidParameter
+                } else {
+                    // Only now do we add this message to the TT Hash
+                    let mut peer_catids: NocCatIds = Default::default();
+                    initiator_noc.get_cat_ids(&mut peer_catids)?;
+                    unwrap!(self.session.tt_hash.as_mut()).update(exchange.rx()?.payload())?;
+
+                    let mut session_keys =
+                        MaybeUninit::<[u8; 3 * crypto::SYMM_KEY_LEN_BYTES]>::uninit(); // TODO MEDIM BUFFER
+                    let session_keys = session_keys.init_zeroed();
+                    self.session
+                        .get_session_keys(fabric.ipk().op_key(), session_keys)?;
+
+                    let peer_addr = exchange.with_session(|sess| Ok(sess.get_peer_addr()))?;
+
+                    session.update(
+                        fabric.node_id(),
+                        initiator_noc.get_node_id()?,
+                        self.session.peer_sessid,
+                        self.session.local_sessid,
+                        peer_addr,
+                        SessionMode::Case {
+                            // Unwrapping is safe, because if the fabric index was 0, we would not be in here
+                            fab_idx: unwrap!(NonZeroU8::new(self.session.local_fabric_idx)),
+                            cat_ids: peer_catids,
+                        },
+                        Some(&session_keys[0..16]),
+                        Some(&session_keys[16..32]),
+                        Some(&session_keys[32..48]),
+                    )?;
+
+                    // Complete the reserved session and thus make the `Session` instance
+                    // immediately available for use by the system.
+                    //
+                    // We need to do this _before_ we send the response to the peer, or else we risk missing
+                    // (dropping) the first messages the peer would send us on the newly-established session,
+                    // as it might start using it right after it receives the response, while it is still marked
+                    // as reserved.
+                    session.complete();
+
+                    SCStatusCodes::SessionEstablishmentSuccess
+                }
+            } else {
+                SCStatusCodes::NoSharedTrustRoots
+            }
+        };
+
+        complete_with_status(exchange, status, &[]).await
+    }
 }
 
 impl Default for Case {
     fn default() -> Self {
         Self::new()
     }
-}
-
-#[derive(FromTLV, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(start = 1, lifetime = "'a")]
-struct Sigma1Req<'a> {
-    initiator_random: OctetStr<'a>,
-    initiator_sessid: u16,
-    dest_id: OctetStr<'a>,
-    peer_pub_key: OctetStr<'a>,
-    session_parameters: Option<SessionParameters>,
-    resumption_id: Option<OctetStr<'a>>,
-    initiator_resume_mic: Option<OctetStr<'a>>,
-}
-
-#[derive(FromTLV, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(start = 1, lifetime = "'a")]
-struct Sigma3Decrypt<'a> {
-    initiator_noc: OctetStr<'a>,
-    initiator_icac: Option<OctetStr<'a>>,
-    signature: OctetStr<'a>,
 }

--- a/rs-matter/src/sc/crypto/esp_mbedtls.rs
+++ b/rs-matter/src/sc/crypto/esp_mbedtls.rs
@@ -113,7 +113,7 @@ impl CryptoSpake2 {
 mod tests {
 
     use super::CryptoSpake2;
-    use crate::sc::spake2p::test_vectors::test_vectors::*;
+    use crate::sc::pake::spake2p::test_vectors::test_vectors::*;
     use openssl::bn::BigNum;
     use openssl::ec::{EcPoint, PointConversionForm};
 

--- a/rs-matter/src/sc/crypto/mbedtls.rs
+++ b/rs-matter/src/sc/crypto/mbedtls.rs
@@ -305,7 +305,7 @@ impl CryptoSpake2 {
 #[cfg(test)]
 mod tests {
     use super::CryptoSpake2;
-    use crate::sc::spake2p::test_vectors::*;
+    use crate::sc::pake::spake2p::test_vectors::*;
     use mbedtls::bignum::Mpi;
     use mbedtls::ecp::EcPoint;
 

--- a/rs-matter/src/sc/crypto/openssl.rs
+++ b/rs-matter/src/sc/crypto/openssl.rs
@@ -332,7 +332,7 @@ impl CryptoSpake2 {
 #[cfg(test)]
 mod tests {
     use super::CryptoSpake2;
-    use crate::sc::spake2p::test_vectors::*;
+    use crate::sc::pake::spake2p::test_vectors::*;
     use openssl::bn::BigNum;
     use openssl::ec::{EcPoint, PointConversionForm};
 

--- a/rs-matter/src/sc/crypto/rustcrypto.rs
+++ b/rs-matter/src/sc/crypto/rustcrypto.rs
@@ -316,7 +316,7 @@ mod tests {
 
     use elliptic_curve::sec1::FromEncodedPoint;
 
-    use crate::sc::spake2p::test_vectors::*;
+    use crate::sc::pake::spake2p::test_vectors::*;
 
     #[test]
     #[allow(non_snake_case)]

--- a/rs-matter/src/sc/pake.rs
+++ b/rs-matter/src/sc/pake.rs
@@ -16,7 +16,10 @@
  */
 
 use core::num::NonZeroU8;
+use core::ops::Add;
 use core::time::Duration;
+
+use spake2p::{Spake2P, VerifierData, MAX_SALT_SIZE_BYTES};
 
 use crate::error::{Error, ErrorCode};
 use crate::sc::{check_opcode, complete_with_status, OpCode, SessionParameters};
@@ -29,39 +32,63 @@ use crate::utils::maybe::Maybe;
 use crate::utils::rand::Rand;
 use crate::{crypto, MatterMdnsService};
 
-use super::spake2p::{Spake2P, VerifierData, MAX_SALT_SIZE_BYTES};
 use super::SCStatusCodes;
 
-pub const MIN_COMM_TIMEOUT_SECS: u16 = 3 * 60;
-pub const MAX_COMM_TIMEOUT_SECS: u16 = 15 * 60;
+pub(crate) mod spake2p;
 
+/// Minimal commissioning window timeout in seconds, as per the Matter Core Spec
+pub const MIN_COMM_WINDOW_TIMEOUT_SECS: u16 = 3 * 60;
+/// Maximal commissioning window timeout in seconds, as per the Matter Core Spec
+pub const MAX_COMM_WINDOW_TIMEOUT_SECS: u16 = 15 * 60;
+
+/// The type of commissioning window
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum PaseSessionType {
+pub enum CommWindowType {
+    /// Basic commissioning window (using passcode)
     Basic,
+    /// Enhanced commissioning window (using verifier)
     Enhanced,
 }
 
 /// The fabric index of the fabric administrator that opened the commissioning window
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct PaseSessionOpener {
+pub struct CommWindowOpener {
+    /// The fabric index
     pub fab_idx: NonZeroU8,
+    /// The vendor ID
     pub vendor_id: u16,
 }
 
-struct PaseSession {
+/// A PASE commissioning window
+pub struct CommWindow {
+    /// The mDNS identifier
     mdns_id: u64,
+    /// The discriminator
     discriminator: u16,
+    /// The verifier data
     verifier: VerifierData,
-    opener: Option<PaseSessionOpener>,
+    /// The opener info
+    opener: Option<CommWindowOpener>,
+    /// The window expiry instant
+    window_expiry: Duration,
 }
 
-impl PaseSession {
+impl CommWindow {
+    /// Initialize a commissioning window with a passcode
+    ///
+    /// # Arguments
+    /// - `password` - The passcode
+    /// - `discriminator` - The discriminator
+    /// - `opener` - The opener info
+    /// - `window_expiry` - The window expiry instant
+    /// - `rand` - The random number generator
     fn init_with_pw(
         password: u32,
         discriminator: u16,
-        opener: Option<PaseSessionOpener>,
+        opener: Option<CommWindowOpener>,
+        window_expiry: Duration,
         rand: Rand,
     ) -> impl Init<Self> {
         init!(Self {
@@ -69,15 +96,26 @@ impl PaseSession {
             discriminator,
             verifier <- VerifierData::init_with_pw(password, rand),
             opener,
+            window_expiry,
         })
     }
 
+    /// Initialize a commissioning window with a verifier
+    ///
+    /// # Arguments
+    /// - `verifier` - The verifier bytes
+    /// - `salt` - The salt bytes
+    /// - `count` - The iteration count
+    /// - `discriminator` - The discriminator
+    /// - `opener` - The opener info
+    /// - `window_expiry` - The window expiry instant
     fn init<'a>(
         verifier: &'a [u8],
         salt: &'a [u8],
         count: u32,
         discriminator: u16,
-        opener: Option<PaseSessionOpener>,
+        opener: Option<CommWindowOpener>,
+        window_expiry: Duration,
         rand: Rand,
     ) -> impl Init<Self, Error> + 'a {
         try_init!(Self {
@@ -85,28 +123,37 @@ impl PaseSession {
             discriminator,
             verifier <- VerifierData::init(verifier, salt, count),
             opener,
+            window_expiry,
         }? Error)
     }
 
-    fn session_type(&self) -> PaseSessionType {
+    /// Get the type of commissioning window
+    pub fn comm_window_type(&self) -> CommWindowType {
         if self.verifier.password.is_some() {
-            PaseSessionType::Basic
+            CommWindowType::Basic
         } else {
-            PaseSessionType::Enhanced
+            CommWindowType::Enhanced
         }
     }
 
-    fn opener(&self) -> Option<PaseSessionOpener> {
+    /// Get the opener info, if any
+    pub fn opener(&self) -> Option<CommWindowOpener> {
         self.opener
     }
 
-    fn mdns_service(&self) -> MatterMdnsService {
+    /// Get the mDNS service info
+    pub fn mdns_service(&self) -> MatterMdnsService {
         MatterMdnsService::Commissionable {
             id: self.mdns_id,
             discriminator: self.discriminator,
         }
     }
 
+    /// Generate a random mDNS identifier
+    ///
+    /// # Arguments
+    /// - `rand` - The random number generator
+    /// - Returns - A random u64 identifier
     fn mdns_id(rand: Rand) -> u64 {
         let mut buf = [0; 8];
         (rand)(&mut buf);
@@ -114,209 +161,496 @@ impl PaseSession {
     }
 }
 
+/// The PASE manager
 pub struct PaseMgr {
-    session: Maybe<PaseSession>,
-    timeout: Option<Timeout>,
+    /// The opened commissioning window, if any
+    comm_window: Maybe<CommWindow>,
+    /// The (one and only) PASE session timeout tracker
+    /// If there is no active PASE session, this is `None`
+    session_timeout: Option<SessionEstTimeout>,
+    /// The epoch function
     epoch: Epoch,
+    /// The random number generator
     rand: Rand,
 }
 
 impl PaseMgr {
+    /// Create a new PASE manager
+    ///
+    /// # Arguments
+    /// - `epoch` - The epoch function
+    /// - `rand` - The random number generator
     #[inline(always)]
     pub const fn new(epoch: Epoch, rand: Rand) -> Self {
         Self {
-            session: Maybe::none(),
-            timeout: None,
+            comm_window: Maybe::none(),
+            session_timeout: None,
             epoch,
             rand,
         }
     }
 
+    /// Return an in-place initializer for the PASE manager
+    ///
+    /// # Arguments
+    /// - `epoch` - The epoch function
+    /// - `rand` - The random number generator
     pub fn init(epoch: Epoch, rand: Rand) -> impl Init<Self> {
         init!(Self {
-            session <- Maybe::init_none(),
-            timeout: None,
+            comm_window <- Maybe::init_none(),
+            session_timeout: None,
             epoch,
             rand,
         })
     }
 
-    pub fn session_type(&self) -> Option<PaseSessionType> {
-        self.session
+    pub fn comm_window(
+        &mut self,
+        mdns_notif: &mut dyn FnMut(),
+    ) -> Result<Option<&CommWindow>, Error> {
+        let expired = self
+            .comm_window
             .as_opt_ref()
-            .map(|session| session.session_type())
+            .map(|comm_window| (self.epoch)() > comm_window.window_expiry)
+            .unwrap_or(false);
+
+        if expired {
+            warn!("PASE Commissioning Window expired, closing");
+
+            self.close_comm_window(mdns_notif)?;
+
+            Ok(None)
+        } else {
+            Ok(self.comm_window.as_opt_ref())
+        }
     }
 
-    pub fn opener(&self) -> Option<PaseSessionOpener> {
-        self.session
-            .as_opt_ref()
-            .and_then(|session| session.opener())
-    }
-
-    pub fn mdns_service(&self) -> Option<MatterMdnsService> {
-        self.session
-            .as_opt_ref()
-            .map(|session| session.mdns_service())
-    }
-
-    pub fn enable_basic_pase_session(
+    /// Open a basic commissioning window using a passcode
+    ///
+    /// # Arguments
+    /// - `password` - The passcode
+    /// - `discriminator` - The discriminator
+    /// - `timeout_secs` - The timeout in seconds of the validity of the window
+    /// - `opener` - The opener info
+    /// - `mdns_notif` - The mDNS notification callback
+    ///
+    /// # Returns
+    /// - `Ok(())` if the window was opened successfully
+    /// - `Err(Error)` if an error occurred
+    ///   (i.e. there is another non-expired commissioning window already opened
+    ///   or the timeout is invalid)
+    pub fn open_basic_comm_window(
         &mut self,
         password: u32,
         discriminator: u16,
         timeout_secs: u16,
-        opener: Option<PaseSessionOpener>,
+        opener: Option<CommWindowOpener>,
         mdns_notif: &mut dyn FnMut(),
     ) -> Result<(), Error> {
-        if self.session.is_some() {
+        if self.comm_window(mdns_notif)?.is_some() {
             Err(ErrorCode::Busy)?;
         }
 
-        if !(MIN_COMM_TIMEOUT_SECS..=MAX_COMM_TIMEOUT_SECS).contains(&timeout_secs) {
+        if !(MIN_COMM_WINDOW_TIMEOUT_SECS..=MAX_COMM_WINDOW_TIMEOUT_SECS).contains(&timeout_secs) {
             Err(ErrorCode::InvalidCommand)?;
         }
 
-        self.session
-            .reinit(Maybe::init_some(PaseSession::init_with_pw(
+        let window_expiry = (self.epoch)().add(Duration::from_secs(timeout_secs as _));
+
+        self.comm_window
+            .reinit(Maybe::init_some(CommWindow::init_with_pw(
                 password,
                 discriminator,
                 opener,
+                window_expiry,
                 self.rand,
             )));
 
         mdns_notif();
 
+        info!("PASE Basic Commissioning Window opened");
+
         Ok(())
     }
 
+    /// Open an enhanced commissioning window using a verifier
+    ///
+    /// # Arguments
+    /// - `verifier` - The verifier bytes
+    /// - `salt` - The salt bytes
+    /// - `count` - The iteration count
+    /// - `discriminator` - The discriminator
+    /// - `timeout_secs` - The timeout in seconds of the validity of the window
+    /// - `opener` - The opener info
+    /// - `mdns_notif` - The mDNS notification callback
+    ///
+    /// # Returns
+    /// - `Ok(())` if the window was opened successfully
+    /// - `Err(Error)` if an error occurred
+    ///   (i.e. there is another non-expired commissioning window already opened
+    ///   or the timeout is invalid)
     #[allow(clippy::too_many_arguments)]
-    pub fn enable_pase_session(
+    pub fn open_comm_window(
         &mut self,
         verifier: &[u8],
         salt: &[u8],
         count: u32,
         discriminator: u16,
-        _timeout_secs: u16,
-        opener: Option<PaseSessionOpener>,
+        timeout_secs: u16,
+        opener: Option<CommWindowOpener>,
         mdns_notif: &mut dyn FnMut(),
     ) -> Result<(), Error> {
-        if self.session.is_some() {
-            Err(ErrorCode::Invalid)?;
+        if self.comm_window(mdns_notif)?.is_some() {
+            Err(ErrorCode::Busy)?;
         }
 
-        self.session.try_reinit(Maybe::init_some(PaseSession::init(
-            verifier,
-            salt,
-            count,
-            discriminator,
-            opener,
-            self.rand,
-        )))?;
+        if !(MIN_COMM_WINDOW_TIMEOUT_SECS..=MAX_COMM_WINDOW_TIMEOUT_SECS).contains(&timeout_secs) {
+            Err(ErrorCode::InvalidCommand)?;
+        }
+
+        let window_expiry = (self.epoch)().add(Duration::from_secs(timeout_secs as _));
+
+        self.comm_window
+            .try_reinit(Maybe::init_some(CommWindow::init(
+                verifier,
+                salt,
+                count,
+                discriminator,
+                opener,
+                window_expiry,
+                self.rand,
+            )))?;
 
         mdns_notif();
 
-        info!("PASE session enabled");
+        info!("PASE Commissioning Window opened");
 
         Ok(())
     }
 
-    pub fn disable_pase_session(&mut self, mdns_notif: &mut dyn FnMut()) -> Result<bool, Error> {
-        if self.session.is_some() {
-            self.session.clear();
+    /// Close the opened commissioning window, if any
+    ///
+    /// # Arguments
+    /// - `mdns_notif` - The mDNS notification callback
+    ///
+    /// # Returns
+    /// - `Ok(true)` if a commissioning window was closed
+    /// - `Ok(false)` if there was no commissioning window to close
+    pub fn close_comm_window(&mut self, mdns_notif: &mut dyn FnMut()) -> Result<bool, Error> {
+        if self.comm_window.is_some() {
+            self.comm_window.clear();
             mdns_notif();
 
-            info!("PASE session disabled");
+            info!("PASE Commissioning Window closed");
 
             Ok(true)
         } else {
-            warn!("No PASE session to disable");
+            warn!("No PASE Commissioning Window to close");
 
             Ok(false)
         }
     }
 }
 
-// This file basically deals with the handlers for the PASE secure channel protocol
-// TLV extraction and encoding is done in this file.
-// We create a Spake2p object and set it up in the exchange-data. This object then
-// handles Spake2+ specific stuff.
-
-const PASE_DISCARD_TIMEOUT_SECS: Duration = Duration::from_secs(60);
+/// The timeout tracker for a PASE session establishment
+const PASE_SESSION_EST_TIMEOUT_SECS: Duration = Duration::from_secs(60);
+/// The info string for SPAKE2 session key derivation
 const SPAKE2_SESSION_KEYS_INFO: &[u8] = b"SessionKeys";
 
-struct Timeout {
-    start_time: Duration,
+/// The PASE session establishment timeout tracker
+struct SessionEstTimeout {
+    /// The session expiry instant
+    session_est_expiry: Duration,
+    /// The exchange identifier
     exch_id: ExchangeId,
 }
 
-impl Timeout {
+impl SessionEstTimeout {
+    /// Create a new session establishment timeout tracker
+    ///
+    /// # Arguments
+    /// - `exchange` - The exchange
+    /// - `epoch` - The epoch function
     fn new(exchange: &Exchange, epoch: Epoch) -> Self {
         Self {
-            start_time: epoch(),
+            session_est_expiry: epoch().add(PASE_SESSION_EST_TIMEOUT_SECS),
             exch_id: exchange.id(),
         }
     }
 
+    /// Check if the session establishment has expired
+    ///
+    /// # Arguments
+    /// - `epoch` - The current epoch
     fn is_sess_expired(&self, epoch: Epoch) -> bool {
-        epoch() - self.start_time > PASE_DISCARD_TIMEOUT_SECS
+        epoch() > self.session_est_expiry
     }
 }
 
-pub struct Pake(());
+/// The PBKDFParamRequest structure
+#[derive(FromTLV, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(lifetime = "'a", start = 1)]
+struct PBKDFParamReq<'a> {
+    /// The initiator random bytes
+    initiator_random: OctetStr<'a>,
+    /// The initiator session identifier
+    initiator_ssid: u16,
+    /// The passcode identifier
+    passcode_id: u16,
+    /// Whether parameters are included
+    has_params: bool,
+    /// The session parameters, if any
+    session_parameters: Option<SessionParameters>,
+}
+
+/// The PBKDFParamResponse structure
+#[derive(ToTLV, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(start = 1)]
+struct PBKDFParamResp<'a> {
+    /// The initiator random bytes
+    init_random: OctetStr<'a>,
+    /// Our random bytes
+    our_random: OctetStr<'a>,
+    /// Our local session identifier
+    local_sessid: u16,
+    /// The PBKDF2 parameters, if any
+    params: Option<PBKDFParamRespParams<'a>>,
+}
+
+/// The PBKDFParamResponse parameters structure
+#[derive(ToTLV, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(start = 1)]
+struct PBKDFParamRespParams<'a> {
+    /// The iteration count
+    count: u32,
+    /// The salt bytes
+    salt: OctetStr<'a>,
+}
+
+/// The Pake1Resp structure
+#[derive(ToTLV, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(start = 1)]
+struct Pake1Resp<'a> {
+    /// The pB bytes
+    pb: OctetStr<'a>,
+    /// The cB bytes
+    cb: OctetStr<'a>,
+}
+
+/// The PASE PAKE handler
+pub struct Pake {
+    spake2p: Spake2P,
+}
 
 impl Pake {
+    /// Create a new PASE PAKE handler
     pub const fn new() -> Self {
         // TODO: Can any PBKDF2 calculation be pre-computed here
-        Self(())
+        Self {
+            spake2p: Spake2P::new(),
+        }
     }
 
-    pub async fn handle(
-        &mut self,
-        exchange: &mut Exchange<'_>,
-        spake2p: &mut Spake2P,
-    ) -> Result<(), Error> {
+    pub fn init() -> impl Init<Self> {
+        init!(Self {
+            spake2p <- Spake2P::init(),
+        })
+    }
+
+    /// Handle a PASE PAKE exchange, where the other peer is the exchange initiator
+    ///
+    /// # Arguments
+    /// - `exchange` - The exchange
+    pub async fn handle(&mut self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
         let session = ReservedSession::reserve(exchange.matter()).await?;
 
-        if !self.update_timeout(exchange, true).await? {
+        if !self.update_session_timeout(exchange, true).await? {
             return Ok(());
         }
 
-        self.handle_pbkdfparamrequest(exchange, spake2p).await?;
+        self.handle_pbkdfparamrequest(exchange).await?;
 
         exchange.recv_fetch().await?;
 
-        if !self.update_timeout(exchange, false).await? {
+        if !self.update_session_timeout(exchange, false).await? {
             return Ok(());
         }
 
-        self.handle_pasepake1(exchange, spake2p).await?;
+        self.handle_pasepake1(exchange).await?;
 
         exchange.recv_fetch().await?;
 
-        if !self.update_timeout(exchange, false).await? {
+        if !self.update_session_timeout(exchange, false).await? {
             return Ok(());
         }
 
-        self.handle_pasepake3(exchange, session, spake2p).await?;
+        self.handle_pasepake3(exchange, session).await?;
 
         exchange.acknowledge().await?;
         exchange.matter().notify_persist();
 
-        self.clear_timeout(exchange);
+        self.clear_session_timeout(exchange);
 
         Ok(())
     }
 
+    /// Handle a PBKDFParamRequest message
+    ///
+    /// # Arguments
+    /// - `exchange` - The exchange
+    async fn handle_pbkdfparamrequest(&mut self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
+        check_opcode(exchange, OpCode::PBKDFParamRequest)?;
+
+        let rx = exchange.rx()?;
+
+        let mut salt = [0; MAX_SALT_SIZE_BYTES];
+        let mut count = 0;
+
+        let has_comm_window = {
+            let matter = exchange.matter();
+            let mut pase = matter.pase_mgr.borrow_mut();
+
+            if let Some(comm_window) =
+                pase.comm_window(&mut || matter.mdns_notification.notify())?
+            {
+                salt.copy_from_slice(&comm_window.verifier.salt);
+                count = comm_window.verifier.count;
+
+                true
+            } else {
+                false
+            }
+        };
+
+        if has_comm_window {
+            let mut our_random = [0; 32];
+            let mut initiator_random = [0; 32];
+
+            let resp = {
+                let a = PBKDFParamReq::from_tlv(&TLVElement::new(rx.payload()))?;
+                if a.passcode_id != 0 {
+                    error!("Can't yet handle passcode_id != 0");
+                    Err(ErrorCode::Invalid)?;
+                }
+
+                (exchange.matter().pase_mgr.borrow().rand)(&mut our_random);
+
+                let local_sessid = exchange
+                    .matter()
+                    .transport_mgr
+                    .session_mgr
+                    .borrow_mut()
+                    .get_next_sess_id();
+                let spake2p_data: u32 = ((local_sessid as u32) << 16) | a.initiator_ssid as u32;
+                self.spake2p.set_app_data(spake2p_data);
+
+                initiator_random[..a.initiator_random.0.len()]
+                    .copy_from_slice(a.initiator_random.0);
+                let initiator_random = &initiator_random[..a.initiator_random.0.len()];
+
+                // Generate response
+                let mut resp = PBKDFParamResp {
+                    init_random: OctetStr::new(initiator_random),
+                    our_random: OctetStr::new(&our_random),
+                    local_sessid,
+                    params: None,
+                };
+                if !a.has_params {
+                    let params_resp = PBKDFParamRespParams {
+                        count,
+                        salt: OctetStr::new(&salt),
+                    };
+                    resp.params = Some(params_resp);
+                }
+
+                resp
+            };
+
+            self.spake2p.set_context()?;
+            self.spake2p.update_context(rx.payload())?;
+
+            let mut context_set = false;
+            exchange
+                .send_with(|_, wb| {
+                    resp.to_tlv(&TagType::Anonymous, &mut *wb)?;
+
+                    if !context_set {
+                        self.spake2p.update_context(wb.as_slice())?;
+                        context_set = true;
+                    }
+
+                    Ok(Some(OpCode::PBKDFParamResponse.into()))
+                })
+                .await
+        } else {
+            complete_with_status(exchange, SCStatusCodes::InvalidParameter, &[]).await
+        }
+    }
+
+    /// Handle a PASEPake1 message
+    ///
+    /// # Arguments
+    /// - `exchange` - The exchange
+    #[allow(non_snake_case)]
+    async fn handle_pasepake1(&mut self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
+        check_opcode(exchange, OpCode::PASEPake1)?;
+
+        let pA = Self::extract_pasepake_1_or_3_params(exchange.rx()?.payload())?;
+        let mut pB: [u8; 65] = [0; 65];
+        let mut cB: [u8; 32] = [0; 32];
+
+        let has_comm_window = {
+            let matter = exchange.matter();
+            let mut pase = matter.pase_mgr.borrow_mut();
+
+            if let Some(comm_window) =
+                pase.comm_window(&mut || matter.mdns_notification.notify())?
+            {
+                self.spake2p.start_verifier(&comm_window.verifier)?;
+                self.spake2p.handle_pA(pA, &mut pB, &mut cB, pase.rand)?;
+
+                true
+            } else {
+                false
+            }
+        };
+
+        if has_comm_window {
+            exchange
+                .send_with(|_, wb| {
+                    let resp = Pake1Resp {
+                        pb: OctetStr::new(&pB),
+                        cb: OctetStr::new(&cB),
+                    };
+                    resp.to_tlv(&TagType::Anonymous, wb)?;
+
+                    Ok(Some(OpCode::PASEPake2.into()))
+                })
+                .await
+        } else {
+            complete_with_status(exchange, SCStatusCodes::InvalidParameter, &[]).await
+        }
+    }
+
+    /// Handle a PASEPake3 message
+    ///
+    /// # Arguments
+    /// - `exchange` - The exchange
+    /// - `session` - The reserved session
     #[allow(non_snake_case)]
     async fn handle_pasepake3(
         &mut self,
         exchange: &mut Exchange<'_>,
         mut session: ReservedSession<'_>,
-        spake2p: &mut Spake2P,
     ) -> Result<(), Error> {
         check_opcode(exchange, OpCode::PASEPake3)?;
 
-        let cA = extract_pasepake_1_or_3_params(exchange.rx()?.payload())?;
-        let (status, ke) = spake2p.handle_cA(cA);
+        let cA = Self::extract_pasepake_1_or_3_params(exchange.rx()?.payload())?;
+        let (status, ke) = self.spake2p.handle_cA(cA);
 
         let result = if status == SCStatusCodes::SessionEstablishmentSuccess {
             // Get the keys
@@ -326,7 +660,7 @@ impl Pake {
                 .map_err(|_x| ErrorCode::InvalidData)?;
 
             // Create a session
-            let data = spake2p.get_app_data();
+            let data = self.spake2p.get_app_data();
             let peer_sessid: u16 = (data & 0xffff) as u16;
             let local_sessid: u16 = ((data >> 16) & 0xffff) as u16;
             let peer_addr = exchange.with_session(|sess| Ok(sess.get_peer_addr()))?;
@@ -367,144 +701,36 @@ impl Pake {
         complete_with_status(exchange, status, &[]).await
     }
 
-    #[allow(non_snake_case)]
-    async fn handle_pasepake1(
-        &mut self,
-        exchange: &mut Exchange<'_>,
-        spake2p: &mut Spake2P,
-    ) -> Result<(), Error> {
-        check_opcode(exchange, OpCode::PASEPake1)?;
-
-        let pA = extract_pasepake_1_or_3_params(exchange.rx()?.payload())?;
-        let mut pB: [u8; 65] = [0; 65];
-        let mut cB: [u8; 32] = [0; 32];
-
-        {
-            let pase = exchange.matter().pase_mgr.borrow();
-            let session = pase.session.as_opt_ref().ok_or(ErrorCode::NoSession)?;
-
-            spake2p.start_verifier(&session.verifier)?;
-            spake2p.handle_pA(pA, &mut pB, &mut cB, pase.rand)?;
-        }
-
-        exchange
-            .send_with(|_, wb| {
-                let resp = Pake1Resp {
-                    pb: OctetStr::new(&pB),
-                    cb: OctetStr::new(&cB),
-                };
-                resp.to_tlv(&TagType::Anonymous, wb)?;
-
-                Ok(Some(OpCode::PASEPake2.into()))
-            })
-            .await
-    }
-
-    async fn handle_pbkdfparamrequest(
-        &mut self,
-        exchange: &mut Exchange<'_>,
-        spake2p: &mut Spake2P,
-    ) -> Result<(), Error> {
-        check_opcode(exchange, OpCode::PBKDFParamRequest)?;
-
-        let rx = exchange.rx()?;
-
-        let mut our_random = [0; 32];
-        let mut initiator_random = [0; 32];
-        let mut salt = [0; MAX_SALT_SIZE_BYTES];
-
-        let resp = {
-            let pase = exchange.matter().pase_mgr.borrow();
-            let session = pase.session.as_opt_ref().ok_or(ErrorCode::NoSession)?;
-
-            let a = PBKDFParamReq::from_tlv(&TLVElement::new(rx.payload()))?;
-            if a.passcode_id != 0 {
-                error!("Can't yet handle passcode_id != 0");
-                Err(ErrorCode::Invalid)?;
-            }
-
-            (exchange.matter().pase_mgr.borrow().rand)(&mut our_random);
-
-            let local_sessid = exchange
-                .matter()
-                .transport_mgr
-                .session_mgr
-                .borrow_mut()
-                .get_next_sess_id();
-            let spake2p_data: u32 = ((local_sessid as u32) << 16) | a.initiator_ssid as u32;
-            spake2p.set_app_data(spake2p_data);
-
-            initiator_random[..a.initiator_random.0.len()].copy_from_slice(a.initiator_random.0);
-            let initiator_random = &initiator_random[..a.initiator_random.0.len()];
-
-            salt.copy_from_slice(&session.verifier.salt);
-
-            // Generate response
-            let mut resp = PBKDFParamResp {
-                init_random: OctetStr::new(initiator_random),
-                our_random: OctetStr::new(&our_random),
-                local_sessid,
-                params: None,
-            };
-            if !a.has_params {
-                let params_resp = PBKDFParamRespParams {
-                    count: session.verifier.count,
-                    salt: OctetStr::new(&salt),
-                };
-                resp.params = Some(params_resp);
-            }
-
-            resp
-        };
-
-        spake2p.set_context()?;
-        spake2p.update_context(rx.payload())?;
-
-        let mut context_set = false;
-        exchange
-            .send_with(|_, wb| {
-                resp.to_tlv(&TagType::Anonymous, &mut *wb)?;
-
-                if !context_set {
-                    spake2p.update_context(wb.as_slice())?;
-                    context_set = true;
-                }
-
-                Ok(Some(OpCode::PBKDFParamResponse.into()))
-            })
-            .await
-    }
-
-    fn clear_timeout(&mut self, exchange: &Exchange) {
-        let mut pase = exchange.matter().pase_mgr.borrow_mut();
-
-        pase.timeout = None;
-    }
-
-    async fn update_timeout(
+    /// Update the PASE session timeout tracker
+    ///
+    /// # Arguments
+    /// - `exchange` - The exchange
+    /// - `new` - Whether this is for a new session
+    ///
+    /// # Returns
+    /// - `Ok(true)` if the session timeout was updated successfully
+    /// - `Ok(false)` if the session timeout could not be updated
+    ///   (e.g. another session is in progress, there is no active PASE session establishment, or the session has expired)
+    async fn update_session_timeout(
         &mut self,
         exchange: &mut Exchange<'_>,
         new: bool,
     ) -> Result<bool, Error> {
-        if !self.check_session(exchange).await? {
-            return Ok(false);
-        }
-
         let status = {
             let mut pase = exchange.matter().pase_mgr.borrow_mut();
 
             if pase
-                .timeout
+                .session_timeout
                 .as_ref()
                 .map(|sd| sd.is_sess_expired(pase.epoch))
                 .unwrap_or(false)
             {
-                pase.timeout = None;
+                pase.session_timeout = None;
             }
 
-            if let Some(sd) = pase.timeout.as_mut() {
+            if let Some(sd) = pase.session_timeout.as_mut() {
                 if sd.exch_id != exchange.id() {
-                    debug!("Other PAKE session in progress");
+                    debug!("Another PAKE session in progress");
                     Some(SCStatusCodes::Busy)
                 } else {
                     None
@@ -523,21 +749,25 @@ impl Pake {
             Ok(false)
         } else {
             let mut pase = exchange.matter().pase_mgr.borrow_mut();
-            pase.timeout = Some(Timeout::new(exchange, pase.epoch));
+            pase.session_timeout = Some(SessionEstTimeout::new(exchange, pase.epoch));
 
             Ok(true)
         }
     }
 
-    async fn check_session(&mut self, exchange: &mut Exchange<'_>) -> Result<bool, Error> {
-        if exchange.matter().pase_mgr.borrow().session.is_none() {
-            error!("PASE not enabled");
-            complete_with_status(exchange, SCStatusCodes::InvalidParameter, &[]).await?;
+    /// Clear the PASE session timeout tracker
+    fn clear_session_timeout(&mut self, exchange: &Exchange) {
+        let mut pase = exchange.matter().pase_mgr.borrow_mut();
 
-            Ok(false)
-        } else {
-            Ok(true)
-        }
+        pase.session_timeout = None;
+    }
+
+    /// Extract the PAKEPake1 or PAKEPake3 parameters from the given buffer
+    #[allow(non_snake_case)]
+    fn extract_pasepake_1_or_3_params(buf: &[u8]) -> Result<&[u8], Error> {
+        let root = get_root_node_struct(buf)?;
+        let pA = root.structure()?.ctx(1)?.str()?;
+        Ok(pA)
     }
 }
 
@@ -545,48 +775,4 @@ impl Default for Pake {
     fn default() -> Self {
         Self::new()
     }
-}
-
-#[derive(ToTLV, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(start = 1)]
-struct Pake1Resp<'a> {
-    pb: OctetStr<'a>,
-    cb: OctetStr<'a>,
-}
-
-#[derive(ToTLV, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(start = 1)]
-struct PBKDFParamRespParams<'a> {
-    count: u32,
-    salt: OctetStr<'a>,
-}
-
-#[derive(ToTLV, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(start = 1)]
-struct PBKDFParamResp<'a> {
-    init_random: OctetStr<'a>,
-    our_random: OctetStr<'a>,
-    local_sessid: u16,
-    params: Option<PBKDFParamRespParams<'a>>,
-}
-
-#[allow(non_snake_case)]
-fn extract_pasepake_1_or_3_params(buf: &[u8]) -> Result<&[u8], Error> {
-    let root = get_root_node_struct(buf)?;
-    let pA = root.structure()?.ctx(1)?.str()?;
-    Ok(pA)
-}
-
-#[derive(FromTLV, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(lifetime = "'a", start = 1)]
-struct PBKDFParamReq<'a> {
-    initiator_random: OctetStr<'a>,
-    initiator_ssid: u16,
-    passcode_id: u16,
-    has_params: bool,
-    session_parameters: Option<SessionParameters>,
 }

--- a/rs-matter/src/sc/pake.rs
+++ b/rs-matter/src/sc/pake.rs
@@ -32,8 +32,8 @@ use crate::{crypto, MatterMdnsService};
 use super::spake2p::{Spake2P, VerifierData, MAX_SALT_SIZE_BYTES};
 use super::SCStatusCodes;
 
-pub const MIN_COMMISSIONING_TIMEOUT_SECS: u16 = 3 * 60;
-pub const MAX_COMMISSIONING_TIMEOUT_SECS: u16 = 15 * 60;
+pub const MIN_COMM_TIMEOUT_SECS: u16 = 3 * 60;
+pub const MAX_COMM_TIMEOUT_SECS: u16 = 15 * 60;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -171,9 +171,7 @@ impl PaseMgr {
             Err(ErrorCode::Busy)?;
         }
 
-        if !(MIN_COMMISSIONING_TIMEOUT_SECS..=MAX_COMMISSIONING_TIMEOUT_SECS)
-            .contains(&timeout_secs)
-        {
+        if !(MIN_COMM_TIMEOUT_SECS..=MAX_COMM_TIMEOUT_SECS).contains(&timeout_secs) {
             Err(ErrorCode::InvalidCommand)?;
         }
 

--- a/rs-matter/src/sc/pake/spake2p.rs
+++ b/rs-matter/src/sc/pake/spake2p.rs
@@ -19,10 +19,10 @@ use subtle::ConstantTimeEq;
 
 use crate::crypto::{self, pbkdf2_hmac, HmacSha256, Sha256};
 use crate::error::{Error, ErrorCode};
+use crate::sc::crypto::CryptoSpake2;
+use crate::sc::SCStatusCodes;
 use crate::utils::init::{init, zeroed, Init, IntoFallibleInit};
 use crate::utils::rand::Rand;
-
-use super::{crypto::CryptoSpake2, SCStatusCodes};
 
 // This file handles Spake2+ specific instructions. In itself, this file is
 // independent from the BigNum and EC operations that are typically required
@@ -58,6 +58,7 @@ pub enum Spake2VerifierState {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Spake2Mode {
     Unknown,
+    #[allow(unused)]
     Prover,
     Verifier(Spake2VerifierState),
 }

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -1348,6 +1348,19 @@ impl<const N: usize> BufferAccess<[u8]> for PacketBufferExternalAccess<'_, N> {
 
         Some(ExternalPacketBuffer(packet))
     }
+
+    fn get_immediate(&self) -> Option<Self::Buffer<'_>> {
+        self.0
+            .try_lock_if(|packet| packet.buf.is_empty())
+            .ok()
+            .map(|mut packet| {
+                // TODO: Resizing might be a bit expensive with large buffers
+                // Resizing to `N` is always safe because the size of `buf` heapless vec is `N`
+                unwrap!(packet.buf.resize_default(N));
+
+                ExternalPacketBuffer(packet)
+            })
+    }
 }
 
 // Wraps the RX or TX packet of the transport manager in something that looks like a `&mut [u8]` buffer.

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -30,17 +30,27 @@ use log::{debug, info, warn};
 
 /// Default tests
 const DEFAULT_TESTS: &[&str] = &[
+    "Test_AddNewFabricFromExistingFabric",
+    "TestAccessControlCluster",
+    //"TestAccessControlConstraints", TODO: Check why it fails
+    "TestArmFailSafe",
     "TestAttributesById",
-    "TestCommandsById",
+    "TestBasicInformation",
     "TestCluster",
     "TestClusterComplexTypes",
-    "TestBasicInformation",
-    "TestAccessControlCluster",
-    "TestArmFailSafe",
-    "TestSelfFabricRemoval",
     "TestClusterMultiFabric",
+    "TestCommandsById",
     "TestCommissionerNodeId",
     "TestCommissioningWindow",
+    "TestConfigVariables",
+    //"TestConstraints", TODO: Check why it fails
+    "TestDelayCommands",
+    //"TestDescriptorCluster", // TODO: Assumes a Power Source device type and expects a lot of clusters to be there
+    "TestEqualities",
+    "TestFabricRemovalWhileSubscribed",
+    "TestSelfFabricRemoval",
+    "TestSubscribe_AdministratorCommissioning",
+    "TestSubscribe_OnOff",
 ];
 
 /// The default Git reference to use for the Chip repository


### PR DESCRIPTION
This PR contains the following commits:

### 1st commit

Simply enables the 7 tests below. Did not require any changes to `rs-matter`
* Test_AddNewFabricFromExistingFabric
* TestConfigVariables
* TestDelayCommands
* TestEqualities
* TestFabricRemovalWhileSubscribed
* TestSubscribe_AdministratorCommissioning
* TestSubscribe_OnOff

### 2nd commit

Enables the `TestDiscovery` test.
For this test, it was necessary to implement all optional mDNS payload:
- Device name
- Device type
- Device pairing hints (used to be hard-coded to "33")
- Device pairing information (used to be hard-coded to the empty string)

While I could've just disabled the tests for the optional payload in the `chip_tests.pics` file, I thought it would be good to support this payload in general, for end users. The payload is now configurable through the `BasicInfo` structure.

### 3rd commit

This is a follow-up to the 2nd commit, which was not strictly necessary but I did it anyway. It documents as well as does a cleanup on the `pairing` module, which is all about computing the commissioning QR code.

Some of the problems addressed with this commit:
- There were too many public freestanding functions that used to take a lot of parameters (i.e. they were difficult to use). They are now all moved into their appropriate structures (`Qr` or `QrPayload`)
- `QrTextPayload` renamed to just `QrPayload`. The purpose in life of `QrPayload` is to compute the QR **text**
- A new type, `Qr` which is the final outcome of the QR computation; it takes (a) text and encodes it into a QR; all utility functions to consume the QR code as ASCII-art are now moved into this type and this type is independent from `QrPayload` in that while it is expected that it will be used to render precisely the text produced by `QrPayload`, that might not be necessarily the case

### 4th commit

This commit introduces a real expiration of the Commissioning Window. Previously, the timeout parameter was not really used and therefore, the commissioning window stayed open until explicitly closed, or in case commissioning did fail - forever.

Furthermore, I've tried to document and tighten up a bit the code in the `case` and `pake` modules.
While I doubt this would be the latest cleanup in these modules (the contain one of the oldest piece of code in the codebase), it is now in a slightly better shape, in that a lot of freestanding functions are moved to their appropriate structures, and some structures like `Spake2p` and `CaseSession` are more private in that the SC layer doesn't need to know about those. It only needs to know about `Pake` and `Case` which handle the establishment of a PASE or CASE session, and `Spake2p` and `CaseSession` are actually their internal implementation detail.


But the most important renaming change is that what used to be called "PASE session" is now called "Commissioning Window" everywhere, because really that's what it is.

The notion of a PASE session is anyway overloaded with two additional meanings so **also** calling the Commissioning Window a "PASE session" was wrong IMO:
- A PASE session might mean a `Session` which was created as a result of a PASE/PAKE session negotiation/establishment. (Ditto - a CASE session might mean a `Session` which was created as a result of a CASE session negotiation/establishment.)
- A PASE session might also mean the process of **establishment** of a `Session` using the PAKE negotiation process. Though I've taken care to always talk there about a PASE session **establishment**, as in the Matter Core Spec


