### PR TITLE
Use more refined array type aliases

### DIFF
--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -431,7 +431,11 @@ impl ClusterHandler for NocHandler {
                 request.admin_vendor_id()?,
                 icac,
                 request.noc_value()?.0,
-                request.ipk_value()?.0,
+                request
+                    .ipk_value()?
+                    .0
+                    .try_into()
+                    .map_err(|_| ErrorCode::ConstraintError)?,
                 request.case_admin_subject()?,
                 buf,
                 &mut || ctx.exchange().matter().notify_mdns(),

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -26,7 +26,7 @@ use crate::cert::{CertRef, MAX_CERT_TLV_LEN};
 use crate::crypto::{self, hkdf_sha256, HmacSha256, KeyPair};
 use crate::dm::Privilege;
 use crate::error::{Error, ErrorCode};
-use crate::group_keys::KeySet;
+use crate::group_keys::{KeySet, KeySetKey};
 use crate::tlv::{FromTLV, TLVElement, TLVTag, TLVWrite, TagType, ToTLV};
 use crate::utils::init::{init, Init, InitMaybeUninit, IntoFallibleInit};
 use crate::utils::storage::{Vec, WriteBuf};
@@ -107,7 +107,7 @@ impl Fabric {
         root_ca: &[u8],
         noc: &[u8],
         icac: &[u8],
-        ipk: Option<&[u8]>,
+        ipk: Option<&KeySetKey>,
         vendor_id: Option<u16>,
         case_admin_subject: Option<u64>,
         mdns_notif: &mut dyn FnMut(),
@@ -137,7 +137,7 @@ impl Fabric {
             Self::compute_compressed_fabric_id(root_ca_p.pubkey()?, self.fabric_id);
 
         if let Some(ipk) = ipk {
-            self.ipk = KeySet::new(ipk, &self.compressed_fabric_id.to_be_bytes())?;
+            self.ipk = KeySet::new(ipk, &self.compressed_fabric_id)?;
         }
 
         if let Some(case_admin_subject) = case_admin_subject {
@@ -578,7 +578,7 @@ impl FabricMgr {
         root_ca: &[u8],
         noc: &[u8],
         icac: &[u8],
-        ipk: &[u8],
+        ipk: &KeySetKey,
         vendor_id: u16,
         case_admin_subject: u64,
         mdns_notif: &mut dyn FnMut(),

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -22,6 +22,7 @@ use crate::cert::{CertRef, MAX_CERT_TLV_LEN};
 use crate::crypto::KeyPair;
 use crate::error::{Error, ErrorCode};
 use crate::fabric::FabricMgr;
+use crate::group_keys::KeySetKey;
 use crate::im::IMStatusCode;
 use crate::tlv::TLVElement;
 use crate::transport::session::SessionMode;
@@ -279,7 +280,7 @@ impl FailSafe {
         vendor_id: u16,
         icac: Option<&[u8]>,
         noc: &[u8],
-        ipk: &[u8],
+        ipk: &KeySetKey,
         case_admin_subject: u64,
         buf: &mut [u8],
         mdns_notif: &mut dyn FnMut(),

--- a/rs-matter/src/sc.rs
+++ b/rs-matter/src/sc.rs
@@ -36,7 +36,7 @@ pub mod case;
 pub mod crypto;
 pub mod pake;
 
-/* Interaction Model ID as per the Matter Spec */
+/// Interaction Model ID as per the Matter Spec
 pub const PROTO_ID_SECURE_CHANNEL: u16 = 0x00;
 
 #[derive(FromPrimitive, Debug, Copy, Clone, Eq, PartialEq)]

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -22,6 +22,7 @@ use core::time::Duration;
 use cfg_if::cfg_if;
 
 use crate::error::*;
+use crate::group_keys::KeySetKey;
 use crate::transport::exchange::ExchangeId;
 use crate::transport::mrp::ReliableMessage;
 use crate::utils::cell::RefCell;
@@ -41,8 +42,6 @@ use super::proto_hdr::ProtoHdr;
 
 pub const MAX_CAT_IDS_PER_NOC: usize = 3;
 pub type NocCatIds = [u32; MAX_CAT_IDS_PER_NOC];
-
-const MATTER_AES128_KEY_SIZE: usize = 16;
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -81,9 +80,9 @@ pub struct Session {
     peer_nodeid: Option<u64>,
     // I find the session initiator/responder role getting confused with exchange initiator/responder
     // So, we might keep this as enc_key and dec_key for now
-    dec_key: [u8; MATTER_AES128_KEY_SIZE],
-    enc_key: [u8; MATTER_AES128_KEY_SIZE],
-    att_challenge: [u8; MATTER_AES128_KEY_SIZE],
+    dec_key: KeySetKey,
+    enc_key: KeySetKey,
+    att_challenge: KeySetKey,
     local_sess_id: u16,
     peer_sess_id: u16,
     msg_ctr: u32,
@@ -115,9 +114,9 @@ impl Session {
             peer_addr,
             local_nodeid: 0,
             peer_nodeid,
-            dec_key: [0; MATTER_AES128_KEY_SIZE],
-            enc_key: [0; MATTER_AES128_KEY_SIZE],
-            att_challenge: [0; MATTER_AES128_KEY_SIZE],
+            dec_key: KeySetKey::default(),
+            enc_key: KeySetKey::default(),
+            att_challenge: KeySetKey::default(),
             peer_sess_id: 0,
             local_sess_id: 0,
             msg_ctr: Self::rand_msg_ctr(rand),
@@ -515,9 +514,9 @@ impl<'a> ReservedSession<'a> {
         local_sessid: u16,
         peer_addr: Address,
         mode: SessionMode,
-        dec_key: Option<&[u8]>,
-        enc_key: Option<&[u8]>,
-        att_challenge: Option<&[u8]>,
+        dec_key: Option<&KeySetKey>,
+        enc_key: Option<&KeySetKey>,
+        att_challenge: Option<&KeySetKey>,
     ) -> Result<(), Error> {
         let mut mgr = self.session_mgr.borrow_mut();
         let session = mgr.get(self.id).ok_or(ErrorCode::NoSession)?;


### PR DESCRIPTION
A follow-up from #334 concerning Case and Pake

- Rather than `&[u8]` use concrete array types (so that the sizes of these are clear). These arrays store AES-128 keys, Sha256 hashes, fixed-size random values etc. - i.e. their sizes are crystal clear at compile time and we better capture those in the type system
- Reduce a few `heapless::Vec` arrays to smaller sizes
- Mark with "TODO MEDIUM BUFFER" a few more places where we allocate relatively large-ish values on-stack