### PR TITLE
Update to esp-hal 1.0; fix the size check task build error

### DIFF
--- a/bloat-check/Cargo.toml
+++ b/bloat-check/Cargo.toml
@@ -64,6 +64,6 @@ hal = { package = "embassy-nrf", version = "0.8", default-features = false, feat
 hal = { package = "embassy-rp", version = "0.8", features = ["defmt", "unstable-pac", "time-driver", "rp2040"] }
 
 [target.riscv32imac-unknown-none-elf.dependencies]
-hal = { package = "esp-hal", version = "=1.0.0-rc.1", features = ["defmt", "exception-handler", "unstable", "esp32c6"] }
-esp-rtos = { version = "0.1.0", features = ["embassy", "esp32c6"] }
+hal = { package = "esp-hal", version = "1", features = ["defmt", "exception-handler", "unstable", "esp32c6"] }
+esp-rtos = { version = "0.2", features = ["embassy", "esp32c6"] }
 #embassy-executor = { version = "0.9", features = ["riscv32"] }


### PR DESCRIPTION
@bjoernQ Congrats on the new release!

We need this because the build started to fail with rc.1... weird!