### PR TITLE
Option to reset the in-memory and persistent Matter data

### DIFF
--- a/rs-matter/src/dm/clusters/basic_info.rs
+++ b/rs-matter/src/dm/clusters/basic_info.rs
@@ -325,11 +325,14 @@ impl BasicInfoSettings {
     }
 
     /// Resets the basic info to initial values
-    pub fn reset(&mut self) {
+    ///
+    /// # Arguments
+    /// - `flag_changed`: whether to mark the basic info settings as changed
+    pub fn reset(&mut self, flag_changed: bool) {
         self.node_label.clear();
         self.location = None;
         self.local_config_disabled = false;
-        self.changed = false;
+        self.changed = flag_changed;
     }
 
     /// Load the basic info settings from the provided TLV data

--- a/rs-matter/src/dm/networks/wireless.rs
+++ b/rs-matter/src/dm/networks/wireless.rs
@@ -137,9 +137,19 @@ where
         })
     }
 
-    /// Reset the state.
-    pub fn reset(&self) {
-        self.state.lock(|state| state.borrow_mut().reset());
+    /// Reset the state
+    ///
+    /// # Arguments
+    /// - `flag_changed`: If `true`, the state will be marked as changed
+    pub fn reset(&self, flag_changed: bool) {
+        self.state
+            .lock(|state| state.borrow_mut().reset(flag_changed));
+
+        self.state_changed.notify();
+
+        if flag_changed {
+            self.persist_state_changed.notify();
+        }
     }
 
     /// Load the state from a byte slice.
@@ -404,9 +414,9 @@ where
         })
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self, flag_changed: bool) {
         self.networks.clear();
-        self.changed = false;
+        self.changed = flag_changed;
     }
 
     fn load(&mut self, data: &[u8]) -> Result<(), Error> {

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -463,9 +463,12 @@ impl FabricMgr {
     }
 
     /// Removes all fabrics
-    pub fn reset(&mut self) {
+    ///
+    /// # Arguments
+    /// - `flag_changed`: Whether to mark the fabrics as changed
+    pub fn reset(&mut self, flag_changed: bool) {
         self.fabrics.clear();
-        self.changed = false;
+        self.changed = flag_changed;
     }
 
     /// Load the fabrics from the provided buffer as TLV data.

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -600,6 +600,21 @@ impl<'a> Matter<'a> {
         self.transport_mgr.run(send, recv)
     }
 
+    /// Reset the Matter state by removing all fabrics and resetting basic info settings
+    ///
+    /// # Arguments
+    /// - `flag_changed`: If true, notifies that fabrics and basic info settings have changed
+    pub fn reset_persist(&self, flag_changed: bool) {
+        self.basic_info_settings.borrow_mut().reset(flag_changed);
+        self.fabric_mgr.borrow_mut().reset(flag_changed);
+
+        self.notify_mdns();
+
+        if flag_changed {
+            self.notify_persist();
+        }
+    }
+
     /// Notify that the ACLs, Fabrics or Basic Info _might_ have changed
     /// This method is supposed to be called after processing SC and IM messages that might affect the ACLs, Fabrics or Basic Info.
     ///


### PR DESCRIPTION
This is a small PR which allows users to completely reset the matter state (fabrics + basic info settings, and separately - wireless networks).

System state reset might be used as part of a "factory reset" or similar procedures.
