### PR TITLE
Remove "backend" from devenv.yaml

### DIFF
--- a/devenv.yaml
+++ b/devenv.yaml
@@ -6,4 +6,3 @@ inputs:
     inputs:
       nixpkgs:
         follows: nixpkgs
-backend: nix


### PR DESCRIPTION
I'm not sure if this is an old field that used to be allowed, but it is not present in the specification for devenv.yaml: https://devenv.sh/reference/yaml-options/

Removing this field makes `devenv shell` work for me, without this change `devenv` says the devenv.yaml contains illegal fields