### PR TITLE
Fix import_globals macro for workspace path dependencies

### DIFF
--- a/rs-matter-macros/src/idl/cluster.rs
+++ b/rs-matter-macros/src/idl/cluster.rs
@@ -450,7 +450,7 @@ pub fn cluster(cluster: &Cluster, globals: &Entities, context: &IdlGenerateConte
         || !globals.bitmaps.is_empty()
     {
         quote!(
-            use crate::dm::clusters::decl::globals::*;
+            use #krate::dm::clusters::decl::globals::*;
         )
     } else {
         quote!()


### PR DESCRIPTION
The import_globals code was using hardcoded 'crate::' which resolves to the calling crate when the macro is expanded. This causes compilation errors when rs-matter is used as a workspace path dependency, because 'crate::dm::clusters::decl::globals' does not exist in the calling crate.

This commit changes the hardcoded 'crate::' to use the #krate variable (which contains the proper crate identifier resolved by get_crate_name()), making the import work correctly in all dependency scenarios

Fixes: unresolved import errors when using rs_matter::import!() macro