### PR TITLE
Configurable raw mutex

### DIFF
--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -55,8 +55,6 @@ use embassy_executor::Executor;
 #[cfg(target_arch = "riscv32")]
 use esp_rtos::embassy::Executor;
 
-use embassy_sync::blocking_mutex::raw::{NoopRawMutex, RawMutex};
-
 use rs_matter::crypto::backend::rustcrypto::RustCrypto;
 use rs_matter::crypto::{Crypto, RngCore, WeakTestOnlyRand};
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _, DescHandler};
@@ -153,20 +151,20 @@ macro_rules! unwrap {
 }
 
 /// One large struct holding the entire Matter stack state
-struct MatterStack<'a, M: RawMutex> {
-    matter: Matter<'a>, // #258 - Can't generify by the raw mutex
-    buffers: PooledBuffers<10, M, IMBuffer>,
-    subscriptions: Subscriptions<{ DEFAULT_MAX_SUBSCRIPTIONS }, M>,
-    events: Events<DEFAULT_BYTES_PER_BUF, M>,
-    networks: WifiNetworks<3, M>,
-    net_ctl_state: NetCtlStateMutex<M>,
+struct MatterStack<'a> {
+    matter: Matter<'a>,
+    buffers: PooledBuffers<10, IMBuffer>,
+    subscriptions: Subscriptions<{ DEFAULT_MAX_SUBSCRIPTIONS }>,
+    events: Events<DEFAULT_BYTES_PER_BUF>,
+    networks: WifiNetworks<3>,
+    net_ctl_state: NetCtlStateMutex,
     btp: Btp,
     wireless_mgr_buffer: MaybeUninit<[u8; MAX_CREDS_SIZE]>,
     // We don't run a persistence task, but emulate its typical memory consumnption
     psm_buffer: MaybeUninit<[u8; 4096]>,
 }
 
-impl<'a, M: RawMutex> MatterStack<'a, M> {
+impl<'a> MatterStack<'a> {
     /// Return an in-place initializer for the Matter stack
     fn init() -> impl Init<Self> {
         init!(Self {
@@ -192,22 +190,22 @@ impl<'a, M: RawMutex> MatterStack<'a, M> {
 // Fully spelled-out types for everything which is passed down as arguments to `embassy-executor` tasks
 // Necessary, because `embassy-executor` doesn't grok generics
 
-type AppNetCtl<'a> = NetCtlWithStatusImpl<'a, NoopRawMutex, FakeWifi>;
-type AppWirelessMgr<'a> = WirelessMgr<'a, &'a WifiNetworks<3, NoopRawMutex>, &'a AppNetCtl<'a>>;
+type AppNetCtl<'a> = NetCtlWithStatusImpl<'a, FakeWifi>;
+type AppWirelessMgr<'a> = WirelessMgr<'a, &'a WifiNetworks<3>, &'a AppNetCtl<'a>>;
 type AppTransport<'a> = ChainedNetwork<FakeUdp, &'a Btp, fn(&Address) -> bool>;
 type AppHandler<'a> = handler_chain_type!(
     EpClMatcher => on_off::HandlerAsyncAdaptor<on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>>,
     EpClMatcher => Async<desc::HandlerAdaptor<DescHandler<'a>>>
     | EmptyHandler
 );
-type AppCrypto = RustCrypto<'static, NoopRawMutex, WeakTestOnlyRand>;
+type AppCrypto = RustCrypto<'static, WeakTestOnlyRand>;
 type AppDmHandler<'a> = WifiHandler<'a, &'a AppNetCtl<'a>, SysHandler<'a, AppHandler<'a>>>;
 type AppDataModel<'a> = DataModel<
     'a,
     DEFAULT_MAX_SUBSCRIPTIONS,
     DEFAULT_BYTES_PER_BUF,
     &'a AppCrypto,
-    PooledBuffers<10, NoopRawMutex, IMBuffer>,
+    PooledBuffers<10, IMBuffer>,
     (Node<'a>, &'a AppDmHandler<'a>),
 >;
 type AppResponder<'d, 'a> = DefaultResponder<
@@ -216,7 +214,7 @@ type AppResponder<'d, 'a> = DefaultResponder<
     DEFAULT_MAX_SUBSCRIPTIONS,
     DEFAULT_BYTES_PER_BUF,
     &'a AppCrypto,
-    PooledBuffers<10, NoopRawMutex, IMBuffer>,
+    PooledBuffers<10, IMBuffer>,
     (Node<'a>, &'a AppDmHandler<'a>),
 >;
 
@@ -262,7 +260,7 @@ fn main() -> ! {
     info!("===================================================");
     info!("Memory usage report");
 
-    let stack = mk_static!(MatterStack<'static, NoopRawMutex>).init_with(MatterStack::init());
+    let stack = mk_static!(MatterStack<'static>).init_with(MatterStack::init());
 
     let mut stack_total = 0;
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ name = "onoff_light"
 
 [[bin]]
 name = "onoff_light_bt"
-#required-features = ["zbus"]
+required-features = ["zbus"]
 
 [[bin]]
 name = "speaker"

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -24,7 +24,6 @@ use core::pin::pin;
 use std::net::UdpSocket;
 
 use embassy_futures::select::{select, select4};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 
 use rand::RngCore;
 use rs_matter::crypto::{default_crypto, Crypto};
@@ -73,13 +72,13 @@ fn main() -> Result<(), Error> {
     matter.initialize_transport_buffers()?;
 
     // Create the transport buffers
-    let buffers = PooledBuffers::<10, NoopRawMutex, _>::new(0);
+    let buffers = PooledBuffers::<10, _>::new(0);
 
     // Create the subscriptions
     let subscriptions = DefaultSubscriptions::new();
 
     // Create the crypto instance
-    let crypto = default_crypto::<NoopRawMutex, _>(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -26,7 +26,6 @@ use std::path::PathBuf;
 use async_signal::{Signal, Signals};
 
 use embassy_futures::select::{select3, select4};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 
 use futures_lite::StreamExt;
 
@@ -87,8 +86,7 @@ const PERSIST_FILE_NAME: &str = "/tmp/chip_kvs";
 // `rs-matter` supports efficient initialization of BSS objects (with `init`)
 // as well as just allocating the objects on-stack or on the heap.
 static MATTER: StaticCell<Matter> = StaticCell::new();
-static BUFFERS: StaticCell<PooledBuffers<10, NoopRawMutex, rs_matter::dm::IMBuffer>> =
-    StaticCell::new();
+static BUFFERS: StaticCell<PooledBuffers<10, rs_matter::dm::IMBuffer>> = StaticCell::new();
 static SUBSCRIPTIONS: StaticCell<DefaultSubscriptions> = StaticCell::new();
 static EVENTS: StaticCell<DefaultEvents> = StaticCell::new();
 static PSM: StaticCell<Psm<32768>> = StaticCell::new();
@@ -112,7 +110,7 @@ fn main() -> Result<(), Error> {
     info!(
         "Matter memory: Matter (BSS)={}B, IM Buffers (BSS)={}B, Subscriptions (BSS)={}B",
         core::mem::size_of::<Matter>(),
-        core::mem::size_of::<PooledBuffers<10, NoopRawMutex, rs_matter::dm::IMBuffer>>(),
+        core::mem::size_of::<PooledBuffers<10, rs_matter::dm::IMBuffer>>(),
         core::mem::size_of::<DefaultSubscriptions>()
     );
 
@@ -136,7 +134,7 @@ fn main() -> Result<(), Error> {
         .init_with(DefaultSubscriptions::init());
 
     // Create the crypto instance
-    let crypto = default_crypto::<NoopRawMutex, _>(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -27,7 +27,6 @@ use std::net::UdpSocket;
 use std::path::PathBuf;
 
 use embassy_futures::select::{select3, select4};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 
 use async_signal::{Signal, Signals};
 use log::{error, info, trace};
@@ -77,7 +76,7 @@ mod mdns;
 // `rs-matter` supports efficient initialization of BSS objects (with `init`)
 // as well as just allocating the objects on-stack or on the heap.
 static MATTER: StaticCell<Matter> = StaticCell::new();
-static BUFFERS: StaticCell<PooledBuffers<10, NoopRawMutex, IMBuffer>> = StaticCell::new();
+static BUFFERS: StaticCell<PooledBuffers<10, IMBuffer>> = StaticCell::new();
 static SUBSCRIPTIONS: StaticCell<DefaultSubscriptions> = StaticCell::new();
 static EVENTS: StaticCell<DefaultEvents> = StaticCell::new();
 static PSM: StaticCell<Psm<4096>> = StaticCell::new();
@@ -120,7 +119,7 @@ fn run() -> Result<(), Error> {
     info!(
         "Matter memory: Matter (BSS)={}B, IM Buffers (BSS)={}B, Subscriptions (BSS)={}B",
         core::mem::size_of::<Matter>(),
-        core::mem::size_of::<PooledBuffers<10, NoopRawMutex, IMBuffer>>(),
+        core::mem::size_of::<PooledBuffers<10, IMBuffer>>(),
         core::mem::size_of::<DefaultSubscriptions>()
     );
 
@@ -144,7 +143,7 @@ fn run() -> Result<(), Error> {
         .init_with(DefaultSubscriptions::init());
 
     // Create the crypto instance
-    let crypto = default_crypto::<NoopRawMutex, _>(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -28,7 +28,6 @@ use core::pin::pin;
 use std::net::UdpSocket;
 
 use embassy_futures::select::{select, select4};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 
 use log::info;
 
@@ -94,13 +93,13 @@ fn main() -> Result<(), Error> {
     matter.initialize_transport_buffers()?;
 
     // Create the transport buffers
-    let buffers = PooledBuffers::<10, NoopRawMutex, _>::new(0);
+    let buffers = PooledBuffers::<10, _>::new(0);
 
     // Create the subscriptions
     let subscriptions = DefaultSubscriptions::new();
 
     // Create the crypto instance
-    let crypto = default_crypto::<NoopRawMutex, _>(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -22,7 +22,6 @@ use core::pin::pin;
 use std::net::UdpSocket;
 
 use embassy_futures::select::{select, select4};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 
 use log::info;
 
@@ -64,7 +63,7 @@ mod mdns;
 // `rs-matter` supports efficient initialization of BSS objects (with `init`)
 // as well as just allocating the objects on-stack or on the heap.
 static MATTER: StaticCell<Matter> = StaticCell::new();
-static BUFFERS: StaticCell<PooledBuffers<10, NoopRawMutex, IMBuffer>> = StaticCell::new();
+static BUFFERS: StaticCell<PooledBuffers<10, IMBuffer>> = StaticCell::new();
 static SUBSCRIPTIONS: StaticCell<DefaultSubscriptions> = StaticCell::new();
 static PSM: StaticCell<Psm<4096>> = StaticCell::new();
 
@@ -92,7 +91,7 @@ fn run() -> Result<(), Error> {
     info!(
         "Matter memory: Matter (BSS)={}B, IM Buffers (BSS)={}B, Subscriptions (BSS)={}B",
         core::mem::size_of::<Matter>(),
-        core::mem::size_of::<PooledBuffers<10, NoopRawMutex, IMBuffer>>(),
+        core::mem::size_of::<PooledBuffers<10, IMBuffer>>(),
         core::mem::size_of::<DefaultSubscriptions>()
     );
 
@@ -116,7 +115,7 @@ fn run() -> Result<(), Error> {
         .init_with(DefaultSubscriptions::init());
 
     // Create the crypto instance
-    let crypto = default_crypto::<NoopRawMutex, _>(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -36,8 +36,6 @@ use std::net::UdpSocket;
 
 use embassy_futures::select::{select, select4};
 
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-
 use log::{info, warn};
 
 use rand::RngCore;
@@ -129,13 +127,13 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
     matter.initialize_transport_buffers()?;
 
     // Create the transport buffers
-    let buffers = PooledBuffers::<10, NoopRawMutex, _>::new(0);
+    let buffers = PooledBuffers::<10, _>::new(0);
 
     // Create the subscriptions
     let subscriptions = DefaultSubscriptions::new();
 
     // Create the crypto instance
-    let crypto = default_crypto::<NoopRawMutex, _>(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 
@@ -150,10 +148,10 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
     );
 
     // A storage for the Wifi networks
-    let networks = WifiNetworks::<3, NoopRawMutex>::new();
+    let networks = WifiNetworks::<3>::new();
 
     // The network controller
-    let net_ctl_state = NetCtlState::new_with_mutex::<NoopRawMutex>();
+    let net_ctl_state = NetCtlState::new_with_mutex();
 
     let net_ctl = NetCtlWithStatusImpl::new(&net_ctl_state, net_ctl);
 

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -23,7 +23,6 @@ use core::pin::pin;
 use std::net::UdpSocket;
 
 use embassy_futures::select::{select, select4};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 
 use rand::RngCore;
 use rs_matter::crypto::{default_crypto, Crypto};
@@ -71,13 +70,13 @@ fn main() -> Result<(), Error> {
     matter.initialize_transport_buffers()?;
 
     // Create the transport buffers
-    let buffers = PooledBuffers::<10, NoopRawMutex, _>::new(0);
+    let buffers = PooledBuffers::<10, _>::new(0);
 
     // Create the subscriptions
     let subscriptions = DefaultSubscriptions::new();
 
     // Create the crypto instance
-    let crypto = default_crypto::<NoopRawMutex, _>(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 rust-version = "1.87"
 
 [features]
-default = ["os", "rustcrypto", "log", "zbus"]
+default = ["os", "rustcrypto", "log"]
 
 # Sizing
 
@@ -101,6 +101,7 @@ alloc = ["defmt?/alloc"]
 openssl = ["alloc", "dep:openssl", "foreign-types", "hmac", "sha2"]
 mbedtls = ["alloc", "dep:mbedtls-rs-sys"]
 rustcrypto = ["alloc", "digest", "cipher", "ccm", "elliptic-curve", "primeorder", "ecdsa", "sec1", "signature", "hmac", "hkdf", "pbkdf2", "crypto-bigint", "sha2", "aes", "p256", "x509-cert"]
+sync-mutex = []
 defmt = ["dep:defmt", "heapless/defmt-03", "embassy-time/defmt", "mbedtls-rs-sys?/defmt"]
 log = ["dep:log", "embassy-time/log"]
 debug-tlv-payload = []

--- a/rs-matter/src/crypto.rs
+++ b/rs-matter/src/crypto.rs
@@ -17,8 +17,6 @@
 
 //! Cryptographic abstractions and backend.
 
-use embassy_sync::blocking_mutex::raw::RawMutex;
-
 use crate::error::Error;
 
 pub use rand_core::{CryptoRng, CryptoRngCore, RngCore};
@@ -624,25 +622,24 @@ pub trait EcPoint<'a, const LEN: usize, const SCALAR_LEN: usize> {
 }
 
 #[allow(unused)]
-pub fn default_crypto<'s, M, R>(
+pub fn default_crypto<'s, R>(
     rand: R,
     singleton_secret_key: CanonPkcSecretKeyRef<'s>,
 ) -> impl Crypto + 's
 where
-    M: RawMutex + 's,
     R: CryptoRngCore + 's,
 {
     #[cfg(feature = "openssl")]
     let crypto = backend::openssl::OpenSslCrypto::new(singleton_secret_key);
 
     #[cfg(all(feature = "mbedtls", not(feature = "openssl")))]
-    let crypto = backend::mbedtls::MbedtlsCrypto::<M, _>::new(rand, singleton_secret_key);
+    let crypto = backend::mbedtls::MbedtlsCrypto::new(rand, singleton_secret_key);
 
     #[cfg(all(
         feature = "rustcrypto",
         not(any(feature = "openssl", feature = "mbedtls"))
     ))]
-    let crypto = backend::rustcrypto::RustCrypto::<M, _>::new(rand, singleton_secret_key);
+    let crypto = backend::rustcrypto::RustCrypto::new(rand, singleton_secret_key);
 
     #[cfg(not(any(feature = "openssl", feature = "mbedtls", feature = "rustcrypto")))]
     let crypto = backend::dummy::DummyCrypto;
@@ -651,7 +648,7 @@ where
 }
 
 pub fn test_only_crypto() -> impl Crypto {
-    default_crypto::<embassy_sync::blocking_mutex::raw::NoopRawMutex, _>(
+    default_crypto(
         WeakTestOnlyRand::new_default(),
         crate::dm::devices::test::DAC_PRIVKEY,
     )

--- a/rs-matter/src/crypto/backend/mbedtls.rs
+++ b/rs-matter/src/crypto/backend/mbedtls.rs
@@ -42,8 +42,6 @@ macro_rules! merr_check {
 
 use core::ffi::{c_int, c_uchar, c_void};
 
-use embassy_sync::blocking_mutex::raw::RawMutex;
-
 use mbedtls_rs_sys::merr;
 
 use rand_core::{CryptoRng, CryptoRngCore, RngCore};
@@ -54,20 +52,19 @@ use crate::utils::cell::RefCell;
 use crate::utils::sync::blocking::Mutex;
 
 /// MbedTLS-based crypto backend for Matter.
-pub struct MbedtlsCrypto<'s, M: RawMutex, T> {
+pub struct MbedtlsCrypto<'s, T> {
     /// Elliptic curve group (secp256r1)
     ec_group: SharedECGroup<
         { crate::crypto::EC_CANON_POINT_LEN },
         { crate::crypto::EC_CANON_SCALAR_LEN },
-        M,
     >,
     /// A shared cryptographic random number generator
-    rng: SharedRand<M, T>,
+    rng: SharedRand<T>,
     /// The singleton secret key to be returned by `Crypto::singleton_singing_secret_key`
     singleton_secret_key: CanonPkcSecretKeyRef<'s>,
 }
 
-impl<'s, M: RawMutex, T> MbedtlsCrypto<'s, M, T> {
+impl<'s, T> MbedtlsCrypto<'s, T> {
     /// Create a new MbedTLS crypto backend.
     ///
     /// # Arguments
@@ -81,24 +78,24 @@ impl<'s, M: RawMutex, T> MbedtlsCrypto<'s, M, T> {
         });
 
         Self {
-            ec_group: SharedECGroup::<_, _, M>::new(ec_group),
+            ec_group: SharedECGroup::new(ec_group),
             rng: SharedRand::new(rng),
             singleton_secret_key,
         }
     }
 }
 
-impl<M: RawMutex, T> crate::crypto::Crypto for MbedtlsCrypto<'_, M, T>
+impl<T> crate::crypto::Crypto for MbedtlsCrypto<'_, T>
 where
     T: CryptoRngCore,
 {
     type Rand<'a>
-        = &'a SharedRand<M, T>
+        = &'a SharedRand<T>
     where
         Self: 'a;
 
     type WeakRand<'a>
-        = &'a SharedRand<M, T>
+        = &'a SharedRand<T>
     where
         Self: 'a;
 
@@ -136,8 +133,7 @@ where
         'a,
         { crate::crypto::EC_CANON_POINT_LEN },
         { crate::crypto::EC_CANON_SCALAR_LEN },
-        M,
-        SharedRand<M, T>,
+        SharedRand<T>,
     >
     where
         Self: 'a;
@@ -147,8 +143,7 @@ where
         'a,
         { crate::crypto::EC_CANON_SCALAR_LEN },
         { crate::crypto::EC_CANON_POINT_LEN },
-        M,
-        SharedRand<M, T>,
+        SharedRand<T>,
     >
     where
         Self: 'a;
@@ -158,8 +153,7 @@ where
         'a,
         { crate::crypto::EC_CANON_SCALAR_LEN },
         { crate::crypto::EC_CANON_POINT_LEN },
-        M,
-        SharedRand<M, T>,
+        SharedRand<T>,
     >
     where
         Self: 'a;
@@ -169,8 +163,7 @@ where
         'a,
         { crate::crypto::EC_CANON_SCALAR_LEN },
         { crate::crypto::EC_CANON_POINT_LEN },
-        M,
-        SharedRand<M, T>,
+        SharedRand<T>,
     >
     where
         Self: 'a;
@@ -180,8 +173,7 @@ where
         'a,
         { crate::crypto::EC_CANON_POINT_LEN },
         { crate::crypto::EC_CANON_SCALAR_LEN },
-        M,
-        SharedRand<M, T>,
+        SharedRand<T>,
     >
     where
         Self: 'a;
@@ -286,7 +278,7 @@ where
                 mbedtls_rs_sys::mbedtls_ecp_gen_privkey(
                     &group.raw,
                     &mut result.mpi.raw,
-                    Some(mbedtls_platform_rng::<SharedRand<M, T>>),
+                    Some(mbedtls_platform_rng::<SharedRand<T>>),
                     &self.rng as *const _ as *const _ as *mut _,
                 )
             })
@@ -726,11 +718,11 @@ impl Drop for Mpi {
 ///
 /// Necessary because a lot of MbedTLS EC functions require a mutable reference to the group,
 /// even for read-only operations.
-pub struct SharedECGroup<const LEN: usize, const SCALAR_LEN: usize, M: RawMutex> {
-    inner: Mutex<M, RefCell<ECGroup<LEN, SCALAR_LEN>>>,
+pub struct SharedECGroup<const LEN: usize, const SCALAR_LEN: usize> {
+    inner: Mutex<RefCell<ECGroup<LEN, SCALAR_LEN>>>,
 }
 
-impl<const LEN: usize, const SCALAR_LEN: usize, M: RawMutex> SharedECGroup<LEN, SCALAR_LEN, M> {
+impl<const LEN: usize, const SCALAR_LEN: usize> SharedECGroup<LEN, SCALAR_LEN> {
     /// Create a new shared EC group instance.
     pub const fn new(group: ECGroup<LEN, SCALAR_LEN>) -> Self {
         Self {
@@ -788,18 +780,16 @@ impl<const LEN: usize, const SCALAR_LEN: usize> Drop for ECGroup<LEN, SCALAR_LEN
 }
 
 /// Elliptic curve point implementation using MbedTLS.
-pub struct ECPoint<'a, const LEN: usize, const SCALAR_LEN: usize, M: RawMutex, R> {
+pub struct ECPoint<'a, const LEN: usize, const SCALAR_LEN: usize, R> {
     /// Associated EC group
-    group: &'a SharedECGroup<LEN, SCALAR_LEN, M>,
+    group: &'a SharedECGroup<LEN, SCALAR_LEN>,
     /// The random number generator
     rng: &'a R,
     /// Raw MbedTLS EC point
     raw: mbedtls_rs_sys::mbedtls_ecp_point,
 }
 
-impl<'a, const LEN: usize, const SCALAR_LEN: usize, M: RawMutex, R>
-    ECPoint<'a, LEN, SCALAR_LEN, M, R>
-{
+impl<'a, const LEN: usize, const SCALAR_LEN: usize, R> ECPoint<'a, LEN, SCALAR_LEN, R> {
     /// Create a new EC point instance with an empty point.
     ///
     /// The point MUST be initialized post-creation using `set()`.
@@ -809,7 +799,7 @@ impl<'a, const LEN: usize, const SCALAR_LEN: usize, M: RawMutex, R>
     ///
     /// # Returns
     /// - New EC point instance.
-    fn new(group: &'a SharedECGroup<LEN, SCALAR_LEN, M>, rng: &'a R) -> Self {
+    fn new(group: &'a SharedECGroup<LEN, SCALAR_LEN>, rng: &'a R) -> Self {
         let mut raw = Default::default();
 
         unsafe {
@@ -864,9 +854,7 @@ impl<'a, const LEN: usize, const SCALAR_LEN: usize, M: RawMutex, R>
     }
 }
 
-impl<const LEN: usize, const SCALAR_LEN: usize, M: RawMutex, R> Drop
-    for ECPoint<'_, LEN, SCALAR_LEN, M, R>
-{
+impl<const LEN: usize, const SCALAR_LEN: usize, R> Drop for ECPoint<'_, LEN, SCALAR_LEN, R> {
     fn drop(&mut self) {
         unsafe {
             mbedtls_rs_sys::mbedtls_ecp_point_free(&mut self.raw);
@@ -874,13 +862,13 @@ impl<const LEN: usize, const SCALAR_LEN: usize, M: RawMutex, R> Drop
     }
 }
 
-impl<'a, const LEN: usize, const SCALAR_LEN: usize, M: RawMutex, R>
-    crate::crypto::EcPoint<'a, LEN, SCALAR_LEN> for ECPoint<'a, LEN, SCALAR_LEN, M, R>
+impl<'a, const LEN: usize, const SCALAR_LEN: usize, R> crate::crypto::EcPoint<'a, LEN, SCALAR_LEN>
+    for ECPoint<'a, LEN, SCALAR_LEN, R>
 where
     for<'r> &'r R: CryptoRngCore,
 {
     type Scalar<'s>
-        = ECScalar<'s, SCALAR_LEN, LEN, M, R>
+        = ECScalar<'s, SCALAR_LEN, LEN, R>
     where
         Self: 'a + 's;
 
@@ -965,15 +953,9 @@ where
     }
 }
 
-impl<
-        'a,
-        const KEY_LEN: usize,
-        const SECRET_KEY_LEN: usize,
-        const SIGNATURE_LEN: usize,
-        M: RawMutex,
-        R,
-    > crate::crypto::PublicKey<'a, KEY_LEN, SIGNATURE_LEN>
-    for ECPoint<'a, KEY_LEN, SECRET_KEY_LEN, M, R>
+impl<'a, const KEY_LEN: usize, const SECRET_KEY_LEN: usize, const SIGNATURE_LEN: usize, R>
+    crate::crypto::PublicKey<'a, KEY_LEN, SIGNATURE_LEN>
+    for ECPoint<'a, KEY_LEN, SECRET_KEY_LEN, R>
 {
     fn verify(
         &self,
@@ -1016,23 +998,21 @@ impl<
 }
 
 /// Elliptic curve scalar implementation using MbedTLS.
-pub struct ECScalar<'a, const LEN: usize, const POINT_LEN: usize, M: RawMutex, R> {
+pub struct ECScalar<'a, const LEN: usize, const POINT_LEN: usize, R> {
     /// Associated EC group
-    group: &'a SharedECGroup<POINT_LEN, LEN, M>,
+    group: &'a SharedECGroup<POINT_LEN, LEN>,
     /// The random number generator
     rng: &'a R,
     /// Scalar
     mpi: Mpi,
 }
 
-impl<'a, const LEN: usize, const POINT_LEN: usize, M: RawMutex, R>
-    ECScalar<'a, LEN, POINT_LEN, M, R>
-{
+impl<'a, const LEN: usize, const POINT_LEN: usize, R> ECScalar<'a, LEN, POINT_LEN, R> {
     /// Create a new, empty EC scalar instance.
     ///
     /// The scalar value MUST be initialized post-creation
     /// using `set()`.
-    fn new(group: &'a SharedECGroup<POINT_LEN, LEN, M>, rng: &'a R) -> Self {
+    fn new(group: &'a SharedECGroup<POINT_LEN, LEN>, rng: &'a R) -> Self {
         Self {
             group,
             rng,
@@ -1051,8 +1031,8 @@ impl<'a, const LEN: usize, const POINT_LEN: usize, M: RawMutex, R>
     }
 }
 
-impl<'a, const LEN: usize, const POINT_LEN: usize, M: RawMutex, R> crate::crypto::EcScalar<'a, LEN>
-    for ECScalar<'a, LEN, POINT_LEN, M, R>
+impl<'a, const LEN: usize, const POINT_LEN: usize, R> crate::crypto::EcScalar<'a, LEN>
+    for ECScalar<'a, LEN, POINT_LEN, R>
 where
     for<'r> &'r R: CryptoRngCore,
 {
@@ -1081,20 +1061,14 @@ where
     }
 }
 
-impl<
-        'a,
-        const KEY_LEN: usize,
-        const PUB_KEY_LEN: usize,
-        const SIGNATURE_LEN: usize,
-        M: RawMutex,
-        R,
-    > crate::crypto::SigningSecretKey<'a, PUB_KEY_LEN, SIGNATURE_LEN>
-    for ECScalar<'a, KEY_LEN, PUB_KEY_LEN, M, R>
+impl<'a, const KEY_LEN: usize, const PUB_KEY_LEN: usize, const SIGNATURE_LEN: usize, R>
+    crate::crypto::SigningSecretKey<'a, PUB_KEY_LEN, SIGNATURE_LEN>
+    for ECScalar<'a, KEY_LEN, PUB_KEY_LEN, R>
 where
     for<'r> &'r R: CryptoRngCore,
 {
     type PublicKey<'s>
-        = ECPoint<'s, PUB_KEY_LEN, KEY_LEN, M, R>
+        = ECPoint<'s, PUB_KEY_LEN, KEY_LEN, R>
     where
         Self: 's;
 
@@ -1251,10 +1225,9 @@ impl<
         const PUB_KEY_LEN: usize,
         const SIGNATURE_LEN: usize,
         const SHARED_SECRET_LEN: usize,
-        M: RawMutex,
         R,
     > crate::crypto::SecretKey<'a, KEY_LEN, PUB_KEY_LEN, SIGNATURE_LEN, SHARED_SECRET_LEN>
-    for ECScalar<'a, KEY_LEN, PUB_KEY_LEN, M, R>
+    for ECScalar<'a, KEY_LEN, PUB_KEY_LEN, R>
 where
     for<'r> &'r R: CryptoRngCore,
 {

--- a/rs-matter/src/crypto/backend/rustcrypto.rs
+++ b/rs-matter/src/crypto/backend/rustcrypto.rs
@@ -60,8 +60,6 @@ use elliptic_curve::{
     Scalar, SecretKey,
 };
 
-use embassy_sync::blocking_mutex::raw::RawMutex;
-
 use primeorder::PrimeCurveParams;
 
 use rand_core::CryptoRngCore;
@@ -85,14 +83,14 @@ use crate::utils::init::InitMaybeUninit;
 extern crate alloc;
 
 /// A RustCrypto backend for the crypto traits
-pub struct RustCrypto<'s, M: RawMutex, T> {
+pub struct RustCrypto<'s, T> {
     /// A shared cryptographic random number generator
-    rng: SharedRand<M, T>,
+    rng: SharedRand<T>,
     /// The singleton secret key to be returned by `Crypto::singleton_singing_secret_key`
     singleton_secret_key: CanonPkcSecretKeyRef<'s>,
 }
 
-impl<'s, M: RawMutex, T> RustCrypto<'s, M, T> {
+impl<'s, T> RustCrypto<'s, T> {
     /// Create a new RustCrypto backend
     ///
     /// # Arguments
@@ -107,17 +105,17 @@ impl<'s, M: RawMutex, T> RustCrypto<'s, M, T> {
     }
 }
 
-impl<M: RawMutex, T> Crypto for RustCrypto<'_, M, T>
+impl<T> Crypto for RustCrypto<'_, T>
 where
     T: CryptoRngCore,
 {
     type Rand<'a>
-        = &'a SharedRand<M, T>
+        = &'a SharedRand<T>
     where
         Self: 'a;
 
     type WeakRand<'a>
-        = &'a SharedRand<M, T>
+        = &'a SharedRand<T>
     where
         Self: 'a;
 

--- a/rs-matter/src/crypto/rand.rs
+++ b/rs-matter/src/crypto/rand.rs
@@ -17,8 +17,6 @@
 
 //! Random number generation utilities.
 
-use embassy_sync::blocking_mutex::raw::RawMutex;
-
 use rand_core::{CryptoRng, RngCore};
 
 use crate::utils::cell::RefCell;
@@ -29,11 +27,11 @@ use crate::utils::sync::blocking::Mutex;
 ///
 /// Implements the `RngCore` and `CryptoRng` traits for `&SharedRand<M, T>`, where `T` is the
 /// underlying RNG type and `M` is the mutex type.
-pub struct SharedRand<M: RawMutex, T> {
-    shared: Mutex<M, RefCell<T>>,
+pub struct SharedRand<T> {
+    shared: Mutex<RefCell<T>>,
 }
 
-impl<M: RawMutex, T> SharedRand<M, T> {
+impl<T> SharedRand<T> {
     /// Creates a new `SharedRand` instance wrapping the provided RNG.
     pub const fn new(rand: T) -> Self {
         Self {
@@ -49,7 +47,7 @@ impl<M: RawMutex, T> SharedRand<M, T> {
     }
 }
 
-impl<M: RawMutex, T> rand_core::RngCore for &SharedRand<M, T>
+impl<T> rand_core::RngCore for &SharedRand<T>
 where
     T: rand_core::RngCore,
 {
@@ -71,7 +69,7 @@ where
     }
 }
 
-impl<M: RawMutex, T> CryptoRng for &SharedRand<M, T> where T: CryptoRng {}
+impl<T> CryptoRng for &SharedRand<T> where T: CryptoRng {}
 
 /// A weak random number generator intended for use in tests only.
 ///

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -22,7 +22,6 @@ use core::pin::pin;
 use core::time::Duration;
 
 use embassy_futures::select::select3;
-use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_time::{Instant, Timer};
 
 use crate::crypto::Crypto;
@@ -843,24 +842,20 @@ where
 /// The responder handles chunking as needed. I.e. if reported data is too large to fit into a single
 /// Matter message, it will send the data in multiple chunks (i.e. with multiple Matter messages), waiting for
 /// a `Success` response from the peer after each chunk, and then continuing to send the next chunk until all data is sent.
-struct ReportDataResponder<'a, 'b, 'c, C, D, B, const NE: usize, M>
-where
-    M: RawMutex,
-{
+struct ReportDataResponder<'a, 'b, 'c, C, D, B, const NE: usize> {
     req: &'a ReportDataReq<'a>,
     node: &'a Node<'a>,
     subscription_id: Option<u32>,
     invoker: HandlerInvoker<'b, 'c, C, D, B>,
     event_reader: EventReader,
-    events: Option<&'a Events<NE, M>>,
+    events: Option<&'a Events<NE>>,
 }
 
-impl<'a, 'b, 'c, C, D, B, const NE: usize, M> ReportDataResponder<'a, 'b, 'c, C, D, B, NE, M>
+impl<'a, 'b, 'c, C, D, B, const NE: usize> ReportDataResponder<'a, 'b, 'c, C, D, B, NE>
 where
     C: Crypto,
     D: AsyncHandler,
     B: BufferAccess<IMBuffer>,
-    M: RawMutex,
 {
     // This is the amount of space we reserve for the structure/array closing TLVs
     // to be attached towards the end of long reads
@@ -873,7 +868,7 @@ where
         subscription_id: Option<u32>,
         invoker: HandlerInvoker<'b, 'c, C, D, B>,
         event_reader: EventReader,
-        events: Option<&'a Events<NE, M>>,
+        events: Option<&'a Events<NE>>,
     ) -> Self {
         Self {
             req,

--- a/rs-matter/src/dm/clusters/level_control.rs
+++ b/rs-matter/src/dm/clusters/level_control.rs
@@ -34,8 +34,6 @@ use core::ops::Mul;
 use core::pin::pin;
 
 use embassy_futures::select::{select, select3, Either, Either3};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_sync::signal::Signal;
 use embassy_time::{Duration, Instant};
 
 pub use crate::dm::clusters::decl::level_control::*;
@@ -46,6 +44,7 @@ use crate::dm::{
 };
 use crate::error::{Error, ErrorCode};
 use crate::tlv::Nullable;
+use crate::utils::sync::Signal;
 
 /// Messages passed to the `notify` closure in `LevelControlHooks::run()` method.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -126,7 +125,7 @@ pub struct LevelControlHandler<'a, H: LevelControlHooks, OH: OnOffHooks> {
     endpoint_id: EndptId,
     hooks: H,
     on_off_handler: Cell<Option<&'a OnOffHandler<'a, OH, H>>>,
-    task_signal: Signal<NoopRawMutex, Task>,
+    task_signal: Signal<Option<Task>>,
     on_level: Cell<Nullable<u8>>,
     options: Cell<OptionsBitmap>,
     remaining_time: Cell<u16>,
@@ -220,7 +219,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
             endpoint_id,
             hooks,
             on_off_handler: Cell::new(None),
-            task_signal: Signal::new(),
+            task_signal: Signal::new(None),
             on_level: Cell::new(attribute_defaults.on_level),
             options: Cell::new(attribute_defaults.options),
             remaining_time: Cell::new(0),
@@ -1222,7 +1221,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         loop {
             let mut task = match select(
                 &mut hooks_fut,
-                self.task_signal.wait(),
+                self.task_signal.wait_signalled(),
             ).await {
                 Either::First(_) => panic!("LevelControlHooks::run returned; implementers MUST not return. Implementations should loop forever or await core::future::pending::<()>()."),
                 Either::Second(task) => task,
@@ -1232,7 +1231,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
                 match select3(
                     &mut hooks_fut,
                     self.task_manager(&ctx, task),
-                    self.task_signal.wait(),
+                    self.task_signal.wait_signalled(),
                 )
                 .await
                 {

--- a/rs-matter/src/dm/clusters/on_off.rs
+++ b/rs-matter/src/dm/clusters/on_off.rs
@@ -33,8 +33,6 @@ use core::future::Future;
 use core::pin::pin;
 
 use embassy_futures::select::{select, select3, Either, Either3};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_sync::signal::Signal;
 use embassy_time::Duration;
 
 use crate::dm::clusters::decl::{level_control, on_off};
@@ -46,6 +44,7 @@ use crate::error::{Error, ErrorCode};
 pub use crate::dm::clusters::decl::on_off::*;
 
 use crate::tlv::Nullable;
+use crate::utils::sync::Signal;
 
 /// Messages passed to the `notify` closure in `OnOffHooks::run()` method.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -115,7 +114,7 @@ pub struct OnOffHandler<'a, H: OnOffHooks, LH: LevelControlHooks> {
     endpoint_id: EndptId,
     hooks: H,
     level_control_handler: Cell<Option<&'a LevelControlHandler<'a, LH, H>>>,
-    state_change_signal: Signal<NoopRawMutex, OnOffCommand>,
+    state_change_signal: Signal<Option<OnOffCommand>>,
     state: Cell<OnOffClusterState>,
     global_scene_control: Cell<bool>,
     on_time: Cell<u16>,
@@ -157,7 +156,7 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
             endpoint_id,
             hooks,
             level_control_handler: Cell::new(None),
-            state_change_signal: Signal::new(),
+            state_change_signal: Signal::new(None),
             state: Cell::new(state),
             global_scene_control: Cell::new(true),
             on_time: Cell::new(0),
@@ -655,7 +654,7 @@ impl<H: OnOffHooks, LH: LevelControlHooks> ClusterAsyncHandler for OnOffHandler<
         loop {
             let mut command = match select(
                 &mut hooks_fut,
-                self.state_change_signal.wait()
+                self.state_change_signal.wait_signalled()
             ).await {
                 Either::First(_) => panic!("OnOffHooks::run returned; implementers MUST not return. Implementations should loop forever or await core::future::pending::<()>()."),
                 Either::Second(command) => command,
@@ -665,7 +664,7 @@ impl<H: OnOffHooks, LH: LevelControlHooks> ClusterAsyncHandler for OnOffHandler<
                 match select3(
                     &mut hooks_fut,
                     self.state_machine(command, &ctx),
-                    self.state_change_signal.wait(),
+                    self.state_change_signal.wait_signalled(),
                 )
                 .await
                 {

--- a/rs-matter/src/dm/events.rs
+++ b/rs-matter/src/dm/events.rs
@@ -18,7 +18,7 @@ use core::cell::Cell;
 use core::fmt::Debug;
 
 use crate::error::{Error, ErrorCode};
-use crate::im::{EventDataTag, EventDataTimestamp, EventPath, EventRespTag};
+use crate::im::{EventData, EventDataTag, EventDataTimestamp, EventPath, EventRespTag};
 use crate::tlv::{
     FromTLV, TLVElement, TLVSequence, TLVSequenceIter, TLVTag, TLVWrite, TagType, ToTLV,
 };
@@ -28,10 +28,6 @@ use crate::utils::storage::WriteBuf;
 use crate::utils::sync::blocking;
 use crate::utils::sync::Notification;
 use crate::utils::sync::{IfMutex, IfMutexGuard};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_sync::blocking_mutex::raw::RawMutex;
-
-use crate::im::EventData;
 
 // TODO we currently only have this singular config to set the size, but the events are stored in three "tiered" buffers, and
 //      we probably want to allow configuring them separately. We also should spend some thinking tokens on what a good default here is.
@@ -41,7 +37,7 @@ pub const DEFAULT_BYTES_PER_BUF: usize = 64;
 pub type DefaultEvents = Events<DEFAULT_BYTES_PER_BUF>;
 
 /// Convenience constant expression if you want to disable events
-pub const NO_EVENTS: Option<&'static Events<0, NoopRawMutex>> = None;
+pub const NO_EVENTS: Option<&'static Events<0>> = None;
 
 /// See EventsPersist for details
 const EVENT_NO_EPOCH_SIZE: u64 = 0x10000;
@@ -84,20 +80,14 @@ pub(crate) struct PersistedState {
 /// to experiment to pick an appropriate size for your event write load.
 ///
 /// If your application emits no events you can disable this subsystem using the NO_EVENTS constant.
-pub struct Events<const N: usize = DEFAULT_BYTES_PER_BUF, M = NoopRawMutex>
-where
-    M: RawMutex,
-{
-    state: IfMutex<M, EventsInner<N>>,
+pub struct Events<const N: usize = DEFAULT_BYTES_PER_BUF> {
+    state: IfMutex<EventsInner<N>>,
     epoch: Epoch,
-    pub(crate) persisted_state: blocking::Mutex<M, Cell<PersistedState>>,
-    persist_notification: Notification<M>,
+    pub(crate) persisted_state: blocking::Mutex<Cell<PersistedState>>,
+    persist_notification: Notification,
 }
 
-impl<const N: usize, M> Events<N, M>
-where
-    M: RawMutex,
-{
+impl<const N: usize> Events<N> {
     const PERSIST_INIT: PersistedState = PersistedState {
         next_event_no: 0,
         event_epoch_end: 0,
@@ -174,7 +164,7 @@ where
 
     /// Lock the events queue so you can read it; the returned guard gives you the ability to iterate over stored events.
     /// TODO: Note that this guard is held across long reads, which will cause writers to be stalled over network waits; we should fix this, see https://github.com/project-chip/rs-matter/pull/361#issuecomment-3906929345
-    pub async fn lock(&'_ self) -> EventsGuard<'_, M, N> {
+    pub async fn lock(&'_ self) -> EventsGuard<'_, N> {
         let internal = self.state.lock().await;
         EventsGuard::new(internal)
     }
@@ -237,18 +227,12 @@ where
 /// Most of the time the stalling of writers is very short, just enough to move the events into outbound
 /// network buffers. However if there are a lot of events, such that we need to chunk publishing into multiple packets,
 /// then we will hold this across network calls, forcing writers to slow down until readers have caught up.
-pub struct EventsGuard<'a, M, const N: usize>
-where
-    M: RawMutex,
-{
-    guard: IfMutexGuard<'a, M, EventsInner<N>>,
+pub struct EventsGuard<'a, const N: usize> {
+    guard: IfMutexGuard<'a, EventsInner<N>>,
 }
 
-impl<'a, M, const N: usize> EventsGuard<'a, M, N>
-where
-    M: RawMutex,
-{
-    fn new(guard: IfMutexGuard<'a, M, EventsInner<N>>) -> Self {
+impl<'a, const N: usize> EventsGuard<'a, N> {
+    fn new(guard: IfMutexGuard<'a, EventsInner<N>>) -> Self {
         Self { guard }
     }
 

--- a/rs-matter/src/dm/networks/wireless.rs
+++ b/rs-matter/src/dm/networks/wireless.rs
@@ -19,8 +19,6 @@
 
 use core::fmt::{Debug, Display};
 
-use embassy_sync::blocking_mutex::raw::RawMutex;
-
 use crate::dm::clusters::net_comm::{
     self, NetCtlError, NetworkCommissioningStatusEnum, NetworkType, NetworksError,
     ThreadCapabilitiesBitmap, WirelessCreds,
@@ -104,18 +102,14 @@ pub trait WirelessNetwork: for<'a> FromTLV<'a> + ToTLV {
 }
 
 /// A fixed-size storage for wireless networks credentials.
-pub struct WirelessNetworks<const N: usize, M, T>
-where
-    M: RawMutex,
-{
-    state: Mutex<M, RefCell<WirelessNetworksStore<N, T>>>,
-    state_changed: Notification<M>,
-    persist_state_changed: Notification<M>,
+pub struct WirelessNetworks<const N: usize, T> {
+    state: Mutex<RefCell<WirelessNetworksStore<N, T>>>,
+    state_changed: Notification,
+    persist_state_changed: Notification,
 }
 
-impl<const N: usize, M, T> WirelessNetworks<N, M, T>
+impl<const N: usize, T> WirelessNetworks<N, T>
 where
-    M: RawMutex,
     T: WirelessNetwork,
 {
     /// Create a new instance.
@@ -300,9 +294,8 @@ where
     }
 }
 
-impl<const N: usize, M, T> Default for WirelessNetworks<N, M, T>
+impl<const N: usize, T> Default for WirelessNetworks<N, T>
 where
-    M: RawMutex,
     T: WirelessNetwork + Clone,
 {
     fn default() -> Self {
@@ -310,9 +303,8 @@ where
     }
 }
 
-impl<const N: usize, M, T> net_comm::Networks for WirelessNetworks<N, M, T>
+impl<const N: usize, T> net_comm::Networks for WirelessNetworks<N, T>
 where
-    M: RawMutex,
     T: WirelessNetwork,
 {
     fn max_networks(&self) -> Result<u8, Error> {
@@ -377,9 +369,8 @@ where
     }
 }
 
-impl<const N: usize, M, T> NetChangeNotif for WirelessNetworks<N, M, T>
+impl<const N: usize, T> NetChangeNotif for WirelessNetworks<N, T>
 where
-    M: RawMutex,
     T: WirelessNetwork,
 {
     async fn wait_changed(&self) {
@@ -744,18 +735,12 @@ impl NetCtlState {
     }
 
     /// Create a new, empty instance of `NetCtlState` wrapped in a mutex.
-    pub const fn new_with_mutex<M>() -> NetCtlStateMutex<M>
-    where
-        M: RawMutex,
-    {
+    pub const fn new_with_mutex() -> NetCtlStateMutex {
         blocking::Mutex::new(RefCell::new(Self::new()))
     }
 
     /// Return an in-place initializer for a new, empty `NetCtlState` wrapped in a mutex.
-    pub fn init_with_mutex<M>() -> impl Init<NetCtlStateMutex<M>>
-    where
-        M: RawMutex,
-    {
+    pub fn init_with_mutex() -> impl Init<NetCtlStateMutex> {
         blocking::Mutex::init(RefCell::init(init!(Self {
             network_id <- OwnedWirelessNetworkId::init(),
             networking_status: None,
@@ -801,14 +786,11 @@ impl NetCtlState {
     /// Update the state with the provided network ID and result of the last operation.
     ///
     /// Return the result of the last operation.
-    pub fn update_with_mutex<M, R>(
-        state: &NetCtlStateMutex<M>,
+    pub fn update_with_mutex<R>(
+        state: &NetCtlStateMutex,
         network_id: Option<&[u8]>,
         result: Result<R, NetCtlError>,
-    ) -> Result<R, NetCtlError>
-    where
-        M: RawMutex,
-    {
+    ) -> Result<R, NetCtlError> {
         state.lock(|state| state.borrow_mut().update(network_id, result))
     }
 
@@ -818,10 +800,7 @@ impl NetCtlState {
     ///
     /// This method is only useful for non-concurrent commisioning using wireless networks and BLE,
     /// and is likely to be used together with `NoopWirelessNetCtl`.
-    pub async fn wait_prov_ready<M>(state: &NetCtlStateMutex<M>, _btp: &Btp)
-    where
-        M: RawMutex,
-    {
+    pub async fn wait_prov_ready(state: &NetCtlStateMutex, _btp: &Btp) {
         while !state.lock(|state| state.borrow().is_prov_ready()) {
             // Provisioning over BTP is considered complete when there is no longer an active connection
             // and the network ID is set (i.e. method `NetCtl::connect` was called successfully)
@@ -838,34 +817,27 @@ impl Default for NetCtlState {
 }
 
 /// A type alias for a `NetCtlState` instance wrapped in a mutex.
-pub type NetCtlStateMutex<M> = blocking::Mutex<M, RefCell<NetCtlState>>;
+pub type NetCtlStateMutex = blocking::Mutex<RefCell<NetCtlState>>;
 
 /// A wrapper around a `NetCtl` network controller that additionally implements the `NetCtlStatus`trait.
-pub struct NetCtlWithStatusImpl<'a, M, T>
-where
-    M: RawMutex,
-{
-    state: &'a NetCtlStateMutex<M>,
+pub struct NetCtlWithStatusImpl<'a, T> {
+    state: &'a NetCtlStateMutex,
     net_ctl: T,
 }
 
-impl<'a, M, T> NetCtlWithStatusImpl<'a, M, T>
-where
-    M: RawMutex,
-{
+impl<'a, T> NetCtlWithStatusImpl<'a, T> {
     /// Create a new instance of `NetCtlWithStatusImpl`.
     ///
     /// # Arguments
     /// - `state`: A reference to a `NetCtlState` instance wrapped in a mutex
     /// - `net_ctl`: A network controller that implements the `NetCtl` trait
-    pub const fn new(state: &'a NetCtlStateMutex<M>, net_ctl: T) -> Self {
+    pub const fn new(state: &'a NetCtlStateMutex, net_ctl: T) -> Self {
         Self { state, net_ctl }
     }
 }
 
-impl<M, T> net_comm::NetCtl for NetCtlWithStatusImpl<'_, M, T>
+impl<T> net_comm::NetCtl for NetCtlWithStatusImpl<'_, T>
 where
-    M: RawMutex,
     T: net_comm::NetCtl,
 {
     fn net_type(&self) -> NetworkType {
@@ -911,9 +883,8 @@ where
     }
 }
 
-impl<M, T> net_comm::NetCtlStatus for NetCtlWithStatusImpl<'_, M, T>
+impl<T> net_comm::NetCtlStatus for NetCtlWithStatusImpl<'_, T>
 where
-    M: RawMutex,
     T: net_comm::NetCtl,
 {
     fn last_networking_status(&self) -> Result<Option<NetworkCommissioningStatusEnum>, Error> {
@@ -940,9 +911,8 @@ where
     }
 }
 
-impl<M, T> NetChangeNotif for NetCtlWithStatusImpl<'_, M, T>
+impl<T> NetChangeNotif for NetCtlWithStatusImpl<'_, T>
 where
-    M: RawMutex,
     T: NetChangeNotif,
 {
     async fn wait_changed(&self) {
@@ -950,9 +920,8 @@ where
     }
 }
 
-impl<M, T> wifi_diag::WirelessDiag for NetCtlWithStatusImpl<'_, M, T>
+impl<T> wifi_diag::WirelessDiag for NetCtlWithStatusImpl<'_, T>
 where
-    M: RawMutex,
     T: wifi_diag::WirelessDiag,
 {
     fn connected(&self) -> Result<bool, Error> {
@@ -960,9 +929,8 @@ where
     }
 }
 
-impl<M, T> wifi_diag::WifiDiag for NetCtlWithStatusImpl<'_, M, T>
+impl<T> wifi_diag::WifiDiag for NetCtlWithStatusImpl<'_, T>
 where
-    M: RawMutex,
     T: wifi_diag::WifiDiag,
 {
     fn bssid(&self, f: &mut dyn FnMut(Option<&[u8]>) -> Result<(), Error>) -> Result<(), Error> {
@@ -986,9 +954,8 @@ where
     }
 }
 
-impl<M, T> thread_diag::ThreadDiag for NetCtlWithStatusImpl<'_, M, T>
+impl<T> thread_diag::ThreadDiag for NetCtlWithStatusImpl<'_, T>
 where
-    M: RawMutex,
     T: thread_diag::ThreadDiag,
 {
     fn channel(&self) -> Result<Option<u16>, Error> {

--- a/rs-matter/src/dm/networks/wireless/thread.rs
+++ b/rs-matter/src/dm/networks/wireless/thread.rs
@@ -27,7 +27,7 @@ use crate::utils::storage::Vec;
 
 use super::{WirelessNetwork, WirelessNetworks};
 
-pub type ThreadNetworks<const N: usize, M> = WirelessNetworks<N, M, Thread>;
+pub type ThreadNetworks<const N: usize> = WirelessNetworks<N, Thread>;
 
 /// A struct implementing the `WirelessNetwork` trait for Thread networks.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, ToTLV, FromTLV)]

--- a/rs-matter/src/dm/networks/wireless/wifi.rs
+++ b/rs-matter/src/dm/networks/wireless/wifi.rs
@@ -27,7 +27,7 @@ use crate::utils::storage::Vec;
 
 use super::{WirelessNetwork, WirelessNetworks};
 
-pub type WifiNetworks<const N: usize, M> = WirelessNetworks<N, M, Wifi>;
+pub type WifiNetworks<const N: usize> = WirelessNetworks<N, Wifi>;
 
 /// A struct implementing the `WirelessNetwork` trait for Wifi networks.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, ToTLV, FromTLV)]

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -17,8 +17,6 @@
 
 use core::num::NonZeroU8;
 
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_time::Instant;
 
 use crate::dm::EventId;
@@ -99,18 +97,12 @@ impl<const N: usize> SubscriptionsInner<N> {
 ///
 /// The `N` type parameter specifies the maximum number of subscriptions that can be tracked at the same time.
 /// Additional subscriptions are rejected by the data model with a "resource exhausted" IM status message.
-pub struct Subscriptions<const N: usize = DEFAULT_MAX_SUBSCRIPTIONS, M = NoopRawMutex>
-where
-    M: RawMutex,
-{
-    state: Mutex<M, RefCell<SubscriptionsInner<N>>>,
-    pub(crate) notification: Notification<M>,
+pub struct Subscriptions<const N: usize = DEFAULT_MAX_SUBSCRIPTIONS> {
+    state: Mutex<RefCell<SubscriptionsInner<N>>>,
+    pub(crate) notification: Notification,
 }
 
-impl<const N: usize, M> Subscriptions<N, M>
-where
-    M: RawMutex,
-{
+impl<const N: usize> Subscriptions<N> {
     /// Create the instance.
     #[inline(always)]
     pub const fn new() -> Self {

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-
 use crate::crypto::backend::dummy::DummyCrypto;
 use crate::crypto::Crypto;
 use crate::dm::IMBuffer;
@@ -154,7 +152,7 @@ pub trait Context: HandlerContext {
             &'static ReadContextInstance<
                 DummyCrypto,
                 EmptyHandler,
-                PooledBuffers<0, NoopRawMutex, IMBuffer>,
+                PooledBuffers<0, IMBuffer>,
             >,
         >::None
     }
@@ -166,7 +164,7 @@ pub trait Context: HandlerContext {
             &'static WriteContextInstance<
                 DummyCrypto,
                 EmptyHandler,
-                PooledBuffers<0, NoopRawMutex, IMBuffer>,
+                PooledBuffers<0, IMBuffer>,
             >,
         >::None
     }
@@ -175,11 +173,7 @@ pub trait Context: HandlerContext {
     /// The operation will return `Some` only if the underlying context represents an invoke operation.
     fn as_invoke_ctx(&self) -> Option<impl InvokeContext> {
         Option::<
-            &'static InvokeContextInstance<
-                DummyCrypto,
-                EmptyHandler,
-                PooledBuffers<0, NoopRawMutex, IMBuffer>,
-            >,
+            &'static InvokeContextInstance<DummyCrypto, EmptyHandler, PooledBuffers<0, IMBuffer>>,
         >::None
     }
 }

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -77,8 +77,6 @@
 
 use core::future::Future;
 
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-
 use crate::crypto::Crypto;
 use crate::dm::clusters::basic_info::{BasicInfoConfig, BasicInfoSettings};
 use crate::dm::clusters::dev_att::DeviceAttestation;
@@ -254,8 +252,8 @@ pub struct Matter<'a> {
     pub(crate) failsafe: RefCell<FailSafe>,
     pub(crate) basic_info_settings: RefCell<BasicInfoSettings>,
     pub transport_mgr: TransportMgr, // Public for tests
-    persist_notification: Notification<NoopRawMutex>,
-    mdns_notification: Notification<NoopRawMutex>,
+    persist_notification: Notification,
+    mdns_notification: Notification,
     epoch: Epoch,
     dev_det: &'a BasicInfoConfig<'a>,
     dev_comm: BasicCommData,

--- a/rs-matter/src/persist.rs
+++ b/rs-matter/src/persist.rs
@@ -29,7 +29,6 @@ pub mod fileio {
     use std::path::Path;
 
     use embassy_futures::select::{select, select3};
-    use embassy_sync::blocking_mutex::raw::{NoopRawMutex, RawMutex};
 
     use crate::dm::events::Events;
     use crate::dm::networks::wireless::{Wifi, WirelessNetwork, WirelessNetworks};
@@ -42,10 +41,10 @@ pub mod fileio {
     use crate::Matter;
 
     /// A constant representing the absence of wireless networks.
-    pub const NO_NETWORKS: Option<&'static WirelessNetworks<0, NoopRawMutex, Wifi>> = None;
+    pub const NO_NETWORKS: Option<&'static WirelessNetworks<0, Wifi>> = None;
 
     /// A constant representing the absence of events.
-    pub const NO_EVENTS: Option<&'static Events<0, NoopRawMutex>> = None;
+    pub const NO_EVENTS: Option<&'static Events<0>> = None;
 
     /// A simple persistent storage manager (PSM) for `rs-matter`.
     ///
@@ -91,16 +90,15 @@ pub mod fileio {
         /// - `matter`: The `Matter` instance to load the state into (for fabrics and basic info settings).
         /// - `networks`: An optional reference to `WirelessNetworks` to load the wireless networks state into (if provided).
         /// - `events`: An optional reference to `Events` to load the events state into (if provided).
-        pub fn load<P, const W: usize, M, T, const NE: usize>(
+        pub fn load<P, const W: usize, T, const NE: usize>(
             &mut self,
             path: P,
             matter: &Matter,
-            networks: Option<&WirelessNetworks<W, M, T>>,
-            events: Option<&Events<NE, M>>,
+            networks: Option<&WirelessNetworks<W, T>>,
+            events: Option<&Events<NE>>,
         ) -> Result<(), Error>
         where
             P: AsRef<Path>,
-            M: RawMutex,
             T: WirelessNetwork,
         {
             let buf = unsafe { self.buf.assume_init_mut() };
@@ -150,16 +148,15 @@ pub mod fileio {
         /// - `matter`: The `Matter` instance whose state to store (for fabrics and basic info settings).
         /// - `networks`: An optional reference to `WirelessNetworks` whose state to store.
         /// - `events`: An optional reference to `Events` whose state to store.
-        pub fn store<P, const W: usize, M, T, const NE: usize>(
+        pub fn store<P, const W: usize, T, const NE: usize>(
             &mut self,
             path: P,
             matter: &Matter,
-            networks: Option<&WirelessNetworks<W, M, T>>,
-            events: Option<&Events<NE, M>>,
+            networks: Option<&WirelessNetworks<W, T>>,
+            events: Option<&Events<NE>>,
         ) -> Result<(), Error>
         where
             P: AsRef<Path>,
-            M: RawMutex,
             T: WirelessNetwork,
         {
             if !matter.fabrics_changed()
@@ -204,16 +201,15 @@ pub mod fileio {
         /// - `matter`: The `Matter` instance to monitor for changes and for state to store (for fabrics and basic info settings).
         /// - `networks`: An optional reference to `WirelessNetworks` to monitor for changes and for state to store (if provided).
         /// - `events`: An optional reference to `Events` to monitor for changes and for state to store (if provided).
-        pub async fn run<P, const W: usize, M, T, const NE: usize>(
+        pub async fn run<P, const W: usize, T, const NE: usize>(
             &mut self,
             path: P,
             matter: &Matter<'_>,
-            networks: Option<&WirelessNetworks<W, M, T>>,
-            events: Option<&Events<NE, M>>,
+            networks: Option<&WirelessNetworks<W, T>>,
+            events: Option<&Events<NE>>,
         ) -> Result<(), Error>
         where
             P: AsRef<Path>,
-            M: RawMutex,
             T: WirelessNetwork,
         {
             // NOTE: Calling `load` here does not make sense, because the `Psm::run` future / async method is executed

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -20,7 +20,6 @@ use core::ops::{Deref, DerefMut};
 use core::pin::pin;
 
 use embassy_futures::select::{select, select3};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_time::Timer;
 
 use rand_core::RngCore;
@@ -78,10 +77,10 @@ pub(crate) const MAX_TX_BUF_SIZE: usize = network::MAX_TX_PACKET_SIZE;
 ///
 /// To the outside world, the transport layer is only visible and usable via the notion of `Exchange`.
 pub struct TransportMgr {
-    pub(crate) rx: IfMutex<NoopRawMutex, Packet<MAX_RX_BUF_SIZE>>,
-    pub(crate) tx: IfMutex<NoopRawMutex, Packet<MAX_TX_BUF_SIZE>>,
-    pub(crate) dropped: Notification<NoopRawMutex>,
-    pub(crate) session_removed: Notification<NoopRawMutex>,
+    pub(crate) rx: IfMutex<Packet<MAX_RX_BUF_SIZE>>,
+    pub(crate) tx: IfMutex<Packet<MAX_TX_BUF_SIZE>>,
+    pub(crate) dropped: Notification,
+    pub(crate) session_removed: Notification,
     pub session_mgr: RefCell<SessionMgr>, // For testing
     device_sai: Option<u16>,
     device_sii: Option<u16>,
@@ -336,7 +335,7 @@ impl TransportMgr {
 
     pub(crate) async fn get_if<'a, F, const N: usize>(
         &'a self,
-        packet_mutex: &'a IfMutex<NoopRawMutex, Packet<N>>,
+        packet_mutex: &'a IfMutex<Packet<N>>,
         f: F,
     ) -> PacketAccess<'a, N>
     where
@@ -345,22 +344,14 @@ impl TransportMgr {
         PacketAccess(packet_mutex.lock_if(f).await, false)
     }
 
-    async fn with_locked<'a, F, R, T>(
-        &'a self,
-        packet_mutex: &'a IfMutex<NoopRawMutex, T>,
-        f: F,
-    ) -> R
+    async fn with_locked<'a, F, R, T>(&'a self, packet_mutex: &'a IfMutex<T>, f: F) -> R
     where
         F: FnMut(&mut T) -> Option<R>,
     {
         packet_mutex.with(f).await
     }
 
-    async fn process_tx<C, S>(
-        &self,
-        crypto: C,
-        send: &IfMutex<NoopRawMutex, S>,
-    ) -> Result<(), Error>
+    async fn process_tx<C, S>(&self, crypto: C, send: &IfMutex<S>) -> Result<(), Error>
     where
         C: Crypto,
         S: NetworkSend,
@@ -392,7 +383,7 @@ impl TransportMgr {
         &self,
         crypto: C,
         mut recv: R,
-        send: &IfMutex<NoopRawMutex, S>,
+        send: &IfMutex<S>,
     ) -> Result<(), Error>
     where
         C: Crypto,
@@ -501,7 +492,7 @@ impl TransportMgr {
         &self,
         crypto: C,
         packet: &mut Packet<N>,
-        send: &IfMutex<NoopRawMutex, S>,
+        send: &IfMutex<S>,
     ) -> Result<bool, Error>
     where
         C: Crypto,
@@ -1126,7 +1117,7 @@ impl TransportMgr {
     }
 
     async fn netw_send<S>(
-        send: &IfMutex<NoopRawMutex, S>,
+        send: &IfMutex<S>,
         peer: Address,
         data: &[u8],
         system: bool,
@@ -1451,7 +1442,7 @@ impl<const N: usize> DerefMut for PacketBuffer<N> {
 // holds a lock on the RX or TX packet. This is enforced by protecting the packets with an `IfMutex` asynchronous mutex.
 //
 // This type is only known and used by `TransportMgr` and the `exchange` module
-pub(crate) struct PacketAccess<'a, const N: usize>(IfMutexGuard<'a, NoopRawMutex, Packet<N>>, bool);
+pub(crate) struct PacketAccess<'a, const N: usize>(IfMutexGuard<'a, Packet<N>>, bool);
 
 impl<const N: usize> PacketAccess<'_, N> {
     pub fn clear_on_drop(&mut self, clear: bool) {
@@ -1491,9 +1482,7 @@ impl<const N: usize> Display for PacketAccess<'_, N> {
 // in case it needs temporary access to a `&mut [u8]`-shaped memory
 //
 // Used by the builtin mDNS responder, as well as by the QR code generator
-pub(crate) struct PacketBufferExternalAccess<'a, const N: usize>(
-    pub(crate) &'a IfMutex<NoopRawMutex, Packet<N>>,
-);
+pub(crate) struct PacketBufferExternalAccess<'a, const N: usize>(pub(crate) &'a IfMutex<Packet<N>>);
 
 impl<const N: usize> BufferAccess<[u8]> for PacketBufferExternalAccess<'_, N> {
     type Buffer<'b>
@@ -1526,7 +1515,7 @@ impl<const N: usize> BufferAccess<[u8]> for PacketBufferExternalAccess<'_, N> {
 }
 
 // Wraps the RX or TX packet of the transport manager in something that looks like a `&mut [u8]` buffer.
-pub struct ExternalPacketBuffer<'a, const N: usize>(IfMutexGuard<'a, NoopRawMutex, Packet<N>>);
+pub struct ExternalPacketBuffer<'a, const N: usize>(IfMutexGuard<'a, Packet<N>>);
 
 impl<const N: usize> Deref for ExternalPacketBuffer<'_, N> {
     type Target = [u8];

--- a/rs-matter/src/transport/network/btp.rs
+++ b/rs-matter/src/transport/network/btp.rs
@@ -20,7 +20,6 @@
 use core::future::Future;
 
 use embassy_futures::select::select;
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_time::{Instant, Timer};
 
 use session::{BTP_ACK_TIMEOUT_SECS, BTP_CONN_IDLE_TIMEOUT_SECS};
@@ -69,13 +68,13 @@ pub(crate) const MAX_MTU: u16 = (MAX_BTP_SEGMENT_SIZE + GATT_HEADER_SIZE) as u16
 ///     The data is to be send via a GATT Write request on the C1 characteristic.
 pub struct Btp {
     /// The inner state of the BTP protocol, containing the session state, the outgoing SDU buffer, and the timeouts configuration.
-    inner: Mutex<NoopRawMutex, RefCell<BtpInner>>,
+    inner: Mutex<RefCell<BtpInner>>,
     /// Notification triggered when (potentially!) a new Matter packet (BTP SDU) is assembled and available for processing.
-    recv_notif: Notification<NoopRawMutex>,
+    recv_notif: Notification,
     /// Notification triggered when (potentially!) there is now space for buffering a new outgoing Matter packet (BTP SDU).
-    send_notif: Notification<NoopRawMutex>,
+    send_notif: Notification,
     /// Notification triggered when (potentially!) there is new outgoing data to be sent to the peer, which can be either a handshake packet or a BTP SDU segment.
-    outg_notif: Notification<NoopRawMutex>,
+    outg_notif: Notification,
 }
 
 impl Btp {

--- a/rs-matter/src/transport/network/mdns/builtin.rs
+++ b/rs-matter/src/transport/network/mdns/builtin.rs
@@ -24,8 +24,6 @@ use core::net::IpAddr;
 use core::pin::pin;
 
 use embassy_futures::select::select;
-use embassy_sync::blocking_mutex::raw::{NoopRawMutex, RawMutex};
-use embassy_sync::mutex::Mutex;
 use embassy_time::{Duration, Timer};
 
 use rand_core::RngCore;
@@ -41,6 +39,7 @@ use crate::transport::network::{
 };
 use crate::utils::select::Coalesce;
 use crate::utils::storage::pooled::BufferAccess;
+use crate::utils::sync::IfMutex;
 use crate::Matter;
 
 use self::proto::Services;
@@ -99,7 +98,7 @@ where
         S: NetworkSend,
         R: NetworkReceive,
     {
-        let send = Mutex::<NoopRawMutex, _>::new(send);
+        let send = IfMutex::new(send);
 
         let mut broadcast = pin!(self.broadcast(&send, host, ipv4_interface, ipv6_interface));
         let mut respond = pin!(self.respond(&send, recv, host, ipv4_interface, ipv6_interface));
@@ -109,7 +108,7 @@ where
 
     async fn broadcast<S>(
         &self,
-        send: &Mutex<impl RawMutex, S>,
+        send: &IfMutex<S>,
         host: &Host<'_>,
         ipv4_interface: Option<Ipv4Addr>,
         ipv6_interface: Option<u32>,
@@ -159,7 +158,7 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn respond<S, R>(
         &self,
-        send: &Mutex<impl RawMutex, S>,
+        send: &IfMutex<S>,
         mut recv: R,
         host: &Host<'_>,
         ipv4_interface: Option<Ipv4Addr>,

--- a/rs-matter/src/transport/network/mdns/builtin/querier.rs
+++ b/rs-matter/src/transport/network/mdns/builtin/querier.rs
@@ -199,7 +199,7 @@ fn parse_response<const D: usize, const AD: usize>(
             write_unwrap!(&mut owner, "{}", record.owner());
 
             if let Ok(Some(ptr)) = record.to_record::<Ptr<_>>() {
-                let mut instance_name = heapless::String::<64>::new();
+                let mut instance_name = heapless::String::<128>::new();
                 write_unwrap!(&mut instance_name, "{}", ptr.data().ptrdname());
 
                 let exists = states

--- a/rs-matter/src/transport/network/wifi/nm.rs
+++ b/rs-matter/src/transport/network/wifi/nm.rs
@@ -26,7 +26,6 @@ use core::cell::RefCell;
 use std::collections::HashMap;
 
 use embassy_futures::select::{select, select3, Either, Either3};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 
 use embassy_time::{Duration, Timer};
 use futures_lite::StreamExt;
@@ -58,8 +57,8 @@ use crate::utils::zbus_proxies::nm::{NM80211ApSecurityFlags, NM80211Mode, NMDevi
 pub struct NetMgrCtl<'a> {
     connection: &'a Connection,
     ifname: &'a str,
-    net_conn: IfMutex<NoopRawMutex, Option<OwnedObjectPath>>,
-    wifi_conn_info: blocking::Mutex<NoopRawMutex, RefCell<Option<WifiConnInfo>>>,
+    net_conn: IfMutex<Option<OwnedObjectPath>>,
+    wifi_conn_info: blocking::Mutex<RefCell<Option<WifiConnInfo>>>,
 }
 
 impl<'a> NetMgrCtl<'a> {
@@ -109,7 +108,7 @@ impl<'a> NetMgrCtl<'a> {
             let bss = wifi.active_access_point().await?;
 
             let (changed, connected) = if bss.len() > 1 {
-                let connected = interface.dev_state().await? == NMDeviceState::Activated as _;
+                let connected = interface.dev_state().await? == NMDeviceState::Activated as u32;
 
                 self.network_scan_info(&bss, |info| {
                     let info = info.map(|info| WifiConnInfo::new(info, connected));
@@ -179,7 +178,7 @@ impl<'a> NetMgrCtl<'a> {
     {
         let bss_info = AccessPointProxy::new(self.connection, bss).await?;
 
-        if bss_info.mode().await? == NM80211Mode::Infra as _ {
+        if bss_info.mode().await? == NM80211Mode::Infra as u32 {
             let wpa = NM80211ApSecurityFlags::from_bits_truncate(bss_info.wpa_flags().await?);
             let rsn = NM80211ApSecurityFlags::from_bits_truncate(bss_info.rsn_flags().await?);
 

--- a/rs-matter/src/transport/network/wifi/wpa_supp.rs
+++ b/rs-matter/src/transport/network/wifi/wpa_supp.rs
@@ -22,7 +22,6 @@ use core::cell::RefCell;
 use std::collections::HashMap;
 
 use embassy_futures::select::{select, Either};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 
 use embassy_time::{Duration, Timer};
 use futures_lite::StreamExt;
@@ -57,8 +56,8 @@ where
     connection: &'a Connection,
     ifname: &'a str,
     ip_stack_ctl: T,
-    network: IfMutex<NoopRawMutex, Option<OwnedObjectPath>>,
-    wifi_conn_info: blocking::Mutex<NoopRawMutex, RefCell<Option<WifiConnInfo>>>,
+    network: IfMutex<Option<OwnedObjectPath>>,
+    wifi_conn_info: blocking::Mutex<RefCell<Option<WifiConnInfo>>>,
 }
 
 impl<'a, T> WpaSuppCtl<'a, T>

--- a/rs-matter/src/transport/network/wifi/wpa_supp/unix.rs
+++ b/rs-matter/src/transport/network/wifi/wpa_supp/unix.rs
@@ -22,7 +22,6 @@ use core::cell::RefCell;
 use std::process::Command;
 
 use embassy_futures::select::{select, Either};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_time::{Duration, Timer};
 
 use crate::dm::clusters::net_comm::NetCtlError;
@@ -40,7 +39,7 @@ use crate::utils::sync::blocking;
 pub struct DhClientCtl {
     ifname: String,
     self_assign_link_local_ipv6: bool,
-    netif: blocking::Mutex<NoopRawMutex, RefCell<Option<UnixNetif>>>,
+    netif: blocking::Mutex<RefCell<Option<UnixNetif>>>,
 }
 
 impl DhClientCtl {

--- a/rs-matter/src/utils/storage/pooled.rs
+++ b/rs-matter/src/utils/storage/pooled.rs
@@ -25,6 +25,7 @@ use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_time::{Duration, Timer};
 
 use crate::utils::init::{init, Init, UnsafeCellInit};
+use crate::utils::sync::blocking::raw::MatterRawMutex;
 use crate::utils::sync::Signal;
 
 /// A trait for getting access to a `&mut T` buffer, potentially awaiting until a buffer becomes available.
@@ -70,13 +71,13 @@ where
 
 /// A concrete implementation of `BufferAccess` utilizing an internal pool of buffers.
 /// Accessing a buffer would fail when all buffers are still used elsewhere after a wait timeout expires.
-pub struct PooledBuffers<const N: usize, M, T> {
-    available: Signal<M, [bool; N]>,
+pub struct PooledBuffers<const N: usize, T, M = MatterRawMutex> {
+    available: Signal<[bool; N], M>,
     pool: UnsafeCell<crate::utils::storage::Vec<T, N>>,
     wait_timeout_ms: u32,
 }
 
-impl<const N: usize, M, T> PooledBuffers<N, M, T>
+impl<const N: usize, T, M> PooledBuffers<N, T, M>
 where
     M: RawMutex,
 {
@@ -106,13 +107,13 @@ where
     }
 }
 
-impl<const N: usize, M, T> BufferAccess<T> for PooledBuffers<N, M, T>
+impl<const N: usize, T, M> BufferAccess<T> for PooledBuffers<N, T, M>
 where
-    M: RawMutex,
     T: Default + Clone,
+    M: RawMutex,
 {
     type Buffer<'b>
-        = PooledBuffer<'b, N, M, T>
+        = PooledBuffer<'b, N, T, M>
     where
         Self: 'b;
 
@@ -175,16 +176,16 @@ where
     }
 }
 
-pub struct PooledBuffer<'a, const N: usize, M, T>
+pub struct PooledBuffer<'a, const N: usize, T, M = MatterRawMutex>
 where
     M: RawMutex,
 {
     index: usize,
     buffer: &'a mut T,
-    access: &'a PooledBuffers<N, M, T>,
+    access: &'a PooledBuffers<N, T, M>,
 }
 
-impl<const N: usize, M, T> Drop for PooledBuffer<'_, N, M, T>
+impl<const N: usize, T, M> Drop for PooledBuffer<'_, N, T, M>
 where
     M: RawMutex,
 {
@@ -196,7 +197,7 @@ where
     }
 }
 
-impl<const N: usize, M, T> Deref for PooledBuffer<'_, N, M, T>
+impl<const N: usize, T, M> Deref for PooledBuffer<'_, N, T, M>
 where
     M: RawMutex,
 {
@@ -207,7 +208,7 @@ where
     }
 }
 
-impl<const N: usize, M, T> DerefMut for PooledBuffer<'_, N, M, T>
+impl<const N: usize, T, M> DerefMut for PooledBuffer<'_, N, T, M>
 where
     M: RawMutex,
 {

--- a/rs-matter/src/utils/sync/blocking.rs
+++ b/rs-matter/src/utils/sync/blocking.rs
@@ -26,9 +26,12 @@ mod mutex {
 
     use core::cell::UnsafeCell;
 
-    use embassy_sync::blocking_mutex::raw::{self, RawMutex};
+    use embassy_sync::blocking_mutex::raw::RawMutex;
 
-    use crate::utils::init::{init, Init, UnsafeCellInit};
+    use crate::utils::{
+        init::{init, Init, UnsafeCellInit},
+        sync::blocking::raw::MatterRawMutex,
+    };
 
     /// Blocking mutex (not async)
     ///
@@ -45,21 +48,21 @@ mod mutex {
     ///
     /// In all cases, the blocking mutex is intended to be short lived and not held across await points.
     /// Use the async [`Mutex`](crate::mutex::Mutex) if you need a lock that is held across await points.
-    pub struct Mutex<R, T: ?Sized> {
+    pub struct Mutex<T: ?Sized, R = MatterRawMutex> {
         // NOTE: `raw` must be FIRST, so when using ThreadModeMutex the "can't drop in non-thread-mode" gets
         // to run BEFORE dropping `data`.
         raw: R,
         data: UnsafeCell<T>,
     }
 
-    unsafe impl<R: RawMutex + Send, T: ?Sized + Send> Send for Mutex<R, T> {}
-    unsafe impl<R: RawMutex + Sync, T: ?Sized + Send> Sync for Mutex<R, T> {}
+    unsafe impl<T: ?Sized + Send, R: RawMutex + Send> Send for Mutex<T, R> {}
+    unsafe impl<T: ?Sized + Send, R: RawMutex + Sync> Sync for Mutex<T, R> {}
 
-    impl<R: RawMutex, T> Mutex<R, T> {
+    impl<T, R: RawMutex> Mutex<T, R> {
         /// Creates a new mutex in an unlocked state ready for use.
         #[inline]
-        pub const fn new(val: T) -> Mutex<R, T> {
-            Mutex {
+        pub const fn new(val: T) -> Self {
+            Self {
                 raw: R::INIT,
                 data: UnsafeCell::new(val),
             }
@@ -83,13 +86,13 @@ mod mutex {
         }
     }
 
-    impl<R, T> Mutex<R, T> {
+    impl<T, R> Mutex<T, R> {
         /// Creates a new mutex based on a pre-existing raw mutex.
         ///
         /// This allows creating a mutex in a constant context on stable Rust.
         #[inline]
-        pub const fn const_new(raw_mutex: R, val: T) -> Mutex<R, T> {
-            Mutex {
+        pub const fn const_new(raw_mutex: R, val: T) -> Self {
+            Self {
                 raw: raw_mutex,
                 data: UnsafeCell::new(val),
             }
@@ -110,117 +113,21 @@ mod mutex {
             unsafe { &mut *self.data.get() }
         }
     }
-
-    /// A mutex that allows borrowing data across executors and interrupts.
-    ///
-    /// # Safety
-    ///
-    /// This mutex is safe to share between different executors and interrupts.
-    pub type CriticalSectionMutex<T> = Mutex<raw::CriticalSectionRawMutex, T>;
-
-    /// A mutex that allows borrowing data in the context of a single executor.
-    ///
-    /// # Safety
-    ///
-    /// **This Mutex is only safe within a single executor.**
-    pub type NoopMutex<T> = Mutex<raw::NoopRawMutex, T>;
-
-    impl<T> Mutex<raw::CriticalSectionRawMutex, T> {
-        /// Borrows the data for the duration of the critical section
-        pub fn borrow<'cs>(&'cs self, _cs: critical_section::CriticalSection<'cs>) -> &'cs T {
-            let ptr = self.data.get() as *const T;
-            unsafe { &*ptr }
-        }
-    }
-
-    impl<T> Mutex<raw::NoopRawMutex, T> {
-        /// Borrows the data
-        pub fn borrow(&self) -> &T {
-            let ptr = self.data.get() as *const T;
-            unsafe { &*ptr }
-        }
-    }
-
-    // // ThreadModeMutex does NOT use the generic mutex from above because it's special:
-    // // it's Send+Sync even if T: !Send. There's no way to do that without specialization (I think?).
-    // //
-    // // There's still a ThreadModeRawMutex for use with the generic Mutex (handy with Channel, for example),
-    // // but that will require T: Send even though it shouldn't be needed.
-
-    // #[cfg(any(cortex_m, feature = "std"))]
-    // pub use thread_mode_mutex::*;
-    // #[cfg(any(cortex_m, feature = "std"))]
-    // mod thread_mode_mutex {
-    //     use super::*;
-
-    //     /// A "mutex" that only allows borrowing from thread mode.
-    //     ///
-    //     /// # Safety
-    //     ///
-    //     /// **This Mutex is only safe on single-core systems.**
-    //     ///
-    //     /// On multi-core systems, a `ThreadModeMutex` **is not sufficient** to ensure exclusive access.
-    //     pub struct ThreadModeMutex<T: ?Sized> {
-    //         inner: UnsafeCell<T>,
-    //     }
-
-    //     // NOTE: ThreadModeMutex only allows borrowing from one execution context ever: thread mode.
-    //     // Therefore it cannot be used to send non-sendable stuff between execution contexts, so it can
-    //     // be Send+Sync even if T is not Send (unlike CriticalSectionMutex)
-    //     unsafe impl<T: ?Sized> Sync for ThreadModeMutex<T> {}
-    //     unsafe impl<T: ?Sized> Send for ThreadModeMutex<T> {}
-
-    //     impl<T> ThreadModeMutex<T> {
-    //         /// Creates a new mutex
-    //         pub const fn new(value: T) -> Self {
-    //             ThreadModeMutex {
-    //                 inner: UnsafeCell::new(value),
-    //             }
-    //         }
-    //     }
-
-    //     impl<T: ?Sized> ThreadModeMutex<T> {
-    //         /// Lock the `ThreadModeMutex`, granting access to the data.
-    //         ///
-    //         /// # Panics
-    //         ///
-    //         /// This will panic if not currently running in thread mode.
-    //         pub fn lock<R>(&self, f: impl FnOnce(&T) -> R) -> R {
-    //             f(self.borrow())
-    //         }
-
-    //         /// Borrows the data
-    //         ///
-    //         /// # Panics
-    //         ///
-    //         /// This will panic if not currently running in thread mode.
-    //         pub fn borrow(&self) -> &T {
-    //             assert!(
-    //                 raw::in_thread_mode(),
-    //                 "ThreadModeMutex can only be borrowed from thread mode."
-    //             );
-    //             unsafe { &*self.inner.get() }
-    //         }
-    //     }
-
-    //     impl<T: ?Sized> Drop for ThreadModeMutex<T> {
-    //         fn drop(&mut self) {
-    //             // Only allow dropping from thread mode. Dropping calls drop on the inner `T`, so
-    //             // `drop` needs the same guarantees as `lock`. `ThreadModeMutex<T>` is Send even if
-    //             // T isn't, so without this check a user could create a ThreadModeMutex in thread mode,
-    //             // send it to interrupt context and drop it there, which would "send" a T even if T is not Send.
-    //             assert!(
-    //                 raw::in_thread_mode(),
-    //                 "ThreadModeMutex can only be dropped from thread mode."
-    //             );
-
-    //             // Drop of the inner `T` happens after this.
-    //         }
-    //     }
-    // }
 }
 
 pub mod raw {
+    /// The raw mutex used throughout the `rs-matter` codebase
+    #[cfg(not(feature = "sync-mutex"))]
+    pub type MatterRawMutex = embassy_sync::blocking_mutex::raw::NoopRawMutex;
+
+    /// The raw mutex used throughout the `rs-matter` codebase
+    #[cfg(all(feature = "sync-mutex", not(feature = "std")))]
+    pub type MatterRawMutex = embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+
+    /// The raw mutex used throughout the `rs-matter` codebase
+    #[cfg(all(feature = "sync-mutex", feature = "std"))]
+    pub type MatterRawMutex = StdRawMutex;
+
     #[cfg(feature = "std")]
     pub use std::*;
 

--- a/rs-matter/src/utils/sync/mutex.rs
+++ b/rs-matter/src/utils/sync/mutex.rs
@@ -25,6 +25,7 @@ use core::ops::{Deref, DerefMut};
 use embassy_sync::blocking_mutex::raw::RawMutex;
 
 use crate::utils::init::{init, Init, UnsafeCellInit};
+use crate::utils::sync::blocking::raw::MatterRawMutex;
 
 use super::signal::Signal;
 
@@ -35,20 +36,20 @@ pub struct TryLockError;
 
 /// Async mutex with conditional locking based on the data inside the mutex.
 /// Check `embassy_sync::Mutex` for the original unconditional implementation.
-pub struct IfMutex<M, T>
+pub struct IfMutex<T, M = MatterRawMutex>
 where
-    M: RawMutex,
     T: ?Sized,
+    M: RawMutex,
 {
-    state: Signal<M, bool>,
+    state: Signal<bool, M>,
     inner: UnsafeCell<T>,
 }
 
-unsafe impl<M: RawMutex + Send, T: ?Sized + Send> Send for IfMutex<M, T> {}
-unsafe impl<M: RawMutex + Sync, T: ?Sized + Send> Sync for IfMutex<M, T> {}
+unsafe impl<T: ?Sized + Send, M: RawMutex + Send> Send for IfMutex<T, M> {}
+unsafe impl<T: ?Sized + Send, M: RawMutex + Sync> Sync for IfMutex<T, M> {}
 
 /// Async mutex.
-impl<M, T> IfMutex<M, T>
+impl<T, M> IfMutex<T, M>
 where
     M: RawMutex,
 {
@@ -56,7 +57,7 @@ where
     #[inline(always)]
     pub const fn new(value: T) -> Self {
         Self {
-            state: Signal::<M, _>::new(false),
+            state: Signal::new(false),
             inner: UnsafeCell::new(value),
         }
     }
@@ -64,28 +65,28 @@ where
     /// Creates a mutex in-place initializer with the given value initializer.
     pub fn init<I: Init<T>>(value: I) -> impl Init<Self> {
         init!(Self {
-            state: Signal::<M, _>::new(false),
+            state: Signal::new(false),
             inner <- UnsafeCell::init(value),
         })
     }
 }
 
-impl<M, T> IfMutex<M, T>
+impl<T, M> IfMutex<T, M>
 where
-    M: RawMutex,
     T: ?Sized,
+    M: RawMutex,
 {
     /// Lock the mutex.
     ///
     /// This will wait for the mutex to be unlocked if it's already locked.
-    pub async fn lock(&self) -> IfMutexGuard<'_, M, T> {
+    pub async fn lock(&self) -> IfMutexGuard<'_, T, M> {
         self.lock_if(|_| true).await
     }
 
     /// Lock the mutex.
     ///
     /// This will wait for the mutex to be unlocked if it's already locked _and_ for the provided condition on the data to become true.
-    pub async fn lock_if<F>(&self, f: F) -> IfMutexGuard<'_, M, T>
+    pub async fn lock_if<F>(&self, f: F) -> IfMutexGuard<'_, T, M>
     where
         F: Fn(&T) -> bool,
     {
@@ -137,14 +138,14 @@ where
     }
 
     /// Attempt to immediately lock the mutex.
-    pub fn try_lock(&self) -> Result<IfMutexGuard<'_, M, T>, TryLockError> {
+    pub fn try_lock(&self) -> Result<IfMutexGuard<'_, T, M>, TryLockError> {
         self.try_lock_if(|_| true)
     }
 
     /// Attempt to immediately lock the mutex.
     ///
     /// If the mutex is already locked or the condition on the data is not true, this will return an error instead of waiting.
-    pub fn try_lock_if<F>(&self, mut f: F) -> Result<IfMutexGuard<'_, M, T>, TryLockError>
+    pub fn try_lock_if<F>(&self, mut f: F) -> Result<IfMutexGuard<'_, T, M>, TryLockError>
     where
         F: FnMut(&T) -> bool,
     {
@@ -188,18 +189,18 @@ where
 /// successfully locked the mutex, and grants access to the contents.
 ///
 /// Dropping it unlocks the mutex.
-pub struct IfMutexGuard<'a, M, T>
+pub struct IfMutexGuard<'a, T, M = MatterRawMutex>
 where
-    M: RawMutex,
     T: ?Sized,
+    M: RawMutex,
 {
-    mutex: &'a IfMutex<M, T>,
+    mutex: &'a IfMutex<T, M>,
 }
 
-impl<M, T> Drop for IfMutexGuard<'_, M, T>
+impl<T, M> Drop for IfMutexGuard<'_, T, M>
 where
-    M: RawMutex,
     T: ?Sized,
+    M: RawMutex,
 {
     fn drop(&mut self) {
         self.mutex.state.modify(|locked| {
@@ -212,10 +213,10 @@ where
     }
 }
 
-impl<M, T> Deref for IfMutexGuard<'_, M, T>
+impl<T, M> Deref for IfMutexGuard<'_, T, M>
 where
-    M: RawMutex,
     T: ?Sized,
+    M: RawMutex,
 {
     type Target = T;
 
@@ -226,10 +227,10 @@ where
     }
 }
 
-impl<M, T> DerefMut for IfMutexGuard<'_, M, T>
+impl<T, M> DerefMut for IfMutexGuard<'_, T, M>
 where
-    M: RawMutex,
     T: ?Sized,
+    M: RawMutex,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         // Safety: the MutexGuard represents exclusive access to the contents

--- a/rs-matter/src/utils/sync/notification.rs
+++ b/rs-matter/src/utils/sync/notification.rs
@@ -17,10 +17,11 @@
 
 use embassy_sync::blocking_mutex::raw::RawMutex;
 
+use super::blocking::raw::MatterRawMutex;
 use super::signal::Signal;
 
 /// A notification primitive that allows for notifying a single waiter.
-pub struct Notification<M>(Signal<M, Option<()>>);
+pub struct Notification<M = MatterRawMutex>(Signal<Option<()>, M>);
 
 impl<M> Default for Notification<M>
 where
@@ -42,14 +43,11 @@ where
 
     /// Notify the waiter.
     pub fn notify(&self) {
-        self.0.modify(|state| {
-            *state = Some(());
-            (true, ())
-        });
+        self.0.signal(());
     }
 
     /// Wait for the notification.
     pub async fn wait(&self) {
-        self.0.wait(|state| state.take()).await;
+        self.0.wait_signalled().await;
     }
 }

--- a/rs-matter/src/utils/sync/signal.rs
+++ b/rs-matter/src/utils/sync/signal.rs
@@ -24,6 +24,7 @@ use embassy_sync::waitqueue::WakerRegistration;
 use crate::utils::cell::RefCell;
 use crate::utils::init::{init, Init};
 
+use super::blocking::raw::MatterRawMutex;
 use super::blocking::Mutex;
 
 struct State<S> {
@@ -58,11 +59,11 @@ impl<S> State<S> {
 /// The generic nature of `Signal` allows for a wide range of use cases, including the implementation of:
 /// - the `Notification` primitive
 /// - the `IfMutex` primitive
-pub struct Signal<M, S> {
-    inner: Mutex<M, RefCell<State<S>>>,
+pub struct Signal<S, M = MatterRawMutex> {
+    inner: Mutex<RefCell<State<S>>, M>,
 }
 
-impl<M, S> Signal<M, S>
+impl<S, M> Signal<S, M>
 where
     M: RawMutex,
 {
@@ -121,5 +122,23 @@ where
                 Poll::Pending
             }
         })
+    }
+}
+
+impl<T, M> Signal<Option<T>, M>
+where
+    M: RawMutex,
+{
+    /// Notify the waiter.
+    pub fn signal(&self, value: T) {
+        self.modify(|state| {
+            *state = Some(value);
+            (true, ())
+        });
+    }
+
+    /// Wait for the notification.
+    pub async fn wait_signalled(&self) -> T {
+        self.wait(|state| state.take()).await
     }
 }

--- a/rs-matter/tests/commissioning.rs
+++ b/rs-matter/tests/commissioning.rs
@@ -39,18 +39,18 @@
     any(target_os = "linux", feature = "astro-dnssd")
 ))]
 
-#[allow(dead_code)]
-mod common;
-
 use core::pin::pin;
 use std::net::UdpSocket;
 
 use embassy_futures::select::{select, select4, Either};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_time::{Duration, Timer};
+
 use log::{debug, info, warn};
+
 use rand_core::RngCore;
+
 use socket2::{Domain, Protocol, Socket, Type};
+
 use static_cell::StaticCell;
 
 use rs_matter::crypto::{test_only_crypto, Crypto};
@@ -88,6 +88,9 @@ use rs_matter::{clusters, devices, Matter, MATTER_PORT};
 
 use crate::common::{init_env_logger, run_device_controller, run_with_transport};
 
+#[allow(dead_code)]
+mod common;
+
 /// Passcode used by `TEST_DEV_COMM`
 const TEST_PASSCODE: u32 = 20202021;
 /// Discriminator used by `TEST_DEV_COMM`
@@ -104,7 +107,7 @@ const MAX_DEVICE_ADDRESSES: usize = 4;
 const MAX_DISCOVERED_DEVICES: usize = 8;
 
 static DEVICE_MATTER: StaticCell<Matter> = StaticCell::new();
-static DEVICE_BUFFERS: StaticCell<PooledBuffers<10, NoopRawMutex, IMBuffer>> = StaticCell::new();
+static DEVICE_BUFFERS: StaticCell<PooledBuffers<10, IMBuffer>> = StaticCell::new();
 static DEVICE_SUBSCRIPTIONS: StaticCell<DefaultSubscriptions> = StaticCell::new();
 static CTRL_MATTER: StaticCell<Matter> = StaticCell::new();
 

--- a/rs-matter/tests/common/e2e.rs
+++ b/rs-matter/tests/common/e2e.rs
@@ -19,10 +19,7 @@ use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use core::num::NonZeroU8;
 
 use embassy_futures::select::select4;
-use embassy_sync::{
-    blocking_mutex::raw::NoopRawMutex,
-    zerocopy_channel::{Channel, Receiver, Sender},
-};
+use embassy_sync::zerocopy_channel::{Channel, Receiver, Sender};
 
 use rs_matter::acl::{AclEntry, AuthMode};
 use rs_matter::crypto::{test_only_crypto, Crypto};
@@ -41,6 +38,7 @@ use rs_matter::transport::session::{NocCatIds, ReservedSession, SessionMode};
 use rs_matter::utils::epoch::Epoch;
 use rs_matter::utils::select::Coalesce;
 use rs_matter::utils::storage::pooled::PooledBuffers;
+use rs_matter::utils::sync::blocking::raw::MatterRawMutex;
 use rs_matter::{Matter, MATTER_PORT};
 
 pub mod im;
@@ -78,7 +76,7 @@ pub struct E2eRunner<C> {
     pub matter: Matter<'static>,
     matter_client: Matter<'static>,
     crypto: C,
-    buffers: PooledBuffers<10, NoopRawMutex, IMBuffer>,
+    buffers: PooledBuffers<10, IMBuffer>,
     pub subscriptions: Subscriptions<3>,
     pub events: Events<E2E_EVENTS_BUF_SIZE>,
     cat_ids: NocCatIds,
@@ -269,9 +267,9 @@ impl<C: Crypto> E2eRunner<C> {
     }
 }
 
-type NetworkPipe<'a, const N: usize> = Channel<'a, NoopRawMutex, heapless::Vec<u8, N>>;
+type NetworkPipe<'a, const N: usize> = Channel<'a, MatterRawMutex, heapless::Vec<u8, N>>;
 
-struct NetworkReceiveImpl<'a, const N: usize>(Receiver<'a, NoopRawMutex, heapless::Vec<u8, N>>);
+struct NetworkReceiveImpl<'a, const N: usize>(Receiver<'a, MatterRawMutex, heapless::Vec<u8, N>>);
 
 impl<const N: usize> NetworkSend for NetworkSendImpl<'_, N> {
     async fn send_to(&mut self, data: &[u8], _addr: Address) -> Result<(), Error> {
@@ -286,7 +284,7 @@ impl<const N: usize> NetworkSend for NetworkSendImpl<'_, N> {
     }
 }
 
-struct NetworkSendImpl<'a, const N: usize>(Sender<'a, NoopRawMutex, heapless::Vec<u8, N>>);
+struct NetworkSendImpl<'a, const N: usize>(Sender<'a, MatterRawMutex, heapless::Vec<u8, N>>);
 
 impl<const N: usize> NetworkReceive for NetworkReceiveImpl<'_, N> {
     async fn wait_available(&mut self) -> Result<(), Error> {


### PR DESCRIPTION
The `rs-matter` codebase uses the `embassy-sync` crate for doing synchronization (and invents a few synchronization primitives of its own, on top of what `embassy-sync` provides).

So far however, the codebase had been pretty inconsistent w.r.t. the exact `RawMutex` type used:
- At some places (notably, inside the `Matter` object and all objects members of the Matter Object where generics should be avoided), it was hard-coded to a `NoopRawMutex`
- At other structures external to `Matter` (`Subscriptions`, `Events`, `PooledBuffers` and others) it was possible for the user to pass their own instantiation of a `RawMutex`. Some of these structures also had a `NoopRawMutex` default

The situation was not so rosy. 

First of all, in 99.9% if not 100% of the cases, it should really be **all or nothing**: 
- I.e. either everything uses a `NoopRawMutex`, or everything uses `WhateverMutex`

... where the default should be a `NoopRawMutex` (= `rs-matter` with non-`Send` futures = single-threaded async executor) ... with an option to use a `StdRawMutex` or a `CriticalSectionRawMutex` for the few use-cases where using a work-stealing multi-threaded async executor with `rs-matter` _might_ be beneficial - mainly the controller use-case. Note that for true `Send` futures, we need to also address #258

Further, the constant mentioning of `NoopRawMutex`, or even worse - the extra weight of the `where M: RawMutex` generic is just not worth it, given that it should really be an "all or nothing" situation, where everything uses a proper sync mutex, or a fake `NoopRawMutex`.

===

This PR addresses these issues by 
(a) Making sure all the `rs-matter` codebase uses only our `rs_matter::utils::sync::*` primitives, instead of ones directly from `embassy-sync`
(b) Changing all our `rs_matter::utils::sync::*` primitives to use - **by default** - the new `MatterRawMutex` raw mutex type
(c) Changing the codebase to never refer to the `rs_matter::utils::sync::*` types with an explicit raw mutex type (so that it defaults to `MatterRawMutex`)
(d) Making `MatterRawMutex` a type alias for `NoopRawMutex` by default - or - if the new `sync-mutex` feature is enabled - for `StdRawMutex` / `CriticalSectionRawMutex`


