### PR TITLE
Port some optimizations from PR 366 - single-line async delegation should not use the async fn syntax

### DIFF
--- a/rs-matter-macros/src/idl/handler.rs
+++ b/rs-matter-macros/src/idl/handler.rs
@@ -438,37 +438,69 @@ fn handler_attribute(
         }
 
         if !delegate && attr.field.is_optional {
+            if asynch {
+                quote!(
+                    fn #attr_name<P: #krate::tlv::TLVBuilderParent>(&self, ctx: impl #krate::dm::ReadContext, builder: #attr_type) -> impl core::future::Future<Output = Result<P, #krate::error::Error>> {
+                        core::future::ready(Err(#krate::error::ErrorCode::InvalidAction.into()))
+                    }
+                )
+            } else {
+                quote!(
+                    #pasync fn #attr_name<P: #krate::tlv::TLVBuilderParent>(&self, ctx: impl #krate::dm::ReadContext, builder: #attr_type) -> Result<P, #krate::error::Error> {
+                        Err(#krate::error::ErrorCode::InvalidAction.into())
+                    }
+                )
+            }
+        } else {
+            if delegate && asynch {
+                quote!(
+                    fn #attr_name<P: #krate::tlv::TLVBuilderParent>(&self, ctx: impl #krate::dm::ReadContext, builder: #attr_type) -> impl core::future::Future<Output = Result<P, #krate::error::Error>> {
+                        T::#attr_name(self, ctx, builder)
+                    }
+                )
+            } else {
+                let stream = quote!(
+                    #pasync fn #attr_name<P: #krate::tlv::TLVBuilderParent>(&self, ctx: impl #krate::dm::ReadContext, builder: #attr_type) -> Result<P, #krate::error::Error>
+                );
+
+                if delegate {
+                    quote!(#stream { T::#attr_name(self, ctx, builder)#sawait })
+                } else {
+                    quote!(#stream;)
+                }
+            }
+        }
+    } else if !delegate && attr.field.is_optional {
+        if asynch {
             quote!(
-                #pasync fn #attr_name<P: #krate::tlv::TLVBuilderParent>(&self, ctx: impl #krate::dm::ReadContext, builder: #attr_type) -> Result<P, #krate::error::Error> {
+                fn #attr_name(&self, ctx: impl #krate::dm::ReadContext) -> impl core::future::Future<Output = Result<#attr_type, #krate::error::Error>> {
+                    core::future::ready(Err(#krate::error::ErrorCode::InvalidAction.into()))
+                }
+            )
+        } else {
+            quote!(
+                #pasync fn #attr_name(&self, ctx: impl #krate::dm::ReadContext) -> Result<#attr_type, #krate::error::Error> {
                     Err(#krate::error::ErrorCode::InvalidAction.into())
+                }
+            )
+        }
+    } else {
+        if delegate && asynch {
+            quote!(
+                fn #attr_name(&self, ctx: impl #krate::dm::ReadContext) -> impl core::future::Future<Output = Result<#attr_type, #krate::error::Error>> {
+                    T::#attr_name(self, ctx)
                 }
             )
         } else {
             let stream = quote!(
-                #pasync fn #attr_name<P: #krate::tlv::TLVBuilderParent>(&self, ctx: impl #krate::dm::ReadContext, builder: #attr_type) -> Result<P, #krate::error::Error>
+                #pasync fn #attr_name(&self, ctx: impl #krate::dm::ReadContext) -> Result<#attr_type, #krate::error::Error>
             );
 
             if delegate {
-                quote!(#stream { T::#attr_name(self, ctx, builder)#sawait })
+                quote!(#stream { T::#attr_name(self, ctx)#sawait })
             } else {
                 quote!(#stream;)
             }
-        }
-    } else if !delegate && attr.field.is_optional {
-        quote!(
-            #pasync fn #attr_name(&self, ctx: impl #krate::dm::ReadContext) -> Result<#attr_type, #krate::error::Error> {
-                Err(#krate::error::ErrorCode::InvalidAction.into())
-            }
-        )
-    } else {
-        let stream = quote!(
-            #pasync fn #attr_name(&self, ctx: impl #krate::dm::ReadContext) -> Result<#attr_type, #krate::error::Error>
-        );
-
-        if delegate {
-            quote!(#stream { T::#attr_name(self, ctx)#sawait })
-        } else {
-            quote!(#stream;)
         }
     }
 }
@@ -525,20 +557,36 @@ fn handler_attribute_write(
     }
 
     if !delegate && attr.field.is_optional {
-        quote!(
-            #pasync fn #attr_name(&self, ctx: impl #krate::dm::WriteContext, value: #attr_type) -> Result<(), #krate::error::Error> {
-                Err(#krate::error::ErrorCode::InvalidAction.into())
-            }
-        )
-    } else {
-        let stream = quote!(
-            #pasync fn #attr_name(&self, ctx: impl #krate::dm::WriteContext, value: #attr_type) -> Result<(), #krate::error::Error>
-        );
-
-        if delegate {
-            quote!(#stream { T::#attr_name(self, ctx, value)#sawait })
+        if asynch {
+            quote!(
+                fn #attr_name(&self, ctx: impl #krate::dm::WriteContext, value: #attr_type) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                    core::future::ready(Err(#krate::error::ErrorCode::InvalidAction.into()))
+                }
+            )
         } else {
-            quote!(#stream;)
+            quote!(
+                #pasync fn #attr_name(&self, ctx: impl #krate::dm::WriteContext, value: #attr_type) -> Result<(), #krate::error::Error> {
+                    Err(#krate::error::ErrorCode::InvalidAction.into())
+                }
+            )
+        }
+    } else {
+        if delegate && asynch {
+            quote!(
+                fn #attr_name(&self, ctx: impl #krate::dm::WriteContext, value: #attr_type) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                    T::#attr_name(self, ctx, value)
+                }
+            )
+        } else {
+            let stream = quote!(
+                #pasync fn #attr_name(&self, ctx: impl #krate::dm::WriteContext, value: #attr_type) -> Result<(), #krate::error::Error>
+            );
+
+            if delegate {
+                quote!(#stream { T::#attr_name(self, ctx, value)#sawait })
+            } else {
+                quote!(#stream;)
+            }
         }
     }
 }
@@ -602,27 +650,78 @@ fn handler_command(
     if let Some(field_req) = field_req {
         if let Some((field_resp, field_resp_builder)) = field_resp {
             if field_resp_builder {
-                let stream = quote!(
-                    #pasync fn #cmd_name<P: #krate::tlv::TLVBuilderParent>(
+                if delegate && asynch {
+                    quote!(
+                        fn #cmd_name<P: #krate::tlv::TLVBuilderParent>(
+                            &self,
+                            ctx: impl #krate::dm::InvokeContext,
+                            request: #field_req,
+                            response: #field_resp,
+                        ) -> impl core::future::Future<Output = Result<P, #krate::error::Error>> {
+                            T::#cmd_name(self, ctx, request, response)
+                        }
+                    )
+                } else {
+                    let stream = quote!(
+                        #pasync fn #cmd_name<P: #krate::tlv::TLVBuilderParent>(
+                            &self,
+                            ctx: impl #krate::dm::InvokeContext,
+                            request: #field_req,
+                            response: #field_resp,
+                        ) -> Result<P, #krate::error::Error>
+                    );
+
+                    if delegate {
+                        quote!(#stream { T::#cmd_name(self, ctx, request, response)#sawait })
+                    } else {
+                        quote!(#stream;)
+                    }
+                }
+            } else {
+                if delegate && asynch {
+                    quote!(
+                        fn #cmd_name(
+                            &self,
+                            ctx: impl #krate::dm::InvokeContext,
+                            request: #field_req,
+                        ) -> impl core::future::Future<Output = Result<#field_resp, #krate::error::Error>> {
+                            T::#cmd_name(self, ctx, request)
+                        }
+                    )
+                } else {
+                    let stream = quote!(
+                        #pasync fn #cmd_name(
+                            &self,
+                            ctx: impl #krate::dm::InvokeContext,
+                            request: #field_req,
+                        ) -> Result<#field_resp, #krate::error::Error>
+                    );
+
+                    if delegate {
+                        quote!(#stream { T::#cmd_name(self, ctx, request)#sawait })
+                    } else {
+                        quote!(#stream;)
+                    }
+                }
+            }
+        } else {
+            if delegate && asynch {
+                quote!(
+                    fn #cmd_name(
                         &self,
                         ctx: impl #krate::dm::InvokeContext,
                         request: #field_req,
-                        response: #field_resp,
-                    ) -> Result<P, #krate::error::Error>
-                );
-
-                if delegate {
-                    quote!(#stream { T::#cmd_name(self, ctx, request, response)#sawait })
-                } else {
-                    quote!(#stream;)
-                }
+                    ) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                        T::#cmd_name(self, ctx, request)
+                    }
+                )
             } else {
                 let stream = quote!(
                     #pasync fn #cmd_name(
                         &self,
                         ctx: impl #krate::dm::InvokeContext,
                         request: #field_req,
-                    ) -> Result<#field_resp, #krate::error::Error>
+                    ) -> Result<(), #krate::error::Error>
                 );
 
                 if delegate {
@@ -631,42 +730,75 @@ fn handler_command(
                     quote!(#stream;)
                 }
             }
-        } else {
-            let stream = quote!(
-                #pasync fn #cmd_name(
-                    &self,
-                    ctx: impl #krate::dm::InvokeContext,
-                    request: #field_req,
-                ) -> Result<(), #krate::error::Error>
-            );
-
-            if delegate {
-                quote!(#stream { T::#cmd_name(self, ctx, request)#sawait })
-            } else {
-                quote!(#stream;)
-            }
         }
     } else if let Some((field_resp, field_resp_builder)) = field_resp {
         if field_resp_builder {
-            let stream = quote!(
-                #pasync fn #cmd_name<P: #krate::tlv::TLVBuilderParent>(
+            if delegate && asynch {
+                quote!(
+                    fn #cmd_name<P: #krate::tlv::TLVBuilderParent>(
+                        &self,
+                        ctx: impl #krate::dm::InvokeContext,
+                        response: #field_resp,
+                    ) -> impl core::future::Future<Output = Result<P, #krate::error::Error>> {
+                        T::#cmd_name(self, ctx, response)
+                    }
+                )
+            } else {
+                let stream = quote!(
+                    #pasync fn #cmd_name<P: #krate::tlv::TLVBuilderParent>(
+                        &self,
+                        ctx: impl #krate::dm::InvokeContext,
+                        response: #field_resp,
+                    ) -> Result<P, #krate::error::Error>
+                );
+
+                if delegate {
+                    quote!(#stream { T::#cmd_name(self, ctx, response)#sawait })
+                } else {
+                    quote!(#stream;)
+                }
+            }
+        } else {
+            if delegate && asynch {
+                quote!(
+                    fn #cmd_name(
+                        &self,
+                        ctx: impl #krate::dm::InvokeContext,
+                    ) -> impl core::future::Future<Output = Result<#field_resp, #krate::error::Error>> {
+                        T::#cmd_name(self, ctx)
+                    }
+                )
+            } else {
+                let stream = quote!(
+                    #pasync fn #cmd_name(
+                        &self,
+                        ctx: impl #krate::dm::InvokeContext,
+                    ) -> Result<#field_resp, #krate::error::Error>
+                );
+
+                if delegate {
+                    quote!(#stream { T::#cmd_name(self, ctx)#sawait })
+                } else {
+                    quote!(#stream;)
+                }
+            }
+        }
+    } else {
+        if delegate && asynch {
+            quote!(
+                fn #cmd_name(
                     &self,
                     ctx: impl #krate::dm::InvokeContext,
-                    response: #field_resp,
-                ) -> Result<P, #krate::error::Error>
-            );
-
-            if delegate {
-                quote!(#stream { T::#cmd_name(self, ctx, response)#sawait })
-            } else {
-                quote!(#stream;)
-            }
+                ) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                    T::#cmd_name(self, ctx)
+                }
+            )
         } else {
             let stream = quote!(
                 #pasync fn #cmd_name(
                     &self,
                     ctx: impl #krate::dm::InvokeContext,
-                ) -> Result<#field_resp, #krate::error::Error>
+                ) -> Result<(), #krate::error::Error>
             );
 
             if delegate {
@@ -674,19 +806,6 @@ fn handler_command(
             } else {
                 quote!(#stream;)
             }
-        }
-    } else {
-        let stream = quote!(
-            #pasync fn #cmd_name(
-                &self,
-                ctx: impl #krate::dm::InvokeContext,
-            ) -> Result<(), #krate::error::Error>
-        );
-
-        if delegate {
-            quote!(#stream { T::#cmd_name(self, ctx)#sawait })
-        } else {
-            quote!(#stream;)
         }
     }
 }

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -1079,32 +1079,36 @@ mod asynch {
         }
 
         /// Read from the requested attribute and encode the result using the provided reply type.
-        async fn read(&self, ctx: impl ReadContext, reply: impl ReadReply) -> Result<(), Error>;
+        fn read(
+            &self,
+            ctx: impl ReadContext,
+            reply: impl ReadReply,
+        ) -> impl Future<Output = Result<(), Error>>;
 
         /// Write into the requested attribute using the provided data.
         ///
         /// The default implementation errors out with `ErrorCode::AttributeNotFound`.
-        async fn write(&self, _ctx: impl WriteContext) -> Result<(), Error> {
-            Err(ErrorCode::AttributeNotFound.into())
+        fn write(&self, _ctx: impl WriteContext) -> impl Future<Output = Result<(), Error>> {
+            core::future::ready(Err(ErrorCode::AttributeNotFound.into()))
         }
 
         /// Invoke the requested command with the provided data and encode the result using the provided reply type.
         ///
         /// The default implementation errors out with `ErrorCode::CommandNotFound`.
-        async fn invoke(
+        fn invoke(
             &self,
             _ctx: impl InvokeContext,
             _reply: impl InvokeReply,
-        ) -> Result<(), Error> {
-            Err(ErrorCode::CommandNotFound.into())
+        ) -> impl Future<Output = Result<(), Error>> {
+            core::future::ready(Err(ErrorCode::CommandNotFound.into()))
         }
 
         /// A hook (a scheduling facility) for placing handler-impl-specific code that needs to run
         /// asynchronously - forever and in the "background".
-        async fn run(&self, _ctx: impl HandlerContext) -> Result<(), Error> {
+        fn run(&self, _ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
             // Default implementation pends forever.
             // This is useful for handlers that do not need to run any async operations in the background.
-            core::future::pending::<Result<(), Error>>().await
+            core::future::pending::<Result<(), Error>>()
         }
     }
 
@@ -1247,20 +1251,24 @@ mod asynch {
             false
         }
 
-        async fn read(&self, ctx: impl ReadContext, reply: impl ReadReply) -> Result<(), Error> {
-            Handler::read(&self.0, ctx, reply)
+        fn read(
+            &self,
+            ctx: impl ReadContext,
+            reply: impl ReadReply,
+        ) -> impl Future<Output = Result<(), Error>> {
+            core::future::ready(Handler::read(&self.0, ctx, reply))
         }
 
-        async fn write(&self, ctx: impl WriteContext) -> Result<(), Error> {
-            Handler::write(&self.0, ctx)
+        fn write(&self, ctx: impl WriteContext) -> impl Future<Output = Result<(), Error>> {
+            core::future::ready(Handler::write(&self.0, ctx))
         }
 
-        async fn invoke(
+        fn invoke(
             &self,
             ctx: impl InvokeContext,
             reply: impl InvokeReply,
-        ) -> Result<(), Error> {
-            Handler::invoke(&self.0, ctx, reply)
+        ) -> impl Future<Output = Result<(), Error>> {
+            core::future::ready(Handler::invoke(&self.0, ctx, reply))
         }
     }
 
@@ -1277,8 +1285,12 @@ mod asynch {
             false
         }
 
-        async fn read(&self, _ctx: impl ReadContext, _reply: impl ReadReply) -> Result<(), Error> {
-            Err(ErrorCode::AttributeNotFound.into())
+        fn read(
+            &self,
+            _ctx: impl ReadContext,
+            _reply: impl ReadReply,
+        ) -> impl Future<Output = Result<(), Error>> {
+            core::future::ready(Err(ErrorCode::AttributeNotFound.into()))
         }
     }
 

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -16,6 +16,7 @@
  */
 
 use core::future::Future;
+use core::pin::pin;
 
 use crate::crypto::backend::dummy::DummyCrypto;
 use crate::crypto::Crypto;
@@ -23,6 +24,7 @@ use crate::dm::IMBuffer;
 use crate::error::{Error, ErrorCode};
 use crate::tlv::TLVElement;
 use crate::transport::exchange::Exchange;
+use crate::utils::select::Coalesce;
 use crate::utils::storage::pooled::{BufferAccess, PooledBuffers};
 use crate::utils::sync::DynBase;
 use crate::Matter;
@@ -30,6 +32,7 @@ use crate::Matter;
 use super::{AttrDetails, AttrId, ClusterId, CmdDetails, EndptId, InvokeReply, ReadReply};
 
 pub use asynch::*;
+use embassy_futures::select::select;
 
 pub trait ChangeNotify: DynBase {
     fn notify(&self, endpt: EndptId, clust: ClusterId, attr: AttrId);
@@ -771,6 +774,10 @@ where
     fn invoke(&self, ctx: impl InvokeContext, reply: impl InvokeReply) -> Result<(), Error> {
         (**self).invoke(ctx, reply)
     }
+
+    fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
+        (**self).run(ctx)
+    }
 }
 
 /// A marker trait that indicates that the handler is non-blocking.
@@ -795,6 +802,10 @@ where
 
     fn invoke(&self, ctx: impl InvokeContext, reply: impl InvokeReply) -> Result<(), Error> {
         self.1.invoke(ctx, reply)
+    }
+
+    fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
+        self.1.run(ctx)
     }
 }
 
@@ -981,6 +992,13 @@ where
         } else {
             self.next.invoke(ctx, reply)
         }
+    }
+
+    async fn run(&self, ctx: impl HandlerContext) -> Result<(), Error> {
+        let mut handler = pin!(self.handler.run(&ctx));
+        let mut next = pin!(self.next.run(&ctx));
+
+        select(&mut handler, &mut next).coalesce().await
     }
 }
 
@@ -1404,6 +1422,10 @@ mod asynch {
 
         fn invoke(&self, ctx: impl InvokeContext, reply: impl InvokeReply) -> Result<(), Error> {
             self.0.invoke(ctx, reply)
+        }
+
+        fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
+            self.0.run(ctx)
         }
     }
 

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+use core::future::Future;
+
 use crate::crypto::backend::dummy::DummyCrypto;
 use crate::crypto::Crypto;
 use crate::dm::IMBuffer;
@@ -723,6 +725,14 @@ pub trait Handler {
     fn invoke(&self, _ctx: impl InvokeContext, _reply: impl InvokeReply) -> Result<(), Error> {
         Err(ErrorCode::CommandNotFound.into())
     }
+
+    /// A hook (a scheduling facility) for placing handler-impl-specific code that needs to run
+    /// asynchronously - forever and in the "background".
+    fn run(&self, _ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
+        // Default implementation pends forever.
+        // This is useful for handlers that do not need to run any async operations in the background.
+        core::future::pending::<Result<(), Error>>()
+    }
 }
 
 impl<T> Handler for &T
@@ -739,6 +749,10 @@ where
 
     fn invoke(&self, ctx: impl InvokeContext, reply: impl InvokeReply) -> Result<(), Error> {
         (**self).invoke(ctx, reply)
+    }
+
+    fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
+        (**self).run(ctx)
     }
 }
 
@@ -1022,6 +1036,7 @@ mod asynch {
 
     use crate::dm::{HandlerContext, InvokeReply, Matcher, ReadReply};
     use crate::error::{Error, ErrorCode};
+    use crate::utils::future::delayed_ready;
     use crate::utils::select::Coalesce;
 
     use super::{
@@ -1256,11 +1271,11 @@ mod asynch {
             ctx: impl ReadContext,
             reply: impl ReadReply,
         ) -> impl Future<Output = Result<(), Error>> {
-            core::future::ready(Handler::read(&self.0, ctx, reply))
+            delayed_ready(|| Handler::read(&self.0, ctx, reply))
         }
 
         fn write(&self, ctx: impl WriteContext) -> impl Future<Output = Result<(), Error>> {
-            core::future::ready(Handler::write(&self.0, ctx))
+            delayed_ready(|| Handler::write(&self.0, ctx))
         }
 
         fn invoke(
@@ -1268,7 +1283,11 @@ mod asynch {
             ctx: impl InvokeContext,
             reply: impl InvokeReply,
         ) -> impl Future<Output = Result<(), Error>> {
-            core::future::ready(Handler::invoke(&self.0, ctx, reply))
+            delayed_ready(|| Handler::invoke(&self.0, ctx, reply))
+        }
+
+        fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
+            Handler::run(&self.0, ctx)
         }
     }
 

--- a/rs-matter/src/utils/future.rs
+++ b/rs-matter/src/utils/future.rs
@@ -15,19 +15,22 @@
  *    limitations under the License.
  */
 
-pub mod bitflags;
-pub mod cell;
-pub mod codec;
-pub mod epoch;
-pub mod future;
-pub mod init;
-pub mod ipv6;
-pub mod iter;
-pub mod maybe;
-pub mod select;
-pub mod storage;
-pub mod sync;
-#[cfg(feature = "zbus")]
-pub mod zbus;
-#[cfg(feature = "zbus")]
-pub mod zbus_proxies;
+use core::future::{poll_fn, Future};
+use core::task::Poll;
+
+/// Create a future that will call the provided closure when polled, allowing for delayed computation of the "ready" value.
+#[inline(always)]
+pub fn delayed_ready<F, O>(f: F) -> impl Future<Output = O>
+where
+    F: FnOnce() -> O,
+{
+    let mut f = Some(f);
+
+    poll_fn(move |_| {
+        if let Some(f) = f.take() {
+            Poll::Ready(f())
+        } else {
+            panic!("delayed_ready polled after completion");
+        }
+    })
+}


### PR DESCRIPTION
Subject says it all - a harmless change that should reduce a bit the code and RAM footprint.