### PR TITLE
Move on-off and level-control back to non-blocking to check for code bloat reduction

### DIFF
--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -195,7 +195,7 @@ type AppNetCtl<'a> = NetCtlWithStatusImpl<'a, FakeWifi>;
 type AppWirelessMgr<'a> = WirelessMgr<'a, &'a WifiNetworks<3>, &'a AppNetCtl<'a>>;
 type AppTransport<'a> = ChainedNetwork<FakeUdp, &'a Btp, fn(&Address) -> bool>;
 type AppHandler<'a> = handler_chain_type!(
-    EpClMatcher => on_off::HandlerAsyncAdaptor<on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>>,
+    EpClMatcher => Async<on_off::HandlerAdaptor<on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>>>,
     EpClMatcher => Async<desc::HandlerAdaptor<DescHandler<'a>>>
     | EmptyHandler
 );
@@ -661,7 +661,7 @@ where
                 )
                 .chain(
                     EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                    on_off::HandlerAsyncAdaptor(on_off),
+                    Async(on_off::HandlerAdaptor(on_off)),
                 ),
         ),
     )

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -261,7 +261,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                         )
                         .chain(
                             EpClMatcher::new(Some(2), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                            on_off::HandlerAsyncAdaptor(on_off_ep2),
+                            Async(on_off::HandlerAdaptor(on_off_ep2)),
                         )
                         .chain(
                             EpClMatcher::new(Some(2), Some(BridgedHandler::CLUSTER.id)),
@@ -277,7 +277,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                         )
                         .chain(
                             EpClMatcher::new(Some(3), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                            on_off::HandlerAsyncAdaptor(on_off_ep3),
+                            Async(on_off::HandlerAdaptor(on_off_ep3)),
                         )
                         .chain(
                             EpClMatcher::new(Some(3), Some(BridgedHandler::CLUSTER.id)),

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -325,7 +325,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                         )
                         .chain(
                             EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                            on_off::HandlerAsyncAdaptor(on_off_1),
+                            Async(on_off::HandlerAdaptor(on_off_1)),
                         )
                         .chain(
                             EpClMatcher::new(Some(1), Some(UnitTestingHandler::CLUSTER.id)),
@@ -348,7 +348,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                         )
                         .chain(
                             EpClMatcher::new(Some(2), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                            on_off::HandlerAsyncAdaptor(on_off_2),
+                            Async(on_off::HandlerAdaptor(on_off_2)),
                         ),
                 ),
             ),

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -308,11 +308,11 @@ fn dm_handler<'a, LH: LevelControlHooks, OH: OnOffHooks>(
                         )
                         .chain(
                             EpClMatcher::new(Some(1), Some(OnOffDeviceLogic::CLUSTER.id)),
-                            on_off::HandlerAsyncAdaptor(on_off),
+                            Async(on_off::HandlerAdaptor(on_off)),
                         )
                         .chain(
                             EpClMatcher::new(Some(1), Some(LevelControlDeviceLogic::CLUSTER.id)),
-                            level_control::HandlerAsyncAdaptor(level_control),
+                            Async(level_control::HandlerAdaptor(level_control)),
                         ),
                 ),
             ),

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -224,7 +224,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                     )
                     .chain(
                         EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                        on_off::HandlerAsyncAdaptor(on_off),
+                        Async(on_off::HandlerAdaptor(on_off)),
                     ),
             ),
         ),

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -247,7 +247,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                         )
                         .chain(
                             EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                            on_off::HandlerAsyncAdaptor(on_off),
+                            Async(on_off::HandlerAdaptor(on_off)),
                         ),
                 ),
             ),

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -311,7 +311,7 @@ where
                         )
                         .chain(
                             EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                            on_off::HandlerAsyncAdaptor(on_off),
+                            Async(on_off::HandlerAdaptor(on_off)),
                         ),
                 ),
             ),

--- a/examples/src/bin/onoff_light_work_stealing.rs
+++ b/examples/src/bin/onoff_light_work_stealing.rs
@@ -58,7 +58,7 @@ use static_cell::StaticCell;
 mod mdns;
 
 type AppHandler<'a> = handler_chain_type!(
-    EpClMatcher => on_off::HandlerAsyncAdaptor<on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>>,
+    EpClMatcher => Async<on_off::HandlerAdaptor<on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>>>,
     EpClMatcher => Async<desc::HandlerAdaptor<DescHandler<'a>>>
     | EmptyHandler
 );
@@ -276,7 +276,7 @@ fn dm_handler<'a>(
                 )
                 .chain(
                     EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                    on_off::HandlerAsyncAdaptor(on_off),
+                    Async(on_off::HandlerAdaptor(on_off)),
                 ),
         ),
     )

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -207,11 +207,11 @@ fn dm_handler<'a, LH: LevelControlHooks, OH: OnOffHooks>(
                     )
                     .chain(
                         EpClMatcher::new(Some(1), Some(TestLevelControlDeviceLogic::CLUSTER.id)),
-                        level_control::HandlerAsyncAdaptor(level_control),
+                        Async(level_control::HandlerAdaptor(level_control)),
                     )
                     .chain(
                         EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                        on_off::HandlerAsyncAdaptor(on_off),
+                        Async(on_off::HandlerAdaptor(on_off)),
                     ),
             ),
         ),

--- a/rs-matter-macros/src/idl/handler.rs
+++ b/rs-matter-macros/src/idl/handler.rs
@@ -78,16 +78,6 @@ pub fn handler(
         .map(|cmd| handler_command(cmd, asynch, delegate, entities, &krate));
 
     if delegate {
-        let run = if asynch {
-            quote!(
-                fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                    (**self).run(ctx)
-                }
-            )
-        } else {
-            quote!()
-        };
-
         quote!(
             impl<T> #handler_name for &T
             where
@@ -98,7 +88,9 @@ pub fn handler(
                 fn dataver(&self) -> u32 { T::dataver(self) }
                 fn dataver_changed(&self) { T::dataver_changed(self) }
 
-                #run
+                fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                    (**self).run(ctx)
+                }
 
                 #(#handler_attribute_methods)*
 
@@ -108,16 +100,6 @@ pub fn handler(
             }
         )
     } else {
-        let run = if asynch {
-            quote!(
-                fn run(&self, _ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                    core::future::pending::<Result::<(), #krate::error::Error>>()
-                }
-            )
-        } else {
-            quote!()
-        };
-
         quote!(
             #[doc = "The handler trait for the cluster."]
             pub trait #handler_name {
@@ -128,7 +110,9 @@ pub fn handler(
 
                 fn dataver_changed(&self);
 
-                #run
+                fn run(&self, _ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                    core::future::pending::<Result::<(), #krate::error::Error>>()
+                }
 
                 #(#handler_attribute_methods)*
 
@@ -272,16 +256,6 @@ pub fn handler_adaptor(
         )
     };
 
-    let run = if asynch {
-        quote!(
-            fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                self.0.run(ctx)
-            }
-        )
-    } else {
-        quote!()
-    };
-
     let pasync = if asynch { quote!(async) } else { quote!() };
 
     let stream = quote!(
@@ -342,7 +316,9 @@ pub fn handler_adaptor(
                 Ok(())
             }
 
-            #run
+            fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                self.0.run(ctx)
+            }
         }
 
         impl<T, Q> core::fmt::Debug for MetadataDebug<(u16, &#handler_adaptor_name<T>, Q)>

--- a/rs-matter/src/dm/clusters/level_control.rs
+++ b/rs-matter/src/dm/clusters/level_control.rs
@@ -406,8 +406,8 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
     }
 
     /// Adapt the handler instance to the generic `rs-matter` `Handler` trait
-    pub const fn adapt(self) -> HandlerAsyncAdaptor<Self> {
-        HandlerAsyncAdaptor(self)
+    pub const fn adapt(self) -> HandlerAdaptor<Self> {
+        HandlerAdaptor(self)
     }
 
     fn with_state<F, R>(&self, f: F) -> R
@@ -1233,7 +1233,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
     }
 }
 
-impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlHandler<'_, H, OH> {
+impl<H: LevelControlHooks, OH: OnOffHooks> ClusterHandler for LevelControlHandler<'_, H, OH> {
     const CLUSTER: Cluster<'static> = H::CLUSTER;
 
     // Runs an async task manager for the cluster handler.
@@ -1275,18 +1275,18 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         self.dataver.changed();
     }
 
-    async fn current_level(&self, _ctx: impl ReadContext) -> Result<Nullable<u8>, Error> {
+    fn current_level(&self, _ctx: impl ReadContext) -> Result<Nullable<u8>, Error> {
         match self.hooks.current_level() {
             Some(level) => Ok(Nullable::some(level)),
             None => Ok(Nullable::none()),
         }
     }
 
-    async fn on_level(&self, _ctx: impl ReadContext) -> Result<Nullable<u8>, Error> {
+    fn on_level(&self, _ctx: impl ReadContext) -> Result<Nullable<u8>, Error> {
         Ok(self.with_state(|state| state.on_level.clone()))
     }
 
-    async fn set_on_level(&self, ctx: impl WriteContext, value: Nullable<u8>) -> Result<(), Error> {
+    fn set_on_level(&self, ctx: impl WriteContext, value: Nullable<u8>) -> Result<(), Error> {
         if let Some(level) = value.clone().into_option() {
             if level > H::MAX_LEVEL || level < H::MIN_LEVEL {
                 return Err(ErrorCode::ConstraintError.into());
@@ -1300,11 +1300,11 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         Ok(())
     }
 
-    async fn options(&self, _ctx: impl ReadContext) -> Result<OptionsBitmap, Error> {
+    fn options(&self, _ctx: impl ReadContext) -> Result<OptionsBitmap, Error> {
         Ok(self.with_state(|state| state.options))
     }
 
-    async fn set_options(&self, ctx: impl WriteContext, value: OptionsBitmap) -> Result<(), Error> {
+    fn set_options(&self, ctx: impl WriteContext, value: OptionsBitmap) -> Result<(), Error> {
         self.with_state_notify(ctx, |state| {
             state.options = value;
         });
@@ -1312,27 +1312,23 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         Ok(())
     }
 
-    async fn remaining_time(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
+    fn remaining_time(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
         Ok(self.with_state(|state| state.remaining_time))
     }
 
-    async fn max_level(&self, _ctx: impl ReadContext) -> Result<u8, Error> {
+    fn max_level(&self, _ctx: impl ReadContext) -> Result<u8, Error> {
         Ok(H::MAX_LEVEL)
     }
 
-    async fn min_level(&self, _ctx: impl ReadContext) -> Result<u8, Error> {
+    fn min_level(&self, _ctx: impl ReadContext) -> Result<u8, Error> {
         Ok(H::MIN_LEVEL)
     }
 
-    async fn on_off_transition_time(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
+    fn on_off_transition_time(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
         Ok(self.with_state(|state| state.on_off_transition_time))
     }
 
-    async fn set_on_off_transition_time(
-        &self,
-        ctx: impl WriteContext,
-        value: u16,
-    ) -> Result<(), Error> {
+    fn set_on_off_transition_time(&self, ctx: impl WriteContext, value: u16) -> Result<(), Error> {
         self.with_state_notify(ctx, |state| {
             state.on_off_transition_time = value;
         });
@@ -1340,11 +1336,11 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         Ok(())
     }
 
-    async fn on_transition_time(&self, _ctx: impl ReadContext) -> Result<Nullable<u16>, Error> {
+    fn on_transition_time(&self, _ctx: impl ReadContext) -> Result<Nullable<u16>, Error> {
         Ok(self.with_state(|state| state.on_transition_time.clone()))
     }
 
-    async fn set_on_transition_time(
+    fn set_on_transition_time(
         &self,
         ctx: impl WriteContext,
         value: Nullable<u16>,
@@ -1356,11 +1352,11 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         Ok(())
     }
 
-    async fn off_transition_time(&self, _ctx: impl ReadContext) -> Result<Nullable<u16>, Error> {
+    fn off_transition_time(&self, _ctx: impl ReadContext) -> Result<Nullable<u16>, Error> {
         Ok(self.with_state(|state| state.off_transition_time.clone()))
     }
 
-    async fn set_off_transition_time(
+    fn set_off_transition_time(
         &self,
         ctx: impl WriteContext,
         value: Nullable<u16>,
@@ -1372,11 +1368,11 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         Ok(())
     }
 
-    async fn default_move_rate(&self, _ctx: impl ReadContext) -> Result<Nullable<u8>, Error> {
+    fn default_move_rate(&self, _ctx: impl ReadContext) -> Result<Nullable<u8>, Error> {
         Ok(self.with_state(|state| state.default_move_rate.clone()))
     }
 
-    async fn set_default_move_rate(
+    fn set_default_move_rate(
         &self,
         ctx: impl WriteContext,
         value: Nullable<u8>,
@@ -1395,14 +1391,14 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         Ok(())
     }
 
-    async fn start_up_current_level(&self, _ctx: impl ReadContext) -> Result<Nullable<u8>, Error> {
+    fn start_up_current_level(&self, _ctx: impl ReadContext) -> Result<Nullable<u8>, Error> {
         match self.hooks.start_up_current_level()? {
             Some(val) => Ok(Nullable::some(val)),
             None => Ok(Nullable::none()),
         }
     }
 
-    async fn set_start_up_current_level(
+    fn set_start_up_current_level(
         &self,
         ctx: impl WriteContext,
         value: Nullable<u8>,
@@ -1421,7 +1417,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         Ok(())
     }
 
-    async fn handle_move_to_level(
+    fn handle_move_to_level(
         &self,
         _ctx: impl InvokeContext,
         request: MoveToLevelRequest<'_>,
@@ -1435,11 +1431,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         )
     }
 
-    async fn handle_move(
-        &self,
-        _ctx: impl InvokeContext,
-        request: MoveRequest<'_>,
-    ) -> Result<(), Error> {
+    fn handle_move(&self, _ctx: impl InvokeContext, request: MoveRequest<'_>) -> Result<(), Error> {
         self.with_state(|state| {
             self.move_command(
                 state,
@@ -1452,11 +1444,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         })
     }
 
-    async fn handle_step(
-        &self,
-        _ctx: impl InvokeContext,
-        request: StepRequest<'_>,
-    ) -> Result<(), Error> {
+    fn handle_step(&self, _ctx: impl InvokeContext, request: StepRequest<'_>) -> Result<(), Error> {
         self.step(
             false,
             request.step_mode()?,
@@ -1467,11 +1455,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         )
     }
 
-    async fn handle_stop(
-        &self,
-        ctx: impl InvokeContext,
-        request: StopRequest<'_>,
-    ) -> Result<(), Error> {
+    fn handle_stop(&self, ctx: impl InvokeContext, request: StopRequest<'_>) -> Result<(), Error> {
         self.stop(
             &ctx,
             false,
@@ -1480,7 +1464,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         )
     }
 
-    async fn handle_move_to_level_with_on_off(
+    fn handle_move_to_level_with_on_off(
         &self,
         _ctx: impl InvokeContext,
         request: MoveToLevelWithOnOffRequest<'_>,
@@ -1494,7 +1478,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         )
     }
 
-    async fn handle_move_with_on_off(
+    fn handle_move_with_on_off(
         &self,
         _ctx: impl InvokeContext,
         request: MoveWithOnOffRequest<'_>,
@@ -1511,7 +1495,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         })
     }
 
-    async fn handle_step_with_on_off(
+    fn handle_step_with_on_off(
         &self,
         _ctx: impl InvokeContext,
         request: StepWithOnOffRequest<'_>,
@@ -1526,7 +1510,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         )
     }
 
-    async fn handle_stop_with_on_off(
+    fn handle_stop_with_on_off(
         &self,
         ctx: impl InvokeContext,
         request: StopWithOnOffRequest<'_>,
@@ -1539,7 +1523,7 @@ impl<H: LevelControlHooks, OH: OnOffHooks> ClusterAsyncHandler for LevelControlH
         )
     }
 
-    async fn handle_move_to_closest_frequency(
+    fn handle_move_to_closest_frequency(
         &self,
         _ctx: impl InvokeContext,
         _request: MoveToClosestFrequencyRequest<'_>,

--- a/rs-matter/src/dm/clusters/on_off.rs
+++ b/rs-matter/src/dm/clusters/on_off.rs
@@ -280,8 +280,8 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
     }
 
     /// Adapt the handler instance to the generic `rs-matter` `Handler` trait
-    pub const fn adapt(self) -> HandlerAsyncAdaptor<Self> {
-        HandlerAsyncAdaptor(self)
+    pub const fn adapt(self) -> HandlerAdaptor<Self> {
+        HandlerAdaptor(self)
     }
 
     /// Request an out-of-band change to the OnOff state.
@@ -701,7 +701,7 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
     }
 }
 
-impl<H: OnOffHooks, LH: LevelControlHooks> ClusterAsyncHandler for OnOffHandler<'_, H, LH> {
+impl<H: OnOffHooks, LH: LevelControlHooks> ClusterHandler for OnOffHandler<'_, H, LH> {
     #[doc = "The cluster-metadata corresponding to this handler trait."]
     const CLUSTER: Cluster<'static> = H::CLUSTER;
 
@@ -742,30 +742,27 @@ impl<H: OnOffHooks, LH: LevelControlHooks> ClusterAsyncHandler for OnOffHandler<
     }
 
     // Attribute accessors
-    async fn on_off(&self, _ctx: impl ReadContext) -> Result<bool, Error> {
+    fn on_off(&self, _ctx: impl ReadContext) -> Result<bool, Error> {
         Ok(self.hooks.on_off())
     }
 
-    async fn global_scene_control(&self, _ctx: impl ReadContext) -> Result<bool, Error> {
+    fn global_scene_control(&self, _ctx: impl ReadContext) -> Result<bool, Error> {
         Ok(self.with_state(|state| state.global_scene_control))
     }
 
-    async fn on_time(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
+    fn on_time(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
         Ok(self.with_state(|state| state.on_time))
     }
 
-    async fn off_wait_time(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
+    fn off_wait_time(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
         Ok(self.with_state(|state| state.off_wait_time))
     }
 
-    async fn start_up_on_off(
-        &self,
-        _ctx: impl ReadContext,
-    ) -> Result<Nullable<StartUpOnOffEnum>, Error> {
+    fn start_up_on_off(&self, _ctx: impl ReadContext) -> Result<Nullable<StartUpOnOffEnum>, Error> {
         Ok(self.hooks.start_up_on_off())
     }
 
-    async fn set_on_time(&self, ctx: impl WriteContext, value: u16) -> Result<(), Error> {
+    fn set_on_time(&self, ctx: impl WriteContext, value: u16) -> Result<(), Error> {
         self.with_state(|state| {
             state.on_time = value;
             self.dataver_changed();
@@ -774,7 +771,7 @@ impl<H: OnOffHooks, LH: LevelControlHooks> ClusterAsyncHandler for OnOffHandler<
         })
     }
 
-    async fn set_off_wait_time(&self, ctx: impl WriteContext, value: u16) -> Result<(), Error> {
+    fn set_off_wait_time(&self, ctx: impl WriteContext, value: u16) -> Result<(), Error> {
         self.with_state(|state| {
             state.off_wait_time = value;
             self.dataver_changed();
@@ -783,7 +780,7 @@ impl<H: OnOffHooks, LH: LevelControlHooks> ClusterAsyncHandler for OnOffHandler<
         })
     }
 
-    async fn set_start_up_on_off(
+    fn set_start_up_on_off(
         &self,
         ctx: impl WriteContext,
         value: Nullable<StartUpOnOffEnum>,
@@ -795,25 +792,25 @@ impl<H: OnOffHooks, LH: LevelControlHooks> ClusterAsyncHandler for OnOffHandler<
     }
 
     // Commands
-    async fn handle_off(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
+    fn handle_off(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
         self.state_change_signal.signal(OnOffCommand::Off);
 
         Ok(())
     }
 
-    async fn handle_on(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
+    fn handle_on(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
         self.state_change_signal.signal(OnOffCommand::On);
 
         Ok(())
     }
 
-    async fn handle_toggle(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
+    fn handle_toggle(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
         self.state_change_signal.signal(OnOffCommand::Toggle);
 
         Ok(())
     }
 
-    async fn handle_off_with_effect(
+    fn handle_off_with_effect(
         &self,
         _ctx: impl InvokeContext,
         request: OffWithEffectRequest<'_>,
@@ -854,10 +851,7 @@ impl<H: OnOffHooks, LH: LevelControlHooks> ClusterAsyncHandler for OnOffHandler<
         Ok(())
     }
 
-    async fn handle_on_with_recall_global_scene(
-        &self,
-        _ctx: impl InvokeContext,
-    ) -> Result<(), Error> {
+    fn handle_on_with_recall_global_scene(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
         self.with_state(|state| {
             // 1.5.7.5.1. Effect on Receipt
             // On receipt of the OnWithRecallGlobalScene command, if the GlobalSceneControl attribute is equal
@@ -879,7 +873,7 @@ impl<H: OnOffHooks, LH: LevelControlHooks> ClusterAsyncHandler for OnOffHandler<
         })
     }
 
-    async fn handle_on_with_timed_off(
+    fn handle_on_with_timed_off(
         &self,
         ctx: impl InvokeContext,
         request: OnWithTimedOffRequest<'_>,

--- a/rs-matter/tests/commissioning.rs
+++ b/rs-matter/tests/commissioning.rs
@@ -147,7 +147,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                     )
                     .chain(
                         EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-                        on_off::HandlerAsyncAdaptor(on_off),
+                        Async(on_off::HandlerAdaptor(on_off)),
                     ),
             ),
         ),

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -15,18 +15,20 @@
  *    limitations under the License.
  */
 
+use core::future::Future;
+
 use rs_matter::crypto::{Crypto, RngCore};
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _, DescHandler};
 use rs_matter::dm::clusters::level_control::LevelControlHooks;
 use rs_matter::dm::clusters::on_off::{
-    self, test::TestOnOffDeviceLogic, ClusterAsyncHandler as _, NoLevelControl, OnOffHandler,
-    OnOffHooks,
+    self, test::TestOnOffDeviceLogic, ClusterHandler as _, NoLevelControl, OnOffHandler, OnOffHooks,
 };
 use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ROOT_NODE};
 use rs_matter::dm::endpoints::{with_eth, with_sys, EthHandler, SysHandler, ROOT_ENDPOINT_ID};
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, ChainedHandler, Dataver, EmptyHandler, Endpoint,
-    EpClMatcher, InvokeContext, InvokeReply, Node, ReadContext, ReadReply, WriteContext,
+    EpClMatcher, HandlerContext, InvokeContext, InvokeReply, Node, ReadContext, ReadReply,
+    WriteContext,
 };
 use rs_matter::error::Error;
 use rs_matter::{clusters, handler_chain_type};
@@ -38,7 +40,7 @@ use super::echo_cluster::{self, EchoHandler};
 /// A sample handler for E2E IM tests.
 pub struct E2eTestHandler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     handler_chain_type!(
-        EpClMatcher => on_off::HandlerAsyncAdaptor<OnOffHandler<'a, OH, LH>>,
+        EpClMatcher => Async<on_off::HandlerAdaptor<OnOffHandler<'a, OH, LH>>>,
         EpClMatcher => Async<EchoHandler>,
         EpClMatcher => Async<desc::HandlerAdaptor<DescHandler<'static>>>,
         EpClMatcher => Async<EchoHandler>
@@ -84,7 +86,7 @@ impl<'a, OH: OnOffHooks, LH: LevelControlHooks> E2eTestHandler<'a, OH, LH> {
         )
         .chain(
             EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
-            on_off::HandlerAsyncAdaptor(on_off),
+            Async(on_off.adapt()),
         );
 
         Self(handler)
@@ -112,16 +114,28 @@ impl<'a, OH: OnOffHooks, LH: LevelControlHooks> AsyncHandler for E2eTestHandler<
         false
     }
 
-    async fn read(&self, ctx: impl ReadContext, reply: impl ReadReply) -> Result<(), Error> {
-        self.0.read(ctx, reply).await
+    fn read(
+        &self,
+        ctx: impl ReadContext,
+        reply: impl ReadReply,
+    ) -> impl Future<Output = Result<(), Error>> {
+        self.0.read(ctx, reply)
     }
 
-    async fn write(&self, ctx: impl WriteContext) -> Result<(), Error> {
-        self.0.write(ctx).await
+    fn write(&self, ctx: impl WriteContext) -> impl Future<Output = Result<(), Error>> {
+        self.0.write(ctx)
     }
 
-    async fn invoke(&self, ctx: impl InvokeContext, reply: impl InvokeReply) -> Result<(), Error> {
-        self.0.invoke(ctx, reply).await
+    fn invoke(
+        &self,
+        ctx: impl InvokeContext,
+        reply: impl InvokeReply,
+    ) -> impl Future<Output = Result<(), Error>> {
+        self.0.invoke(ctx, reply)
+    }
+
+    fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
+        self.0.run(ctx)
     }
 }
 

--- a/rs-matter/tests/common/mod.rs
+++ b/rs-matter/tests/common/mod.rs
@@ -16,6 +16,7 @@
  */
 
 pub mod e2e;
+#[cfg(feature = "async-io")]
 pub mod mdns;
 
 use core::future::Future;

--- a/rs-matter/tests/data_model/attributes.rs
+++ b/rs-matter/tests/data_model/attributes.rs
@@ -16,7 +16,7 @@
  */
 
 use rs_matter::dm::clusters::on_off::{
-    self, test::TestOnOffDeviceLogic, ClusterAsyncHandler as _, NoLevelControl,
+    self, test::TestOnOffDeviceLogic, ClusterHandler as _, NoLevelControl,
 };
 use rs_matter::dm::GlobalElements;
 use rs_matter::im::GenericPath;

--- a/rs-matter/tests/data_model/commands.rs
+++ b/rs-matter/tests/data_model/commands.rs
@@ -16,7 +16,7 @@
  */
 
 use rs_matter::dm::clusters::on_off::{
-    self, test::TestOnOffDeviceLogic, ClusterAsyncHandler as _, NoLevelControl,
+    self, test::TestOnOffDeviceLogic, ClusterHandler as _, NoLevelControl,
 };
 use rs_matter::im::IMStatusCode;
 use rs_matter::im::{CmdPath, CmdStatus};


### PR DESCRIPTION
Subject says it all. 

Now that the `Handler` trait also has an `async fn run()` method, there is nothing stopping up from re-implementing the on-off and the level-control handlers as regular non-blocking ones.

What is interesting here is in how much code size reduction this would result.