### PR TITLE
Use configurable SAI/SII TXT records for operational mDNS discovery

### DIFF
--- a/rs-matter/src/transport/network/mdns.rs
+++ b/rs-matter/src/transport/network/mdns.rs
@@ -534,25 +534,29 @@ impl Service<'_> {
         match matter_service {
             MatterMdnsService::Commissioned { .. } => {
                 // Matter Core Spec Section 4.3.1 — Operational Discovery TXT records
-                let mut sai_str = heapless::String::<5>::new();
-                let mut sii_str = heapless::String::<5>::new();
+                // Use a plain array to avoid heapless::Vec monomorphization cost.
+                let mut sai_str = heapless::String::<10>::new();
+                let mut sii_str = heapless::String::<10>::new();
 
-                let mut txt_kvs = heapless::Vec::<_, 3>::new();
+                let mut txt_kvs: [(&str, &str); 3] = [("", ""); 3];
+                let mut txt_count = 0;
 
                 if let Some(sai) = dev_det.sai {
                     write_unwrap!(sai_str, "{}", sai);
-                    unwrap!(txt_kvs.push(("SAI", sai_str.as_str())));
+                    txt_kvs[txt_count] = ("SAI", sai_str.as_str());
+                    txt_count += 1;
                 }
 
                 if let Some(sii) = dev_det.sii {
                     write_unwrap!(sii_str, "{}", sii);
-                    unwrap!(txt_kvs.push(("SII", sii_str.as_str())));
+                    txt_kvs[txt_count] = ("SII", sii_str.as_str());
+                    txt_count += 1;
                 }
 
-                // If no TXT records configured, use dummy to satisfy mDNS
-                // responders that reject empty TXT records
-                if txt_kvs.is_empty() {
-                    unwrap!(txt_kvs.push(("dummy", "dummy")));
+                // Some mDNS responders do not accept empty TXT records
+                if txt_count == 0 {
+                    txt_kvs[0] = ("dummy", "dummy");
+                    txt_count = 1;
                 }
 
                 f(&Service {
@@ -562,7 +566,7 @@ impl Service<'_> {
                     service_protocol: "_matter._tcp",
                     port: matter_port,
                     service_subtypes: &[],
-                    txt_kvs: txt_kvs.as_slice(),
+                    txt_kvs: &txt_kvs[..txt_count],
                 })
                 .await
             }

--- a/rs-matter/src/transport/network/mdns.rs
+++ b/rs-matter/src/transport/network/mdns.rs
@@ -533,6 +533,28 @@ impl Service<'_> {
 
         match matter_service {
             MatterMdnsService::Commissioned { .. } => {
+                // Matter Core Spec Section 4.3.1 — Operational Discovery TXT records
+                let mut sai_str = heapless::String::<5>::new();
+                let mut sii_str = heapless::String::<5>::new();
+
+                let mut txt_kvs = heapless::Vec::<_, 3>::new();
+
+                if let Some(sai) = dev_det.sai {
+                    write_unwrap!(sai_str, "{}", sai);
+                    unwrap!(txt_kvs.push(("SAI", sai_str.as_str())));
+                }
+
+                if let Some(sii) = dev_det.sii {
+                    write_unwrap!(sii_str, "{}", sii);
+                    unwrap!(txt_kvs.push(("SII", sii_str.as_str())));
+                }
+
+                // If no TXT records configured, use dummy to satisfy mDNS
+                // responders that reject empty TXT records
+                if txt_kvs.is_empty() {
+                    unwrap!(txt_kvs.push(("dummy", "dummy")));
+                }
+
                 f(&Service {
                     name: matter_service.name(&mut name_buf),
                     service: "_matter",
@@ -540,8 +562,7 @@ impl Service<'_> {
                     service_protocol: "_matter._tcp",
                     port: matter_port,
                     service_subtypes: &[],
-                    // Some mDNS responders do not accept empty TXT records
-                    txt_kvs: &[("dummy", "dummy")],
+                    txt_kvs: txt_kvs.as_slice(),
                 })
                 .await
             }


### PR DESCRIPTION
## Summary

- The operational (commissioned) mDNS service currently emits a `("dummy", "dummy")` TXT record placeholder
- This uses the existing `sai`/`sii` fields on `BasicInfoConfig` to emit spec-correct `SAI` and `SII` TXT key-value pairs when configured
- Falls back to the dummy record when neither field is set, preserving backwards compatibility

Reference: Matter Core Spec Section 4.3.1