### PR TITLE
Enable the TestMultiAdmin YAML test as part of CI

### DIFF
--- a/rs-matter/src/dm/clusters/groups.rs
+++ b/rs-matter/src/dm/clusters/groups.rs
@@ -57,7 +57,7 @@ impl GroupsHandler {
         fab_idx: NonZeroU8,
         group_id: u16,
     ) -> Result<bool, Error> {
-        let fabric = state.fabrics.get(fab_idx).ok_or(ErrorCode::NotFound)?;
+        let fabric = state.fabrics.fabric(fab_idx)?;
 
         let result = fabric
             .groups()
@@ -165,7 +165,7 @@ impl ClusterHandler for GroupsHandler {
 
         ctx.exchange().with_state(|state| {
             // Check membership for group_id
-            let fabric = state.fabrics.get(fab_idx).ok_or(ErrorCode::NotFound)?;
+            let fabric = state.fabrics.fabric(fab_idx)?;
 
             let endpoint_id = ctx.cmd().endpoint_id;
             if let Some(entry) = fabric.groups().get(group_id) {

--- a/rs-matter/src/dm/clusters/grp_key_mgmt.rs
+++ b/rs-matter/src/dm/clusters/grp_key_mgmt.rs
@@ -425,7 +425,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         let group_key_set_id = request.group_key_set_id()?;
 
         ctx.exchange().with_state(|state| {
-            let fabric = state.fabrics.get(fab_idx).ok_or(ErrorCode::NotFound)?;
+            let fabric = state.fabrics.fabric(fab_idx)?;
             let entry = fabric
                 .groups()
                 .key_set_get(group_key_set_id)

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -907,13 +907,7 @@ impl Fabrics {
         noc: &[u8],
         icac: &[u8],
     ) -> Result<&mut Fabric, Error> {
-        let Some(fabric) = self
-            .fabrics
-            .iter_mut()
-            .find(|fabric| fabric.fab_idx == fab_idx)
-        else {
-            return Err(ErrorCode::NotFound.into());
-        };
+        let fabric = self.fabric_mut(fab_idx)?;
 
         fabric.update(crypto, root_ca, noc, icac, secret_key, None, None, None)?;
 
@@ -927,7 +921,7 @@ impl Fabrics {
             return Err(ErrorCode::Invalid.into());
         }
 
-        let fabric = self.get_mut(fab_idx).ok_or(ErrorCode::NotFound)?;
+        let fabric = self.fabric_mut(fab_idx)?;
         fabric.label.clear();
         fabric
             .label
@@ -939,9 +933,7 @@ impl Fabrics {
 
     /// Remove a fabric from the fabrics
     pub fn remove(&mut self, fab_idx: NonZeroU8) -> Result<(), Error> {
-        if self.get(fab_idx).is_none() {
-            return Err(ErrorCode::NotFound.into());
-        }
+        let _ = self.fabric(fab_idx)?;
 
         self.fabrics.retain(|fabric| fabric.fab_idx != fab_idx);
 

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -358,14 +358,33 @@ impl FailSafe {
             NocFlags::UPDATE_NOC_RECVD,
         )?;
 
-        Self::validate_certs(
-            &crypto,
-            &CertRef::new(TLVElement::new(noc)),
-            icac.map(|icac| CertRef::new(TLVElement::new(icac)))
-                .as_ref(),
-            &CertRef::new(TLVElement::new(&self.root_ca)),
-            buf,
-        )?;
+        {
+            let noc_ref = CertRef::new(TLVElement::new(noc));
+            let icac_ref = icac.map(|icac| CertRef::new(TLVElement::new(icac)));
+            let root_ref = CertRef::new(TLVElement::new(&self.root_ca));
+
+            // Validate the certs first
+            Self::validate_certs(&crypto, &noc_ref, icac_ref.as_ref(), &root_ref, buf)?;
+
+            // Check that the fabric ID and root cert pubkey in the NOC
+            // match the ones of the fabric which is being updated
+
+            let fabric_id = noc_ref.get_fabric_id()?;
+            let root_cert_pubkey = root_ref.pubkey()?;
+
+            let fabric = fabrics.fabric(fab_idx)?;
+
+            if fabric_id != fabric.fabric_id() {
+                Err(ErrorCode::NocFabricConflict)?;
+            }
+
+            let f_root_ref = CertRef::new(TLVElement::new(fabric.root_ca()));
+            let f_root_pubkey = f_root_ref.pubkey()?;
+
+            if root_cert_pubkey != f_root_pubkey {
+                Err(ErrorCode::NocFabricConflict)?;
+            }
+        }
 
         let fabric = fabrics.update(
             &crypto,
@@ -411,17 +430,33 @@ impl FailSafe {
             NocFlags::ADD_NOC_RECVD,
         )?;
 
-        Self::validate_certs(
-            &crypto,
-            &CertRef::new(TLVElement::new(noc)),
-            icac.map(|icac| CertRef::new(TLVElement::new(icac)))
-                .as_ref(),
-            &CertRef::new(TLVElement::new(&self.root_ca)),
-            buf,
-        )?;
+        {
+            let noc_ref = CertRef::new(TLVElement::new(noc));
+            let icac_ref = icac.map(|icac| CertRef::new(TLVElement::new(icac)));
+            let root_ref = CertRef::new(TLVElement::new(&self.root_ca));
 
-        // TODO: Copy functionality from C++ FabricTable::FindExistingFabricByNocChaining
-        // i.e. need to check to see if a fabric with these creds are already present
+            // Validate the certs first
+            Self::validate_certs(&crypto, &noc_ref, icac_ref.as_ref(), &root_ref, buf)?;
+
+            // Check that there is no fabric with the same fabric ID and root cert pubkey
+            // as the one in the NOC, to avoid adding duplicate fabrics
+
+            let fabric_id = noc_ref.get_fabric_id()?;
+            let root_cert_pubkey = root_ref.pubkey()?;
+
+            for fabric in fabrics.iter() {
+                if fabric_id == fabric.fabric_id() {
+                    let f_root_ref = CertRef::new(TLVElement::new(fabric.root_ca()));
+                    let f_root_pubkey = f_root_ref.pubkey()?;
+
+                    if root_cert_pubkey == f_root_pubkey {
+                        // A fabric with the same ID and root cert pubkey already exists,
+                        // which means that this NOC cannot be accepted
+                        Err(ErrorCode::NocFabricConflict)?;
+                    }
+                }
+            }
+        }
 
         let fabric = fabrics
             .add(

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -58,7 +58,7 @@ const DEFAULT_TESTS: &[&str] = &[
     "TestGroupKeyManagementCluster",
     // "TestIdentifyCluster", // TODO: specific cluster, to be implemented with all others
     "TestLogCommands",
-    // "TestMultiAdmin", // TODO: Involved fix to not add duplicate NOC, see failsafe.rs & FabricTable::FindExistingFabricByNocChaining
+    "TestMultiAdmin",
     "TestOperationalCredentialsCluster",
     // "TestOperationalState", // TODO: specific cluster, to be implemented with all others
     "TestSelfFabricRemoval",


### PR DESCRIPTION
I just needed to add checks to AddNOC/UpdateNOC that compare the fabric ID and root pubkey from the NOC with the ones of the fabric being updated (on UpdateNOC) / with all fabrics (on AddNOC).
