### PR TITLE
Events - remove async push, cleanup, make sure YAML tests pass

### DIFF
--- a/bloat-check/Cargo.toml
+++ b/bloat-check/Cargo.toml
@@ -66,4 +66,5 @@ hal = { package = "embassy-rp", version = "0.8", features = ["defmt", "unstable-
 [target.riscv32imac-unknown-none-elf.dependencies]
 hal = { package = "esp-hal", version = "1", features = ["defmt", "exception-handler", "unstable", "esp32c6"] }
 esp-rtos = { version = "0.2", features = ["embassy", "esp32c6"] }
+esp-rom-sys = "=0.1.3"
 #embassy-executor = { version = "0.9", features = ["riscv32"] }

--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -67,7 +67,7 @@ use rs_matter::dm::clusters::wifi_diag::{SecurityTypeEnum, WiFiVersionEnum, Wifi
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints::WifiSysHandler;
-use rs_matter::dm::events::{Events, DEFAULT_BYTES_PER_BUF};
+use rs_matter::dm::events::{Events, DEFAULT_MAX_EVENTS_BUF_SIZE};
 use rs_matter::dm::networks::wireless::{
     NetCtlState, NetCtlStateMutex, NetCtlWithStatusImpl, WifiNetworks, WirelessMgr, MAX_CREDS_SIZE,
 };
@@ -154,8 +154,8 @@ macro_rules! unwrap {
 struct MatterStack<'a> {
     matter: Matter<'a>,
     buffers: PooledBuffers<10, IMBuffer>,
-    subscriptions: Subscriptions<{ DEFAULT_MAX_SUBSCRIPTIONS }>,
-    events: Events<DEFAULT_BYTES_PER_BUF>,
+    subscriptions: Subscriptions,
+    events: Events,
     networks: SharedNetworks<WifiNetworks<3>>,
     net_ctl_state: NetCtlStateMutex,
     btp: Btp,
@@ -204,7 +204,7 @@ type AppDmHandler<'a> = WifiSysHandler<'a, &'a AppNetCtl<'a>, AppHandler<'a>>;
 type AppDataModel<'a> = DataModel<
     'a,
     DEFAULT_MAX_SUBSCRIPTIONS,
-    DEFAULT_BYTES_PER_BUF,
+    DEFAULT_MAX_EVENTS_BUF_SIZE,
     &'a AppCrypto,
     PooledBuffers<10, IMBuffer>,
     (Node<'a>, &'a AppDmHandler<'a>),
@@ -215,7 +215,7 @@ type AppResponder<'d, 'a> = DefaultResponder<
     'd,
     'a,
     DEFAULT_MAX_SUBSCRIPTIONS,
-    DEFAULT_BYTES_PER_BUF,
+    DEFAULT_MAX_EVENTS_BUF_SIZE,
     &'a AppCrypto,
     PooledBuffers<10, IMBuffer>,
     (Node<'a>, &'a AppDmHandler<'a>),
@@ -356,7 +356,7 @@ fn main() -> ! {
             crypto,
             &stack.buffers,
             &stack.subscriptions,
-            Some(&stack.events),
+            &stack.events,
             (NODE, handler),
             kv,
             &stack.networks,

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -36,10 +36,10 @@ use rs_matter::dm::clusters::on_off::{self, test::TestOnOffDeviceLogic, OnOffHoo
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::{DEV_TYPE_AGGREGATOR, DEV_TYPE_BRIDGED_NODE, DEV_TYPE_ON_OFF_LIGHT};
 use rs_matter::dm::endpoints;
-use rs_matter::dm::events::DefaultEvents;
+use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::unix::UnixNetifs;
-use rs_matter::dm::subscriptions::DefaultSubscriptions;
+use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver, EmptyHandler, Endpoint,
     EpClMatcher, InvokeContext, Node, ReadContext,
@@ -74,24 +74,25 @@ fn main() -> Result<(), Error> {
     // Need to call this once
     matter.initialize_transport_buffers()?;
 
+    // Create the events
+    let mut events: Events = Events::new_default();
+
     // Persistence
     let mut kv_buf = [0; 4096];
     let mut kv = DirKvBlobStore::new_default();
     futures_lite::future::block_on(matter.load_persist(&mut kv, &mut kv_buf))?;
+    futures_lite::future::block_on(events.load_persist(&mut kv, &mut kv_buf))?;
 
     // Create the transport buffers
     let buffers = PooledBuffers::<10, _>::new(0);
 
     // Create the subscriptions
-    let subscriptions = DefaultSubscriptions::new();
+    let subscriptions: Subscriptions = Subscriptions::new();
 
     // Create the crypto instance
     let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
-
-    // Create the events
-    let events = DefaultEvents::new_default();
 
     // Our on-off clusters
     let on_off_handler_ep2 = on_off::OnOffHandler::new_standalone(
@@ -111,7 +112,7 @@ fn main() -> Result<(), Error> {
         &crypto,
         &buffers,
         &subscriptions,
-        Some(&events),
+        &events,
         dm_handler(rand, &on_off_handler_ep2, &on_off_handler_ep3),
         SharedKvBlobStore::new(kv, kv_buf.as_mut_slice()),
         SharedNetworks::new(EthNetwork::new_default()),

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -47,10 +47,10 @@ use rs_matter::dm::clusters::unit_testing::{
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints;
-use rs_matter::dm::events::DefaultEvents;
+use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::unix::UnixNetifs;
-use rs_matter::dm::subscriptions::DefaultSubscriptions;
+use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
     Node,
@@ -78,8 +78,8 @@ mod mdns;
 // as well as just allocating the objects on-stack or on the heap.
 static MATTER: StaticCell<Matter> = StaticCell::new();
 static BUFFERS: StaticCell<PooledBuffers<10, rs_matter::dm::IMBuffer>> = StaticCell::new();
-static SUBSCRIPTIONS: StaticCell<DefaultSubscriptions> = StaticCell::new();
-static EVENTS: StaticCell<DefaultEvents> = StaticCell::new();
+static SUBSCRIPTIONS: StaticCell<Subscriptions> = StaticCell::new();
+static EVENTS: StaticCell<Events> = StaticCell::new();
 static KV_BUF: StaticCell<[u8; 4096]> = StaticCell::new();
 static UNIT_TESTING_DATA: StaticCell<RefCell<UnitTestingHandlerData>> = StaticCell::new();
 
@@ -102,7 +102,7 @@ fn main() -> Result<(), Error> {
         "Matter memory: Matter (BSS)={}B, IM Buffers (BSS)={}B, Subscriptions (BSS)={}B",
         core::mem::size_of::<Matter>(),
         core::mem::size_of::<PooledBuffers<10, rs_matter::dm::IMBuffer>>(),
-        core::mem::size_of::<DefaultSubscriptions>()
+        core::mem::size_of::<Subscriptions>()
     );
 
     let matter = MATTER.uninit().init_with(Matter::init(
@@ -116,28 +116,25 @@ fn main() -> Result<(), Error> {
     // Need to call this once
     matter.initialize_transport_buffers()?;
 
+    // Create the event queue
+    let events = EVENTS.uninit().init_with(Events::init_default());
+
     // Persistence
     let kv_buf = KV_BUF.uninit().init_zeroed().as_mut_slice();
     let mut kv = FileKvBlobStore::new_default();
     futures_lite::future::block_on(matter.load_persist(&mut kv, kv_buf))?;
+    futures_lite::future::block_on(events.load_persist(&mut kv, kv_buf))?;
 
     // Create the transport buffers
     let buffers = BUFFERS.uninit().init_with(PooledBuffers::init(0));
 
     // Create the subscriptions
-    let subscriptions = SUBSCRIPTIONS
-        .uninit()
-        .init_with(DefaultSubscriptions::init());
+    let subscriptions = SUBSCRIPTIONS.uninit().init_with(Subscriptions::init());
 
     // Create the crypto instance
     let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
-
-    // Create the event queue
-    let events = EVENTS
-        .uninit()
-        .init_with(DefaultEvents::init(rs_matter::utils::epoch::sys_epoch));
 
     // Our on-off cluster
     let on_off_handler_1 = OnOffHandler::new_standalone(
@@ -164,7 +161,7 @@ fn main() -> Result<(), Error> {
         &crypto,
         buffers,
         subscriptions,
-        Some(events),
+        events,
         dm_handler(
             rand,
             unit_testing_data,

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -47,10 +47,10 @@ use rs_matter::dm::clusters::on_off::{self, OnOffHooks, StartUpOnOffEnum};
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_DIMMABLE_LIGHT;
 use rs_matter::dm::endpoints;
-use rs_matter::dm::events::DefaultEvents;
+use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::unix::UnixNetifs;
-use rs_matter::dm::subscriptions::DefaultSubscriptions;
+use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::IMBuffer;
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver, EmptyHandler, Endpoint,
@@ -79,8 +79,8 @@ mod mdns;
 // as well as just allocating the objects on-stack or on the heap.
 static MATTER: StaticCell<Matter> = StaticCell::new();
 static BUFFERS: StaticCell<PooledBuffers<10, IMBuffer>> = StaticCell::new();
-static SUBSCRIPTIONS: StaticCell<DefaultSubscriptions> = StaticCell::new();
-static EVENTS: StaticCell<DefaultEvents> = StaticCell::new();
+static SUBSCRIPTIONS: StaticCell<Subscriptions> = StaticCell::new();
+static EVENTS: StaticCell<Events> = StaticCell::new();
 static KV_BUF: StaticCell<[u8; 4096]> = StaticCell::new();
 
 fn main() -> Result<(), Error> {
@@ -119,7 +119,7 @@ fn run() -> Result<(), Error> {
         "Matter memory: Matter (BSS)={}B, IM Buffers (BSS)={}B, Subscriptions (BSS)={}B",
         core::mem::size_of::<Matter>(),
         core::mem::size_of::<PooledBuffers<10, IMBuffer>>(),
-        core::mem::size_of::<DefaultSubscriptions>()
+        core::mem::size_of::<Subscriptions>()
     );
 
     let matter = MATTER.uninit().init_with(Matter::init(
@@ -133,6 +133,9 @@ fn run() -> Result<(), Error> {
     // Need to call this once
     matter.initialize_transport_buffers()?;
 
+    // Create the event queue
+    let events = EVENTS.uninit().init_with(Events::init_default());
+
     // Persistence
     let kv_buf = KV_BUF.uninit().init_zeroed().as_mut_slice();
     #[cfg(feature = "chip-test")]
@@ -140,24 +143,18 @@ fn run() -> Result<(), Error> {
     #[cfg(not(feature = "chip-test"))]
     let mut kv = rs_matter::persist::DirKvBlobStore::new_default();
     futures_lite::future::block_on(matter.load_persist(&mut kv, kv_buf))?;
+    futures_lite::future::block_on(events.load_persist(&mut kv, kv_buf))?;
 
     // Create the transport buffers
     let buffers = BUFFERS.uninit().init_with(PooledBuffers::init(0));
 
     // Create the subscriptions
-    let subscriptions = SUBSCRIPTIONS
-        .uninit()
-        .init_with(DefaultSubscriptions::init());
+    let subscriptions = SUBSCRIPTIONS.uninit().init_with(Subscriptions::init());
 
     // Create the crypto instance
     let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
-
-    // Create the event queue
-    let events = EVENTS
-        .uninit()
-        .init_with(DefaultEvents::init(rs_matter::utils::epoch::sys_epoch));
 
     // OnOff cluster setup
     let on_off_handler =
@@ -185,7 +182,7 @@ fn run() -> Result<(), Error> {
         &crypto,
         buffers,
         subscriptions,
-        Some(events),
+        events,
         dm_handler(rand, &on_off_handler, &level_control_handler),
         SharedKvBlobStore::new(kv, kv_buf),
         SharedNetworks::new(EthNetwork::new_default()),

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -59,10 +59,10 @@ use rs_matter::dm::clusters::on_off::{self, test::TestOnOffDeviceLogic, OnOffHoo
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_CASTING_VIDEO_PLAYER;
 use rs_matter::dm::endpoints;
-use rs_matter::dm::events::DefaultEvents;
+use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::unix::UnixNetifs;
-use rs_matter::dm::subscriptions::DefaultSubscriptions;
+use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
     ArrayAttributeRead, Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver,
     EmptyHandler, Endpoint, EpClMatcher, InvokeContext, Node, ReadContext,
@@ -93,24 +93,25 @@ fn main() -> Result<(), Error> {
     // Need to call this once
     matter.initialize_transport_buffers()?;
 
+    // Create the event queue
+    let mut events: Events = Events::new_default();
+
     // Persistence
     let mut kv_buf = [0; 4096];
     let mut kv = DirKvBlobStore::new_default();
     futures_lite::future::block_on(matter.load_persist(&mut kv, &mut kv_buf))?;
+    futures_lite::future::block_on(events.load_persist(&mut kv, &mut kv_buf))?;
 
     // Create the transport buffers
     let buffers = PooledBuffers::<10, _>::new(0);
 
     // Create the subscriptions
-    let subscriptions = DefaultSubscriptions::new();
+    let subscriptions: Subscriptions = Subscriptions::new();
 
     // Create the crypto instance
     let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
-
-    // Create the event queue
-    let events = DefaultEvents::new_default();
 
     // Assemble our Data Model handler by composing the predefined Root Endpoint handler with our custom Speaker handler
     let on_off_handler = on_off::OnOffHandler::new_standalone(
@@ -125,7 +126,7 @@ fn main() -> Result<(), Error> {
         &crypto,
         &buffers,
         &subscriptions,
-        Some(&events),
+        &events,
         dm_handler(rand, &on_off_handler),
         SharedKvBlobStore::new(kv, kv_buf.as_mut_slice()),
         SharedNetworks::new(EthNetwork::new_default()),

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -36,10 +36,10 @@ use rs_matter::dm::clusters::on_off::{self, test::TestOnOffDeviceLogic, OnOffHoo
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints;
-use rs_matter::dm::events::NO_EVENTS;
+use rs_matter::dm::events::NoEvents;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::unix::UnixNetifs;
-use rs_matter::dm::subscriptions::DefaultSubscriptions;
+use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::IMBuffer;
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
@@ -67,7 +67,7 @@ mod mdns;
 // as well as just allocating the objects on-stack or on the heap.
 static MATTER: StaticCell<Matter> = StaticCell::new();
 static BUFFERS: StaticCell<PooledBuffers<10, IMBuffer>> = StaticCell::new();
-static SUBSCRIPTIONS: StaticCell<DefaultSubscriptions> = StaticCell::new();
+static SUBSCRIPTIONS: StaticCell<Subscriptions> = StaticCell::new();
 static KV_BUF: StaticCell<[u8; 4096]> = StaticCell::new();
 
 fn main() -> Result<(), Error> {
@@ -95,7 +95,7 @@ fn run() -> Result<(), Error> {
         "Matter memory: Matter (BSS)={}B, IM Buffers (BSS)={}B, Subscriptions (BSS)={}B",
         core::mem::size_of::<Matter>(),
         core::mem::size_of::<PooledBuffers<10, IMBuffer>>(),
-        core::mem::size_of::<DefaultSubscriptions>()
+        core::mem::size_of::<Subscriptions>()
     );
 
     let matter = MATTER.uninit().init_with(Matter::init(
@@ -118,9 +118,7 @@ fn run() -> Result<(), Error> {
     let buffers = BUFFERS.uninit().init_with(PooledBuffers::init(0));
 
     // Create the subscriptions
-    let subscriptions = SUBSCRIPTIONS
-        .uninit()
-        .init_with(DefaultSubscriptions::init());
+    let subscriptions = SUBSCRIPTIONS.uninit().init_with(Subscriptions::init());
 
     // Create the crypto instance
     let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
@@ -134,13 +132,15 @@ fn run() -> Result<(), Error> {
         TestOnOffDeviceLogic::new(true),
     );
 
+    let events = NoEvents::new_default();
+
     // Create the Data Model instance
     let dm = DataModel::new(
         matter,
         &crypto,
         buffers,
         subscriptions,
-        NO_EVENTS,
+        &events,
         dm_handler(rand, &on_off_handler),
         SharedKvBlobStore::new(kv, kv_buf),
         SharedNetworks::new(EthNetwork::new_default()),

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -50,10 +50,10 @@ use rs_matter::dm::clusters::wifi_diag::WifiDiag;
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints;
-use rs_matter::dm::events::DefaultEvents;
+use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::unix::UnixNetifs;
 use rs_matter::dm::networks::wireless::{NetCtlState, NetCtlWithStatusImpl, WifiNetworks};
-use rs_matter::dm::subscriptions::DefaultSubscriptions;
+use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
     Node,
@@ -130,11 +130,15 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
     // A storage for the Wifi networks
     let mut networks = WifiNetworks::<3>::new();
 
+    // Create the event queue
+    let mut events: Events = Events::new_default();
+
     // Persistence
     let mut kv_buf = [0; 4096];
     let mut kv = DirKvBlobStore::new_default();
     futures_lite::future::block_on(matter.load_persist(&mut kv, &mut kv_buf))?;
     futures_lite::future::block_on(networks.load_persist(&mut kv, &mut kv_buf))?;
+    futures_lite::future::block_on(events.load_persist(&mut kv, &mut kv_buf))?;
 
     let networks = SharedNetworks::new(networks);
 
@@ -142,15 +146,12 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
     let buffers = PooledBuffers::<10, _>::new(0);
 
     // Create the subscriptions
-    let subscriptions = DefaultSubscriptions::new();
+    let subscriptions: Subscriptions = Subscriptions::new();
 
     // Create the crypto instance
     let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
-
-    // Create the event queue
-    let events = DefaultEvents::new_default();
 
     // Our on-off cluster
     let on_off_handler = on_off::OnOffHandler::new_standalone(
@@ -170,7 +171,7 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
         &crypto,
         &buffers,
         &subscriptions,
-        Some(&events),
+        &events,
         dm_handler(rand, &on_off_handler, &net_ctl, &net_ctl),
         SharedKvBlobStore::new(kv, kv_buf.as_mut_slice()),
         &networks,

--- a/examples/src/bin/onoff_light_work_stealing.rs
+++ b/examples/src/bin/onoff_light_work_stealing.rs
@@ -36,10 +36,10 @@ use rs_matter::dm::clusters::on_off::{self, test::TestOnOffDeviceLogic, OnOffHoo
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints::{self, EthSysHandler};
-use rs_matter::dm::events::NO_EVENTS;
+use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::unix::UnixNetifs;
-use rs_matter::dm::subscriptions::DefaultSubscriptions;
+use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::IMBuffer;
 use rs_matter::dm::{Async, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node};
 use rs_matter::error::Error;
@@ -70,7 +70,8 @@ type AppDmHandler<'a> = EthSysHandler<'a, AppHandler<'a>>;
 // as well as just allocating the objects on-stack or on the heap.
 static MATTER: StaticCell<Matter> = StaticCell::new();
 static BUFFERS: StaticCell<PooledBuffers<10, IMBuffer>> = StaticCell::new();
-static SUBSCRIPTIONS: StaticCell<DefaultSubscriptions> = StaticCell::new();
+static SUBSCRIPTIONS: StaticCell<Subscriptions> = StaticCell::new();
+static EVENTS: StaticCell<Events> = StaticCell::new();
 static CRYPTO: StaticCell<RustCrypto<'static, FakeRng>> = StaticCell::new();
 static KV_BUF: StaticCell<[u8; 4096]> = StaticCell::new();
 
@@ -99,7 +100,7 @@ fn run() -> Result<(), Error> {
         "Matter memory: Matter (BSS)={}B, IM Buffers (BSS)={}B, Subscriptions (BSS)={}B",
         core::mem::size_of::<Matter>(),
         core::mem::size_of::<PooledBuffers<10, IMBuffer>>(),
-        core::mem::size_of::<DefaultSubscriptions>()
+        core::mem::size_of::<Subscriptions>()
     );
 
     let matter = MATTER.uninit().init_with(Matter::init(
@@ -113,18 +114,20 @@ fn run() -> Result<(), Error> {
     // Need to call this once
     matter.initialize_transport_buffers()?;
 
+    // Create the events
+    let events = EVENTS.uninit().init_with(Events::init_default());
+
     // Persistence
     let kv_buf = KV_BUF.uninit().init_zeroed().as_mut_slice();
     let mut kv = DirKvBlobStore::new_default();
     futures_lite::future::block_on(matter.load_persist(&mut kv, kv_buf))?;
+    futures_lite::future::block_on(events.load_persist(&mut kv, kv_buf))?;
 
     // Create the transport buffers
     let buffers = &*BUFFERS.uninit().init_with(PooledBuffers::init(0));
 
     // Create the subscriptions
-    let subscriptions = &*SUBSCRIPTIONS
-        .uninit()
-        .init_with(DefaultSubscriptions::init());
+    let subscriptions = &*SUBSCRIPTIONS.uninit().init_with(Subscriptions::init());
 
     // Create the crypto instance
     let crypto = &*CRYPTO.init(RustCrypto::new(FakeRng, DAC_PRIVKEY));
@@ -144,7 +147,7 @@ fn run() -> Result<(), Error> {
         crypto,
         buffers,
         subscriptions,
-        NO_EVENTS,
+        events,
         (NODE, dm_handler(rand, on_off_handler)),
         SharedKvBlobStore::new(kv, kv_buf),
         SharedNetworks::new(EthNetwork::new_default()),

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -36,10 +36,10 @@ use rs_matter::dm::clusters::on_off::{self, test::TestOnOffDeviceLogic, OnOffHan
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_SMART_SPEAKER;
 use rs_matter::dm::endpoints;
-use rs_matter::dm::events::DefaultEvents;
+use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::unix::UnixNetifs;
-use rs_matter::dm::subscriptions::DefaultSubscriptions;
+use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
     Node,
@@ -70,24 +70,25 @@ fn main() -> Result<(), Error> {
     // Need to call this once
     matter.initialize_transport_buffers()?;
 
+    // Create the event queue
+    let mut events: Events = Events::new_default();
+
     // Persistence
     let mut kv_buf = [0; 4096];
     let mut kv = DirKvBlobStore::new_default();
     futures_lite::future::block_on(matter.load_persist(&mut kv, &mut kv_buf))?;
+    futures_lite::future::block_on(events.load_persist(&mut kv, &mut kv_buf))?;
 
     // Create the transport buffers
     let buffers = PooledBuffers::<10, _>::new(0);
 
     // Create the subscriptions
-    let subscriptions = DefaultSubscriptions::new();
+    let subscriptions: Subscriptions = Subscriptions::new();
 
     // Create the crypto instance
     let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
-
-    // Create the event queue
-    let events = DefaultEvents::new_default();
 
     // OnOff cluster setup
     let on_off_handler = on_off::OnOffHandler::new(
@@ -121,7 +122,7 @@ fn main() -> Result<(), Error> {
         &crypto,
         &buffers,
         &subscriptions,
-        Some(&events),
+        &events,
         dm_handler(rand, &on_off_handler, &level_control_handler),
         SharedKvBlobStore::new(kv, kv_buf.as_mut_slice()),
         SharedNetworks::new(EthNetwork::new_default()),

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -26,15 +26,16 @@ use embassy_time::{Instant, Timer};
 
 use crate::crypto::Crypto;
 use crate::dm::clusters::net_comm::NetworksAccess;
+use crate::dm::events::EventTLVWrite;
 use crate::error::{Error, ErrorCode};
 use crate::im::{
-    IMStatusCode, InvReq, InvRespTag, OpCode, ReadReq, ReportDataReq, ReportDataRespTag,
-    StatusResp, SubscribeReq, SubscribeResp, TimedReq, WriteReq, WriteRespTag,
-    PROTO_ID_INTERACTION_MODEL,
+    EventPriority, EventRespTag, EventStatus, IMStatusCode, InvReq, InvRespTag, OpCode, ReadReq,
+    ReportDataReq, ReportDataRespTag, StatusResp, SubscribeReq, SubscribeResp, TimedReq, WriteReq,
+    WriteRespTag, PROTO_ID_INTERACTION_MODEL,
 };
 use crate::persist::KvBlobStoreAccess;
 use crate::respond::ExchangeHandler;
-use crate::tlv::{get_root_node_struct, FromTLV, Nullable, TLVElement, TLVTag, TLVWrite};
+use crate::tlv::{get_root_node_struct, FromTLV, Nullable, TLVElement, TLVTag, TLVWrite, ToTLV};
 use crate::transport::exchange::{Exchange, MAX_EXCHANGE_RX_BUF_SIZE, MAX_EXCHANGE_TX_BUF_SIZE};
 use crate::utils::select::Coalesce;
 use crate::utils::storage::pooled::BufferAccess;
@@ -86,7 +87,7 @@ where
     kv: S,
     subscriptions: &'a Subscriptions<NS>,
     subscriptions_buffers: Mutex<RefCell<Vec<SubscriptionBuffer<B::Buffer<'a>>, NS>>>,
-    events: Option<&'a Events<NE>>,
+    events: &'a Events<NE>,
     networks: N,
     handler: T,
 }
@@ -106,7 +107,7 @@ where
     /// - `buffers` - a reference to an implementation of `BufferAccess<IMBuffer>` which is used for allocating RX and TX buffers on the fly, when necessary
     /// - `subscriptions` - a reference to a `Subscriptions<N>` struct which is used for managing subscriptions. `N` designates the maximum
     ///   number of subscriptions that can be managed by this handler.
-    /// - `events` - an optional reference to an `Events<N>` struct which is used for managing events in the data model. `N` designates the maximum number of events that can be buffered in the event management system.
+    /// - `events` - a reference to an `Events<N>` struct which is used for managing events in the data model. `N` designates the maximum number of events that can be buffered in the event management system.
     /// - `handler` - an instance of type `T` which implements the `DataModelHandler` trait. This instance is used for interacting with the underlying
     ///   clusters of the data model. Note that the expectations is for the user to provide a handler that handles the Matter system clusters
     ///   as well (Endpoint 0), possibly by decorating her own clusters with the `rs_matter::dm::root_endpoint::with_` methods
@@ -119,7 +120,7 @@ where
         crypto: C,
         buffers: &'a B,
         subscriptions: &'a Subscriptions<NS>,
-        events: Option<&'a Events<NE>>,
+        events: &'a Events<NE>,
         handler: T,
         kv: S,
         networks: N,
@@ -279,12 +280,14 @@ where
         let metadata = self.handler.lock().await;
         let node = metadata.node();
 
+        let mut min_event_number = 0;
+
         let mut resp = ReportDataResponder::new(
             &req,
             &node,
             None,
             HandlerInvoker::new(exchange, self),
-            EventReader::new(0),
+            EventReader::new(&mut min_event_number),
             self.events,
         );
 
@@ -434,20 +437,20 @@ where
             }
         });
 
+        let mut min_event_number = 0;
+
         let primed = self
             .report_data(
                 id,
                 fabric_idx.get(),
                 peer_node_id,
-                0, // min-event-number is zero initially, though the subscription req itself may have separate filters
+                &mut min_event_number,
                 &rx,
                 &mut tx,
                 exchange,
                 true,
             )
             .await?;
-
-        let min_event_number = self.events.map_or(0, |e| e.peek_next_event_no());
 
         if primed {
             exchange
@@ -488,7 +491,12 @@ where
 
         let metadata = self.handler.lock().await;
 
+        let mut has_attrs = false;
+        let mut has_events = false;
+
         if let Some(attr_requests) = req.attr_requests()? {
+            has_attrs = true;
+
             let node = metadata.node();
 
             for attr_req in attr_requests {
@@ -508,7 +516,33 @@ where
             }
         }
 
-        // TODO(events) validate event_reqs
+        if let Some(event_reqs) = req.event_requests()? {
+            has_events = true;
+
+            let node = metadata.node();
+
+            for event_req in event_reqs {
+                let event_req = event_req?;
+
+                if let Some(endpt) = event_req.endpoint {
+                    let endpoint = node.endpoint(endpt).ok_or(ErrorCode::InvalidAction)?;
+
+                    if let Some(clst) = event_req.cluster {
+                        let _cluster = endpoint.cluster(clst).ok_or(ErrorCode::InvalidAction)?;
+
+                        // TODO: Validate the event ID
+                        // if let Some(attr) = event_req.attr {
+                        //     let _ = cluster.attribute(attr).ok_or(ErrorCode::InvalidAction)?;
+                        // }
+                    }
+                }
+            }
+        }
+
+        if !has_attrs && !has_events {
+            // Empty subscribe requests are not allowed either
+            return Err(ErrorCode::InvalidAction.into());
+        }
 
         Ok(())
     }
@@ -561,7 +595,7 @@ where
             loop {
                 let sub = self.subscriptions.find_report_due(now);
 
-                if let Some((fabric_idx, peer_node_id, session_id, id)) = sub {
+                if let Some((_, _, session_id, id)) = sub {
                     let subscribed = Mutex::<_, MatterRawMutex>::new(Cell::new(false));
 
                     let _guard = scopeguard::guard((), |_| {
@@ -571,7 +605,7 @@ where
                     });
 
                     // TODO: Do a more sophisticated check whether something had actually changed w.r.t. this subscription
-                    let sub = self.subscriptions_buffers.lock(|sb| {
+                    let mut sub = self.subscriptions_buffers.lock(|sb| {
                         let mut sb = sb.borrow_mut();
 
                         let index = unwrap!(sb.iter().position(|sb| sb.subscription_id == id));
@@ -580,22 +614,14 @@ where
                     });
 
                     let result = self
-                        .process_subscription(matter, fabric_idx, peer_node_id, session_id, &sub)
+                        .process_subscription(matter, session_id, &mut sub)
                         .await;
-
-                    let min_event_number = self.events.map_or(0, |e| e.peek_next_event_no());
 
                     match result {
                         Ok(primed) => {
                             if primed && self.subscriptions.mark_reported(id) {
                                 self.subscriptions_buffers.lock(|sb| {
-                                    let _ = sb.borrow_mut().push(SubscriptionBuffer {
-                                        fabric_idx,
-                                        peer_node_id,
-                                        subscription_id: id,
-                                        min_event_number,
-                                        buffer: sub.buffer,
-                                    });
+                                    let _ = sb.borrow_mut().push(sub);
 
                                     subscribed.lock(|s| s.set(true));
                                 });
@@ -623,10 +649,8 @@ where
     async fn process_subscription(
         &self,
         matter: &Matter<'_>,
-        fabric_idx: NonZeroU8,
-        peer_node_id: u64,
         session_id: Option<u32>,
-        sub: &SubscriptionBuffer<B::Buffer<'_>>,
+        sub: &mut SubscriptionBuffer<B::Buffer<'_>>,
     ) -> Result<bool, Error> {
         let mut exchange = if let Some(session_id) = session_id {
             Exchange::initiate_for_session(matter, session_id)?
@@ -644,9 +668,9 @@ where
             let primed = self
                 .report_data(
                     sub.subscription_id,
-                    fabric_idx.get(),
-                    peer_node_id,
-                    sub.min_event_number,
+                    sub.fabric_idx.get(),
+                    sub.peer_node_id,
+                    &mut sub.min_event_number,
                     &sub.buffer,
                     &mut tx,
                     &mut exchange,
@@ -660,7 +684,7 @@ where
         } else {
             error!(
                 "No TX buffer available for processing subscription [F:{:x},P:{:x}]::{}",
-                fabric_idx, peer_node_id, sub.subscription_id,
+                sub.fabric_idx, sub.peer_node_id, sub.subscription_id,
             );
 
             Ok(false)
@@ -714,7 +738,7 @@ where
     /// - `id` - the subscription ID
     /// - `fabric_idx` - the fabric index of the peer
     /// - `peer_node_id` - the node ID of the peer
-    /// - `min_event_number` TODO
+    /// - `min_event_number` - the minimum event number to report
     /// - `rx` - the received data for the subscription, when the subscription was primed
     /// - `tx` - the TX buffer to write the response to
     /// - `exchange` - the exchange to respond to
@@ -725,7 +749,7 @@ where
         id: u32,
         fabric_idx: u8,
         peer_node_id: u64,
-        min_event_number: u64,
+        min_event_number: &mut u64,
         rx: &[u8],
         tx: &mut [u8],
         exchange: &mut Exchange<'_>,
@@ -929,6 +953,21 @@ where
         self.change_notify()
             .notify(endpoint_id, cluster_id, attr_id)
     }
+
+    fn emit_event<F>(
+        &self,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        self.events
+            .push(endpoint_id, cluster_id, event_id, priority, &self.kv, f)
+    }
 }
 
 /// This type responds with a `ReportData` response to all of:
@@ -944,8 +983,8 @@ struct ReportDataResponder<'a, 'b, 'c, const NE: usize, C> {
     node: &'a Node<'a>,
     subscription_id: Option<u32>,
     invoker: HandlerInvoker<'b, 'c, C>,
-    event_reader: EventReader,
-    events: Option<&'a Events<NE>>,
+    event_reader: EventReader<'a>,
+    events: &'a Events<NE>,
 }
 
 impl<'a, 'b, 'c, const NE: usize, C> ReportDataResponder<'a, 'b, 'c, NE, C>
@@ -962,8 +1001,8 @@ where
         node: &'a Node<'a>,
         subscription_id: Option<u32>,
         invoker: HandlerInvoker<'b, 'c, C>,
-        event_reader: EventReader,
-        events: Option<&'a Events<NE>>,
+        event_reader: EventReader<'a>,
+        events: &'a Events<NE>,
     ) -> Self {
         Self {
             req,
@@ -1045,39 +1084,94 @@ where
             wb.end_container()?;
         }
 
-        if let Some(events) = self.events {
-            if let Some(event_reqs) = self.req.event_requests()? {
-                wb.start_array(&TLVTag::Context(ReportDataRespTag::EventReports as _))?;
-                let events_guard = events.lock().await;
-                for event in events_guard.iter() {
-                    let event = event?;
-                    loop {
-                        let result = self
-                            .event_reader
-                            .process_read(&event, &event_reqs, self.req.event_filters()?, &mut *wb)
-                            .await;
+        if let Some(event_reqs) = self.req.event_requests()? {
+            wb.start_array(&TLVTag::Context(ReportDataRespTag::EventReports as _))?;
 
-                        match result {
-                            Ok(()) => break,
-                            Err(err) if err.code() == ErrorCode::NoSpace => {
-                                debug!("<<< No TX space, chunking >>>");
-                                if !self
-                                    .send(ReportDataChunkState::ChunkingEvents, false, wb)
-                                    .await?
-                                {
-                                    return Ok(false);
-                                }
+            // Validate non-wildcard event paths against node metadata
+            // and emit EventStatusIB for paths that don't match
+            for event_path in event_reqs.iter() {
+                let event_path = event_path?;
+
+                if let Some(endpoint_id) = event_path.endpoint {
+                    if let Some(endpoint) = self.node.endpoint(endpoint_id) {
+                        if let Some(cluster_id) = event_path.cluster {
+                            if endpoint.cluster(cluster_id).is_none() {
+                                // Cluster does not exist on this endpoint
+                                Self::write_event_status(
+                                    &event_path,
+                                    IMStatusCode::UnsupportedCluster,
+                                    wb,
+                                )?;
                             }
-                            Err(err) => Err(err)?,
                         }
+                    } else {
+                        // Endpoint does not exist
+                        Self::write_event_status(
+                            &event_path,
+                            IMStatusCode::UnsupportedEndpoint,
+                            wb,
+                        )?;
                     }
                 }
-                wb.end_container()?;
             }
+
+            let event_filters = self.req.event_filters()?;
+
+            loop {
+                let finished = self.events.fetch(|events| {
+                    for event in events {
+                        let result = self.event_reader.process_read(
+                            event,
+                            &event_reqs,
+                            event_filters.clone(),
+                            &mut *wb,
+                        );
+
+                        if let Err(e) = &result {
+                            if e.code() == ErrorCode::NoSpace {
+                                return Ok::<_, Error>(false);
+                            }
+                        }
+
+                        result?;
+                    }
+
+                    Ok(true)
+                })?;
+
+                if finished {
+                    break;
+                }
+
+                debug!("<<< No TX space, chunking >>>");
+                if !self
+                    .send(ReportDataChunkState::ChunkingEvents, false, wb)
+                    .await?
+                {
+                    return Ok(false);
+                }
+            }
+
+            wb.end_container()?;
         }
 
         self.send(ReportDataChunkState::Done, suppress_last_resp, wb)
             .await
+    }
+
+    /// Write an `EventStatusIB` entry inside the `EventReportIBs` array.
+    ///
+    /// This is used when event path validation finds a non-wildcard path
+    /// that does not match any endpoint/cluster in the node metadata.
+    fn write_event_status(
+        event_path: &crate::im::EventPath,
+        status: IMStatusCode,
+        wb: &mut WriteBuf<'_>,
+    ) -> Result<(), Error> {
+        let event_status = EventStatus::new(event_path.clone(), status, None);
+        wb.start_struct(&TLVTag::Anonymous)?;
+        event_status.to_tlv(&TLVTag::Context(EventRespTag::Status as _), &mut *wb)?;
+        wb.end_container()
     }
 
     /// Send the items of an array attribute one by one, until the end of the array is reached.

--- a/rs-matter/src/dm/clusters/unit_testing.rs
+++ b/rs-matter/src/dm/clusters/unit_testing.rs
@@ -19,11 +19,13 @@
 
 use core::num::NonZeroU8;
 
+use crate::dm::events::EVENT_DATA_TAG;
 use crate::dm::{
     ArrayAttributeRead, ArrayAttributeWrite, Cluster, Dataver, InvokeContext, ReadContext,
     WriteContext,
 };
 use crate::error::{Error, ErrorCode};
+use crate::im::EventPriority;
 use crate::tlv::{
     Nullable, NullableBuilder, OctetStr, Octets, OctetsArrayBuilder, OctetsBuilder, TLVArray,
     TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite, ToTLVArrayBuilder, ToTLVBuilder, Utf8Str,
@@ -2899,11 +2901,25 @@ impl ClusterHandler for UnitTestingHandler<'_> {
 
     fn handle_test_emit_test_event_request<P: TLVBuilderParent>(
         &self,
-        _ctx: impl InvokeContext,
-        _request: TestEmitTestEventRequestRequest<'_>,
-        _response: TestEmitTestEventResponseBuilder<P>,
+        ctx: impl InvokeContext,
+        request: TestEmitTestEventRequestRequest<'_>,
+        response: TestEmitTestEventResponseBuilder<P>,
     ) -> Result<P, Error> {
-        todo!()
+        let arg1 = request.arg_1()?;
+        let arg2 = request.arg_2()? as u8;
+        let arg3 = request.arg_3()?;
+
+        let event_no = ctx.emit_own_event(1, EventPriority::Info, |mut tw| {
+            tw.start_struct(&EVENT_DATA_TAG)?;
+
+            tw.u8(&TLVTag::Context(1), arg1)?;
+            tw.u8(&TLVTag::Context(2), arg2)?;
+            tw.bool(&TLVTag::Context(3), arg3)?;
+
+            tw.end_container()
+        })?;
+
+        response.value(event_no)?.end()
     }
 
     fn handle_test_emit_test_fabric_scoped_event_request<P: TLVBuilderParent>(

--- a/rs-matter/src/dm/events.rs
+++ b/rs-matter/src/dm/events.rs
@@ -17,110 +17,44 @@
 
 use core::fmt::Debug;
 
+use crate::dm::{ClusterId, EndptId, EventId};
 use crate::error::{Error, ErrorCode};
-use crate::im::{EventData, EventDataTag, EventDataTimestamp, EventPath, EventRespTag};
-use crate::persist::{KvBlobStore, KvBlobStoreAccess, Persist, EVENT_EPOCH_KEY};
-use crate::tlv::{
-    FromTLV, TLVElement, TLVSequence, TLVSequenceIter, TLVTag, TLVWrite, TagType, ToTLV,
+use crate::im::{
+    EventData, EventDataTag, EventDataTimestamp, EventPath, EventPriority, EventRespTag,
 };
+use crate::persist::{KvBlobStore, KvBlobStoreAccess, Persist, EVENT_EPOCH_KEY};
+use crate::tlv::{FromTLV, TLVElement, TLVSequence, TLVSequenceIter, TLVTag, TLVWrite};
 use crate::utils::cell::RefCell;
 use crate::utils::epoch::Epoch;
 use crate::utils::init::{init, Init};
-use crate::utils::storage::WriteBuf;
-use crate::utils::sync::blocking;
-use crate::utils::sync::{IfMutex, IfMutexGuard};
+use crate::utils::sync::blocking::Mutex;
 
-// TODO we currently only have this singular config to set the size, but the events are stored in three "tiered" buffers, and
-//      we probably want to allow configuring them separately. We also should spend some thinking tokens on what a good default here is.
-pub const DEFAULT_BYTES_PER_BUF: usize = 64;
+/// The default size of each event buffer in bytes.
+/// This is a tradeoff between memory use and the risk of evicting events before subscribers have had a chance to read them.
+pub const DEFAULT_MAX_EVENTS_BUF_SIZE: usize = 256;
 
-/// A type alias for `Events` with the default maximum number of subscriptions.
-pub type DefaultEvents = Events<DEFAULT_BYTES_PER_BUF>;
+/// The size when events won't be used
+pub const NO_EVENTS_BUF_SIZE: usize = 0;
 
-/// Convenience constant expression if you want to disable events
-pub const NO_EVENTS: Option<&'static Events<0>> = None;
+/// A type alias for `Events` with zero capacity, for when events need to be disabled.
+pub type NoEvents = Events<NO_EVENTS_BUF_SIZE>;
 
-/// See EventsPersist for details
-const EVENT_NO_EPOCH_SIZE: u64 = 0x10000;
+/// Only persist every `EVENT_NUMBER_EPOCH_SIZE` event numbers to avoid flash wear.
+const EVENT_NUMBER_EPOCH_SIZE: u64 = 10000;
 
-/// How far before the epoch boundary to trigger a persist, so the persistence
-/// system has time to write before we actually reach the boundary.
-/// TODO: While this helps, there's till a proper race condition here; we should update the code to wait if persistence is lagging behind
-const EVENT_ID_COUNTER_PERSIST_AHEAD: u64 = 1000;
-
-/// Persistence state for events.
+/// Events queue.
 ///
-/// We need event numbers to always be incrementing and never be reused.
-/// To handle that we need to persist them, so reboots don't cause event number reuse.
-/// However, we can't persist every event number increment, because of flash wear. Hence
-/// this thing. We store "epoch" increments of 2^16; then we use up that epoch to emit events
-/// and then persist another epoch. The result is that we only write once every ~2h if we're
-/// writing 10 events per second, but we still ensure we don't re-use event numbers.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct PersistedState {
-    /// The next event number to assign; this is actually *not* persisted, ironically, but
-    /// the locking is simpler if we keep this here next to the epoch stuff
-    pub(crate) next_event_no: u64,
-    /// The persisted epoch boundary. Events up to `epoch_end - 1` can be
-    /// emitted without a new flash write. When we approach this boundary
-    /// (within `EVENT_ID_COUNTER_PERSIST_AHEAD`), we bump it by another epoch.
-    pub(crate) event_epoch_end: u64,
-}
-
-impl PersistedState {
-    const fn new() -> Self {
-        Self {
-            next_event_no: 0,
-            event_epoch_end: 0,
-        }
-    }
-
-    fn init() -> impl Init<Self> {
-        init!(Self {
-            next_event_no: 0,
-            event_epoch_end: 0,
-        })
-    }
-
-    fn reset(&mut self) {
-        self.next_event_no = 0;
-        self.event_epoch_end = 0;
-    }
-
-    /// Restore events from previously persisted state.
-    fn load(&mut self, data: &[u8]) -> Result<(), Error> {
-        let epoch_end = TLVElement::new(data).u64()?;
-
-        self.next_event_no = epoch_end;
-        self.event_epoch_end = epoch_end.saturating_add(EVENT_NO_EPOCH_SIZE);
-
-        Ok(())
-    }
-
-    /// Store events persistence state into a byte slice.
-    fn store(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
-        let mut wb = WriteBuf::new(buf);
-        wb.u64(&TLVTag::Anonymous, self.event_epoch_end)?;
-        Ok(wb.get_tail())
-    }
-}
-
-/// This is the event queue system, it lets you publish Matter Events into a priority queue,
-/// and allows subscribers and remote clients to read the data you've published.
-///
-/// If you are in a concurrent environment you need to select an appropriate mutex implementation for M.
-///
-/// NOTE: The API of this is provisional and subject to change
+/// It lets one publish Matter Events into a priority queue,
+/// and allows subscribers and remote clients to read the published events.
 ///
 /// The queue is implemented as three equally sized ring buffers, the size of the buffers is set by N.
-/// Hence the memory use of the buffers will be 3 * N. If you pick a very small N clients that poll may
-/// miss events as they fall out of the queue, but a large N of course uses more memory. You may need
-/// to experiment to pick an appropriate size for your event write load.
+/// Hence the memory use of the buffers will be 3 * N.
+/// If a very small N is picked, then clients that poll may miss events as they fall out of the queue;
+/// but a large N of course uses more memory.
 ///
-/// If your application emits no events you can disable this subsystem using the NO_EVENTS constant.
-pub struct Events<const N: usize = DEFAULT_BYTES_PER_BUF> {
-    state: IfMutex<EventsInner<N>>,
-    pub(crate) persisted_state: blocking::Mutex<RefCell<PersistedState>>,
+/// If the app emits no events, this subsystem can be disabled by using the `NoEvents` type alias.
+pub struct Events<const N: usize = DEFAULT_MAX_EVENTS_BUF_SIZE> {
+    inner: Mutex<RefCell<EventsInner<N>>>,
     epoch: Epoch,
 }
 
@@ -128,8 +62,7 @@ impl<const N: usize> Events<N> {
     #[inline(always)]
     pub const fn new(epoch: Epoch) -> Self {
         Self {
-            state: IfMutex::new(EventsInner::new()),
-            persisted_state: blocking::Mutex::new(RefCell::new(PersistedState::new())),
+            inner: Mutex::new(RefCell::new(EventsInner::new())),
             epoch,
         }
     }
@@ -143,80 +76,167 @@ impl<const N: usize> Events<N> {
 
     pub fn init(epoch: Epoch) -> impl Init<Self> {
         init!(Self {
-            state <- IfMutex::init(EventsInner::init()),
-            persisted_state <- blocking::Mutex::init(RefCell::init(PersistedState::init())),
+            inner <- Mutex::init(RefCell::init(EventsInner::init())),
             epoch,
         })
     }
 
+    #[cfg(feature = "std")]
+    pub fn init_default() -> impl Init<Self> {
+        init!(Self {
+            inner <- Mutex::init(RefCell::init(EventsInner::init())),
+            epoch: crate::utils::epoch::sys_epoch,
+        })
+    }
+
     pub fn reset(&mut self) {
-        self.state.get_mut().reset();
-        self.persisted_state.get_mut().get_mut().reset();
-    }
-
-    /// Push a new event into the event queue, making it visible to any subscribers.
-    /// NOTE: This API is unstable and may change, for instance it currently requires knowing the tag number for writing data
-    ///
-    /// To write event data you use the provided EventQueueWriter and write the tag EventDataTag::Data.
-    pub async fn push<S>(
-        &self,
-        path: EventPath,
-        priority: u8,
-        kv: S,
-        data: impl FnOnce(&mut EventQueueWriter<N>) -> Result<(), Error>,
-    ) -> Result<(), Error>
-    where
-        S: KvBlobStoreAccess,
-    {
-        let event_no = {
-            let mut persist = Persist::new(kv);
-
-            let event_no = self.persisted_state.lock(|cell| {
-                let mut state = cell.borrow_mut();
-                let event_no = state.next_event_no;
-                state.next_event_no += 1;
-
-                if state.next_event_no
-                    >= state
-                        .event_epoch_end
-                        .saturating_sub(EVENT_ID_COUNTER_PERSIST_AHEAD)
-                {
-                    state.event_epoch_end = state.next_event_no.saturating_add(EVENT_NO_EPOCH_SIZE);
-
-                    persist.store(EVENT_EPOCH_KEY, |buf| state.store(buf).map(Some))?;
-                }
-
-                Ok::<_, Error>(event_no)
-            })?;
-
-            persist.run()?;
-
-            event_no
-        };
-
-        let mut internal = self.state.lock().await;
-        let timestamp = EventDataTimestamp::EpochTimestamp((self.epoch)().as_millis() as u64);
-        let mut tw = internal.push(path, event_no, priority, timestamp)?;
-        data(&mut tw)?;
-        tw.end()
-    }
-
-    /// Lock the events queue so you can read it; the returned guard gives you the ability to iterate over stored events.
-    /// TODO: Note that this guard is held across long reads, which will cause writers to be stalled over network waits; we should fix this, see https://github.com/project-chip/rs-matter/pull/361#issuecomment-3906929345
-    pub async fn lock(&'_ self) -> EventsGuard<'_, N> {
-        let internal = self.state.lock().await;
-        EventsGuard::new(internal)
-    }
-
-    // TODO(events) we can't do it like this, this will miss events when pushing happens after for_each but before we call this
-    //              we need to return the last processed one from for_each or something like that
-    pub fn peek_next_event_no(&self) -> u64 {
-        self.persisted_state
-            .lock(|cell| cell.borrow().next_event_no)
+        self.inner.get_mut().borrow_mut().reset();
     }
 
     /// Remove persisted state from the given key-value store.
-    pub async fn reset_persist<S>(&mut self, mut kv: S, buf: &mut [u8]) -> Result<(), Error>
+    pub async fn reset_persist<S>(&mut self, kv: S, buf: &mut [u8]) -> Result<(), Error>
+    where
+        S: KvBlobStore,
+    {
+        self.inner
+            .get_mut()
+            .borrow_mut()
+            .reset_persist(kv, buf)
+            .await
+    }
+
+    /// Load persisted state from the given key-value store, so that we can continue emitting events without reusing event numbers.
+    pub async fn load_persist<S>(&mut self, kv: S, buf: &mut [u8]) -> Result<(), Error>
+    where
+        S: KvBlobStore,
+    {
+        self.inner
+            .get_mut()
+            .borrow_mut()
+            .load_persist(kv, buf)
+            .await
+    }
+
+    pub fn fetch<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(EventsIter<'_, N>) -> R,
+    {
+        self.inner.lock(|state| {
+            let state = state.borrow();
+
+            f(state.iter())
+        })
+    }
+
+    /// Push a new event into the event queue.
+    ///
+    /// # Arguments
+    /// - `endpoint_id`: The endpoint ID of the event source.
+    /// - `cluster_id`: The cluster ID of the event source.
+    /// - `event_id`: The event ID of the event source.
+    /// - `priority`: The priority of the event.
+    /// - `kv`: A key-value store access object for persisting event state as needed.
+    /// - `f`: A closure that takes an `EventTLVWrite` and writes
+    ///   the event data into it using TLV encoding. The closure should return an error if writing the event data fails for any reason, in which case the event will not be pushed into the queue.
+    ///
+    /// # Returns
+    /// - `Ok(u64)`: The sequence number of the emitted event, if the event was successfully emitted.
+    /// - `Err(Error)`: An error if the event could not be emitted.
+    pub fn push<S, F>(
+        &self,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        event_id: EventId,
+        priority: EventPriority,
+        kv: S,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        S: KvBlobStoreAccess,
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        let mut persist = Persist::new(kv);
+
+        let event_number = self.inner.lock(|state| {
+            let mut state = state.borrow_mut();
+
+            let event_number = state.next_event_number(&mut persist)?;
+
+            let timestamp = EventDataTimestamp::EpochTimestamp((self.epoch)().as_millis() as u64);
+
+            state.push(
+                endpoint_id,
+                cluster_id,
+                event_id,
+                event_number,
+                priority,
+                timestamp,
+                f,
+            )?;
+
+            Ok::<_, Error>(event_number)
+        })?;
+
+        persist.run()?;
+
+        Ok(event_number)
+    }
+}
+
+/// The inner state of the events queue, protected by a mutex in the outer Events struct. This is where all the actual logic lives.
+///
+/// It's modeled after the tiered ring buffer design used in the C++ matter SDK:
+/// - *Every* new event is written to the next slot in the DEBUG buffer.
+/// - If there is no space for the new event, events are FIFO evicted from the first buffer.
+/// - If the evicted event has a priority as high as or higher than the next buffer in the chain,
+///   then the evicted event is promoted to there, surviving to see another day.
+/// - Promotion may in turn require more eviction in the next buffer, and so on up the chain.
+/// - The end result is that critical events get to live in any of the buffers, making their way through
+///   all three until they finally age out. Info lives in one of the first two, and debug only in the first.
+///
+/// N.B: the discussion in PR 361 that introduced this:
+/// We were not able to determine a way to implement a priority queue that both met the specs requirements
+/// (low-prio events must not cause eviction of high-prio events) while also allowing debug and info-prio events
+/// to be emitted at all.
+/// Instead we opted to replicate the approach used in the C++ impl, which we believe is reasonable but also seemingly in violation of the spec.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+struct EventsInner<const N: usize> {
+    // TODO(events): Allow per-ring const generics, so the rings can be sized independently
+    buf_debug: EventsBuf<N>,
+    buf_info: EventsBuf<N>,
+    buf_critical: EventsBuf<N>,
+    next_event_number: u64,
+}
+
+impl<const N: usize> EventsInner<N> {
+    const fn new() -> Self {
+        Self {
+            buf_debug: EventsBuf::new(),
+            buf_info: EventsBuf::new(),
+            buf_critical: EventsBuf::new(),
+            next_event_number: 0,
+        }
+    }
+
+    fn init() -> impl Init<Self> {
+        init!(Self {
+            buf_debug <- EventsBuf::init(),
+            buf_info <- EventsBuf::init(),
+            buf_critical <- EventsBuf::init(),
+            next_event_number: 0,
+        })
+    }
+
+    fn reset(&mut self) {
+        self.buf_debug.reset();
+        self.buf_info.reset();
+        self.buf_critical.reset();
+        self.next_event_number = 0;
+    }
+
+    /// Remove persisted state from the given key-value store.
+    async fn reset_persist<S>(&mut self, mut kv: S, buf: &mut [u8]) -> Result<(), Error>
     where
         S: KvBlobStore,
     {
@@ -230,7 +250,7 @@ impl<const N: usize> Events<N> {
     }
 
     /// Load persisted state from the given key-value store, so that we can continue emitting events without reusing event numbers.
-    pub async fn load_persist<S>(&mut self, mut kv: S, buf: &mut [u8]) -> Result<(), Error>
+    async fn load_persist<S>(&mut self, mut kv: S, buf: &mut [u8]) -> Result<(), Error>
     where
         S: KvBlobStore,
     {
@@ -246,305 +266,322 @@ impl<const N: usize> Events<N> {
     }
 
     /// Restore events from previously persisted state.
-    pub fn load(&mut self, data: &[u8]) -> Result<(), Error> {
-        let cell = self.persisted_state.get_mut();
-        cell.borrow_mut().load(data)
-    }
-}
+    fn load(&mut self, data: &[u8]) -> Result<(), Error> {
+        self.next_event_number = TLVElement::new(data).u64()?;
 
-/// A thin guard that acts both to keep the event queue stable while we iterate over it, but also
-/// as back-pressure to writers. If writers are faster than we're able to publish events on the network,
-/// events will get dropped, leading to errors. Hence, while we write to the network we force writers to stall.
-///
-/// Most of the time the stalling of writers is very short, just enough to move the events into outbound
-/// network buffers. However if there are a lot of events, such that we need to chunk publishing into multiple packets,
-/// then we will hold this across network calls, forcing writers to slow down until readers have caught up.
-pub struct EventsGuard<'a, const N: usize> {
-    guard: IfMutexGuard<'a, EventsInner<N>>,
-}
-
-impl<'a, const N: usize> EventsGuard<'a, N> {
-    fn new(guard: IfMutexGuard<'a, EventsInner<N>>) -> Self {
-        Self { guard }
+        Ok(())
     }
 
-    pub fn iter(&'_ self) -> EventQueueIter<'_, N> {
-        self.guard.iter()
-    }
-}
-
-/// This is the central event queue storage system. It's modeled after the tiered ring buffer design
-/// used in the C++ matter SDK. *Every* new event is written to the next slot in the DEBUG level buffer.
-/// If there is not space for the new event, events are FIFO evicted from the first level buffer.
-/// If the evicted event has a priority level as high as or higher than the next level buffer in the chain,
-/// then the evicted event is promoted to there, surviving to see another day.
-/// Promotion may in turn require more eviction in the next buffer, and so on up the chain.
-/// The end result is that critical events get to live in any of the level buffers, making their way through
-/// all three until they finally age out. Info lives in one of the first two, and debug only in the first.
-///
-/// n.b. the discussion in PR #361 that introduced this: We were not able to determine a way to
-/// implement a priority queue that both met the specs requirements (low-prio events must not cause
-/// eviction of high-prio events) while also allowing debug and info-prio events to be emitted at all.
-/// Instead we opted to replicate the approach used in the C++ impl, which we believe is reasonable but
-/// also seemingly in violation of the spec.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-struct EventsInner<const N: usize> {
-    // TODO(events): Allow per-ring const generics, so the rings can be sized independently
-    buf_debug: LevelBuf<N>,
-    buf_info: LevelBuf<N>,
-    buf_critical: LevelBuf<N>,
-}
-
-impl<const N: usize> EventsInner<N> {
-    const fn new() -> Self {
-        Self {
-            buf_debug: LevelBuf::new(),
-            buf_info: LevelBuf::new(),
-            buf_critical: LevelBuf::new(),
-        }
-    }
-
-    pub fn init() -> impl Init<Self> {
-        init!(Self {
-            buf_debug <- LevelBuf::init(),
-            buf_info <- LevelBuf::init(),
-            buf_critical <- LevelBuf::init(),
-        })
-    }
-
-    pub fn reset(&mut self) {
-        self.buf_debug.reset();
-        self.buf_info.reset();
-        self.buf_critical.reset();
-    }
-
-    pub fn push<'a>(
-        &'a mut self,
-        path: EventPath,
+    #[allow(clippy::too_many_arguments)]
+    fn push<F>(
+        &mut self,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        event_id: EventId,
         event_number: u64,
-        priority: u8,
+        priority: EventPriority,
         timestamp: EventDataTimestamp,
-    ) -> Result<EventQueueWriter<'a, N>, Error> {
-        let mut tw = EventQueueWriter::new(self, Level::Debug);
-        tw.start_struct(&TLVTag::Context(EventRespTag::Data as _))?;
-        path.to_tlv(&TagType::Context(EventDataTag::Path as _), &mut tw)?;
-        tw.u64(
-            &TagType::Context(EventDataTag::EventNumber as _),
-            event_number,
-        )?;
-        tw.u8(&TagType::Context(EventDataTag::Priority as _), priority)?;
-        match timestamp {
-            EventDataTimestamp::EpochTimestamp(ts) => {
-                tw.u64(&TagType::Context(EventDataTag::EpochTimestamp as _), ts)?
+        f: F,
+    ) -> Result<(), Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        let mut event_writer = EventWriter::new(self);
+
+        let pos = event_writer.get_tail();
+
+        let result = (|| {
+            EventData {
+                path: EventPath {
+                    endpoint: Some(endpoint_id),
+                    cluster: Some(cluster_id),
+                    event: Some(event_id),
+                    ..Default::default()
+                },
+                event_number,
+                priority,
+                timestamp,
+                data: TLVElement::new(&[]),
             }
-            EventDataTimestamp::SystemTimestamp(ts) => {
-                tw.u64(&TagType::Context(EventDataTag::SystemTimestamp as _), ts)?
-            }
-            EventDataTimestamp::DeltaEpochTimestamp(ts) => tw.u64(
-                &TagType::Context(EventDataTag::DeltaEpochTimestamp as _),
-                ts,
-            )?,
-            EventDataTimestamp::DeltaSystemTimestamp(ts) => tw.u64(
-                &TagType::Context(EventDataTag::DeltaSystemTimestamp as _),
-                ts,
-            )?,
-        };
-        Ok(tw)
+            .write_preamble(&EVENT_TAG, event_writer.tw())?;
+
+            f(event_writer.tw())?;
+
+            event_writer.tw().end_container()
+        })();
+
+        if result.is_err() {
+            event_writer.rewind_to(pos);
+        }
+
+        result
     }
 
-    fn iter<'a>(&'a self) -> EventQueueIter<'a, N> {
-        EventQueueIter {
-            queue: self,
-            buf_ref: Level::Critical,
+    fn next_event_number<S>(&mut self, persist: &mut Persist<S>) -> Result<u64, Error>
+    where
+        S: KvBlobStoreAccess,
+    {
+        let event_number = self.next_event_number;
+
+        if event_number.is_multiple_of(EVENT_NUMBER_EPOCH_SIZE) {
+            // We're at an epoch start boundary. Therefore, we need to persist the new epoch to storage
+            // so we don't lose it on reboot and end up reusing event numbers.
+            persist.store_tlv(
+                EVENT_EPOCH_KEY,
+                event_number.wrapping_add(EVENT_NUMBER_EPOCH_SIZE),
+            )?;
+        }
+
+        self.next_event_number = event_number.wrapping_add(1);
+
+        Ok(event_number)
+    }
+
+    fn iter(&self) -> EventsIter<'_, N> {
+        EventsIter {
+            events: self,
+            buf_ref: EventPriority::Critical,
             buf_iter: self.buf_critical.iter(),
         }
     }
-}
 
-pub struct EventQueueIter<'a, const N: usize> {
-    queue: &'a EventsInner<N>,
-    buf_ref: Level<N>,
-    buf_iter: TLVSequenceIter<'a>,
-}
-
-impl<'a, const N: usize> Iterator for EventQueueIter<'a, N> {
-    type Item = Result<EventData<'a>, Error>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(res) = self.buf_iter.next() {
-            match res {
-                Ok(tr) => return Some(parse_event(tr)),
-                Err(e) => return Some(Err(e)),
-            }
+    /// Return a reference to the buffer corresponding to the provided priority level
+    fn buf(&self, priority: EventPriority) -> &EventsBuf<N> {
+        match priority {
+            EventPriority::Debug => &self.buf_debug,
+            EventPriority::Info => &self.buf_info,
+            EventPriority::Critical => &self.buf_critical,
         }
+    }
 
-        if let Some(next_buf_ref) = self.buf_ref.prior_level() {
-            self.buf_iter = next_buf_ref.get(self.queue).iter();
-            self.buf_ref = next_buf_ref;
-            return self.next();
+    /// Return a mutable reference to the buffer corresponding to the provided priority level
+    fn buf_mut(&mut self, priority: EventPriority) -> &mut EventsBuf<N> {
+        match priority {
+            EventPriority::Debug => &mut self.buf_debug,
+            EventPriority::Info => &mut self.buf_info,
+            EventPriority::Critical => &mut self.buf_critical,
         }
-        None
+    }
+
+    /// Return a reference to the buffer corresponding to the provided priority level, and a mutable reference to the next buffer in the chain if it exists
+    fn buf_and_next_mut(
+        &mut self,
+        priority: EventPriority,
+    ) -> (&EventsBuf<N>, Option<&mut EventsBuf<N>>) {
+        match priority {
+            EventPriority::Debug => (&self.buf_debug, Some(&mut self.buf_info)),
+            EventPriority::Info => (&self.buf_info, Some(&mut self.buf_critical)),
+            EventPriority::Critical => (&self.buf_critical, None),
+        }
     }
 }
 
-fn parse_event<'a>(tr: TLVElement<'a>) -> Result<EventData<'a>, Error> {
-    let mut path = None;
-    let mut event_number = None;
-    let mut priority = None;
-    let mut timestamp = None;
-    let mut data = None;
-
-    tr.structure()?.scan_map(|elem| {
-        if elem.is_empty() {
-            return Ok(Some(elem));
-        }
-
-        match EventDataTag::try_from(elem.ctx()?)? {
-            EventDataTag::Path => path = Some(EventPath::from_tlv(&elem)?),
-            EventDataTag::EventNumber => event_number = Some(elem.u64()?),
-            EventDataTag::Priority => priority = Some(elem.u8()?),
-            EventDataTag::SystemTimestamp => {
-                timestamp = Some(EventDataTimestamp::SystemTimestamp(elem.u64()?))
-            }
-            EventDataTag::EpochTimestamp => {
-                timestamp = Some(EventDataTimestamp::EpochTimestamp(elem.u64()?))
-            }
-            EventDataTag::DeltaSystemTimestamp => {
-                timestamp = Some(EventDataTimestamp::DeltaSystemTimestamp(elem.u64()?))
-            }
-            EventDataTag::DeltaEpochTimestamp => {
-                timestamp = Some(EventDataTimestamp::DeltaEpochTimestamp(elem.u64()?))
-            }
-            EventDataTag::Data => data = Some(elem.clone()),
-        }
-        Ok(None)
-    })?;
-
-    Ok(EventData::new(
-        path.ok_or(Error::new(ErrorCode::AttributeNotFound))?,
-        event_number.ok_or(Error::new(ErrorCode::AttributeNotFound))?,
-        priority.ok_or(Error::new(ErrorCode::AttributeNotFound))?,
-        timestamp.ok_or(Error::new(ErrorCode::AttributeNotFound))?,
-        data.ok_or(Error::new(ErrorCode::AttributeNotFound))?,
-    ))
+/// An iterator over the events in the queue, starting from the highest priority and oldest event.
+pub struct EventsIter<'a, const N: usize> {
+    events: &'a EventsInner<N>,
+    buf_ref: EventPriority,
+    buf_iter: TLVSequenceIter<'a>,
 }
 
-pub struct EventQueueWriter<'a, const N: usize> {
-    queue: &'a mut EventsInner<N>,
-    buf_ref: Level<N>,
+impl<'a, const N: usize> Iterator for EventsIter<'a, N> {
+    type Item = EventData<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(res) = self.buf_iter.next() {
+            let event = unwrap!(
+                res,
+                "Should not have iter errors as we only put well-formed TLVs in the buffer"
+            );
+            let event = unwrap!(
+                EventData::from_tlv(&event),
+                "Should not have parsing errors as we only put well-formed TLVs in the buffer"
+            );
+
+            return Some(event);
+        }
+
+        if let Some(next_buf_ref) = self.buf_ref.prev() {
+            self.buf_iter = self.events.buf(next_buf_ref).iter();
+            self.buf_ref = next_buf_ref;
+
+            self.next()
+        } else {
+            None
+        }
+    }
+}
+
+/// A helper struct for writing event data into the buffers, handling eviction and promotion as needed to make space for the new event.
+struct EventWriter<'a, const N: usize> {
+    events: &'a mut EventsInner<N>,
     bytes_written: usize,
 }
 
-impl<'a, const N: usize> EventQueueWriter<'a, N> {
-    fn new(queue: &'a mut EventsInner<N>, buf_ref: Level<N>) -> Self {
+impl<'a, const N: usize> EventWriter<'a, N> {
+    // We always write at the end of the debug buffer
+    // Events are flowing to higher-prio buffers by eviction
+    const OPER_BUF: EventPriority = EventPriority::Debug;
+
+    /// Create a new EventWriter for the given EventsInner, starting with zero bytes written.
+    #[inline(always)]
+    const fn new(events: &'a mut EventsInner<N>) -> Self {
         Self {
-            queue,
-            buf_ref,
+            events,
             bytes_written: 0,
         }
     }
 
-    fn end(&mut self) -> Result<(), Error> {
-        self.end_container()?;
+    /// Get a TLVWrite decorator for this EventWriter,
+    /// which handles writing TLV data and rolling back on errors by rewinding the write head to the position before the write started.
+    #[inline(always)]
+    fn tw(&mut self) -> EventTLVWrite<'_> {
+        EventTLVWrite(self)
+    }
+
+    /// Write a byte to the current buffer, evicting and promoting events as needed to make space for the new byte.
+    fn write(&mut self, byte: u8) -> Result<(), Error> {
+        if N == 0 {
+            // Events are disabled, we should never write anything to the buffer and should always succeed.
+            return Ok(());
+        }
+
+        if self.bytes_written == N {
+            // This event is larger than the buffer, the client needs to change the buffer size for this to work
+            return Err(Error::new(ErrorCode::ResourceExhausted));
+        }
+
+        while self.events.buf_mut(Self::OPER_BUF).append(byte).is_err() {
+            // Overflow, need to evict an event to make space.
+            // This may cascade and cause evictions in the higher priority buffers, but that's fine,
+            // as we just want to make space for this new event and the priority guarantees are maintained by the eviction logic.
+            self.evict(Self::OPER_BUF);
+        }
+
+        self.bytes_written += 1;
+
         Ok(())
     }
 
-    // Evict one entry from the given buffer, potentially promoting it to the next buffer if
-    // it meets the priority threshold. If promotion happens the eviction "cascades", until
-    // we either evict an event that doesn't meet the next buffers prio level or we run out of
-    // level buffers and drop the oldest critical event.
-    fn evict(&mut self, buf_ref: Level<N>) -> Result<(), Error> {
-        let (victim_prio, victim_ref) = self.prepare_eviction(buf_ref.get(self.queue))?;
+    /// Rewind the write head to the position before the current event started being written, effectively discarding any bytes written for the current event so far. This is used to roll back writes when an error occurs during event writing.
+    fn rewind_to(&mut self, bytes_written: usize) {
+        assert!(self.bytes_written >= bytes_written);
 
-        if let Some(next_buf_ref) = buf_ref.next_level() {
-            if next_buf_ref.threshold() <= victim_prio {
-                // There is another level and our victim record meets the priority threshold, we should promote it
-                self.promote(buf_ref, next_buf_ref, victim_ref)?;
+        self.events
+            .buf_mut(Self::OPER_BUF)
+            .rewind_by(self.bytes_written - bytes_written);
+        self.bytes_written = bytes_written;
+    }
+
+    /// Evict the first event from the buffer corresponding to the provided priority level,
+    /// promoting it to the next buffer if its priority meets the threshold, and cascading evictions/promotions as needed.
+    fn evict(&mut self, buf_ref: EventPriority) {
+        let event_len = self.events.buf(buf_ref).first_event_len();
+
+        if let Some(next_buf_ref) = buf_ref.next() {
+            let event_prio = self.events.buf(buf_ref).first_event_prio();
+
+            if next_buf_ref as u8 <= event_prio {
+                // There is another level and our event meets the priority threshold, so we should promote it
+                self.promote(buf_ref, next_buf_ref, event_len);
             }
         }
 
-        buf_ref.get_mut(self.queue).evict(victim_ref);
-        Ok(())
+        // Evict the event from the current buffer, whether we promoted it or not
+        self.events.buf_mut(buf_ref).evict_first_event();
     }
 
-    // Work out the size and priority of the next victim in the given buffer
-    fn prepare_eviction(&self, buf: &LevelBuf<N>) -> Result<(u8, VictimRef), Error> {
-        let victim_ref = buf.prepare_eviction()?;
-        let priority = victim_ref
-            .tlv(buf)
-            .structure()?
-            .find_ctx(EventDataTag::Priority as _)?
-            .u8()?;
-        Ok((priority, victim_ref))
-    }
-
-    // Promotes victim_ref from src to dst, making space in dst (potentially cascading) if needed
-    fn promote(
-        &mut self,
-        src_buf: Level<N>,
-        dst_buf: Level<N>,
-        victim_ref: VictimRef,
-    ) -> Result<(), Error> {
-        // Make space (n.b. this assumes the next level is always at least as large as the current level, which is currently always true)
-        while dst_buf.get(self.queue).capacity() < victim_ref.len() {
-            self.evict(dst_buf)?;
+    // Promote the first event from the source buffer to the destination buffer,
+    // evicting events from the destination buffer as needed to make space and potentially
+    // cascading promotion to higher buffers if evicted events meet the priority threshold
+    fn promote(&mut self, src_buf: EventPriority, dst_buf: EventPriority, event_len: usize) {
+        // Make space (n.b. this assumes the next buffer is always at least as large as the current buffer, which is currently always true)
+        while self.events.buf(dst_buf).capacity() < event_len {
+            self.evict(dst_buf);
         }
 
-        let (src, dst) = src_buf.get_mut_and_next(self.queue);
-        let dst = dst.expect("dst buffer should always exist as this is checked in evict()");
-        dst.write_slice(victim_ref.raw(src))
-            .expect("should not overflow as eviction should have cleared space");
-        Ok(())
+        let (src, dst) = self.events.buf_and_next_mut(src_buf);
+
+        let dst = unwrap!(
+            dst,
+            "Dst buffer should always exist as this is checked in evict()"
+        );
+
+        unwrap!(
+            dst.append_slice(src.slice(event_len)),
+            "Should not overflow as eviction should have cleared space"
+        );
     }
 }
 
-impl<'a, const N: usize> TLVWrite for EventQueueWriter<'a, N> {
+/// A dyn-compatible writer for event data
+/// Necessary so that we can implement `EventTLVWrite`, which is a `TLVWrite` with an erased `const N: usize` generic
+trait DynEventWriter {
+    fn write(&mut self, byte: u8) -> Result<(), Error>;
+
+    fn get_tail(&self) -> usize;
+
+    fn rewind_to(&mut self, pos: usize);
+}
+
+impl<'a, const N: usize> DynEventWriter for EventWriter<'a, N> {
+    fn write(&mut self, byte: u8) -> Result<(), Error> {
+        EventWriter::write(self, byte)
+    }
+
+    fn get_tail(&self) -> usize {
+        self.bytes_written
+    }
+
+    fn rewind_to(&mut self, pos: usize) {
+        EventWriter::rewind_to(self, pos)
+    }
+}
+
+/// A `TLVWrite` wrapper around EventWriter that erases the const generic,
+/// allowing it to be used in the closure passed to `Events::push()` and the various `emit_event` handler context methods.
+pub struct EventTLVWrite<'a>(&'a mut dyn DynEventWriter);
+
+impl<'a> TLVWrite for EventTLVWrite<'a> {
     type Position = usize;
 
     fn write(&mut self, byte: u8) -> Result<(), Error> {
-        if self.bytes_written == N {
-            // This event is larger than the buffer, the client needs to change the buffer size for this to work
-            return Err(Error::new(ErrorCode::NoSpace));
-        }
-        while let Err(OverflowError {}) = self.buf_ref.get_mut(self.queue).write(byte) {
-            // Overflow, need to evict an entry
-            self.evict(Level::Debug)?;
-        }
-        self.bytes_written += 1;
-        Ok(())
+        self.0.write(byte)
     }
 
     fn get_tail(&self) -> Self::Position {
-        // n.b. TLVWrite calls the next position to be written "tail", but our level buffer calls that position "head"
-        self.queue.buf_debug.head
+        self.0.get_tail()
     }
 
     fn rewind_to(&mut self, pos: Self::Position) {
-        self.queue.buf_debug.head = pos;
+        self.0.rewind_to(pos)
     }
 }
 
-/// LevelBuf stores one "level" of events, see the doc string on EventsInner for more info on that.
+const EVENT_TAG: TLVTag = TLVTag::Context(EventRespTag::Data as _);
+
+/// The context tag corresponding to the event data field in the Event Response TLV structure.
+pub const EVENT_DATA_TAG: TLVTag = TLVTag::Context(EventDataTag::Data as _);
+
+/// Stores one "priority level" of events, see the doc string on EventsInner for more info on that.
 ///
 /// This behaves very similar to a ring buffer - you can append data at the write head, and eventually
 /// the head will catch up and "eat" the tail, implementing a sort of sliding window of visible data.
 ///
-/// This is a much less efficient variant though - it left-shifts the entire buffer to "evict" old records,
+/// This is a much less efficient variant though - it left-shifts the entire buffer to "evict" old events,
 /// rather than just track head/tail pointers with wrap-around.
 ///
-/// The thing we gain from the less efficient implementation is that records are never "split up", they are
-/// always complete TLVs in contiguous memory, which allows us to use TLVElement to read the records.
+/// The thing we gain from the less efficient implementation is that events are never "split up", they are
+/// always complete TLVs in contiguous memory, which allows to use TLVElement to read/iterate over the events.
 ///
 /// If you feel enthusiastic, it might give some performance gains to replace this with a real ring buffer.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-struct LevelBuf<const N: usize> {
+struct EventsBuf<const N: usize> {
     data: [u8; N],
     head: usize,
 }
 
-impl<const N: usize> LevelBuf<N> {
+impl<const N: usize> EventsBuf<N> {
     const fn new() -> Self {
         Self {
             data: [0; N],
@@ -552,53 +589,77 @@ impl<const N: usize> LevelBuf<N> {
         }
     }
 
-    pub fn init() -> impl Init<Self> {
+    fn init() -> impl Init<Self> {
         init!(Self {
             data <- crate::utils::init::zeroed(),
             head: 0,
         })
     }
 
-    pub fn reset(&mut self) {
+    fn reset(&mut self) {
         self.head = 0;
     }
 
-    fn write(&mut self, byte: u8) -> Result<(), OverflowError> {
+    fn rewind_by(&mut self, bytes_written: usize) {
+        assert!(self.head >= bytes_written);
+
+        self.head -= bytes_written;
+    }
+
+    fn slice(&self, len: usize) -> &[u8] {
+        assert!(self.head >= len);
+        &self.data[..len]
+    }
+
+    fn append(&mut self, byte: u8) -> Result<(), OverflowError> {
         if self.capacity() == 0 {
-            return Err(OverflowError {});
+            return Err(OverflowError);
         }
+
         self.data[self.head] = byte;
         self.head += 1;
         Ok(())
     }
 
-    fn write_slice(&mut self, data: &[u8]) -> Result<(), OverflowError> {
+    fn append_slice(&mut self, data: &[u8]) -> Result<(), OverflowError> {
         if self.capacity() < data.len() {
-            return Err(OverflowError {});
+            return Err(OverflowError);
         }
+
         self.data[self.head..self.head + data.len()].copy_from_slice(data);
         self.head += data.len();
-        Ok(())
-    }
 
-    // Get the size of the record at the given position; the caller is responsible for ensuring pos is aligned on a record
-    fn record_len(&self, pos: usize) -> Result<usize, Error> {
-        TLVSequence(&self.data[pos..]).container_len()
+        Ok(())
     }
 
     fn capacity(&self) -> usize {
         self.data.len() - self.head
     }
 
-    fn prepare_eviction(&self) -> Result<VictimRef, Error> {
-        Ok(VictimRef {
-            victim_len: self.record_len(0)?,
-        })
+    /// Get the TLV length of the event in the buffer
+    ///
+    /// The method will panic if the buffer is empty or if the buffer contains invalid data
+    fn first_event_len(&self) -> usize {
+        assert!(self.head > 0);
+        unwrap!(TLVSequence(&self.data[..self.head]).container_len())
     }
 
-    fn evict(&mut self, victim: VictimRef) {
-        self.data.copy_within(victim.len()..self.head, 0);
-        self.head -= victim.len();
+    /// Get the priority of the event at the start of the buffer
+    ///
+    /// The method will panic if the buffer is empty or if the buffer contains invalid data
+    fn first_event_prio(&self) -> u8 {
+        unwrap!(unwrap!(
+            unwrap!(TLVElement::new(&self.data[..self.head]).structure())
+                .find_ctx(EventDataTag::Priority as _)
+        )
+        .u8())
+    }
+
+    fn evict_first_event(&mut self) {
+        let tlv_len = self.first_event_len();
+
+        self.data.copy_within(tlv_len..self.head, 0);
+        self.head -= tlv_len;
     }
 
     fn iter(&self) -> TLVSequenceIter<'_> {
@@ -606,114 +667,20 @@ impl<const N: usize> LevelBuf<N> {
     }
 }
 
-/// During eviction we need the size of the record to be evicted several times (for promotion and then for actual moving the tail index)
-/// to avoid reading the whole entry lots of times for this we read it once to get its size and store that in this reference
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-struct VictimRef {
-    victim_len: usize,
-}
-
-impl VictimRef {
-    fn tlv<'a, const N: usize>(&self, buf: &'a LevelBuf<N>) -> TLVElement<'a> {
-        TLVElement::new(self.raw(buf))
-    }
-
-    fn raw<'a, const N: usize>(&self, buf: &'a LevelBuf<N>) -> &'a [u8] {
-        &buf.data[0..self.victim_len]
-    }
-
-    fn len(&self) -> usize {
-        self.victim_len
-    }
-}
-
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct OverflowError;
-
-// This is how we handle the "levels" of buffers, using this reference we can access the current
-// level and get access to the next level, if there is one
-#[derive(PartialEq, Clone, Copy)]
-enum Level<const N: usize> {
-    Debug,
-    Info,
-    Critical,
-}
-
-impl<const N: usize> Level<N> {
-    fn threshold(&self) -> u8 {
-        // 7.19.2.17
-        match self {
-            Level::Debug => 0,
-            Level::Info => 1,
-            Level::Critical => 2,
-        }
-    }
-
-    fn get_mut<'a>(&self, queue: &'a mut EventsInner<N>) -> &'a mut LevelBuf<N> {
-        match self {
-            Level::Debug => &mut queue.buf_debug,
-            Level::Info => &mut queue.buf_info,
-            Level::Critical => &mut queue.buf_critical,
-        }
-    }
-
-    fn get<'a>(&self, queue: &'a EventsInner<N>) -> &'a LevelBuf<N> {
-        match self {
-            Level::Debug => &queue.buf_debug,
-            Level::Info => &queue.buf_info,
-            Level::Critical => &queue.buf_critical,
-        }
-    }
-
-    /// Used during promotion, when we need both the src and dst buffers at the same time
-    fn get_mut_and_next<'a>(
-        &self,
-        queue: &'a mut EventsInner<N>,
-    ) -> (&'a mut LevelBuf<N>, Option<&'a mut LevelBuf<N>>) {
-        match self {
-            Level::Debug => (&mut queue.buf_debug, Some(&mut queue.buf_info)),
-            Level::Info => (&mut queue.buf_info, Some(&mut queue.buf_critical)),
-            Level::Critical => (&mut queue.buf_critical, None),
-        }
-    }
-
-    fn next_level(&self) -> Option<Level<N>> {
-        match self {
-            Level::Debug => Some(Level::Info),
-            Level::Info => Some(Level::Critical),
-            Level::Critical => None,
-        }
-    }
-
-    /// Used during iteration, note that this goes "backwards" compared to get_mut_and_next;
-    /// when iterating we want to start with the oldest events, so we start with the "highest"
-    /// level where the oldest survivors are and work back
-    fn prior_level(&self) -> Option<Level<N>> {
-        match self {
-            Level::Debug => None,
-            Level::Info => Some(Level::Debug),
-            Level::Critical => Some(Level::Info),
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::tlv::ToTLV;
 
-    const EP1: EventPath = EventPath {
-        node: Some(1337),
-        endpoint: Some(42),
-        cluster: Some(1),
-        event: Some(0xB33F),
-        is_urgent: Some(true),
-    };
+    use super::*;
 
     #[test]
     fn one_entry() {
-        let crit1 = TestEvent::new(1, 2);
-        let mut q: EventsInner<64> = EventsInner::new();
+        let crit1 = TestEvent::new(1, EventPriority::Critical);
+        let mut q: EventsInner<32> = EventsInner::new();
 
         crit1.push_into(&mut q).unwrap();
 
@@ -722,10 +689,10 @@ mod tests {
 
     #[test]
     fn critical_is_promoted() {
-        let crit1 = TestEvent::new(1, 2);
-        let crit2 = TestEvent::new(2, 2);
-        let crit3 = TestEvent::new(3, 2);
-        let mut q: EventsInner<64> = EventsInner::new();
+        let crit1 = TestEvent::new(1, EventPriority::Critical);
+        let crit2 = TestEvent::new(2, EventPriority::Info);
+        let crit3 = TestEvent::new(3, EventPriority::Info);
+        let mut q: EventsInner<32> = EventsInner::new();
 
         crit1.push_into(&mut q).unwrap();
         crit2.push_into(&mut q).unwrap();
@@ -738,10 +705,10 @@ mod tests {
 
     #[test]
     fn debug_is_dropped() {
-        let crit1 = TestEvent::new(1, 2);
-        let dbg2 = TestEvent::new(2, 0);
-        let crit3: TestEvent = TestEvent::new(3, 2);
-        let mut q: EventsInner<64> = EventsInner::new();
+        let crit1 = TestEvent::new(1, EventPriority::Critical);
+        let dbg2 = TestEvent::new(2, EventPriority::Debug);
+        let crit3: TestEvent = TestEvent::new(3, EventPriority::Critical);
+        let mut q: EventsInner<32> = EventsInner::new();
 
         crit1.push_into(&mut q).unwrap();
         dbg2.push_into(&mut q).unwrap();
@@ -758,12 +725,12 @@ mod tests {
 
     #[test]
     fn event_larger_than_buffer() {
-        let crit1 = TestEvent::new(1, 2);
+        let crit1 = TestEvent::new(1, EventPriority::Critical);
         let mut q: EventsInner<8> = EventsInner::new();
 
         assert_eq!(
             crit1.push_into(&mut q).expect_err("").code(),
-            ErrorCode::NoSpace
+            ErrorCode::ResourceExhausted
         );
     }
 
@@ -771,17 +738,21 @@ mod tests {
 
     #[derive(PartialEq, Clone, Debug)]
     struct TestEvent {
-        path: EventPath,
+        endpoint: EndptId,
+        cluster: ClusterId,
+        event: EventId,
         event_number: u64,
-        priority: u8,
+        priority: EventPriority,
         timestamp: EventDataTimestamp,
         data: u64,
     }
 
     impl TestEvent {
-        fn new(event_number: u64, priority: u8) -> Self {
+        const fn new(event_number: u64, priority: EventPriority) -> Self {
             Self {
-                path: EP1.clone(),
+                endpoint: 42,
+                cluster: 1,
+                event: 0xB33F,
                 event_number,
                 priority,
                 timestamp: EventDataTimestamp::EpochTimestamp(10_000 + event_number),
@@ -790,13 +761,15 @@ mod tests {
         }
 
         fn vec_from<const N: usize>(
-            buf: &LevelBuf<N>,
-        ) -> Result<heapless::Vec<TestEvent, 16>, Error> {
+            buf: &EventsBuf<N>,
+        ) -> Result<heapless::Vec<TestEvent, N>, Error> {
             let mut out = heapless::Vec::new();
             for tr in buf.iter() {
-                let e = parse_event(tr?)?;
+                let e = EventData::from_tlv(&tr?)?;
                 out.push(TestEvent {
-                    path: e.path,
+                    endpoint: e.path.endpoint.unwrap(),
+                    cluster: e.path.cluster.unwrap(),
+                    event: e.path.event.unwrap(),
                     event_number: e.event_number,
                     priority: e.priority,
                     timestamp: e.timestamp,
@@ -804,18 +777,20 @@ mod tests {
                 })
                 .unwrap();
             }
+
             Ok(out)
         }
 
         fn push_into<const N: usize>(&self, q: &mut EventsInner<N>) -> Result<(), Error> {
-            let mut tw = q.push(
-                self.path.clone(),
+            q.push(
+                self.endpoint,
+                self.cluster,
+                self.event,
                 self.event_number,
                 self.priority,
                 self.timestamp.clone(),
-            )?;
-            tw.u64(&TLVTag::Context(EventDataTag::Data as _), self.data)?;
-            tw.end()
+                |tw| self.data.to_tlv(&EVENT_DATA_TAG, tw),
+            )
         }
     }
 }

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -31,9 +31,6 @@ use crate::utils::sync::{DynBase, Notification};
 /// According to the Matter spec, at least 3 subscriptions per fabric should be supported.
 pub const DEFAULT_MAX_SUBSCRIPTIONS: usize = MAX_FABRICS * 3;
 
-/// A type alias for `Subscriptions` with the default maximum number of subscriptions.
-pub type DefaultSubscriptions = Subscriptions<DEFAULT_MAX_SUBSCRIPTIONS>;
-
 struct Subscription {
     fabric_idx: NonZeroU8,
     peer_node_id: u64,

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -22,8 +22,10 @@ use embassy_futures::select::select;
 
 use crate::crypto::Crypto;
 use crate::dm::clusters::net_comm::NetworksAccess;
-use crate::dm::IMBuffer;
+use crate::dm::events::EventTLVWrite;
+use crate::dm::{EventId, IMBuffer};
 use crate::error::{Error, ErrorCode};
+use crate::im::EventPriority;
 use crate::persist::KvBlobStoreAccess;
 use crate::tlv::TLVElement;
 use crate::transport::exchange::Exchange;
@@ -97,10 +99,28 @@ pub trait HandlerContext {
         attr_id: AttrId,
     );
 
-    /// Notify that the state of an attribute has changed.
-    fn notify_attribute_path_changed(&self, attr: &AttrDetails) {
-        self.notify_attribute_changed(attr.endpoint_id, attr.cluster_id, attr.attr_id);
-    }
+    /// Emit an event.
+    ///
+    /// # Arguments
+    /// - `endpoint_id`: The endpoint ID of the cluster that emits the event.
+    /// - `cluster_id`: The cluster ID of the cluster that emits the event.
+    /// - `event_id`: The event ID of the event being emitted.
+    /// - `priority`: The priority of the event.
+    /// - `f`: A closure that takes an `EventTLVWrite` and writes the event data into it using TLV encoding.
+    ///
+    /// # Returns
+    /// - `Ok(u64)`: The sequence number of the emitted event, if the event was successfully emitted.
+    /// - `Err(Error)`: An error if the event could not be emitted.
+    fn emit_event<F>(
+        &self,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>;
 }
 
 impl<T> HandlerContext for &T
@@ -140,8 +160,18 @@ where
         (**self).notify_attribute_changed(endpoint_id, cluster_id, attr_id);
     }
 
-    fn notify_attribute_path_changed(&self, attr: &AttrDetails) {
-        (**self).notify_attribute_path_changed(attr)
+    fn emit_event<F>(
+        &self,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        (**self).emit_event(endpoint_id, cluster_id, event_id, priority, f)
     }
 }
 
@@ -155,6 +185,30 @@ pub trait OperationContext: HandlerContext {
 
     /// Return the cluster ID that is associated with this operation.
     fn cluster(&self) -> ClusterId;
+
+    /// Emit an event with the same endpoint ID and cluster ID as the current operation.
+    ///
+    /// This is a convenience method that calls `emit_event` with the endpoint ID and cluster ID of the current operation, so that the caller doesn't have to specify them again.
+    ///
+    /// # Arguments
+    /// - `event_id`: The event ID of the event being emitted.
+    /// - `priority`: The priority of the event.
+    /// - `f`: A closure that takes an `EventTLVWrite` and writes the event data into it using TLV encoding.
+    ///
+    /// # Returns
+    /// - `Ok(u64)`: The sequence number of the emitted event, if the event was successfully emitted.
+    /// - `Err(Error)`: An error if the event could not be emitted.
+    fn emit_own_event<F>(
+        &self,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        self.emit_event(self.endpt(), self.cluster(), event_id, priority, f)
+    }
 }
 
 impl<T> OperationContext for &T
@@ -171,6 +225,18 @@ where
 
     fn cluster(&self) -> ClusterId {
         (**self).cluster()
+    }
+
+    fn emit_own_event<F>(
+        &self,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        (**self).emit_own_event(event_id, priority, f)
     }
 }
 
@@ -199,7 +265,11 @@ pub trait WriteContext: OperationContext {
 
     /// Notify that the state of the attribute whose write operation is processed has changed.
     fn notify_changed(&self) {
-        self.notify_attribute_path_changed(self.attr());
+        self.notify_attribute_changed(
+            self.attr().endpoint_id,
+            self.attr().cluster_id,
+            self.attr().attr_id,
+        );
     }
 }
 
@@ -304,6 +374,21 @@ where
         self.context
             .notify_attribute_changed(endpoint_id, cluster_id, attr_id);
     }
+
+    fn emit_event<F>(
+        &self,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        self.context
+            .emit_event(endpoint_id, cluster_id, event_id, priority, f)
+    }
 }
 
 impl<C> OperationContext for ReadContextInstance<'_, C>
@@ -320,6 +405,19 @@ where
 
     fn cluster(&self) -> ClusterId {
         self.attr.cluster_id
+    }
+
+    fn emit_own_event<F>(
+        &self,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        self.context
+            .emit_event(self.endpt(), self.cluster(), event_id, priority, f)
     }
 }
 
@@ -399,6 +497,21 @@ where
         self.context
             .notify_attribute_changed(endpoint_id, cluster_id, attr_id);
     }
+
+    fn emit_event<F>(
+        &self,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        self.context
+            .emit_event(endpoint_id, cluster_id, event_id, priority, f)
+    }
 }
 
 impl<C> OperationContext for WriteContextInstance<'_, C>
@@ -415,6 +528,19 @@ where
 
     fn cluster(&self) -> ClusterId {
         self.attr.cluster_id
+    }
+
+    fn emit_own_event<F>(
+        &self,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        self.context
+            .emit_event(self.endpt(), self.cluster(), event_id, priority, f)
     }
 }
 
@@ -498,6 +624,21 @@ where
         self.context
             .notify_attribute_changed(endpoint_id, cluster_id, attr_id);
     }
+
+    fn emit_event<F>(
+        &self,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        self.context
+            .emit_event(endpoint_id, cluster_id, event_id, priority, f)
+    }
 }
 
 impl<C> OperationContext for InvokeContextInstance<'_, C>
@@ -514,6 +655,19 @@ where
 
     fn cluster(&self) -> ClusterId {
         self.cmd.cluster_id
+    }
+
+    fn emit_own_event<F>(
+        &self,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<u64, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        self.context
+            .emit_event(self.endpt(), self.cluster(), event_id, priority, f)
     }
 }
 

--- a/rs-matter/src/dm/types/reply.rs
+++ b/rs-matter/src/dm/types/reply.rs
@@ -19,7 +19,7 @@ use crate::dm::{AsyncHandler, HandlerContext};
 use crate::error::{Error, ErrorCode};
 use crate::im::{
     AttrDataTag, AttrPath, AttrResp, AttrRespTag, AttrStatus, CmdDataTag, CmdPath, CmdResp,
-    CmdRespTag, CmdStatus, EventData, EventFilter, EventPath, EventRespTag, IMStatusCode,
+    CmdRespTag, CmdStatus, EventData, EventFilter, EventPath, EventResp, IMStatusCode,
 };
 use crate::tlv::{TLVArray, TLVElement, TLVTag, TLVWrite, TagType, ToTLV};
 use crate::transport::exchange::Exchange;
@@ -294,48 +294,51 @@ where
     }
 }
 
-pub struct EventReader {
-    // This is applied in combination with any event number filters that are
-    // inside the request itself; it's the "what's the min event number this subscription should see next"
-    // that's tracked with each active Subscription and updated each time we emit events to the subscriber
-    min_event_number: u64,
+pub struct EventReader<'a> {
+    /// On construction - a reference to the minimum event number that should be emitted to the subscriber. This is updated after each event is emitted, so it always reflects the minimum event number that should be processed / appended to the writer.
+    /// After each successive call to `process_read`, this is updated to the biggest event number seen during the processing.
+    min_event_number: &'a mut u64,
 }
 
-impl EventReader {
-    pub fn new(min_event_number: u64) -> Self {
+impl<'a> EventReader<'a> {
+    pub const fn new(min_event_number: &'a mut u64) -> Self {
         Self { min_event_number }
     }
 
-    pub async fn process_read<T: TLVWrite>(
-        &self,
-        event: &EventData<'_>,
+    pub fn process_read<T: TLVWrite>(
+        &mut self,
+        event: EventData<'_>,
         paths: &TLVArray<'_, EventPath>,
         event_filters: Option<TLVArray<'_, EventFilter>>,
         mut tw: T,
     ) -> Result<(), Error> {
         let tail = tw.get_tail();
 
-        let result = self
-            .do_process_read(event, paths, event_filters, &mut tw)
-            .await;
+        let event_number = event.event_number;
+
+        let result = self.do_process_read(event, paths, event_filters, &mut tw);
 
         if result.is_err() {
             // If there was an error, rewind to the tail so we don't write any data.
             tw.rewind_to(tail);
+        } else {
+            if event_number >= *self.min_event_number {
+                *self.min_event_number = event_number.wrapping_add(1);
+            }
         }
 
         result
     }
 
-    async fn do_process_read<T: TLVWrite>(
-        &self,
-        event: &EventData<'_>,
+    fn do_process_read<T: TLVWrite>(
+        &mut self,
+        event: EventData<'_>,
         paths: &TLVArray<'_, EventPath>,
         event_filters: Option<TLVArray<'_, EventFilter>>,
         mut tw: T,
     ) -> Result<(), Error> {
-        if event.event_number < self.min_event_number {
-            // This event has already been seen by this subscription, skip
+        if event.event_number < *self.min_event_number {
+            // This event has already been seen by the caller, skip
             return Ok(());
         }
 
@@ -387,9 +390,7 @@ impl EventReader {
             return Ok(());
         }
 
-        tw.start_struct(&TLVTag::Anonymous)?;
-        event.to_tlv(&TLVTag::Context(EventRespTag::Data as _), &mut tw)?;
-        tw.end_container()
+        EventResp::Data(event).to_tlv(&TagType::Anonymous, &mut tw)
     }
 }
 

--- a/rs-matter/src/im/event.rs
+++ b/rs-matter/src/im/event.rs
@@ -153,11 +153,11 @@ pub struct EventData<'a> {
     pub path: EventPath,
     /// The event number counter for the node. While the node is running it is
     /// monotonically increasing, but the spec allows for (large) incremental jumps
-    /// on node reboot
+    /// on node reboot.
     pub event_number: u64,
-    // Event priority, lower means higher priority
-    pub priority: u8,
-    // Event timestamp, one of multiple mutually exclusive options
+    /// Event priority.
+    pub priority: EventPriority,
+    /// Event timestamp, one of multiple mutually exclusive options.
     pub timestamp: EventDataTimestamp,
     /// The data for the event, represented as a TLV element.
     pub data: TLVElement<'a>,
@@ -168,7 +168,7 @@ impl<'a> EventData<'a> {
     pub const fn new(
         path: EventPath,
         event_number: u64,
-        priority: u8,
+        priority: EventPriority,
         timestamp: EventDataTimestamp,
         data: TLVElement<'a>,
     ) -> Self {
@@ -180,21 +180,21 @@ impl<'a> EventData<'a> {
             data,
         }
     }
-}
 
-// Manually implemented because of the tagged union used for the timestamp
-impl<'a> ToTLV for EventData<'a> {
-    fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, mut tw: W) -> Result<(), Error> {
+    pub fn write_preamble<T: TLVWrite>(&self, tag: &TLVTag, mut tw: T) -> Result<(), Error> {
         tw.start_struct(tag)?;
+
         self.path
             .to_tlv(&TagType::Context(EventDataTag::Path as _), &mut tw)?;
+
         tw.u64(
             &TagType::Context(EventDataTag::EventNumber as _),
             self.event_number,
         )?;
+
         tw.u8(
             &TagType::Context(EventDataTag::Priority as _),
-            self.priority,
+            self.priority as _,
         )?;
 
         match self.timestamp {
@@ -212,7 +212,16 @@ impl<'a> ToTLV for EventData<'a> {
                 &TagType::Context(EventDataTag::DeltaSystemTimestamp as _),
                 ts,
             )?,
-        };
+        }
+
+        Ok(())
+    }
+}
+
+// Manually implemented because of the tagged union used for the timestamp
+impl<'a> ToTLV for EventData<'a> {
+    fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, mut tw: W) -> Result<(), Error> {
+        self.write_preamble(tag, &mut tw)?;
 
         self.data
             .to_tlv(&TagType::Context(EventDataTag::Data as _), &mut tw)?;
@@ -223,9 +232,11 @@ impl<'a> ToTLV for EventData<'a> {
     fn tlv_iter(&self, tag: crate::tlv::TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
         let (timestamp_tag, timestamp_val) = match self.timestamp {
             EventDataTimestamp::EpochTimestamp(ts) => (EventDataTag::EpochTimestamp, ts),
-            EventDataTimestamp::SystemTimestamp(ts) => (EventDataTag::EpochTimestamp, ts),
-            EventDataTimestamp::DeltaEpochTimestamp(ts) => (EventDataTag::EpochTimestamp, ts),
-            EventDataTimestamp::DeltaSystemTimestamp(ts) => (EventDataTag::EpochTimestamp, ts),
+            EventDataTimestamp::SystemTimestamp(ts) => (EventDataTag::SystemTimestamp, ts),
+            EventDataTimestamp::DeltaEpochTimestamp(ts) => (EventDataTag::DeltaEpochTimestamp, ts),
+            EventDataTimestamp::DeltaSystemTimestamp(ts) => {
+                (EventDataTag::DeltaSystemTimestamp, ts)
+            }
         };
 
         let header = [Ok(TLV::structure(tag))].into_iter();
@@ -236,7 +247,7 @@ impl<'a> ToTLV for EventData<'a> {
             )),
             Ok(TLV::u8(
                 TLVTag::Context(EventDataTag::Priority as _),
-                self.priority,
+                self.priority as _,
             )),
             Ok(TLV::u64(TLVTag::Context(timestamp_tag as _), timestamp_val)),
         ]
@@ -258,13 +269,15 @@ impl<'a> FromTLV<'a> for EventData<'a> {
         let mut priority = None;
         let mut timestamp = None;
         let mut data = None;
+
         for field in element.structure()?.iter() {
             let el = field?;
+
             match el.tag()? {
                 TLVTag::Context(tag) => match EventDataTag::try_from(tag)? {
                     EventDataTag::Path => path = Some(EventPath::from_tlv(&el)?),
                     EventDataTag::EventNumber => event_number = Some(el.u64()?),
-                    EventDataTag::Priority => priority = Some(el.u8()?),
+                    EventDataTag::Priority => priority = Some(EventPriority::from_tlv(&el)?),
                     EventDataTag::EpochTimestamp => {
                         timestamp = Some(EventDataTimestamp::EpochTimestamp(el.u64()?))
                     }
@@ -282,6 +295,7 @@ impl<'a> FromTLV<'a> for EventData<'a> {
                 _ => return Err(Error::new(ErrorCode::Invalid)),
             }
         }
+
         Ok(EventData::new(
             path.ok_or(Error::new(ErrorCode::Invalid))?,
             event_number.ok_or(Error::new(ErrorCode::Invalid))?,
@@ -289,6 +303,37 @@ impl<'a> FromTLV<'a> for EventData<'a> {
             timestamp.ok_or(Error::new(ErrorCode::Invalid))?,
             data.ok_or(Error::new(ErrorCode::Invalid))?,
         ))
+    }
+}
+
+/// An enum type describing the priority each event might have
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, FromTLV, ToTLV)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(datatype = "u8")]
+#[repr(u8)]
+pub enum EventPriority {
+    Debug = 0,
+    Info = 1,
+    Critical = 2,
+}
+
+impl EventPriority {
+    /// Get the next (higher) priority, if any
+    pub const fn next(&self) -> Option<Self> {
+        match self {
+            Self::Debug => Some(Self::Info),
+            Self::Info => Some(Self::Critical),
+            Self::Critical => None,
+        }
+    }
+
+    /// Get the previous (lower) priority, if any
+    pub const fn prev(&self) -> Option<Self> {
+        match self {
+            Self::Debug => None,
+            Self::Info => Some(Self::Debug),
+            Self::Critical => Some(Self::Info),
+        }
     }
 }
 

--- a/rs-matter/tests/commissioning.rs
+++ b/rs-matter/tests/commissioning.rs
@@ -57,9 +57,9 @@ use rs_matter::dm::clusters::on_off::{self, test::TestOnOffDeviceLogic, OnOffHoo
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints;
-use rs_matter::dm::events::NO_EVENTS;
+use rs_matter::dm::events::NoEvents;
 use rs_matter::dm::networks::unix::UnixNetifs;
-use rs_matter::dm::subscriptions::DefaultSubscriptions;
+use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::IMBuffer;
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
@@ -109,7 +109,7 @@ const MAX_DISCOVERED_DEVICES: usize = 8;
 
 static DEVICE_MATTER: StaticCell<Matter> = StaticCell::new();
 static DEVICE_BUFFERS: StaticCell<PooledBuffers<10, IMBuffer>> = StaticCell::new();
-static DEVICE_SUBSCRIPTIONS: StaticCell<DefaultSubscriptions> = StaticCell::new();
+static DEVICE_SUBSCRIPTIONS: StaticCell<Subscriptions> = StaticCell::new();
 static CTRL_MATTER: StaticCell<Matter> = StaticCell::new();
 
 // ============================================================================
@@ -179,7 +179,7 @@ async fn run_test() -> Result<(), Error> {
     let device_buffers = DEVICE_BUFFERS.uninit().init_with(PooledBuffers::init(0));
     let device_subscriptions = DEVICE_SUBSCRIPTIONS
         .uninit()
-        .init_with(DefaultSubscriptions::init());
+        .init_with(Subscriptions::init());
 
     let on_off_handler = on_off::OnOffHandler::new_standalone(
         Dataver::new_rand(&mut rand),
@@ -187,12 +187,14 @@ async fn run_test() -> Result<(), Error> {
         TestOnOffDeviceLogic::new(false),
     );
 
+    let events = NoEvents::new_default();
+
     let dm = DataModel::new(
         device_matter,
         &device_crypto,
         device_buffers,
         device_subscriptions,
-        NO_EVENTS,
+        &events,
         dm_handler(rand, &on_off_handler),
         DummyKvBlobStoreAccess,
         DummyNetworkAccess,

--- a/rs-matter/tests/common/e2e.rs
+++ b/rs-matter/tests/common/e2e.rs
@@ -187,7 +187,7 @@ impl<C: Crypto> E2eRunner<C> {
             &self.crypto,
             &self.buffers,
             &self.subscriptions,
-            Some(&self.events),
+            &self.events,
             handler,
             DummyKvBlobStoreAccess,
             DummyNetworkAccess,

--- a/rs-matter/tests/common/e2e/im/events.rs
+++ b/rs-matter/tests/common/e2e/im/events.rs
@@ -16,7 +16,9 @@
  */
 
 use rs_matter::error::Error;
-use rs_matter::im::{EventDataTimestamp, EventPath, EventStatus};
+use rs_matter::im::{
+    EventDataTag, EventDataTimestamp, EventPath, EventPriority, EventRespTag, EventStatus,
+};
 use rs_matter::tlv::{TLVTag, TLVWrite};
 use rs_matter::utils::storage::WriteBuf;
 
@@ -97,7 +99,7 @@ pub struct TestEventData<'a> {
     /// The path to the event.
     pub path: EventPath,
     pub event_number: u64,
-    pub priority: u8,
+    pub priority: EventPriority,
     pub timestamp: EventDataTimestamp,
     pub data: Option<&'a dyn TestToTLV>,
 }
@@ -108,18 +110,33 @@ impl TestToTLV for TestEventData<'_> {
 
         self.path.test_to_tlv(&TLVTag::Context(0), tw)?;
 
-        tw.u64(&TLVTag::Context(1), self.event_number)?;
-        tw.u8(&TLVTag::Context(2), self.priority)?;
+        tw.u64(
+            &TLVTag::Context(EventDataTag::EventNumber as _),
+            self.event_number,
+        )?;
+        tw.u8(
+            &TLVTag::Context(EventDataTag::Priority as _),
+            self.priority as u8,
+        )?;
 
         match self.timestamp {
-            EventDataTimestamp::EpochTimestamp(ts) => tw.u64(&TLVTag::Context(3), ts)?,
-            EventDataTimestamp::SystemTimestamp(ts) => tw.u64(&TLVTag::Context(4), ts)?,
-            EventDataTimestamp::DeltaEpochTimestamp(ts) => tw.u64(&TLVTag::Context(5), ts)?,
-            EventDataTimestamp::DeltaSystemTimestamp(ts) => tw.u64(&TLVTag::Context(6), ts)?,
+            EventDataTimestamp::EpochTimestamp(ts) => {
+                tw.u64(&TLVTag::Context(EventDataTag::EpochTimestamp as _), ts)?
+            }
+            EventDataTimestamp::SystemTimestamp(ts) => {
+                tw.u64(&TLVTag::Context(EventDataTag::SystemTimestamp as _), ts)?
+            }
+            EventDataTimestamp::DeltaEpochTimestamp(ts) => {
+                tw.u64(&TLVTag::Context(EventDataTag::DeltaEpochTimestamp as _), ts)?
+            }
+            EventDataTimestamp::DeltaSystemTimestamp(ts) => tw.u64(
+                &TLVTag::Context(EventDataTag::DeltaSystemTimestamp as _),
+                ts,
+            )?,
         }
 
         if let Some(data) = self.data {
-            data.test_to_tlv(&TLVTag::Context(7), tw)?;
+            data.test_to_tlv(&TLVTag::Context(EventDataTag::Data as _), tw)?;
         }
 
         tw.end_container()?;
@@ -142,8 +159,12 @@ impl TestToTLV for TestEventResp<'_> {
         tw.start_struct(tag)?;
 
         match self {
-            TestEventResp::EventStatus(status) => status.test_to_tlv(&TLVTag::Context(0), tw),
-            TestEventResp::EventData(data) => data.test_to_tlv(&TLVTag::Context(1), tw),
+            TestEventResp::EventStatus(status) => {
+                status.test_to_tlv(&TLVTag::Context(EventRespTag::Status as _), tw)
+            }
+            TestEventResp::EventData(data) => {
+                data.test_to_tlv(&TLVTag::Context(EventRespTag::Data as _), tw)
+            }
         }?;
 
         tw.end_container()

--- a/rs-matter/tests/data_model/events.rs
+++ b/rs-matter/tests/data_model/events.rs
@@ -15,11 +15,11 @@
  *    limitations under the License.
  */
 
-use embassy_futures::block_on;
 use rs_matter::error::Error;
 use rs_matter::im::EventDataTag;
 use rs_matter::im::EventFilter;
 use rs_matter::im::EventPath;
+use rs_matter::im::EventPriority;
 use rs_matter::im::GenericPath;
 use rs_matter::im::IMStatusCode;
 use rs_matter::im::StatusResp;
@@ -61,12 +61,12 @@ fn test_read_event_filtered() {
         &im,
         &[
             // Event no set to 0 on all, because Events will assign these, starting at zero
-            event_data_req!(ep0_event1, 0, 2, Some(&0x41u8)),
-            event_data_req!(ep0_event1, 0, 2, Some(&0x42u8)),
-            event_data_req!(ep0_event1, 0, 2, Some(&0x43u8)),
-            event_data_req!(ep1_event1, 0, 2, Some(&0x44u8)),
-            event_data_req!(ep1_event2, 0, 2, Some(&0x45u8)),
-            event_data_req!(cl2_ep0_event1, 0, 2, Some(&0x46u8)),
+            event_data_req!(ep0_event1, 0, EventPriority::Critical, Some(&0x41u8)),
+            event_data_req!(ep0_event1, 0, EventPriority::Critical, Some(&0x42u8)),
+            event_data_req!(ep0_event1, 0, EventPriority::Critical, Some(&0x43u8)),
+            event_data_req!(ep1_event1, 0, EventPriority::Critical, Some(&0x44u8)),
+            event_data_req!(ep1_event2, 0, EventPriority::Critical, Some(&0x45u8)),
+            event_data_req!(cl2_ep0_event1, 0, EventPriority::Critical, Some(&0x46u8)),
         ],
     );
 
@@ -76,12 +76,12 @@ fn test_read_event_filtered() {
         TLVTest::read_events(
             &[WILDCARD_PATH.clone()],
             &[
-                event_data_path!(ep0_event1, 0, 2, Some(&0x41u8)),
-                event_data_path!(ep0_event1, 1, 2, Some(&0x42u8)),
-                event_data_path!(ep0_event1, 2, 2, Some(&0x43u8)),
-                event_data_path!(ep1_event1, 3, 2, Some(&0x44u8)),
-                event_data_path!(ep1_event2, 4, 2, Some(&0x45u8)),
-                event_data_path!(cl2_ep0_event1, 5, 2, Some(&0x46u8)),
+                event_data_path!(ep0_event1, 0, EventPriority::Critical, Some(&0x41u8)),
+                event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&0x42u8)),
+                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x43u8)),
+                event_data_path!(ep1_event1, 3, EventPriority::Critical, Some(&0x44u8)),
+                event_data_path!(ep1_event2, 4, EventPriority::Critical, Some(&0x45u8)),
+                event_data_path!(cl2_ep0_event1, 5, EventPriority::Critical, Some(&0x46u8)),
             ],
         ),
     );
@@ -99,10 +99,10 @@ fn test_read_event_filtered() {
             },
             TestReportDataMsg::event_reports(&[
                 // n.b. first two events excluded
-                event_data_path!(ep0_event1, 2, 2, Some(&0x43u8)),
-                event_data_path!(ep1_event1, 3, 2, Some(&0x44u8)),
-                event_data_path!(ep1_event2, 4, 2, Some(&0x45u8)),
-                event_data_path!(cl2_ep0_event1, 5, 2, Some(&0x46u8)),
+                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x43u8)),
+                event_data_path!(ep1_event1, 3, EventPriority::Critical, Some(&0x44u8)),
+                event_data_path!(ep1_event2, 4, EventPriority::Critical, Some(&0x45u8)),
+                event_data_path!(cl2_ep0_event1, 5, EventPriority::Critical, Some(&0x46u8)),
             ]),
             ReplyProcessor::none,
         ),
@@ -123,10 +123,10 @@ fn test_read_event_filtered() {
             },
             TestReportDataMsg::event_reports(&[
                 // n.b. events that aren't from endpoint 0 are excluded
-                event_data_path!(ep0_event1, 0, 2, Some(&0x41u8)),
-                event_data_path!(ep0_event1, 1, 2, Some(&0x42u8)),
-                event_data_path!(ep0_event1, 2, 2, Some(&0x43u8)),
-                event_data_path!(cl2_ep0_event1, 5, 2, Some(&0x46u8)),
+                event_data_path!(ep0_event1, 0, EventPriority::Critical, Some(&0x41u8)),
+                event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&0x42u8)),
+                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x43u8)),
+                event_data_path!(cl2_ep0_event1, 5, EventPriority::Critical, Some(&0x46u8)),
             ]),
             ReplyProcessor::none,
         ),
@@ -147,11 +147,11 @@ fn test_read_event_filtered() {
             },
             TestReportDataMsg::event_reports(&[
                 // n.b. only events with id 1
-                event_data_path!(ep0_event1, 0, 2, Some(&0x41u8)),
-                event_data_path!(ep0_event1, 1, 2, Some(&0x42u8)),
-                event_data_path!(ep0_event1, 2, 2, Some(&0x43u8)),
-                event_data_path!(ep1_event1, 3, 2, Some(&0x44u8)),
-                event_data_path!(cl2_ep0_event1, 5, 2, Some(&0x46u8)),
+                event_data_path!(ep0_event1, 0, EventPriority::Critical, Some(&0x41u8)),
+                event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&0x42u8)),
+                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x43u8)),
+                event_data_path!(ep1_event1, 3, EventPriority::Critical, Some(&0x44u8)),
+                event_data_path!(cl2_ep0_event1, 5, EventPriority::Critical, Some(&0x46u8)),
             ]),
             ReplyProcessor::none,
         ),
@@ -193,7 +193,7 @@ fn test_read_event_filtered() {
             TestReportDataMsg::event_reports(&[event_data_path!(
                 cl2_ep0_event1,
                 5,
-                2,
+                EventPriority::Critical,
                 Some(&0x46u8)
             )]),
             ReplyProcessor::none,
@@ -213,7 +213,15 @@ fn test_subscribe_events() {
     let ep0_event1 = GenericPath::new(Some(0), Some(echo_cluster::ID), Some(1));
 
     // Given there is 1 event published so far
-    push_events(&im, &[event_data_req!(ep0_event1, 0, 2, Some(&0x41u8))]);
+    push_events(
+        &im,
+        &[event_data_req!(
+            ep0_event1,
+            0,
+            EventPriority::Critical,
+            Some(&0x41u8)
+        )],
+    );
 
     im.test_all(
         &handler,
@@ -227,7 +235,12 @@ fn test_subscribe_events() {
                 },
                 TestReportDataMsg {
                     subscription_id: Some(1),
-                    event_reports: Some(&[event_data_path!(ep0_event1, 0, 2, Some(&0x41u8))]),
+                    event_reports: Some(&[event_data_path!(
+                        ep0_event1,
+                        0,
+                        EventPriority::Critical,
+                        Some(&0x41u8)
+                    )]),
                     ..Default::default()
                 },
                 ReplyProcessor::none,
@@ -254,14 +267,22 @@ fn test_subscribe_events() {
                 TestReportDataMsg::event_reports(&[event_data_path!(
                     ep0_event1,
                     0,
-                    2,
+                    EventPriority::Critical,
                     Some(&0x41u8)
                 )]),
                 ReplyProcessor::none,
             ),
             &TLVTest::subscription_report(
                 || -> Result<(), Error> {
-                    push_events(&im, &[event_data_req!(ep0_event1, 0, 2, Some(&0x42u8))]);
+                    push_events(
+                        &im,
+                        &[event_data_req!(
+                            ep0_event1,
+                            0,
+                            EventPriority::Critical,
+                            Some(&0x42u8)
+                        )],
+                    );
                     im.subscriptions
                         .notify_event_emitted(0, echo_cluster::ID, 2);
                     Ok(())
@@ -271,7 +292,12 @@ fn test_subscribe_events() {
                 // payload is 0x42, matching the new event we emitted, vs 0x41 for the first event that we already saw.
                 TestReportDataMsg {
                     subscription_id: Some(1),
-                    event_reports: Some(&[event_data_path!(ep0_event1, 1, 2, Some(&0x42u8))]),
+                    event_reports: Some(&[event_data_path!(
+                        ep0_event1,
+                        1,
+                        EventPriority::Critical,
+                        Some(&0x42u8)
+                    )]),
                     ..Default::default()
                 },
                 ReplyProcessor::none,
@@ -298,9 +324,9 @@ fn test_long_read_events() {
     push_events(
         &im,
         &[
-            event_data_req!(ep0_event1, 0, 2, Some(&[1u8; 256])),
-            event_data_req!(ep0_event1, 0, 2, Some(&[2u8; 256])),
-            event_data_req!(ep0_event1, 0, 2, Some(&[3u8; 256])),
+            event_data_req!(ep0_event1, 0, EventPriority::Critical, Some(&[1u8; 256])),
+            event_data_req!(ep0_event1, 0, EventPriority::Critical, Some(&[2u8; 256])),
+            event_data_req!(ep0_event1, 0, EventPriority::Critical, Some(&[3u8; 256])),
         ],
     );
 
@@ -311,8 +337,8 @@ fn test_long_read_events() {
                 TestReadReq::event_reqs(&[WILDCARD_PATH.clone()]),
                 TestReportDataMsg {
                     event_reports: Some(&[
-                        event_data_path!(ep0_event1, 0, 2, Some(&[1u8; 256])),
-                        event_data_path!(ep0_event1, 1, 2, Some(&[2u8; 256])),
+                        event_data_path!(ep0_event1, 0, EventPriority::Critical, Some(&[1u8; 256])),
+                        event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&[2u8; 256])),
                     ]),
                     more_chunks: Some(true),
                     ..Default::default()
@@ -324,7 +350,12 @@ fn test_long_read_events() {
                     status: IMStatusCode::Success,
                 },
                 TestReportDataMsg {
-                    event_reports: Some(&[event_data_path!(ep0_event1, 2, 2, Some(&[3u8; 256]))]),
+                    event_reports: Some(&[event_data_path!(
+                        ep0_event1,
+                        2,
+                        EventPriority::Critical,
+                        Some(&[3u8; 256])
+                    )]),
                     suppress_response: Some(true),
                     ..Default::default()
                 },
@@ -339,21 +370,25 @@ where
     C: rs_matter::crypto::Crypto,
 {
     for ev in events {
-        block_on(im.events.push(
-            ev.path.clone(),
-            ev.priority,
-            DummyKvBlobStoreAccess,
-            |tw| -> Result<(), Error> {
-                if let Some(data) = ev.data {
-                    let mut b = [0u8; 2048];
-                    let mut wb = WriteBuf::new(&mut b[0..]);
-                    data.test_to_tlv(&TLVTag::Context(EventDataTag::Data as _), &mut wb)?;
-                    let end = wb.get_tail();
-                    tw.write_raw_data(b[..end].iter().copied())?;
-                }
-                Ok(())
-            },
-        ))
-        .unwrap();
+        im.events
+            .push(
+                ev.path.endpoint.unwrap(),
+                ev.path.cluster.unwrap(),
+                ev.path.event.unwrap(),
+                ev.priority,
+                DummyKvBlobStoreAccess,
+                |mut tw| -> Result<(), Error> {
+                    if let Some(data) = ev.data {
+                        let mut b = [0u8; 2048];
+                        let mut wb = WriteBuf::new(&mut b[0..]);
+                        data.test_to_tlv(&TLVTag::Context(EventDataTag::Data as _), &mut wb)?;
+                        let end = wb.get_tail();
+
+                        tw.write_raw_data(b[..end].iter().copied())?;
+                    }
+                    Ok(())
+                },
+            )
+            .unwrap();
     }
 }

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -49,8 +49,8 @@ const DEFAULT_TESTS: &[&str] = &[
     // "TestDiagnosticLogs", // TODO: specific cluster, to be implemented with all others
     "TestDiscovery",
     "TestEqualities",
-    // "TestEvents", // TODO: specific cluster, to be implemented with all others
-    // "TestEventsById", // TODO: specific cluster, to be implemented with all others
+    "TestEvents",
+    "TestEventsById",
     "TestFabricRemovalWhileSubscribed",
     "TestGeneralCommissioning",
     "TestGroupMessaging",
@@ -61,6 +61,7 @@ const DEFAULT_TESTS: &[&str] = &[
     "TestMultiAdmin",
     "TestOperationalCredentialsCluster",
     // "TestOperationalState", // TODO: specific cluster, to be implemented with all others
+    "TestReadNoneSubscribeNone",
     "TestSelfFabricRemoval",
     "TestSubscribe_AdministratorCommissioning",
     "TestSubscribe_OnOff",


### PR DESCRIPTION
... or in more details:

##### `Events::push` was changed from `async` to `non-async` 

Reasons: 
  - async push cannot be used from non-async handlers (this immediately became a problem with the Unit Test handler which is currently non-async)
  - As per my original comment when the initial events async push was committed, this did not sound right. For example, this means pushing should await until events data reporting code is finished (which can span multiple matter packets!)
  - **Seems the Matter C++ SDK does not do this either** Had a long (AI-assisted) session to prove that.
 
##### Two YAML tests enabled: TestEvents and TestEventsById

Besides the above change, this also required to do validation that the event paths sent to us actually do exist (in terms of endpoints and clusters). We actually discussed this already during the initial PR, but we went without these checks and the YAML tests failed, as they are deliberately sending non-existing endpoints/clusters.

##### Persistence simplified

Now that we have in-band persistence, I could simplify the persistence logic a bit in that we no longer need the "hey we are approaching the end of the epoch" logic

##### Reporting on events from subscriptions should work a tad better

The "peek next max event" hack is removed and replaced with a (hopefully) correct logic, where each subscription is now **indeed** tracking up until which event number "it had seen it", without the possibility to skip over an event number which still exists in the buffers.

##### Code in `events.rs` reshuffled a bit

- Tried to unify the naming; previously, we had `Events`, `EventsInner`, but then `Event*Queue*Iter`, `Event*Queue*Writer`, `LevelBuf` etc.
- Moved all state - including the event counter - into `EventsInner` which is now behind a single blocking mutex (as push is no longer async)
- Tried to simplify the evict/promote logic a bit. Also made it infallible. If we fail to parse the TLV saved in the events buffer, we have a serious problem (i.e. we cannot actually recover as we don't know where the event ends!). We can (and probably should) check the TLV for well-formedness after the user had written it, but after that, when we forget the length of the event (because we don't save it in the buffer, remember that topic?) - if the TLV is invalid we are basically dead.

##### Event priority now modeled with EventPriority rather than `u8`

...because priority can only be 0, 1 or 2 (= debug, info, critical).

Also `Level` is now retired, as it is essentially duplicated by `EventPriority`.

##### Utility methods - `emit*event()` in the various Handler Contexts (`dm.rs`)

... because we might want to emit event directly from a cluster handler. And then, injecting the `Events` thing into each handler is very cumbersome.


