### PR TITLE
Intelligent reporting on subscriptions

### DIFF
--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-use core::cell::{Cell, RefCell};
 use core::future::Future;
 use core::num::NonZeroU8;
 use core::pin::pin;
@@ -28,6 +27,7 @@ use crate::acl::Accessor;
 use crate::crypto::Crypto;
 use crate::dm::clusters::net_comm::NetworksAccess;
 use crate::dm::events::EventTLVWrite;
+use crate::dm::subscriptions::SubscriptionsBuffers;
 use crate::error::{Error, ErrorCode};
 use crate::im::{
     EventPriority, EventResp, EventStatus, IMStatusCode, InvReq, InvRespTag, OpCode, ReadReq,
@@ -40,13 +40,11 @@ use crate::tlv::{get_root_node_struct, FromTLV, Nullable, TLVElement, TLVTag, TL
 use crate::transport::exchange::{Exchange, MAX_EXCHANGE_RX_BUF_SIZE, MAX_EXCHANGE_TX_BUF_SIZE};
 use crate::utils::select::Coalesce;
 use crate::utils::storage::pooled::BufferAccess;
-use crate::utils::storage::{Vec, WriteBuf};
-use crate::utils::sync::blocking::raw::MatterRawMutex;
-use crate::utils::sync::blocking::Mutex;
+use crate::utils::storage::WriteBuf;
 use crate::Matter;
 
 use events::Events;
-use subscriptions::Subscriptions;
+use subscriptions::{ReportContext, Subscriptions};
 
 pub use types::*;
 
@@ -67,15 +65,6 @@ const MAX_WRITE_ATTRS_IN_ONE_TRANS: usize = 15;
 
 pub type IMBuffer = heapless::Vec<u8, MAX_EXCHANGE_RX_BUF_SIZE>;
 
-struct SubscriptionBuffer<B> {
-    fabric_idx: NonZeroU8,
-    peer_node_id: u64,
-    subscription_id: u32,
-    // Tracks how far along into the event stream this subscription has seen, updated as we emit events
-    min_event_number: u64,
-    buffer: B,
-}
-
 /// An `ExchangeHandler` implementation capable of handling responder exchanges for the Interaction Model protocol.
 /// The implementation needs a `DataModelHandler` instance to interact with the underlying clusters of the data model.
 pub struct DataModel<'a, const NS: usize, const NE: usize, C, B, T, S, N>
@@ -87,7 +76,7 @@ where
     buffers: &'a B,
     kv: S,
     subscriptions: &'a Subscriptions<NS>,
-    subscriptions_buffers: Mutex<RefCell<Vec<SubscriptionBuffer<B::Buffer<'a>>, NS>>>,
+    subscriptions_buffers: SubscriptionsBuffers<'a, B, NS>,
     events: &'a Events<NE>,
     networks: N,
     handler: T,
@@ -116,7 +105,7 @@ where
     /// - `networks` - an instance of type `N` which implements the `NetworksAccess` trait. This instance is used for interacting with the network management cluster.
     #[inline(always)]
     #[allow(clippy::too_many_arguments)]
-    pub const fn new(
+    pub fn new(
         matter: &'a Matter<'a>,
         crypto: C,
         buffers: &'a B,
@@ -126,12 +115,14 @@ where
         kv: S,
         networks: N,
     ) -> Self {
+        subscriptions.clear();
+
         Self {
             matter,
             crypto,
             buffers,
             subscriptions,
-            subscriptions_buffers: Mutex::new(RefCell::new(Vec::new())),
+            subscriptions_buffers: SubscriptionsBuffers::new(),
             events,
             handler,
             kv,
@@ -179,9 +170,9 @@ where
 
     fn timeout_checks(&self) -> Result<(), Error> {
         let mut notify_mdns = || self.matter.notify_mdns_changed();
-        let mut notify_change = |endpt_id, clust_id, attr_id| {
+        let mut notify_change = |endpt_id, clust_id| {
             self.change_notify()
-                .notify_attr_changed(endpt_id, clust_id, attr_id)
+                .notify_cluster_changed(endpt_id, clust_id)
         };
 
         self.matter.with_state(|state| {
@@ -283,18 +274,16 @@ where
         let metadata = self.handler.lock().await;
         let node = metadata.node();
 
-        let mut min_event_number = 0;
-
         let mut resp = ReportDataResponder::new(
             &req,
             &node,
             None,
             HandlerInvoker::new(exchange, self),
-            EventReader::new(&mut min_event_number),
+            EventReader::new(0),
             self.events,
         );
 
-        resp.respond(&mut wb, true).await?;
+        resp.respond(&mut wb, true, true, |_, _, _| true).await?;
 
         Ok(())
     }
@@ -397,92 +386,55 @@ where
             return Self::send_status(exchange, err.code().into()).await;
         }
 
-        let (fabric_idx, peer_node_id) = exchange.with_state(|state| {
+        let (fab_idx, peer_node_id) = exchange.with_state(|state| {
             let sess = exchange.id().session(&mut state.sessions);
 
-            let fabric_idx =
-                NonZeroU8::new(sess.get_local_fabric_idx()).ok_or(ErrorCode::Invalid)?;
+            let fab_idx = NonZeroU8::new(sess.get_local_fabric_idx()).ok_or(ErrorCode::Invalid)?;
             let peer_node_id = sess.get_peer_node_id().ok_or(ErrorCode::Invalid)?;
 
-            Ok((fabric_idx, peer_node_id))
+            Ok((fab_idx, peer_node_id))
         })?;
 
         if !req.keep_subs()? {
             self.subscriptions
-                .remove(Some(fabric_idx), Some(peer_node_id), None);
-            self.subscriptions_buffers.lock(|sb| {
-                sb.borrow_mut()
-                    .retain(|sb| sb.fabric_idx != fabric_idx || sb.peer_node_id != peer_node_id)
-            });
-
-            debug!(
-                "All subscriptions for [F:{:x},P:{:x}] removed",
-                fabric_idx, peer_node_id
-            );
+                .remove(&self.subscriptions_buffers, |sub| {
+                    (sub.ids().fab_idx == fab_idx && sub.ids().peer_node_id == peer_node_id)
+                        .then_some("new subscription request")
+                });
         }
 
         let max_int_secs = core::cmp::max(req.max_int_ceil()?, 40); // Say we need at least 4 secs for potential latencies
         let min_int_secs = req.min_int_floor()?;
 
-        let Some(id) = self.subscriptions.add(
-            fabric_idx,
+        let now = Instant::now();
+
+        let Some(mut rctx) = self.subscriptions.add(
+            now,
+            fab_idx,
             peer_node_id,
             exchange.id().session_id(),
             min_int_secs,
             max_int_secs,
+            self.events.watermark(),
+            rx,
+            &self.subscriptions_buffers,
         ) else {
             return Self::send_status(exchange, IMStatusCode::ResourceExhausted).await;
         };
 
-        let subscribed = Mutex::<_, MatterRawMutex>::new(Cell::new(false));
-
-        let _guard = scopeguard::guard((), |_| {
-            if !subscribed.lock(|s| s.get()) {
-                self.subscriptions.remove(None, None, Some(id));
-            }
-        });
-
-        let mut min_event_number = 0;
-
-        let primed = self
-            .report_data(
-                id,
-                fabric_idx.get(),
-                peer_node_id,
-                &mut min_event_number,
-                &rx,
-                &mut tx,
-                exchange,
-                true,
-            )
-            .await?;
+        let primed = self.report_data(&mut rctx, &mut tx, exchange, true).await?;
 
         if primed {
             exchange
                 .send_with(|_, wb| {
-                    SubscribeResp::write(wb, id, max_int_secs)?;
+                    SubscribeResp::write(wb, rctx.subscription().ids().id, max_int_secs)?;
                     Ok(Some(OpCode::SubscribeResponse.into()))
                 })
                 .await?;
 
-            debug!(
-                "Subscription [F:{:x},P:{:x}]::{} created",
-                fabric_idx, peer_node_id, id
-            );
+            rctx.set_keep();
 
-            if self.subscriptions.mark_reported(id) {
-                let _ = self.subscriptions_buffers.lock(|sb| {
-                    sb.borrow_mut().push(SubscriptionBuffer {
-                        fabric_idx,
-                        peer_node_id,
-                        subscription_id: id,
-                        min_event_number,
-                        buffer: rx,
-                    })
-                });
-
-                subscribed.lock(|s| s.set(true));
-            }
+            info!("Subscription {:?} primed", rctx.subscription().ids());
         }
 
         Ok(())
@@ -550,83 +502,72 @@ where
 
             select3(&mut notification, &mut timeout, &mut session_removed).await;
 
-            while let Some((fabric_idx, peer_node_id, session_id, id)) =
-                self.subscriptions.find_removed_session(|session_id| {
-                    matter.with_state(|state| state.sessions.get(session_id).is_none())
-                })
-            {
-                self.subscriptions.remove(None, None, Some(id));
-                self.subscriptions_buffers.lock(|sb| {
-                    sb.borrow_mut().retain(|sb| sb.subscription_id != id);
-                });
-
-                debug!(
-                    "Subscription [F:{:x},P:{:x}]::{} removed since its session ({}) had been removed too",
-                    fabric_idx,
-                    peer_node_id,
-                    id,
-                    session_id
-                );
-            }
-
             let now = Instant::now();
 
-            while let Some((fabric_idx, peer_node_id, _, id)) = self.subscriptions.find_expired(now)
-            {
-                self.subscriptions.remove(None, None, Some(id));
-                self.subscriptions_buffers.lock(|sb| {
-                    sb.borrow_mut().retain(|sb| sb.subscription_id != id);
-                });
-
-                warn!(
-                    "Subscription [F:{:x},P:{:x}]::{} removed due to inactivity",
-                    fabric_idx, peer_node_id, id
-                );
-            }
+            // First remove all expired or no-longer valid subscriptions
 
             loop {
-                let sub = self.subscriptions.find_report_due(now);
-
-                if let Some((_, _, session_id, id)) = sub {
-                    let subscribed = Mutex::<_, MatterRawMutex>::new(Cell::new(false));
-
-                    let _guard = scopeguard::guard((), |_| {
-                        if !subscribed.lock(|s| s.get()) {
-                            self.subscriptions.remove(None, None, Some(id));
+                let removed_any = self
+                    .subscriptions
+                    .remove(&self.subscriptions_buffers, |sub| {
+                        if sub.is_expired(now) {
+                            return Some("expired");
                         }
-                    });
 
-                    // TODO: Do a more sophisticated check whether something had actually changed w.r.t. this subscription
-                    let mut sub = self.subscriptions_buffers.lock(|sb| {
-                        let mut sb = sb.borrow_mut();
-
-                        let index = unwrap!(sb.iter().position(|sb| sb.subscription_id == id));
-
-                        sb.remove(index)
-                    });
-
-                    let result = self
-                        .process_subscription(matter, session_id, &mut sub)
-                        .await;
-
-                    match result {
-                        Ok(primed) => {
-                            if primed && self.subscriptions.mark_reported(id) {
-                                self.subscriptions_buffers.lock(|sb| {
-                                    let _ = sb.borrow_mut().push(sub);
-
-                                    subscribed.lock(|s| s.set(true));
-                                });
+                        matter.with_state(|state| {
+                            if state.fabrics.get(sub.ids().fab_idx).is_none() {
+                                return Some("fabric removed");
                             }
-                        }
-                        Err(e) => {
-                            error!("Error while processing subscription: {:?}", e);
-                        }
-                    }
-                } else {
+
+                            // The session the subscription was accepted on was
+                            // torn down (eviction, explicit close, peer-side
+                            // CASE re-handshake, ...). Per Matter spec §8.5.1
+                            // subscriptions are scoped to the session they
+                            // were established on, and the publisher can no
+                            // longer route reports to the subscriber. Drop
+                            // immediately rather than waiting for `max_int`
+                            // to expire and time-out the send.
+                            if state.sessions.get(sub.session_id()).is_none() {
+                                return Some("session removed");
+                            }
+
+                            None
+                        })
+                    });
+
+                if !removed_any {
                     break;
                 }
             }
+
+            // Now report while there are subscriptions which are due for reporting
+
+            let max_event_number = self.events.watermark();
+
+            loop {
+                let Some(mut rctx) =
+                    self.subscriptions
+                        .report(now, max_event_number, &self.subscriptions_buffers)
+                else {
+                    break;
+                };
+
+                let result = self.process_subscription(matter, &mut rctx).await;
+
+                match result {
+                    Ok(true) => rctx.set_keep(),
+                    Ok(false) => (),
+                    Err(e) => error!(
+                        "Error processing subscription {:?}: {:?}",
+                        rctx.subscription().ids(),
+                        e
+                    ),
+                }
+            }
+
+            // Periodically trim changed-attr entries that have been reported by every
+            // subscription, so the table does not accumulate stale promoted wildcards.
+            self.subscriptions.purge_reported_changes();
         }
     }
 
@@ -638,36 +579,24 @@ where
     /// - `peer_node_id` - the node ID of the peer
     /// - `session_id` - the session ID of the peer, if any
     /// - `sub` - the received and saved data for the subscription, when the subscription was primed
+    /// - `min_event_number` - the subscription's current event watermark; updated
+    ///   in place as events are emitted so the caller can persist it
+    /// - `ctx` - the report context for this subscription
+    #[allow(clippy::too_many_arguments)]
     async fn process_subscription(
         &self,
         matter: &Matter<'_>,
-        session_id: Option<u32>,
-        sub: &mut SubscriptionBuffer<B::Buffer<'_>>,
+        rctx: &mut ReportContext<'_, '_, B, NS>,
     ) -> Result<bool, Error> {
-        let mut exchange = if let Some(session_id) = session_id {
-            Exchange::initiate_for_session(matter, session_id)?
-        } else {
-            // Commented out as we have issues on HomeKit with that:
-            // https://github.com/ivmarkov/esp-idf-matter/issues/3
-            // Exchange::initiate(matter, fabric_idx, peer_node_id, true).await?
-            Err(ErrorCode::NoSession)?
-        };
+        let mut exchange =
+            Exchange::initiate_for_session(matter, rctx.subscription().session_id())?;
 
         if let Some(mut tx) = self.buffers.get().await {
             // Always safe as `IMBuffer` is defined to be `MAX_EXCHANGE_RX_BUF_SIZE`, which is bigger than `MAX_EXCHANGE_TX_BUF_SIZE`
             unwrap!(tx.resize_default(MAX_EXCHANGE_TX_BUF_SIZE));
 
             let primed = self
-                .report_data(
-                    sub.subscription_id,
-                    sub.fabric_idx.get(),
-                    sub.peer_node_id,
-                    &mut sub.min_event_number,
-                    &sub.buffer,
-                    &mut tx,
-                    &mut exchange,
-                    false,
-                )
+                .report_data(rctx, &mut tx, &mut exchange, false)
                 .await?;
 
             exchange.acknowledge().await?;
@@ -675,8 +604,8 @@ where
             Ok(primed)
         } else {
             error!(
-                "No TX buffer available for processing subscription [F:{:x},P:{:x}]::{}",
-                sub.fabric_idx, sub.peer_node_id, sub.subscription_id,
+                "No TX buffer available for processing subscription {:?}",
+                rctx.subscription().ids(),
             );
 
             Ok(false)
@@ -738,11 +667,7 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn report_data(
         &self,
-        id: u32,
-        fabric_idx: u8,
-        peer_node_id: u64,
-        min_event_number: &mut u64,
-        rx: &[u8],
+        rctx: &mut ReportContext<'_, '_, B, NS>,
         tx: &mut [u8],
         exchange: &mut Exchange<'_>,
         with_dataver: bool,
@@ -752,7 +677,7 @@ where
     {
         let mut wb = WriteBuf::new(tx);
 
-        let sub_req = SubscribeReq::new(TLVElement::new(rx));
+        let sub_req = SubscribeReq::new(TLVElement::new(rctx.rx()));
         let req = if with_dataver {
             ReportDataReq::Subscribe(&sub_req)
         } else {
@@ -765,17 +690,23 @@ where
         let mut resp = ReportDataResponder::new(
             &req,
             &node,
-            Some(id),
+            Some(rctx.subscription().ids().id),
             HandlerInvoker::new(exchange, self),
-            EventReader::new(min_event_number),
+            EventReader::new(rctx.max_seen_event_number()),
             self.events,
         );
 
-        let sub_valid = resp.respond(&mut wb, false).await?;
-        if !sub_valid {
-            debug!(
-                "Subscription [F:{:x},P:{:x}]::{} removed during reporting",
-                fabric_idx, peer_node_id, id
+        let sub_valid = resp
+            .respond(&mut wb, false, rctx.should_send_if_empty(), |e, c, a| {
+                rctx.should_report_attr(e, c, a)
+            })
+            .await?;
+        if sub_valid {
+            rctx.update_max_seen_event_number(resp.event_reader.max_seen_event_number());
+        } else {
+            warn!(
+                "Subscription {:?} removed during reporting",
+                rctx.subscription().ids()
             );
         }
 
@@ -950,6 +881,20 @@ where
         self.subscriptions
             .notify_attribute_changed(endpoint_id, cluster_id, attr_id)
     }
+
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        self.subscriptions
+            .notify_cluster_attrs_changed(endpoint_id, cluster_id)
+    }
+
+    fn notify_endpoint_changed(&self, endpoint_id: EndptId) {
+        self.subscriptions
+            .notify_endpoint_attrs_changed(endpoint_id)
+    }
+
+    fn notify_all_changed(&self) {
+        self.subscriptions.notify_all_attrs_changed()
+    }
 }
 
 impl<const NS: usize, const NE: usize, C, B, T, S, N> EventEmitter
@@ -972,9 +917,21 @@ where
     where
         F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
     {
-        self.events
-            .push(endpoint_id, cluster_id, event_id, priority, &self.kv, f)
+        let event_number =
+            self.events
+                .push(endpoint_id, cluster_id, event_id, priority, &self.kv, f)?;
+
+        self.subscriptions
+            .notify_event_emitted(endpoint_id, cluster_id, event_id);
+
+        Ok(event_number)
     }
+}
+
+pub enum RespondOutcome {
+    Accepted,
+    Rejected,
+    Empty,
 }
 
 /// This type responds with a `ReportData` response to all of:
@@ -990,7 +947,7 @@ struct ReportDataResponder<'a, 'b, 'c, const NE: usize, C> {
     node: &'a Node<'a>,
     subscription_id: Option<u32>,
     invoker: HandlerInvoker<'b, 'c, C>,
-    event_reader: EventReader<'a>,
+    event_reader: EventReader,
     events: &'a Events<NE>,
 }
 
@@ -1008,7 +965,7 @@ where
         node: &'a Node<'a>,
         subscription_id: Option<u32>,
         invoker: HandlerInvoker<'b, 'c, C>,
-        event_reader: EventReader<'a>,
+        event_reader: EventReader,
         events: &'a Events<NE>,
     ) -> Self {
         Self {
@@ -1029,33 +986,56 @@ where
     /// - `suppress_last_resp` - whether to suppress the response from the peer. When multiple Matter messages are
     ///   being sent due to chunking, this is valid for the last chunk only, as the others - by necessity need to have a
     ///   status response by the other peer
-    async fn respond(
+    async fn respond<F>(
         &mut self,
         wb: &mut WriteBuf<'_>,
         suppress_last_resp: bool,
-    ) -> Result<bool, Error> {
+        send_if_empty: bool,
+        mut filter: F,
+    ) -> Result<bool, Error>
+    where
+        F: FnMut(EndptId, ClusterId, u32) -> bool,
+    {
+        let mut empty = true;
+
         self.start_reply(wb)?;
 
-        if !self.report_attributes(wb).await? {
+        if !self.report_attributes(wb, &mut empty, &mut filter).await? {
             return Ok(false);
         }
 
-        if !self.report_events(wb).await? {
+        if !self.report_events(wb, &mut empty).await? {
             return Ok(false);
         }
 
-        self.send(ReportDataChunkState::Done, suppress_last_resp, wb)
-            .await
+        if send_if_empty || !empty {
+            self.send(ReportDataChunkState::Done, suppress_last_resp, wb)
+                .await
+        } else {
+            info!("No data to report, skipping sending ReportData response");
+
+            Ok(true)
+        }
     }
 
-    async fn report_attributes(&mut self, wb: &mut WriteBuf<'_>) -> Result<bool, Error> {
+    async fn report_attributes<F>(
+        &mut self,
+        wb: &mut WriteBuf<'_>,
+        empty: &mut bool,
+        mut filter: F,
+    ) -> Result<bool, Error>
+    where
+        F: FnMut(EndptId, ClusterId, u32) -> bool,
+    {
         let accessor = self.invoker.exchange().accessor()?;
 
         if self.req.attr_requests()?.is_some() {
             wb.start_array(&TLVTag::Context(ReportDataRespTag::AttributeReports as u8))?;
 
-            for item in self.node.read(self.req, &accessor)? {
+            for item in self.node.read(self.req, &accessor, &mut filter)? {
                 let item = item?;
+
+                *empty = false;
 
                 loop {
                     let result = self.invoker.process_read(&item, &mut *wb).await;
@@ -1103,7 +1083,11 @@ where
         Ok(true)
     }
 
-    async fn report_events(&mut self, wb: &mut WriteBuf<'_>) -> Result<bool, Error> {
+    async fn report_events(
+        &mut self,
+        wb: &mut WriteBuf<'_>,
+        empty: &mut bool,
+    ) -> Result<bool, Error> {
         let accessor = self.invoker.exchange().accessor()?;
 
         if let Some(event_reqs) = self.req.event_requests()? {
@@ -1113,6 +1097,8 @@ where
             // and emit EventStatusIB for non-wildcard paths that don't match
             for event_req in event_reqs.iter() {
                 let path = event_req?;
+
+                *empty = false;
 
                 if !path.is_wildcard() {
                     if let Err(status) = self.node.validate_event_path(&path, &accessor) {

--- a/rs-matter/src/dm/clusters/adm_comm.rs
+++ b/rs-matter/src/dm/clusters/adm_comm.rs
@@ -79,8 +79,7 @@ impl ClusterHandler for AdminCommHandler {
 
     fn window_status(&self, ctx: impl ReadContext) -> Result<CommissioningWindowStatusEnum, Error> {
         let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
-        let notify_change =
-            |endpt_id, clust_id, attr_id| ctx.notify_attr_changed(endpt_id, clust_id, attr_id);
+        let notify_change = |_, _| ctx.notify_own_cluster_changed();
 
         ctx.exchange().with_state(|state| {
             state
@@ -101,8 +100,7 @@ impl ClusterHandler for AdminCommHandler {
 
     fn admin_fabric_index(&self, ctx: impl ReadContext) -> Result<Nullable<u8>, Error> {
         let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
-        let notify_change =
-            |endpt_id, clust_id, attr_id| ctx.notify_attr_changed(endpt_id, clust_id, attr_id);
+        let notify_change = |_, _| ctx.notify_own_cluster_changed();
 
         ctx.exchange().with_state(|state| {
             state
@@ -125,8 +123,7 @@ impl ClusterHandler for AdminCommHandler {
 
     fn admin_vendor_id(&self, ctx: impl ReadContext) -> Result<Nullable<u16>, Error> {
         let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
-        let notify_change =
-            |endpt_id, clust_id, attr_id| ctx.notify_attr_changed(endpt_id, clust_id, attr_id);
+        let notify_change = |_, _| ctx.notify_own_cluster_changed();
 
         ctx.exchange().with_state(|state| {
             state
@@ -149,8 +146,7 @@ impl ClusterHandler for AdminCommHandler {
         request: OpenCommissioningWindowRequest<'_>,
     ) -> Result<(), Error> {
         let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
-        let notify_change =
-            |endpt_id, clust_id, attr_id| ctx.notify_attr_changed(endpt_id, clust_id, attr_id);
+        let notify_change = |_, _| ctx.notify_own_cluster_changed();
 
         ctx.exchange().with_state(|state| {
             state
@@ -181,8 +177,7 @@ impl ClusterHandler for AdminCommHandler {
         request: OpenBasicCommissioningWindowRequest<'_>,
     ) -> Result<(), Error> {
         let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
-        let notify_change =
-            |endpt_id, clust_id, attr_id| ctx.notify_attr_changed(endpt_id, clust_id, attr_id);
+        let notify_change = |_, _| ctx.notify_own_cluster_changed();
 
         ctx.exchange().with_state(|state| {
             state
@@ -215,8 +210,7 @@ impl ClusterHandler for AdminCommHandler {
 
     fn handle_revoke_commissioning(&self, ctx: impl InvokeContext) -> Result<(), Error> {
         let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
-        let notify_change =
-            |endpt_id, clust_id, attr_id| ctx.notify_attr_changed(endpt_id, clust_id, attr_id);
+        let notify_change = |_, _| ctx.notify_own_cluster_changed();
 
         ctx.exchange()
             .with_state(|state| state.pase.close_comm_window(notify_mdns, notify_change))?;

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -266,6 +266,9 @@ impl ClusterHandler for GenCommHandler<'_> {
             )
         }))?;
 
+        // Breadcrumb (and possibly failsafe-arm state) may have changed
+        ctx.notify_own_cluster_changed();
+
         response.error_code(status)?.debug_text("")?.end()
     }
 
@@ -300,6 +303,10 @@ impl ClusterHandler for GenCommHandler<'_> {
 
         persist.run()?;
 
+        // Regulatory config mutates both this cluster (RegulatoryConfig, Breadcrumb)
+        // and Basic Information (Location) on the same endpoint
+        ctx.notify_own_endpoint_changed();
+
         response.error_code(status)?.debug_text("")?.end()
     }
 
@@ -310,8 +317,7 @@ impl ClusterHandler for GenCommHandler<'_> {
     ) -> Result<P, Error> {
         info!("Got Commissioning Complete Request");
 
-        let notify_change =
-            |endpt_id, clust_id, attr_id| ctx.notify_attr_changed(endpt_id, clust_id, attr_id);
+        let notify_change = |endpt_id, clust_id| ctx.notify_cluster_changed(endpt_id, clust_id);
 
         let mut persist = FabricPersist::new(ctx.kv());
 
@@ -343,6 +349,11 @@ impl ClusterHandler for GenCommHandler<'_> {
             }))?;
 
         persist.run()?;
+
+        // Commissioning-complete mutates many clusters on the root endpoint:
+        // breadcrumb (this cluster), fabrics (NOC), networks (NetCommissioning).
+        // The closed commissioning window was already notified via `notify_change`.
+        ctx.notify_own_endpoint_changed();
 
         response.error_code(status)?.debug_text("")?.end()
     }

--- a/rs-matter/src/dm/clusters/grp_key_mgmt.rs
+++ b/rs-matter/src/dm/clusters/grp_key_mgmt.rs
@@ -410,6 +410,8 @@ impl ClusterHandler for GrpKeyMgmtHandler {
             Ok(())
         })?;
 
+        ctx.notify_own_cluster_changed();
+
         persist.run()
     }
 
@@ -496,6 +498,8 @@ impl ClusterHandler for GrpKeyMgmtHandler {
 
             Ok(())
         })?;
+
+        ctx.notify_own_cluster_changed();
 
         persist.run()
     }

--- a/rs-matter/src/dm/clusters/level_control.rs
+++ b/rs-matter/src/dm/clusters/level_control.rs
@@ -642,7 +642,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
             })?;
 
         self.move_to_level_blocking(
-            ctx,
+            &ctx,
             true,
             target_level,
             Some(transition_time),
@@ -652,11 +652,23 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
         .await?;
 
         if !on {
-            self.with_state(|state| {
+            let restored = self.with_state(|state| {
                 if state.on_level.is_none() {
                     self.hooks.set_current_level(temp_current_level);
+                    true
+                } else {
+                    false
                 }
             });
+            if restored {
+                // CurrentLevel was restored to the pre-Off stored value
+                self.dataver_changed();
+                ctx.notify_attr_changed(
+                    self.endpoint_id,
+                    Self::CLUSTER.id,
+                    AttributeId::CurrentLevel as _,
+                );
+            }
         }
 
         Ok(())

--- a/rs-matter/src/dm/clusters/net_comm.rs
+++ b/rs-matter/src/dm/clusters/net_comm.rs
@@ -1337,6 +1337,9 @@ where
             }),
         )?;
 
+        // Networks list mutated
+        ctx.notify_own_cluster_changed();
+
         status.read_into(index, response)
     }
 
@@ -1358,6 +1361,9 @@ where
             }),
         )?;
 
+        // Networks list mutated
+        ctx.notify_own_cluster_changed();
+
         status.read_into(index, response)
     }
 
@@ -1376,6 +1382,9 @@ where
                 })
             }),
         )?;
+
+        // Networks list mutated
+        ctx.notify_own_cluster_changed();
 
         status.read_into(index, response)
     }
@@ -1484,6 +1493,9 @@ where
             }
         };
 
+        // LastNetworkingStatus / LastNetworkID / LastConnectErrorValue mutated
+        ctx.notify_own_cluster_changed();
+
         response
             .networking_status(status)?
             .debug_text(None)?
@@ -1507,6 +1519,9 @@ where
                 })
             }),
         )?;
+
+        // Networks order mutated
+        ctx.notify_own_cluster_changed();
 
         status.read_into(index, response)
     }

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -476,6 +476,9 @@ impl ClusterHandler for NocHandler {
             },
         ))?;
 
+        // AddNOC mutates NOCs, Fabrics, CommissionedFabrics, TrustedRootCerts, etc.
+        ctx.notify_own_cluster_changed();
+
         response
             .status_code(status)?
             .fabric_index(added_fab_idx)?
@@ -518,6 +521,9 @@ impl ClusterHandler for NocHandler {
             },
         ))?;
 
+        // UpdateNOC mutates the NOCs / Fabrics lists for the calling fabric
+        ctx.notify_own_cluster_changed();
+
         response
             .status_code(status)?
             .fabric_index(Some(ctx.cmd().fab_idx))?
@@ -557,6 +563,9 @@ impl ClusterHandler for NocHandler {
 
             Ok(())
         }))?;
+
+        // UpdateFabricLabel mutates the Fabrics list
+        ctx.notify_own_cluster_changed();
 
         response
             .status_code(status)?
@@ -613,6 +622,9 @@ impl ClusterHandler for NocHandler {
         })?;
 
         persist.run()?;
+
+        // RemoveFabric mutates NOCs, Fabrics, CommissionedFabrics, TrustedRootCerts
+        ctx.notify_own_cluster_changed();
 
         response
             .status_code(status)?

--- a/rs-matter/src/dm/clusters/on_off.rs
+++ b/rs-matter/src/dm/clusters/on_off.rs
@@ -320,10 +320,23 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
         // ... on receipt of the On command, a server SHALL set the OnOff attribute to TRUE.
         self.hooks.set_on_off(true);
 
-        let _ = Self::update_attr_on(state);
+        let lighting_attrs_updated = Self::update_attr_on(state);
 
         self.dataver_changed();
         ctx.notify_attr_changed(self.endpoint_id, Self::CLUSTER.id, AttributeId::OnOff as _);
+        if lighting_attrs_updated {
+            // `update_attr_on` may have forced OffWaitTime to 0 and GlobalSceneControl to TRUE
+            ctx.notify_attr_changed(
+                self.endpoint_id,
+                Self::CLUSTER.id,
+                AttributeId::OffWaitTime as _,
+            );
+            ctx.notify_attr_changed(
+                self.endpoint_id,
+                Self::CLUSTER.id,
+                AttributeId::GlobalSceneControl as _,
+            );
+        }
 
         // LevelControl coupling logic defined in section 1.6.4.1.1
         if !level_control_initiated {
@@ -374,7 +387,7 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
             return true;
         }
 
-        let attr_updated = Self::update_attr_off(state);
+        let on_time_updated = Self::update_attr_off(state);
 
         // LevelControl coupling logic defined in section 1.6.4.1.1
         let level_control_handler = self.level_control_handler.lock(|h| h.get());
@@ -382,12 +395,18 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
             if !level_control_initiated {
                 level_control_handler.coupled_on_off_cluster_on_off_state_change(false);
 
-                if attr_updated {
+                if on_time_updated {
                     self.dataver_changed();
                     ctx.notify_attr_changed(
                         self.endpoint_id,
                         Self::CLUSTER.id,
                         AttributeId::OnOff as _,
+                    );
+                    // `update_attr_off` forced OnTime to 0
+                    ctx.notify_attr_changed(
+                        self.endpoint_id,
+                        Self::CLUSTER.id,
+                        AttributeId::OnTime as _,
                     );
                 }
 
@@ -403,6 +422,10 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
         self.hooks.set_on_off(false);
         self.dataver_changed();
         ctx.notify_attr_changed(self.endpoint_id, Self::CLUSTER.id, AttributeId::OnOff as _);
+        if on_time_updated {
+            // `update_attr_off` forced OnTime to 0
+            ctx.notify_attr_changed(self.endpoint_id, Self::CLUSTER.id, AttributeId::OnTime as _);
+        }
 
         true
     }
@@ -434,7 +457,7 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
 
                 state.state = OnOffClusterState::On;
 
-                let _ = Self::update_attr_on(state);
+                let lighting_attrs_updated = Self::update_attr_on(state);
 
                 self.dataver_changed();
                 ctx.notify_attr_changed(
@@ -442,6 +465,18 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
                     Self::CLUSTER.id,
                     AttributeId::OnOff as _,
                 );
+                if lighting_attrs_updated {
+                    ctx.notify_attr_changed(
+                        self.endpoint_id,
+                        Self::CLUSTER.id,
+                        AttributeId::OffWaitTime as _,
+                    );
+                    ctx.notify_attr_changed(
+                        self.endpoint_id,
+                        Self::CLUSTER.id,
+                        AttributeId::GlobalSceneControl as _,
+                    );
+                }
             }
             false => {
                 if state.state == OnOffClusterState::Off {
@@ -450,7 +485,7 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
 
                 state.state = OnOffClusterState::Off;
 
-                let _ = Self::update_attr_off(state);
+                let on_time_updated = Self::update_attr_off(state);
 
                 self.dataver_changed();
                 ctx.notify_attr_changed(
@@ -458,6 +493,13 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
                     Self::CLUSTER.id,
                     AttributeId::OnOff as _,
                 );
+                if on_time_updated {
+                    ctx.notify_attr_changed(
+                        self.endpoint_id,
+                        Self::CLUSTER.id,
+                        AttributeId::OnTime as _,
+                    );
+                }
             }
         }
     }
@@ -496,7 +538,16 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
                             // If the GlobalSceneControl attribute is equal to TRUE, the server SHALL store its settings in its global
                             // scene then set the GlobalSceneControl attribute to FALSE...
                             // todo: store the GlobalSceneControl setting (true) in the global scene.
+                            let gsc_changed = state.global_scene_control;
                             state.global_scene_control = false;
+                            if gsc_changed {
+                                self.dataver_changed();
+                                ctx.notify_attr_changed(
+                                    self.endpoint_id,
+                                    Self::CLUSTER.id,
+                                    AttributeId::GlobalSceneControl as _,
+                                );
+                            }
 
                             Outcome::OffWithEffect {
                                 effect_variant: effect,
@@ -559,7 +610,16 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
                                 // If the GlobalSceneControl attribute is equal to TRUE, the server SHALL store its settings in its global
                                 // scene then set the GlobalSceneControl attribute to FALSE...
                                 // todo: store the GlobalSceneControl setting (true) in the global scene.
+                                let gsc_changed = state.global_scene_control;
                                 state.global_scene_control = false;
+                                if gsc_changed {
+                                    self.dataver_changed();
+                                    ctx.notify_attr_changed(
+                                        self.endpoint_id,
+                                        Self::CLUSTER.id,
+                                        AttributeId::GlobalSceneControl as _,
+                                    );
+                                }
 
                                 Outcome::OffWithEffect {
                                     effect_variant: effect,
@@ -928,14 +988,32 @@ impl<H: OnOffHooks, LH: LevelControlHooks> ClusterAsyncHandler for OnOffHandler<
                 // equal to FALSE, then the server SHALL set the OffWaitTime attribute to the minimum of the
                 // OffWaitTime attribute and the value specified in the OffWaitTime field.
                 if state.off_wait_time > 0 && !self.hooks.on_off() {
-                    state.off_wait_time = state.off_wait_time.min(request.off_wait_time()?);
+                    let new_off_wait_time = state.off_wait_time.min(request.off_wait_time()?);
+                    if new_off_wait_time != state.off_wait_time {
+                        state.off_wait_time = new_off_wait_time;
+                        self.dataver_changed();
+                        ctx.notify_own_attr_changed(AttributeId::OffWaitTime as _);
+                    }
                 }
                 // In all other cases, the server SHALL set the OnTime attribute to the maximum of the OnTime
                 // attribute and the value specified in the OnTime field, set the OffWaitTime attribute to the value
                 // specified in the OffWaitTime field and set the OnOff attribute to TRUE.
                 else {
-                    state.on_time = state.on_time.max(request.on_time()?);
-                    state.off_wait_time = request.off_wait_time()?;
+                    let new_on_time = state.on_time.max(request.on_time()?);
+                    let new_off_wait_time = request.off_wait_time()?;
+                    let on_time_changed = new_on_time != state.on_time;
+                    let off_wait_time_changed = new_off_wait_time != state.off_wait_time;
+                    state.on_time = new_on_time;
+                    state.off_wait_time = new_off_wait_time;
+                    if on_time_changed || off_wait_time_changed {
+                        self.dataver_changed();
+                        if on_time_changed {
+                            ctx.notify_own_attr_changed(AttributeId::OnTime as _);
+                        }
+                        if off_wait_time_changed {
+                            ctx.notify_own_attr_changed(AttributeId::OffWaitTime as _);
+                        }
+                    }
                     self.set_on(state, false, &ctx);
                 }
 

--- a/rs-matter/src/dm/events.rs
+++ b/rs-matter/src/dm/events.rs
@@ -17,7 +17,7 @@
 
 use core::fmt::Debug;
 
-use crate::dm::{ClusterId, EndptId, EventEmitter, EventId};
+use crate::dm::{ClusterId, EndptId, EventId};
 use crate::error::{Error, ErrorCode};
 use crate::im::{
     EventData, EventDataTag, EventDataTimestamp, EventNumber, EventPath, EventPriority,
@@ -120,7 +120,7 @@ impl<const N: usize> Events<N> {
             .await
     }
 
-    pub fn fetch<F, R>(&self, f: F) -> R
+    pub(crate) fn fetch<F, R>(&self, f: F) -> R
     where
         F: FnOnce(EventsIter<'_, N>) -> R,
     {
@@ -129,6 +129,10 @@ impl<const N: usize> Events<N> {
 
             f(state.iter())
         })
+    }
+
+    pub(crate) fn watermark(&self) -> EventNumber {
+        self.inner.lock(|state| state.borrow().next_event_number)
     }
 
     /// Push a new event into the event queue.
@@ -183,23 +187,6 @@ impl<const N: usize> Events<N> {
         persist.run()?;
 
         Ok(event_number)
-    }
-}
-
-impl<const N: usize, S: KvBlobStoreAccess> EventEmitter for (&Events<N>, S) {
-    fn emit_event<F>(
-        &self,
-        endpoint_id: EndptId,
-        cluster_id: ClusterId,
-        event_id: EventId,
-        priority: EventPriority,
-        f: F,
-    ) -> Result<EventNumber, Error>
-    where
-        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
-    {
-        self.0
-            .push(endpoint_id, cluster_id, event_id, priority, &self.1, f)
     }
 }
 

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -19,10 +19,14 @@ use core::num::NonZeroU8;
 
 use embassy_time::Instant;
 
-use crate::dm::{AttrChangeNotifier, AttrId, ClusterId, EndptId, EventId};
+use crate::dm::{
+    AttrChangeNotifier, AttrId, ClusterId, EndptId, EventId, EventNumber, IMBuffer, NodeId,
+};
 use crate::fabric::MAX_FABRICS;
 use crate::utils::cell::RefCell;
 use crate::utils::init::{init, Init};
+use crate::utils::storage::pooled::BufferAccess;
+use crate::utils::storage::Vec;
 use crate::utils::sync::blocking::Mutex;
 use crate::utils::sync::{DynBase, Notification};
 
@@ -31,63 +35,64 @@ use crate::utils::sync::{DynBase, Notification};
 /// According to the Matter spec, at least 3 subscriptions per fabric should be supported.
 pub const DEFAULT_MAX_SUBSCRIPTIONS: usize = MAX_FABRICS * 3;
 
-struct Subscription {
-    fabric_idx: NonZeroU8,
-    peer_node_id: u64,
-    session_id: Option<u32>,
-    id: u32,
-    // We use u16 instead of embassy::Duration to save some storage
-    min_int_secs: u16,
-    // Ditto
-    max_int_secs: u16,
-    // TODO: Change to `Option<Instant>` to avoid using `Instant::MAX` as a sentinel value
-    reported_at: Instant,
-    changed: bool,
+/// The maximum number of changed-attribute entries tracked simultaneously.
+///
+/// When the table is full, entries are coalesced ("promoted") to coarser-grained
+/// wildcards so that new changes can always be recorded.
+pub const MAX_CHANGED_ATTRS: usize = 16;
+
+// REVIEW: `SubscriptionsBuffers` is a thin wrapper around a second
+// `Mutex<RefCell<Vec<..>>>` that is *always* locked in lockstep with
+// `Subscriptions::state` (see `Subscriptions::with`). As long as that lock
+// order is respected the pair is safe, but the two locks let someone (now or
+// in the future) lock only one of them and violate the invariant that
+// `subscriptions.len() == buffers.len()`. The cleanest fix is to move the
+// `Vec<B::Buffer<'a>, N>` *into* `SubscriptionsInner` behind the same mutex
+// so it cannot be locked independently. The current layout also forces all
+// public APIs to thread an extra `&SubscriptionsBuffers` argument everywhere,
+// which is why `remove` / `report` / `add` all grew a second ref parameter.
+pub struct SubscriptionsBuffers<'a, B, const N: usize = DEFAULT_MAX_SUBSCRIPTIONS>
+where
+    B: BufferAccess<IMBuffer> + 'a,
+{
+    buffers: Mutex<RefCell<SubscriptionsBuffersInner<'a, B, N>>>,
 }
 
-impl Subscription {
-    pub fn report_due(&self, now: Instant) -> bool {
-        // Either the data for the subscription had changed and therefore we need to report,
-        // or the data for the subscription had not changed yet, however the report interval is due
-        self.changed && self.expired(self.min_int_secs, now)
-            || self.expired(self.min_int_secs.max(self.max_int_secs / 2), now)
-    }
-
-    pub fn is_expired(&self, now: Instant) -> bool {
-        self.expired(self.max_int_secs, now)
-    }
-
-    fn expired(&self, secs: u16, now: Instant) -> bool {
-        self.reported_at
-            .checked_add(embassy_time::Duration::from_secs(secs as _))
-            .map(|expiry| expiry <= now)
-            .unwrap_or(false)
+impl<'a, B, const N: usize> Default for SubscriptionsBuffers<'a, B, N>
+where
+    B: BufferAccess<IMBuffer> + 'a,
+{
+    fn default() -> Self {
+        Self::new()
     }
 }
 
-struct SubscriptionsInner<const N: usize> {
-    next_subscription_id: u32,
-    subscriptions: crate::utils::storage::Vec<Subscription, N>,
-}
-
-impl<const N: usize> SubscriptionsInner<N> {
-    /// Create the instance.
-    #[inline(always)]
-    const fn new() -> Self {
+impl<'a, B, const N: usize> SubscriptionsBuffers<'a, B, N>
+where
+    B: BufferAccess<IMBuffer> + 'a,
+{
+    pub const fn new() -> Self {
         Self {
-            next_subscription_id: 1,
-            subscriptions: crate::utils::storage::Vec::new(),
+            buffers: Mutex::new(RefCell::new(Vec::new())),
         }
     }
 
-    /// Create an in-place initializer for the instance.
-    fn init() -> impl Init<Self> {
+    pub fn init() -> impl Init<Self> {
         init!(Self {
-            next_subscription_id: 1,
-            subscriptions <- crate::utils::storage::Vec::init(),
+            buffers <- Mutex::init(RefCell::init(Vec::init())),
         })
     }
+
+    fn with<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut SubscriptionsBuffersInner<'a, B, N>) -> R,
+    {
+        self.buffers.lock(|buffers| f(&mut buffers.borrow_mut()))
+    }
 }
+
+type SubscriptionsBuffersInner<'a, B, const N: usize> =
+    Vec<<B as BufferAccess<IMBuffer>>::Buffer<'a>, N>;
 
 /// A utility for tracking subscriptions accepted by the data model.
 ///
@@ -125,20 +130,63 @@ impl<const N: usize> Subscriptions<N> {
     /// - `endpoint_id`: The endpoint ID of the cluster that had changed.
     /// - `cluster_id`: The cluster ID of the cluster that had changed.
     /// - `attr_id`: The attribute ID of the attribute that changed.
-    pub fn notify_attribute_changed(
+    pub(crate) fn notify_attribute_changed(
         &self,
-        _endpoint_id: EndptId,
-        _cluster_id: ClusterId,
-        _attr_id: AttrId,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        attr_id: AttrId,
     ) {
-        // TODO: Make use of the endpoint_id, cluster_id, and attr_id parameters
-        // to implement more intelligent reporting on subscriptions
-
         self.state.lock(|internal| {
-            let subscriptions = &mut internal.borrow_mut().subscriptions;
-            for sub in subscriptions.iter_mut() {
-                sub.changed = true;
-            }
+            internal
+                .borrow_mut()
+                .changed_attrs
+                .record(endpoint_id, cluster_id, attr_id);
+        });
+
+        // The per-subscription decision of whether anything needs to be reported is
+        // computed on-the-fly by `find_report_due` (and by the responder's filter)
+        // by consulting the live `changed_attrs` table, so there is no per-sub flag
+        // to flip here. We just wake the reporter task.
+        self.notification.notify();
+    }
+
+    /// Record a cluster-wide change. Every attribute of `(endpoint_id,
+    /// cluster_id)` is treated as changed for the purposes of subscription
+    /// reporting.
+    pub(crate) fn notify_cluster_attrs_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        self.state.lock(|internal| {
+            internal
+                .borrow_mut()
+                .changed_attrs
+                .record_wildcard(Some(endpoint_id), Some(cluster_id));
+        });
+
+        self.notification.notify();
+    }
+
+    /// Record an endpoint-wide change. Every attribute on every cluster of
+    /// `endpoint_id` is treated as changed for the purposes of subscription
+    /// reporting.
+    pub(crate) fn notify_endpoint_attrs_changed(&self, endpoint_id: EndptId) {
+        self.state.lock(|internal| {
+            internal
+                .borrow_mut()
+                .changed_attrs
+                .record_wildcard(Some(endpoint_id), None);
+        });
+
+        self.notification.notify();
+    }
+
+    /// Record a fully-global change. Every attribute on every cluster on
+    /// every endpoint is treated as changed for the purposes of subscription
+    /// reporting. Intended for coarse-grained reset / restart scenarios.
+    pub(crate) fn notify_all_attrs_changed(&self) {
+        self.state.lock(|internal| {
+            internal
+                .borrow_mut()
+                .changed_attrs
+                .record_wildcard(None, None);
         });
 
         self.notification.notify();
@@ -150,137 +198,185 @@ impl<const N: usize> Subscriptions<N> {
         _cluster_id: ClusterId,
         _event_id: EventId,
     ) {
-        // TODO: Make use of the endpoint_id, cluster_id, and event_id parameters
-        // to implement more intelligent reporting on subscriptions
-
-        self.state.lock(|internal| {
-            let subscriptions = &mut internal.borrow_mut().subscriptions;
-            for sub in subscriptions.iter_mut() {
-                sub.changed = true;
-            }
-        });
-
+        // Events are filtered at report time by `min_event_number` + event path matching.
+        // Whether a subscription is due to report because of new events is recomputed on
+        // the fly in `find_report_due`, so here we only need to kick the reporter task.
         self.notification.notify();
     }
 
-    pub(crate) fn add(
-        &self,
+    pub(crate) fn clear(&self) {
+        self.state.lock(|state| state.borrow_mut().clear());
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn add<'a, 's, B>(
+        &'s self,
+        now: Instant,
         fabric_idx: NonZeroU8,
         peer_node_id: u64,
         session_id: u32,
         min_int_secs: u16,
         max_int_secs: u16,
-    ) -> Option<u32> {
-        self.state.lock(|internal| {
-            let mut state = internal.borrow_mut();
-            let id = state.next_subscription_id;
-            state.next_subscription_id += 1;
-
-            state
-                .subscriptions
-                .push(Subscription {
-                    fabric_idx,
-                    peer_node_id,
-                    session_id: Some(session_id),
-                    id,
-                    min_int_secs,
-                    max_int_secs,
-                    reported_at: Instant::MAX,
-                    changed: false,
-                })
-                .map(|_| id)
-                .ok()
-        })
-    }
-
-    /// Mark the subscription with the given ID as reported.
-    ///
-    /// Will return `false` if the subscription with the given ID does no longer exist, as it might be
-    /// removed by a concurrent transaction while being reported on.
-    pub(crate) fn mark_reported(&self, id: u32) -> bool {
-        self.state.lock(|internal| {
-            let subscriptions = &mut internal.borrow_mut().subscriptions;
-
-            if let Some(sub) = subscriptions.iter_mut().find(|sub| sub.id == id) {
-                sub.reported_at = Instant::now();
-                sub.changed = false;
-
-                true
-            } else {
-                false
-            }
-        })
-    }
-
-    pub(crate) fn remove(
-        &self,
-        fabric_idx: Option<NonZeroU8>,
-        peer_node_id: Option<u64>,
-        id: Option<u32>,
-    ) {
-        self.state.lock(|internal| {
-            let subscriptions = &mut internal.borrow_mut().subscriptions;
-            while let Some(index) = subscriptions.iter().position(|sub| {
-                sub.fabric_idx == fabric_idx.unwrap_or(sub.fabric_idx)
-                    && sub.peer_node_id == peer_node_id.unwrap_or(sub.peer_node_id)
-                    && sub.id == id.unwrap_or(sub.id)
-            }) {
-                subscriptions.swap_remove(index);
-            }
-        })
-    }
-
-    pub(crate) fn find_removed_session<F>(
-        &self,
-        session_removed: F,
-    ) -> Option<(NonZeroU8, u64, u32, u32)>
+        max_event_number: EventNumber,
+        buffer: B::Buffer<'a>,
+        buffers: &'s SubscriptionsBuffers<'a, B, N>,
+    ) -> Option<ReportContext<'a, 's, B, N>>
     where
-        F: Fn(u32) -> bool,
+        B: BufferAccess<IMBuffer> + 'a,
     {
-        self.state.lock(|internal| {
-            internal.borrow_mut().subscriptions.iter().find_map(|sub| {
-                sub.session_id
-                    .map(&session_removed)
-                    .unwrap_or(false)
-                    .then_some((
-                        sub.fabric_idx,
-                        sub.peer_node_id,
-                        unwrap!(sub.session_id),
-                        sub.id,
-                    ))
-            })
+        // REVIEW: `next_max_seen_attr_change_id` is hard-coded to `0` here,
+        // but the matching path in `report()` uses `changed_attrs.watermark()`.
+        // For `add()` the value doesn't actually matter (the subscription is
+        // freshly constructed below with `max_seen_attr_change_id =
+        // changed_attrs.watermark()`, and `set_complete()` is what ultimately
+        // writes this field back via `report_complete`), but the asymmetry is
+        // confusing and means `set_complete()` called from the *priming*
+        // report path will overwrite `max_seen_attr_change_id` with 0,
+        // effectively resetting the subscription's `since` watermark to 0 on
+        // its very first commit.  Changes that occurred *during* the priming
+        // report will then be re-emitted in the next incremental report, but
+        // changes that happened between `add()` and the start of priming will
+        // be replayed twice.
+        let (sub, buf, next_max_seen_attr_change_id) = self.with(buffers, |state, buffers| {
+            let (sub, buf) = state.add::<B>(
+                fabric_idx,
+                peer_node_id,
+                session_id,
+                min_int_secs,
+                max_int_secs,
+                max_event_number,
+                buffer,
+                buffers,
+            )?;
+
+            // Mirror `report()`: commit the current watermark so the priming
+            // report's `set_keep` does not regress the subscription's `since`
+            // to 0 (which would cause every pre-`add` change to be replayed
+            // on the first incremental report).
+            Some((sub, buf, state.changed_attrs.watermark()))
+        })?;
+
+        Some(ReportContext {
+            subscriptions: self,
+            subscriptions_buffers: buffers,
+            subscription: Some(sub),
+            subscription_buffer: Some(buf),
+            next_max_seen_attr_change_id,
+            next_reported_at: now,
+            keep: false,
         })
     }
 
-    pub(crate) fn find_expired(&self, now: Instant) -> Option<(NonZeroU8, u64, Option<u32>, u32)> {
-        self.state.lock(|internal| {
-            internal.borrow_mut().subscriptions.iter().find_map(|sub| {
-                sub.is_expired(now).then_some((
-                    sub.fabric_idx,
-                    sub.peer_node_id,
-                    sub.session_id,
-                    sub.id,
-                ))
-            })
-        })
+    // REVIEW: a subscription that is currently being reported on has been
+    // `swap_remove`d from `state.subscriptions` (see `SubscriptionsInner::report`)
+    // and only lives inside its `ReportContext`. `remove` scans
+    // `state.subscriptions` only, so an in-flight subscription is *invisible*
+    // to `remove` and will silently survive any removal request (e.g. a
+    // `keep_subs=false` Subscribe handled by another task, or a session
+    // removal). It is put back verbatim by `Drop` via `report_complete`.
+    // This is a correctness regression vs. the pre-refactor code and probably
+    // deserves either a "pending removal" flag on `ReportContext` or holding
+    // the subscription in place during reporting (e.g. with a `reporting`
+    // marker) so `remove` can still act on it.
+    pub(crate) fn remove<B, F>(&self, buffers: &SubscriptionsBuffers<'_, B, N>, mut f: F) -> bool
+    where
+        B: BufferAccess<IMBuffer>,
+        F: FnMut(&Subscription) -> Option<&'static str>,
+    {
+        let removed = self.with(buffers, |state, buffers| {
+            let mut removed = false;
+
+            loop {
+                let next = state
+                    .subscriptions
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, subscription)| {
+                        f(subscription).map(|reason| (index, subscription.ids().clone(), reason))
+                    })
+                    .next();
+
+                let Some((index, ids, reason)) = next else {
+                    break;
+                };
+
+                state.subscriptions.swap_remove(index);
+                buffers.swap_remove(index);
+
+                state.subscriptions_count -= 1;
+
+                info!("Removed subscription {:?}, reason: {}", ids, reason);
+
+                removed = true;
+            }
+
+            removed
+        });
+
+        if removed {
+            self.notification.notify();
+        }
+
+        removed
     }
 
-    /// Note that this method has a side effect:
-    /// it updates the `reported_at` field of the subscription that is returned.
-    pub(crate) fn find_report_due(
-        &self,
+    pub(crate) fn report<'a, 's, B>(
+        &'s self,
         now: Instant,
-    ) -> Option<(NonZeroU8, u64, Option<u32>, u32)> {
-        self.state.lock(|internal| {
-            internal
-                .borrow_mut()
-                .subscriptions
-                .iter_mut()
-                .find(|sub| sub.report_due(now))
-                .map(|sub| {
-                    sub.reported_at = now;
-                    (sub.fabric_idx, sub.peer_node_id, sub.session_id, sub.id)
-                })
+        max_event_number: EventNumber,
+        buffers: &'s SubscriptionsBuffers<'a, B, N>,
+    ) -> Option<ReportContext<'a, 's, B, N>>
+    where
+        B: BufferAccess<IMBuffer> + 'a,
+    {
+        let (sub, buf, next_max_seen_attr_change_id) = self.with(buffers, |state, buffers| {
+            let (sub, buf) = state.report::<B>(now, max_event_number, buffers)?;
+
+            Some((sub, buf, state.changed_attrs.watermark()))
+        })?;
+
+        Some(ReportContext {
+            subscriptions: self,
+            subscriptions_buffers: buffers,
+            subscription: Some(sub),
+            subscription_buffer: Some(buf),
+            next_max_seen_attr_change_id,
+            next_reported_at: now,
+            keep: false,
+        })
+    }
+
+    /// Remove entries that every subscription has already reported on.
+    pub(crate) fn purge_reported_changes(&self) {
+        self.state
+            .lock(|state| state.borrow_mut().purge_reported_changes())
+    }
+
+    fn report_complete<'a, B>(&self, report: &mut ReportContext<'a, '_, B, N>)
+    where
+        B: BufferAccess<IMBuffer> + 'a,
+    {
+        let mut sub = unwrap!(report.subscription.take());
+        let buf = unwrap!(report.subscription_buffer.take());
+
+        sub.max_seen_attr_change_id = report.next_max_seen_attr_change_id;
+        sub.reported_at = report.next_reported_at;
+
+        let keep = report.keep;
+
+        self.with(report.subscriptions_buffers, |state, buffers| {
+            state.report_complete::<B>(sub, buf, buffers, keep)
+        })
+    }
+
+    fn with<'a, B, F, R>(&self, buffers: &SubscriptionsBuffers<'a, B, N>, f: F) -> R
+    where
+        B: BufferAccess<IMBuffer> + 'a,
+        F: FnOnce(&mut SubscriptionsInner<N>, &mut SubscriptionsBuffersInner<'a, B, N>) -> R,
+    {
+        self.state.lock(|state| {
+            let mut state = state.borrow_mut();
+            buffers.with(|buffers| f(&mut state, buffers))
         })
     }
 }
@@ -295,6 +391,1731 @@ impl<const N: usize> AttrChangeNotifier for Subscriptions<N> {
     fn notify_attr_changed(&self, endpt: EndptId, clust: ClusterId, attr: AttrId) {
         Subscriptions::<N>::notify_attribute_changed(self, endpt, clust, attr);
     }
+
+    fn notify_cluster_changed(&self, endpt: EndptId, clust: ClusterId) {
+        Subscriptions::<N>::notify_cluster_attrs_changed(self, endpt, clust);
+    }
+
+    fn notify_endpoint_changed(&self, endpt: EndptId) {
+        Subscriptions::<N>::notify_endpoint_attrs_changed(self, endpt);
+    }
+
+    fn notify_all_changed(&self) {
+        Subscriptions::<N>::notify_all_attrs_changed(self);
+    }
 }
 
 impl<const N: usize> DynBase for Subscriptions<N> {}
+
+struct SubscriptionsInner<const N: usize> {
+    next_subscription_id: u32,
+    subscriptions_count: usize,
+    subscriptions: Vec<Subscription, N>,
+    changed_attrs: ChangedAttributes,
+}
+
+impl<const N: usize> SubscriptionsInner<N> {
+    /// Create the instance.
+    #[inline(always)]
+    const fn new() -> Self {
+        Self {
+            next_subscription_id: 1,
+            subscriptions_count: 0,
+            subscriptions: Vec::new(),
+            changed_attrs: ChangedAttributes::new(),
+        }
+    }
+
+    /// Create an in-place initializer for the instance.
+    fn init() -> impl Init<Self> {
+        init!(Self {
+            next_subscription_id: 1,
+            subscriptions_count: 0,
+            subscriptions <- Vec::init(),
+            changed_attrs <- ChangedAttributes::init(),
+        })
+    }
+
+    fn clear(&mut self) {
+        self.subscriptions.clear();
+        self.subscriptions_count = 0;
+    }
+
+    /// Add a subscription with the given parameters.
+    ///
+    /// Returns the assigned subscription ID on success, or `None` if the subscription table is full.
+    #[allow(clippy::too_many_arguments)]
+    fn add<'a, B>(
+        &mut self,
+        fab_idx: NonZeroU8,
+        peer_node_id: u64,
+        session_id: u32,
+        min_int_secs: u16,
+        max_int_secs: u16,
+        _max_event_number: EventNumber,
+        buffer: B::Buffer<'a>,
+        _buffers: &mut SubscriptionsBuffersInner<'a, B, N>,
+    ) -> Option<(Subscription, B::Buffer<'a>)>
+    where
+        B: BufferAccess<IMBuffer> + 'a,
+    {
+        if self.subscriptions_count >= N {
+            return None;
+        }
+
+        self.subscriptions_count += 1;
+
+        let id = self.next_subscription_id;
+        self.next_subscription_id += 1;
+
+        // Start with the current watermark so that only changes happening AFTER the
+        // subscription was accepted will be reported as incremental updates.
+        let max_seen_attr_change_id = self.changed_attrs.watermark();
+
+        let subscription = Subscription {
+            ids: SubscriptionIds {
+                id,
+                fab_idx,
+                peer_node_id,
+            },
+            session_id,
+            min_int_secs,
+            max_int_secs,
+            reported_at: Instant::MAX,
+            max_seen_attr_change_id,
+            // Start at 0 so the priming report delivers every event that was
+            // already in the event buffer at subscribe time. The reader will
+            // advance this via `update_max_seen_event_number` once the
+            // priming report has consumed the events.
+            max_seen_event_number: 0,
+        };
+
+        info!("Added subscription {:?}", subscription.ids());
+
+        Some((subscription, buffer))
+    }
+
+    /// Begin a report for the subscription with the given ID.
+    ///
+    /// Returns a small [`ReportContext`] capturing the subscription's current
+    /// `since` watermark and the watermark to commit via [`Self::mark_reported`]
+    /// on success. Unlike a snapshot, the `changed_attrs` table itself is not
+    /// copied; the report uses a [`SubAttrChangeFilter`] that consults the
+    /// live table one attribute at a time.
+    ///
+    /// `priming = true` produces a context with filtering disabled; it is
+    /// used for the initial ("priming") report delivered right after a
+    /// subscription is accepted.
+    fn report<'a, B>(
+        &mut self,
+        now: Instant,
+        max_event_number: EventNumber,
+        buffers: &mut SubscriptionsBuffersInner<'a, B, N>,
+    ) -> Option<(Subscription, B::Buffer<'a>)>
+    where
+        B: BufferAccess<IMBuffer> + 'a,
+    {
+        if let Some(index) = self.find_reportable::<B>(now, max_event_number, buffers) {
+            let sub = self.subscriptions.swap_remove(index);
+            let buf = buffers.swap_remove(index);
+
+            info!("About to report on subscription {:?}", sub.ids());
+
+            Some((sub, buf))
+        } else {
+            None
+        }
+    }
+
+    fn report_complete<'a, B>(
+        &mut self,
+        sub: Subscription,
+        buffer: B::Buffer<'a>,
+        buffers: &mut SubscriptionsBuffersInner<'a, B, N>,
+        keep: bool,
+    ) where
+        B: BufferAccess<IMBuffer> + 'a,
+    {
+        if keep {
+            unwrap!(self.subscriptions.push(sub));
+            unwrap!(buffers.push(buffer).map_err(|_| ()));
+        } else {
+            warn!("Subscription {:?} removed during reporting", sub.ids());
+
+            self.subscriptions_count -= 1;
+        }
+    }
+
+    fn find_reportable<'a, B>(
+        &self,
+        now: Instant,
+        max_event_number: EventNumber,
+        buffers: &SubscriptionsBuffersInner<'a, B, N>,
+    ) -> Option<usize>
+    where
+        B: BufferAccess<IMBuffer> + 'a,
+    {
+        self.subscriptions
+            .iter()
+            .enumerate()
+            .map(|(index, sub)| (sub, &buffers[index]))
+            .position(|(sub, rx)| sub.is_reportable(now, rx, &self.changed_attrs, max_event_number))
+    }
+
+    /// Remove entries that every subscription has already reported on.
+    fn purge_reported_changes(&mut self) {
+        if let Some(min_seen_attr_change_id) = self
+            .subscriptions
+            .iter()
+            .map(|s| s.max_seen_attr_change_id)
+            .min()
+        {
+            self.changed_attrs.purge_up_to(min_seen_attr_change_id);
+        } else {
+            self.changed_attrs.clear();
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SubscriptionIds {
+    /// The ID of the subscription. Uniquely identifies the subscription across all of them.
+    pub id: u32,
+    /// The fabric index of the subscriber. Used to route reports and to remove all subscriptions of a fabric when it gets removed.
+    pub fab_idx: NonZeroU8,
+    /// The node ID of the subscriber. Used to route reports and to remove all subscriptions of a peer when it gets removed.
+    pub peer_node_id: NodeId,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Subscription {
+    /// The IDs of the subscription
+    ids: SubscriptionIds,
+    /// The ID of the session on which the subscription was accepted. Used by
+    /// the reporter task to route outgoing reports back to the exact session
+    /// the subscriber established, rather than picking any secure session
+    /// matching `(fab_idx, peer_node_id)` (which may not be the one the peer
+    /// is actually listening on, breaking at least HomeKit and chip-tool).
+    session_id: u32,
+    /// The minimum interval in seconds. The subscription should not receive reports more frequently than this interval, but may receive them less frequently.
+    /// We use u16 instead of embassy::Duration to save some storage
+    min_int_secs: u16,
+    /// The maximum interval in seconds. The subscription should receive reports at least this frequently, even if there are no changes to report (i.e. it is a liveness deadline).
+    /// We use u16 instead of embassy::Duration to save some storage
+    max_int_secs: u16,
+    /// The timestamp of the last report sent to this subscription. Used to decide when the next report is due based on the min/max intervals.
+    /// Set to `Instant::MAX` when the subscription is created to indicate that no report has been sent yet, so the first report is due immediately. After the first report, it is updated to the actual timestamp of the last report.
+    reported_at: Instant,
+    /// The largest attribute change ID from the [`ChangedAttributes`] table this subscription
+    /// has already reported on. Entries with a larger change ID represent pending changes the subscription still needs to emit.
+    max_seen_attr_change_id: u64,
+    /// The largest event number this subscription has already reported on. Events with a larger event number represent pending events the subscription still needs to emit.
+    max_seen_event_number: u64,
+}
+
+impl Subscription {
+    pub const fn ids(&self) -> &SubscriptionIds {
+        &self.ids
+    }
+
+    /// The session ID on which this subscription was accepted.
+    pub const fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn is_expired(&self, now: Instant) -> bool {
+        self.reported_at
+            .checked_add(embassy_time::Duration::from_secs(self.max_int_secs as _))
+            .map(|expiry| expiry <= now)
+            .unwrap_or(false)
+    }
+
+    // REVIEW: `is_expired(now)` returning `true` here *prevents* the
+    // subscription from being picked up for reporting. That's a correctness
+    // problem: the expected flow for an expired subscription is to be removed
+    // (by `Subscriptions::remove` with an `is_expired` reason — which is
+    // indeed what `dm.rs` does). But if the reporter task wakes up on the
+    // change notification path and races past the `remove` pass, the expired
+    // subscription will be silently starved instead of being removed or
+    // reported. Consider dropping the `is_expired` check here entirely — the
+    // "remove expired" step in `dm.rs` is the single source of truth.
+    fn is_reportable(
+        &self,
+        now: Instant,
+        rx: &[u8],
+        changed_attrs: &ChangedAttributes,
+        max_event_number: EventNumber,
+    ) -> bool {
+        if self.is_expired(now) || !self.is_report_allowed(now) {
+            return false;
+        }
+
+        self.is_report_due(now)
+            || self.is_affected_by_attr_changes(rx, changed_attrs)
+            || self.is_affected_by_new_events(rx, max_event_number)
+    }
+
+    fn is_report_allowed(&self, now: Instant) -> bool {
+        self.reported_at
+            .checked_add(embassy_time::Duration::from_secs(self.min_int_secs as _))
+            .map(|next_report| next_report <= now)
+            .unwrap_or(true)
+    }
+
+    fn is_report_due(&self, now: Instant) -> bool {
+        self.reported_at
+            .checked_add(embassy_time::Duration::from_secs(self.max_int_secs as _))
+            .map(|next_report| {
+                next_report <= now
+                    || next_report - now
+                        <= embassy_time::Duration::from_secs((self.max_int_secs / 2) as _)
+            })
+            .unwrap_or(true)
+    }
+
+    fn is_affected_by_attr_changes(&self, _rx: &[u8], changes: &ChangedAttributes) -> bool {
+        changes.any_since(self.max_seen_attr_change_id)
+    }
+
+    fn is_affected_by_new_events(&self, _rx: &[u8], max_event_number: EventNumber) -> bool {
+        self.max_seen_event_number < max_event_number
+    }
+}
+
+/// A table of recently-changed attribute triples, each tagged with an
+/// ever-increasing `change_id`.
+///
+/// Subscriptions consult this table to decide which attributes they should
+/// re-emit on their next report: only attributes with a matching entry whose
+/// `change_id` is strictly greater than the subscription's own watermark
+/// (`last_change_id`) need to be reported.
+///
+/// The table has a fixed capacity of [`MAX_CHANGED_ATTRS`] entries. When it
+/// fills up, existing entries are coalesced to coarser-grained wildcards
+/// (`(endpoint, cluster, *)` → `(endpoint, *, *)` → `(*, *, *)`) so that a new change can always
+/// be recorded. A wildcard entry over-covers and will therefore cause the
+/// affected subscriptions to emit a slightly wider set of attributes on their
+/// next report, but this is a bounded loss of precision that preserves
+/// correctness.
+pub(crate) struct ChangedAttributes {
+    /// Monotonically increasing ID assigned to every recorded change.
+    /// The first assigned ID is 1; `0` is reserved as the "no change seen yet"
+    /// sentinel used by fresh subscriptions.
+    next_change_id: u64,
+    /// The actual table of recent changes, ordered from oldest to newest.
+    /// The newest change has `change_id == next_change_id - 1`.
+    entries: Vec<ChangedAttr, MAX_CHANGED_ATTRS>,
+}
+
+impl ChangedAttributes {
+    /// Create the instance.
+    #[inline(always)]
+    const fn new() -> Self {
+        Self {
+            next_change_id: 1,
+            entries: Vec::new(),
+        }
+    }
+
+    /// Return an in-place initializer for the instance.
+    fn init() -> impl Init<Self> {
+        init!(Self {
+            next_change_id: 1,
+            entries <- Vec::init(),
+        })
+    }
+
+    /// The largest change ID that has been assigned so far. A subscription
+    /// whose max seen change ID is equal to the watermark has seen every change.
+    #[inline]
+    fn watermark(&self) -> u64 {
+        self.next_change_id.wrapping_sub(1)
+    }
+
+    /// Record a change to the attribute triple `(endpoint, cluster, attr)`.
+    /// Returns the newly assigned change ID.
+    fn record(&mut self, endpoint: EndptId, cluster: ClusterId, attr: AttrId) -> u64 {
+        self.record_raw(ChangedAttr::concrete(endpoint, cluster, attr, 0))
+    }
+
+    /// Record a cluster- or endpoint-wide wildcard change. `endpoint == None`
+    /// together with `cluster == None` represents a global wildcard.
+    /// Returns the newly assigned change ID.
+    fn record_wildcard(&mut self, endpoint: Option<EndptId>, cluster: Option<ClusterId>) -> u64 {
+        self.record_raw(ChangedAttr {
+            endpoint,
+            cluster,
+            attr: None,
+            change_id: 0,
+        })
+    }
+
+    /// Insert `new` into the table. The caller is expected to leave `new.change_id`
+    /// at any value - it is overwritten by a freshly-assigned ID.
+    fn record_raw(&mut self, mut new: ChangedAttr) -> u64 {
+        let change_id = self.next_change_id;
+        self.next_change_id = self.next_change_id.wrapping_add(1).max(1);
+        new.change_id = change_id;
+
+        // If an existing entry already covers `new`, just refresh its change ID.
+        if let Some(existing) = self.entries.iter_mut().find(|x| x.covers(&new)) {
+            existing.change_id = change_id;
+            return change_id;
+        }
+
+        // `new` may itself subsume existing concrete entries - drop those to
+        // keep the table compact and avoid wasting slots on redundant paths.
+        let mut i = 0;
+        while i < self.entries.len() {
+            if new.covers(&self.entries[i]) {
+                self.entries.swap_remove(i);
+            } else {
+                i += 1;
+            }
+        }
+
+        if let Err(new) = self.entries.push(new) {
+            // The table is full - promote entries to coarser wildcards to free a slot.
+            self.promote_and_insert(new);
+        }
+
+        change_id
+    }
+
+    /// Returns `true` if the table contains at least one entry covering
+    /// `(endpoint, cluster, attr)` with `change_id > since`.
+    fn contains_since(
+        &self,
+        endpoint: EndptId,
+        cluster: ClusterId,
+        attr: AttrId,
+        since: u64,
+    ) -> bool {
+        self.entries
+            .iter()
+            .any(|x| x.change_id > since && x.matches(endpoint, cluster, attr))
+    }
+
+    /// Returns `true` if the table contains at least one entry with
+    /// `change_id > since` (of any path).
+    fn any_since(&self, since: u64) -> bool {
+        self.entries.iter().any(|x| x.change_id > since)
+    }
+
+    /// Drop all entries with `change_id <= threshold`.
+    fn purge_up_to(&mut self, threshold: u64) {
+        if threshold == 0 {
+            return;
+        }
+
+        let mut i = 0;
+        while i < self.entries.len() {
+            if self.entries[i].change_id <= threshold {
+                self.entries.swap_remove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    /// Drop every recorded change. Used when no subscriptions exist.
+    fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// Coalesce existing entries to coarser wildcards so that `new` can be inserted.
+    ///
+    /// The strategy is to promote as little as possible: on each iteration we
+    /// collapse the single largest collapsible group at the finest available
+    /// level into one coarser wildcard entry, freeing at least one slot. Only
+    /// once no fine-grained group of two or more entries exists do we escalate
+    /// to the next level, and finally to a global wildcard as a last resort.
+    fn promote_and_insert(&mut self, new: ChangedAttr) {
+        loop {
+            // If an existing (possibly just-promoted) entry already covers `new`,
+            // refresh its change ID and we're done.
+            if let Some(existing) = self.entries.iter_mut().find(|x| x.covers(&new)) {
+                existing.change_id = new.change_id;
+                return;
+            }
+
+            if self.entries.push(new.clone()).is_ok() {
+                return;
+            }
+
+            // Full - promote exactly one group at the finest granularity that
+            // actually yields compaction. Levels:
+            // - 1: (endpoint, cluster, *)
+            // - 2: (endpoint, *, *)
+            if !self.promote_largest_group(1) && !self.promote_largest_group(2) {
+                // No collapsible group at either level - last-ditch fallback:
+                // collapse the whole table into a single global wildcard entry.
+                self.entries.clear();
+
+                unwrap!(self.entries.push(ChangedAttr {
+                    endpoint: None,
+                    cluster: None,
+                    attr: None,
+                    change_id: new.change_id,
+                }));
+
+                return;
+            }
+        }
+    }
+
+    /// Find the largest group of entries (>= 2) that share the same key at the
+    /// given promotion level, and collapse it into one coarser wildcard entry.
+    ///
+    /// Returns `true` if any promotion happened.
+    fn promote_largest_group(&mut self, level: u8) -> bool {
+        // Pick a pivot whose group is largest.
+        let mut best_pivot: Option<ChangedAttr> = None;
+        let mut best_count = 1usize;
+
+        for i in 0..self.entries.len() {
+            let pivot = &self.entries[i];
+            let Some(coarsened) = pivot.coarsen(level) else {
+                continue;
+            };
+
+            let count = self.entries.iter().filter(|e| coarsened.covers(e)).count();
+            if count > best_count {
+                best_count = count;
+                best_pivot = Some(pivot.clone());
+            }
+        }
+
+        let Some(pivot) = best_pivot else {
+            return false;
+        };
+        // `coarsen` already returned `Some` above for this pivot.
+        let mut coarsened = pivot.coarsen(level).unwrap();
+
+        // Remove all entries covered by `coarsened`, keeping the largest
+        // change_id to preserve recency.
+        let mut max_change_id = 0u64;
+        let mut i = 0;
+        while i < self.entries.len() {
+            if coarsened.covers(&self.entries[i]) {
+                if self.entries[i].change_id > max_change_id {
+                    max_change_id = self.entries[i].change_id;
+                }
+                self.entries.swap_remove(i);
+            } else {
+                i += 1;
+            }
+        }
+        coarsened.change_id = max_change_id;
+        // Safe: we just removed `best_count >= 2` entries, so there is room.
+        unwrap!(self.entries.push(coarsened));
+        true
+    }
+}
+
+/// A record of one recently changed attribute.
+///
+/// A `None` field acts as a wildcard. Wildcards appear only as a result of
+/// "promotion" when the `changed_attrs` table becomes full and several
+/// concrete entries need to be coalesced into a coarser one.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+struct ChangedAttr {
+    endpoint: Option<EndptId>,
+    cluster: Option<ClusterId>,
+    attr: Option<AttrId>,
+    change_id: u64,
+}
+
+impl ChangedAttr {
+    const fn concrete(endpoint: EndptId, cluster: ClusterId, attr: AttrId, change_id: u64) -> Self {
+        Self {
+            endpoint: Some(endpoint),
+            cluster: Some(cluster),
+            attr: Some(attr),
+            change_id,
+        }
+    }
+
+    /// Whether this record covers the concrete attribute triple
+    /// `(endpoint, cluster, attr)`.
+    fn matches(&self, endpoint: EndptId, cluster: ClusterId, attr: AttrId) -> bool {
+        self.endpoint.map(|x| x == endpoint).unwrap_or(true)
+            && self.cluster.map(|x| x == cluster).unwrap_or(true)
+            && self.attr.map(|x| x == attr).unwrap_or(true)
+    }
+
+    /// Whether `other` is semantically covered by `self` (i.e. `self` is as
+    /// coarse as or coarser than `other` on every axis).
+    fn covers(&self, other: &ChangedAttr) -> bool {
+        fn cov<T: Eq>(a: Option<T>, b: Option<T>) -> bool {
+            match (a, b) {
+                (None, _) => true,        // self wildcard covers anything
+                (Some(_), None) => false, // concrete doesn't cover wildcard
+                (Some(a), Some(b)) => a == b,
+            }
+        }
+        cov(self.endpoint, other.endpoint)
+            && cov(self.cluster, other.cluster)
+            && cov(self.attr, other.attr)
+    }
+
+    /// Build the coarsened wildcard entry representing `pivot`'s group at the
+    /// given level. Returns `None` if `pivot` cannot be promoted at that level
+    /// (e.g. its endpoint is already a wildcard for level 1 or 2).
+    fn coarsen(&self, level: u8) -> Option<Self> {
+        let (endpoint, cluster) = match level {
+            1 => (self.endpoint?, self.cluster?),
+            2 => {
+                return Some(Self {
+                    endpoint: Some(self.endpoint?),
+                    cluster: None,
+                    attr: None,
+                    change_id: 0,
+                })
+            }
+            _ => unreachable!(),
+        };
+
+        Some(Self {
+            endpoint: Some(endpoint),
+            cluster: Some(cluster),
+            attr: None,
+            change_id: 0,
+        })
+    }
+}
+
+/// Per-subscription context for an in-progress report.
+pub struct ReportContext<'a, 's, B, const N: usize>
+where
+    B: BufferAccess<IMBuffer> + 'a,
+{
+    subscriptions: &'s Subscriptions<N>,
+    subscriptions_buffers: &'s SubscriptionsBuffers<'a, B, N>,
+    subscription: Option<Subscription>,
+    subscription_buffer: Option<B::Buffer<'a>>,
+    next_max_seen_attr_change_id: u64,
+    next_reported_at: Instant,
+    keep: bool,
+}
+
+impl<'a, 's, B, const N: usize> ReportContext<'a, 's, B, N>
+where
+    B: BufferAccess<IMBuffer> + 'a,
+{
+    pub fn subscription(&self) -> &Subscription {
+        unwrap!(self.subscription.as_ref())
+    }
+
+    pub fn rx(&self) -> &[u8] {
+        unwrap!(self.subscription_buffer.as_ref()).as_ref()
+    }
+
+    pub fn should_send_if_empty(&self) -> bool {
+        // A fresh subscription has `reported_at == Instant::MAX`, which makes
+        // `is_report_due` return `true` via its overflow-to-`unwrap_or(true)`
+        // branch, so priming reports are delivered unconditionally without a
+        // separate `priming` flag.
+        unwrap!(self.subscription.as_ref()).is_report_due(self.next_reported_at)
+    }
+
+    pub fn should_report_attr(
+        &self,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        attr_id: AttrId,
+    ) -> bool {
+        let sub = self.subscription();
+
+        // A fresh subscription (priming report) has never reported anything
+        // yet; its `reported_at` sentinel doubles as the "priming" marker and
+        // means every selected attribute must be delivered, regardless of
+        // whether it appears in `changed_attrs`.
+        if sub.reported_at == Instant::MAX {
+            return true;
+        }
+
+        self.subscriptions.state.lock(|state| {
+            state.borrow().changed_attrs.contains_since(
+                endpoint_id,
+                cluster_id,
+                attr_id,
+                sub.max_seen_attr_change_id,
+            )
+        })
+    }
+
+    pub fn max_seen_event_number(&self) -> EventNumber {
+        unwrap!(self.subscription.as_ref()).max_seen_event_number
+    }
+
+    pub fn update_max_seen_event_number(&mut self, max_seen_event_number: EventNumber) {
+        let sub = unwrap!(self.subscription.as_mut());
+
+        assert!(sub.max_seen_event_number <= max_seen_event_number);
+        sub.max_seen_event_number = max_seen_event_number;
+    }
+
+    pub fn set_keep(&mut self) {
+        self.keep = true;
+    }
+}
+
+impl<'a, 's, B, const N: usize> Drop for ReportContext<'a, 's, B, N>
+where
+    B: BufferAccess<IMBuffer> + 'a,
+{
+    fn drop(&mut self) {
+        self.subscriptions.report_complete(self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::storage::pooled::PooledBuffers;
+
+    use super::*;
+
+    use embassy_time::Duration;
+
+    type TestPool<const N: usize> = PooledBuffers<N, IMBuffer>;
+
+    // ---------- ChangedAttributes ----------
+
+    #[test]
+    fn changed_attrs_starts_empty() {
+        let attrs = ChangedAttributes::new();
+        assert_eq!(attrs.watermark(), 0);
+        assert!(!attrs.any_since(0));
+        assert!(!attrs.contains_since(1, 2, 3, 0));
+    }
+
+    #[test]
+    fn changed_attrs_record_assigns_monotonic_ids() {
+        let mut attrs = ChangedAttributes::new();
+        let id1 = attrs.record(1, 2, 3);
+        let id2 = attrs.record(1, 2, 4);
+        let id3 = attrs.record(2, 2, 3);
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(id3, 3);
+        assert_eq!(attrs.watermark(), 3);
+    }
+
+    #[test]
+    fn changed_attrs_contains_since_and_any_since() {
+        let mut attrs = ChangedAttributes::new();
+        attrs.record(1, 2, 3);
+        attrs.record(1, 2, 4);
+
+        assert!(attrs.any_since(0));
+        assert!(attrs.any_since(1));
+        assert!(!attrs.any_since(2));
+
+        assert!(attrs.contains_since(1, 2, 3, 0));
+        assert!(attrs.contains_since(1, 2, 4, 1));
+        // After watermark 2 there are no more changes
+        assert!(!attrs.contains_since(1, 2, 3, 2));
+        // A never-recorded triple is not covered
+        assert!(!attrs.contains_since(9, 9, 9, 0));
+    }
+
+    #[test]
+    fn changed_attrs_duplicate_refreshes_change_id() {
+        let mut attrs = ChangedAttributes::new();
+        attrs.record(1, 2, 3);
+        attrs.record(1, 2, 4);
+        // Same triple as first record - should refresh, not add a new entry.
+        let id3 = attrs.record(1, 2, 3);
+        assert_eq!(id3, 3);
+        assert_eq!(attrs.entries.len(), 2);
+        // The (1, 2, 3) entry now has change_id 3, so it is visible from since=2
+        assert!(attrs.contains_since(1, 2, 3, 2));
+        // But it was originally at id=1, which is now lost - `since=0` still sees it
+        // through the refreshed id.
+        assert!(attrs.contains_since(1, 2, 3, 0));
+    }
+
+    #[test]
+    fn changed_attrs_record_wildcard_cluster_covers_every_attr() {
+        let mut attrs = ChangedAttributes::new();
+        let id = attrs.record_wildcard(Some(7), Some(42));
+
+        // Any concrete attribute on that (endpoint, cluster) is now covered.
+        assert!(attrs.contains_since(7, 42, 0, 0));
+        assert!(attrs.contains_since(7, 42, 1, 0));
+        assert!(attrs.contains_since(7, 42, u32::MAX, 0));
+        // Unrelated clusters / endpoints are not.
+        assert!(!attrs.contains_since(7, 99, 0, 0));
+        assert!(!attrs.contains_since(8, 42, 0, 0));
+        assert_eq!(id, attrs.watermark());
+    }
+
+    #[test]
+    fn changed_attrs_record_wildcard_endpoint_covers_every_cluster() {
+        let mut attrs = ChangedAttributes::new();
+        attrs.record_wildcard(Some(5), None);
+
+        assert!(attrs.contains_since(5, 1, 1, 0));
+        assert!(attrs.contains_since(5, 1000, 1000, 0));
+        assert!(!attrs.contains_since(6, 1, 1, 0));
+    }
+
+    #[test]
+    fn changed_attrs_record_wildcard_absorbs_existing_concrete_entries() {
+        let mut attrs = ChangedAttributes::new();
+        // Seed three concrete attrs on (1, 2).
+        attrs.record(1, 2, 10);
+        attrs.record(1, 2, 11);
+        attrs.record(1, 2, 12);
+        // And one concrete on a different cluster - should survive.
+        attrs.record(1, 3, 20);
+        assert_eq!(attrs.entries.len(), 4);
+
+        // Recording a cluster-wide wildcard for (1, 2) must collapse the three
+        // concrete (1, 2, *) entries into the single wildcard.
+        attrs.record_wildcard(Some(1), Some(2));
+
+        assert_eq!(attrs.entries.len(), 2);
+        assert!(attrs
+            .entries
+            .iter()
+            .any(|e| e.endpoint == Some(1) && e.cluster == Some(2) && e.attr.is_none()));
+        assert!(attrs.contains_since(1, 3, 20, 0));
+    }
+
+    #[test]
+    fn changed_attrs_record_wildcard_is_refreshed_when_already_covered() {
+        let mut attrs = ChangedAttributes::new();
+        // Endpoint-wide wildcard covers any cluster on that endpoint.
+        attrs.record_wildcard(Some(1), None);
+        let before_len = attrs.entries.len();
+
+        // A cluster-wide wildcard for the same endpoint is already covered
+        // by the endpoint-wide one - it must not grow the table and must
+        // refresh the existing entry's change id.
+        let id = attrs.record_wildcard(Some(1), Some(2));
+        assert_eq!(attrs.entries.len(), before_len);
+        assert_eq!(attrs.watermark(), id);
+    }
+
+    #[test]
+    fn changed_attrs_purge_up_to_removes_old_entries() {
+        let mut attrs = ChangedAttributes::new();
+        attrs.record(1, 2, 3); // id 1
+        attrs.record(1, 2, 4); // id 2
+        attrs.record(2, 2, 3); // id 3
+
+        attrs.purge_up_to(2);
+
+        assert!(!attrs.contains_since(1, 2, 3, 0));
+        assert!(!attrs.contains_since(1, 2, 4, 0));
+        assert!(attrs.contains_since(2, 2, 3, 0));
+
+        // Purging with 0 is a no-op.
+        attrs.purge_up_to(0);
+        assert!(attrs.contains_since(2, 2, 3, 0));
+    }
+
+    #[test]
+    fn changed_attrs_clear_empties_table_but_keeps_watermark() {
+        let mut attrs = ChangedAttributes::new();
+        attrs.record(1, 2, 3);
+        attrs.record(1, 2, 4);
+        let wm_before = attrs.watermark();
+        attrs.clear();
+        assert!(!attrs.any_since(0));
+        // Watermark is preserved so subsequent records remain strictly monotonic.
+        assert_eq!(attrs.watermark(), wm_before);
+        let id = attrs.record(5, 5, 5);
+        assert_eq!(id, wm_before + 1);
+    }
+
+    #[test]
+    fn changed_attrs_promotion_on_overflow_same_cluster() {
+        let mut attrs = ChangedAttributes::new();
+        // Fill the table with distinct concrete entries on the same (endpoint, cluster).
+        for attr in 0..MAX_CHANGED_ATTRS as u32 {
+            attrs.record(1, 2, attr);
+        }
+        assert_eq!(attrs.entries.len(), MAX_CHANGED_ATTRS);
+
+        // One more record must still succeed - the existing entries get promoted.
+        let overflow_id = attrs.record(1, 2, 9999);
+        assert_eq!(overflow_id as usize, MAX_CHANGED_ATTRS + 1);
+
+        // The table must never overflow its capacity.
+        assert!(attrs.entries.len() <= MAX_CHANGED_ATTRS);
+
+        // Every originally-recorded concrete attribute must still be reported as
+        // "changed" when queried from since=0 (possibly via a coarser wildcard).
+        for attr in 0..MAX_CHANGED_ATTRS as u32 {
+            assert!(
+                attrs.contains_since(1, 2, attr, 0),
+                "attr {} lost after promotion",
+                attr
+            );
+        }
+        assert!(attrs.contains_since(1, 2, 9999, 0));
+
+        // The new overflow entry is visible from the previous watermark.
+        assert!(attrs.contains_since(1, 2, 9999, MAX_CHANGED_ATTRS as u64));
+    }
+
+    #[test]
+    fn changed_attrs_promotion_to_global_wildcard() {
+        let mut attrs = ChangedAttributes::new();
+        // Entries spread across many endpoints/clusters/attrs to force promotion
+        // past the (endpoint, cluster, *) and (endpoint, *, *) levels.
+        for i in 0..(MAX_CHANGED_ATTRS as u16 + 5) {
+            attrs.record(i, i as u32, i as u32);
+        }
+        assert!(attrs.entries.len() <= MAX_CHANGED_ATTRS);
+        // All previously-recorded triples must still report as changed.
+        for i in 0..(MAX_CHANGED_ATTRS as u16 + 5) {
+            assert!(attrs.contains_since(i, i as u32, i as u32, 0));
+        }
+        // And an arbitrary never-recorded triple may or may not be covered
+        // (over-reporting is allowed), but `any_since(0)` must be true.
+        assert!(attrs.any_since(0));
+    }
+
+    #[test]
+    fn promotion_prefers_largest_level_1_group() {
+        // 10 entries on (1, 1, *) and 5 singletons on (1, k, 0) for k=2..=6
+        // (= 15 entries total). One extra record fills the table, then an
+        // overflowing record forces exactly ONE level-1 promotion which must
+        // collapse the big (1, 1, *) group while leaving singletons concrete.
+        let mut attrs = ChangedAttributes::new();
+        for attr in 0..10u32 {
+            attrs.record(1, 1, attr);
+        }
+        for cluster in 2..=6u32 {
+            attrs.record(1, cluster, 0);
+        }
+        // Fill exactly to capacity without overflow.
+        attrs.record(1, 1, 100);
+        assert_eq!(attrs.entries.len(), MAX_CHANGED_ATTRS);
+
+        // Now overflow to trigger promotion.
+        attrs.record(2, 2, 2);
+        assert!(attrs.entries.len() <= MAX_CHANGED_ATTRS);
+
+        // The big (1, 1, *) group became exactly one wildcard entry.
+        let wild_11 = attrs
+            .entries
+            .iter()
+            .filter(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_none())
+            .count();
+        assert_eq!(wild_11, 1);
+        // No concrete (1, 1, _) entries survived.
+        let concrete_11 = attrs
+            .entries
+            .iter()
+            .filter(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_some())
+            .count();
+        assert_eq!(concrete_11, 0);
+        // Singletons on (1, k, 0) for k=2..=6 remain concrete.
+        for cluster in 2..=6u32 {
+            let n = attrs
+                .entries
+                .iter()
+                .filter(|e| {
+                    e.endpoint == Some(1) && e.cluster == Some(cluster) && e.attr == Some(0)
+                })
+                .count();
+            assert_eq!(n, 1, "singleton (1, {}, 0) should remain concrete", cluster);
+        }
+        // The new (2, 2, 2) entry is present as a concrete entry.
+        assert!(attrs
+            .entries
+            .iter()
+            .any(|e| e.endpoint == Some(2) && e.cluster == Some(2) && e.attr == Some(2)));
+
+        // All original triples still report as changed.
+        for attr in 0..10u32 {
+            assert!(attrs.contains_since(1, 1, attr, 0));
+        }
+        for cluster in 2..=6u32 {
+            assert!(attrs.contains_since(1, cluster, 0, 0));
+        }
+        assert!(attrs.contains_since(1, 1, 100, 0));
+        assert!(attrs.contains_since(2, 2, 2, 0));
+    }
+
+    #[test]
+    fn promotion_is_minimal_only_one_group_collapsed_per_overflow() {
+        // Two big level-1 groups of equal size. A single overflow must collapse
+        // only ONE of them, not both (minimal promotion).
+        let mut attrs = ChangedAttributes::new();
+        // Group A: (1, 1, 0..8) = 8 entries
+        for attr in 0..8u32 {
+            attrs.record(1, 1, attr);
+        }
+        // Group B: (2, 2, 0..8) = 8 entries
+        for attr in 0..8u32 {
+            attrs.record(2, 2, attr);
+        }
+        assert_eq!(attrs.entries.len(), MAX_CHANGED_ATTRS);
+
+        // Overflow with an unrelated entry.
+        attrs.record(9, 9, 9);
+
+        // Exactly one of the groups got collapsed into a wildcard.
+        let a_wild = attrs
+            .entries
+            .iter()
+            .any(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_none());
+        let b_wild = attrs
+            .entries
+            .iter()
+            .any(|e| e.endpoint == Some(2) && e.cluster == Some(2) && e.attr.is_none());
+        assert!(
+            a_wild ^ b_wild,
+            "expected exactly one of the groups to be collapsed (A: {}, B: {})",
+            a_wild,
+            b_wild
+        );
+        // The un-collapsed group still has all 8 concrete entries.
+        let a_concrete = attrs
+            .entries
+            .iter()
+            .filter(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_some())
+            .count();
+        let b_concrete = attrs
+            .entries
+            .iter()
+            .filter(|e| e.endpoint == Some(2) && e.cluster == Some(2) && e.attr.is_some())
+            .count();
+        assert!(
+            (a_wild && a_concrete == 0 && b_concrete == 8)
+                || (b_wild && b_concrete == 0 && a_concrete == 8)
+        );
+    }
+
+    #[test]
+    fn promotion_falls_back_to_level_2_when_no_level_1_group() {
+        // All (endpoint, cluster) pairs are unique (level-1 groups are all
+        // singletons) but endpoints repeat, so level-2 groups are non-trivial.
+        let mut attrs = ChangedAttributes::new();
+        for cluster in 0..8u32 {
+            attrs.record(1, cluster, 0);
+        }
+        for cluster in 0..8u32 {
+            attrs.record(2, cluster, 0);
+        }
+        assert_eq!(attrs.entries.len(), MAX_CHANGED_ATTRS);
+
+        attrs.record(3, 9, 9);
+        assert!(attrs.entries.len() <= MAX_CHANGED_ATTRS);
+
+        // No level-1 wildcard (endpoint, cluster, *) was produced.
+        let lvl1_wild = attrs
+            .entries
+            .iter()
+            .filter(|e| e.endpoint.is_some() && e.cluster.is_some() && e.attr.is_none())
+            .count();
+        assert_eq!(lvl1_wild, 0);
+        // Exactly one level-2 wildcard on endpoint 1 or 2 was produced.
+        let ep1_wild = attrs
+            .entries
+            .iter()
+            .any(|e| e.endpoint == Some(1) && e.cluster.is_none() && e.attr.is_none());
+        let ep2_wild = attrs
+            .entries
+            .iter()
+            .any(|e| e.endpoint == Some(2) && e.cluster.is_none() && e.attr.is_none());
+        assert!(ep1_wild ^ ep2_wild);
+        // No global wildcard was produced either.
+        assert!(!attrs
+            .entries
+            .iter()
+            .any(|e| e.endpoint.is_none() && e.cluster.is_none() && e.attr.is_none()));
+
+        // All originals still visible.
+        for cluster in 0..8u32 {
+            assert!(attrs.contains_since(1, cluster, 0, 0));
+            assert!(attrs.contains_since(2, cluster, 0, 0));
+        }
+        assert!(attrs.contains_since(3, 9, 9, 0));
+    }
+
+    #[test]
+    fn promotion_falls_back_to_global_only_when_no_lower_group() {
+        // All-distinct endpoints AND (endpoint, cluster) pairs: no level-1 or
+        // level-2 group has >=2 entries. Overflow must collapse everything to
+        // a single global wildcard.
+        let mut attrs = ChangedAttributes::new();
+        for i in 0..MAX_CHANGED_ATTRS as u16 {
+            attrs.record(i, i as u32, i as u32);
+        }
+        assert_eq!(attrs.entries.len(), MAX_CHANGED_ATTRS);
+
+        attrs.record(100, 200, 300);
+        assert_eq!(attrs.entries.len(), 1);
+        let only = &attrs.entries[0];
+        assert!(only.endpoint.is_none() && only.cluster.is_none() && only.attr.is_none());
+
+        // Every previously-recorded triple is still covered.
+        for i in 0..MAX_CHANGED_ATTRS as u16 {
+            assert!(attrs.contains_since(i, i as u32, i as u32, 0));
+        }
+        assert!(attrs.contains_since(100, 200, 300, 0));
+    }
+
+    #[test]
+    fn promotion_preserves_max_change_id_in_coarsened_entry() {
+        // After collapsing a (1, 1, *) group, the resulting wildcard's
+        // change_id must equal the max change_id of the collapsed entries.
+        let mut attrs = ChangedAttributes::new();
+        for attr in 0..MAX_CHANGED_ATTRS as u32 {
+            attrs.record(1, 1, attr);
+        }
+        let max_before = attrs.watermark();
+
+        attrs.record(2, 2, 2);
+        let wild = attrs
+            .entries
+            .iter()
+            .find(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_none())
+            .expect("(1, 1, *) wildcard was produced");
+        assert_eq!(wild.change_id, max_before);
+
+        // contains_since respects that watermark exactly.
+        assert!(attrs.contains_since(1, 1, 0, max_before - 1));
+        assert!(!attrs.contains_since(1, 1, 0, max_before));
+    }
+
+    #[test]
+    fn promotion_with_existing_wildcard_refreshes_instead_of_promoting_again() {
+        // Build a state where (1, 1, *) wildcard already exists via a forced
+        // promotion. Recording another (1, 1, k) must refresh that wildcard's
+        // change_id without producing any new entry.
+        let mut attrs = ChangedAttributes::new();
+        for attr in 0..MAX_CHANGED_ATTRS as u32 {
+            attrs.record(1, 1, attr);
+        }
+        attrs.record(2, 2, 2); // forces (1, 1, *) promotion
+
+        // Now the table has 2 entries: (1, 1, *) and (2, 2, 2).
+        assert_eq!(attrs.entries.len(), 2);
+        let wm_after_promo = attrs.watermark();
+
+        let new_id = attrs.record(1, 1, 42);
+        // No new entry: still 2 entries. Wildcard's change_id advanced.
+        assert_eq!(attrs.entries.len(), 2);
+        assert_eq!(new_id, wm_after_promo + 1);
+        let wild = attrs
+            .entries
+            .iter()
+            .find(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_none())
+            .unwrap();
+        assert_eq!(wild.change_id, new_id);
+    }
+
+    #[test]
+    fn promotion_capacity_invariant_under_sustained_churn() {
+        // Sustained mixed churn must never let the table exceed its capacity,
+        // and every freshly-recorded triple must remain visible immediately
+        // after recording.
+        let mut attrs = ChangedAttributes::new();
+        for i in 0..1000u32 {
+            let endpoint = (i % 7) as u16;
+            let cluster = i % 13;
+            let attr = i;
+            attrs.record(endpoint, cluster, attr);
+            assert!(
+                attrs.entries.len() <= MAX_CHANGED_ATTRS,
+                "capacity exceeded at i={}",
+                i
+            );
+            assert!(
+                attrs.contains_since(endpoint, cluster, attr, 0),
+                "just-recorded triple lost at i={}",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn promotion_iterated_into_same_existing_wildcard() {
+        // Once (1, 1, *) exists, repeated inserts on that group must never
+        // grow the table, and never trigger further promotion.
+        let mut attrs = ChangedAttributes::new();
+        for attr in 0..MAX_CHANGED_ATTRS as u32 {
+            attrs.record(1, 1, attr);
+        }
+        attrs.record(2, 2, 2); // -> [(1,1,*), (2,2,2)]
+        assert_eq!(attrs.entries.len(), 2);
+
+        for attr in 100..200u32 {
+            attrs.record(1, 1, attr);
+            assert_eq!(attrs.entries.len(), 2);
+        }
+    }
+
+    #[test]
+    fn promotion_escalates_when_level_1_group_still_insufficient() {
+        // Pathological case: a single level-1 group of size 2 exists, the rest
+        // are singletons. After the first overflow, that group collapses
+        // (freeing 1 slot), but the table is still full once the new record
+        // tries to be inserted on a fresh singleton location. Subsequent
+        // overflows must escalate to level-2 / global.
+        let mut attrs = ChangedAttributes::new();
+        // 2 entries sharing (1, 1, *) -- a single level-1 group of size 2.
+        attrs.record(1, 1, 0);
+        attrs.record(1, 1, 1);
+        // Fill the rest with unique (endpoint, cluster) pairs.
+        for i in 0..(MAX_CHANGED_ATTRS as u16 - 2) {
+            attrs.record(10 + i, 100 + i as u32, i as u32);
+        }
+        assert_eq!(attrs.entries.len(), MAX_CHANGED_ATTRS);
+
+        // First overflow: the only level-1 group collapses; then the new entry
+        // gets inserted.
+        attrs.record(50, 50, 50);
+        assert!(attrs.entries.len() <= MAX_CHANGED_ATTRS);
+        // The (1, 1, *) wildcard is present.
+        assert!(attrs
+            .entries
+            .iter()
+            .any(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_none()));
+
+        // Keep feeding: eventually we must fall back to level-2 or global
+        // without breaking correctness.
+        for i in 0..200u32 {
+            let endpoint = 200 + (i % 5) as u16;
+            let cluster = 300 + (i % 3);
+            let attr = i;
+            attrs.record(endpoint, cluster, attr);
+            assert!(attrs.entries.len() <= MAX_CHANGED_ATTRS);
+            assert!(attrs.contains_since(endpoint, cluster, attr, 0));
+        }
+        // Historical triples still covered.
+        assert!(attrs.contains_since(1, 1, 0, 0));
+        assert!(attrs.contains_since(1, 1, 1, 0));
+        assert!(attrs.contains_since(50, 50, 50, 0));
+    }
+
+    #[test]
+    fn changed_attr_covers_wildcards() {
+        let concrete = ChangedAttr::concrete(1, 2, 3, 1);
+        let any_attr = ChangedAttr {
+            endpoint: Some(1),
+            cluster: Some(2),
+            attr: None,
+            change_id: 1,
+        };
+        let any_cluster = ChangedAttr {
+            endpoint: Some(1),
+            cluster: None,
+            attr: None,
+            change_id: 1,
+        };
+        let global = ChangedAttr {
+            endpoint: None,
+            cluster: None,
+            attr: None,
+            change_id: 1,
+        };
+
+        assert!(any_attr.covers(&concrete));
+        assert!(any_cluster.covers(&concrete));
+        assert!(global.covers(&concrete));
+        // Concrete does not cover wildcards.
+        assert!(!concrete.covers(&any_attr));
+        assert!(!concrete.covers(&global));
+        // Concrete matches itself.
+        assert!(concrete.matches(1, 2, 3));
+        assert!(!concrete.matches(1, 2, 4));
+        // Wildcards match any concrete triple on the wildcarded axis.
+        assert!(any_attr.matches(1, 2, 99));
+        assert!(!any_attr.matches(1, 9, 99));
+        assert!(global.matches(99, 99, 99));
+    }
+
+    // ---------- Subscriptions ----------
+
+    fn fab(i: u8) -> NonZeroU8 {
+        NonZeroU8::new(i).unwrap()
+    }
+
+    #[test]
+    fn add_returns_monotonic_ids_and_rejects_when_full() {
+        let subs: Subscriptions<2> = Subscriptions::new();
+        let pool = TestPool::<3>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<3>, 2> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+
+        let rctx1 = subs
+            .add(
+                now,
+                fab(1),
+                10,
+                100,
+                1,
+                60,
+                0,
+                pool.get_immediate().unwrap(),
+                &subs_bufs,
+            )
+            .unwrap();
+        let rctx2 = subs
+            .add(
+                now,
+                fab(1),
+                10,
+                100,
+                1,
+                60,
+                0,
+                pool.get_immediate().unwrap(),
+                &subs_bufs,
+            )
+            .unwrap();
+        assert_eq!(rctx1.subscription().ids().id, 1);
+        assert_eq!(rctx2.subscription().ids().id, 2);
+
+        // Third add exceeds N=2.
+        assert!(subs
+            .add(
+                now,
+                fab(1),
+                10,
+                100,
+                1,
+                60,
+                0,
+                pool.get_immediate().unwrap(),
+                &subs_bufs
+            )
+            .is_none());
+    }
+
+    #[test]
+    fn begin_report_snapshots_watermark_and_pending() {
+        let subs: Subscriptions<2> = Subscriptions::new();
+        let pool = TestPool::<3>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<3>, 2> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+
+        subs.notify_attribute_changed(1, 2, 3);
+        {
+            let mut rctx = subs
+                .add(
+                    now,
+                    fab(1),
+                    10,
+                    100,
+                    1,
+                    60,
+                    0,
+                    pool.get_immediate().unwrap(),
+                    &subs_bufs,
+                )
+                .unwrap();
+
+            // The priming report is un-filtered: every attribute is reported and
+            // `should_send_if_empty` is true so that the snapshot is delivered
+            // unconditionally.
+            assert!(rctx.should_send_if_empty());
+            assert!(rctx.should_report_attr(1, 2, 3));
+            assert!(rctx.should_report_attr(42, 55555, 1234556677));
+
+            rctx.set_keep();
+        }
+
+        // A new change bumps the watermark and becomes pending.
+        subs.notify_attribute_changed(1, 2, 4);
+        // `min_int` = 1s has not elapsed at `now`, so the subscription is not
+        // yet report-allowed; step past it.
+        let later = now + Duration::from_secs(2);
+        let rctx = subs.report(later, 0, &subs_bufs).unwrap();
+        assert!(!rctx.should_send_if_empty());
+        // The priming commit advanced the sub's `since` past the (1, 2, 3)
+        // change, so only the new (1, 2, 4) is pending.
+        assert!(!rctx.should_report_attr(1, 2, 3));
+        assert!(rctx.should_report_attr(1, 2, 4));
+    }
+
+    // The following tests cover the public API of `Subscriptions` /
+    // `SubscriptionsBuffers` / `ReportContext` post-refactor. A few of the
+    // pre-refactor tests had no meaningful successor and were deleted:
+    //
+    //   * `sub_attr_change_filter_honors_since_watermark` — `SubAttrChangeFilter`
+    //     is now dead code (see REVIEW above); the `since`-watermark logic is
+    //     already covered by `changed_attrs_contains_since_and_any_since`.
+    //   * `find_report_due_events_pending_receives_subscription_watermark` —
+    //     the old `events_pending` callback no longer exists; the
+    //     subscription's `max_seen_event_number` is now compared directly
+    //     against the `max_event_number` passed to `Subscriptions::report`.
+    //   * `find_removed_session_matches_predicate` — `session_id` tracking
+    //     was dropped in the refactor (see REVIEW on `SubscriptionsInner::add`).
+    //     Predicate-based removal is covered by `remove_invokes_predicate_*`.
+
+    /// Helper: add a subscription with sensible defaults and return its `ReportContext`.
+    fn add_sub<'a, 's, const N: usize, const B: usize>(
+        subs: &'s Subscriptions<N>,
+        subs_bufs: &'s SubscriptionsBuffers<'a, TestPool<B>, N>,
+        pool: &'a TestPool<B>,
+        now: Instant,
+        fab_idx: u8,
+        peer_node_id: u64,
+        min_int: u16,
+        max_int: u16,
+    ) -> ReportContext<'a, 's, TestPool<B>, N>
+    where
+        'a: 's,
+    {
+        subs.add(
+            now,
+            fab(fab_idx),
+            peer_node_id,
+            /* session_id */ 0,
+            min_int,
+            max_int,
+            /* max_event_number */ 0,
+            pool.get_immediate().unwrap(),
+            subs_bufs,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn priming_report_context_is_report_due_and_keeps_sub() {
+        // A subscription returned from `add` is the "priming" report: it must be
+        // report-due regardless of time (so the initial report is delivered
+        // unconditionally) and, when dropped with `set_keep`, must survive in
+        // the subscription table for subsequent incremental reports.
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 60);
+            assert!(rctx.should_send_if_empty());
+            assert_eq!(rctx.max_seen_event_number(), 0);
+            rctx.set_keep();
+        }
+
+        // After priming, a zero-delta report at the same instant finds nothing
+        // pending (no attr changes, no new events, min_int not elapsed).
+        assert!(subs.report(now, 0, &subs_bufs).is_none());
+    }
+
+    #[test]
+    fn report_without_keep_frees_the_slot() {
+        // Dropping a `ReportContext` *without* `set_keep` must remove the
+        // subscription from the table (and free its buffer), so a new
+        // subscription can take its place up to the `N` capacity.
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+
+        // Add then drop without keep.
+        drop(add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 60));
+
+        // The slot is free again: a second add succeeds even with N=1.
+        let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 11, 1, 60);
+        // IDs are still strictly monotonic across add/remove cycles.
+        assert_eq!(rctx.subscription().ids().id, 2);
+        rctx.set_keep();
+    }
+
+    #[test]
+    fn report_with_keep_advances_reported_at_and_watermark() {
+        // After a "kept" report, the subscription must not be picked up again
+        // at the same instant unless new changes arrive.
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+
+        // Prime and keep.
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 60);
+            rctx.set_keep();
+        }
+
+        // Record one attribute change — watermark advances to 1.
+        subs.notify_attribute_changed(1, 2, 3);
+
+        // At the same instant, min_int (1s) has NOT elapsed so the sub is not
+        // report-allowed: even though there is a pending change, `report()`
+        // returns None.
+        assert!(subs.report(now, 0, &subs_bufs).is_none());
+
+        // Past min_int: the pending change makes the sub reportable.
+        let later = now + Duration::from_secs(2);
+        {
+            let mut rctx = subs.report(later, 0, &subs_bufs).unwrap();
+            assert!(rctx.should_report_attr(1, 2, 3));
+            // A fresh (never recorded) triple is NOT in the table and must
+            // not be spuriously reported.
+            assert!(!rctx.should_report_attr(9, 9, 9));
+            rctx.set_keep();
+        }
+
+        // Watermark has been committed — another call at `later` with no new
+        // activity finds nothing.
+        assert!(subs.report(later, 0, &subs_bufs).is_none());
+    }
+
+    #[test]
+    fn report_triggered_by_new_events() {
+        // A bump in `max_event_number` (i.e. a newly emitted event) makes the
+        // subscription reportable even without attribute changes.
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 60);
+            rctx.set_keep();
+        }
+
+        // Same instant, no new events (max_event_number = 0 same as sub's
+        // max_seen), min_int not elapsed → nothing to report.
+        assert!(subs.report(now, 0, &subs_bufs).is_none());
+
+        let later = now + Duration::from_secs(2);
+
+        // Still no new events at `later` (min_int elapsed though).
+        assert!(subs.report(later, 0, &subs_bufs).is_none());
+
+        // A new event bumps max_event_number → sub is reportable.
+        {
+            let mut rctx = subs.report(later, 5, &subs_bufs).unwrap();
+            assert_eq!(rctx.max_seen_event_number(), 0);
+            rctx.update_max_seen_event_number(5);
+            assert_eq!(rctx.max_seen_event_number(), 5);
+            rctx.set_keep();
+        }
+
+        // After reporting, max_event_number=5 is no longer "new" for this sub.
+        assert!(subs.report(later, 5, &subs_bufs).is_none());
+        // But a further bump does trigger again (past min_int is needed).
+        let even_later = later + Duration::from_secs(2);
+        {
+            let mut rctx = subs.report(even_later, 6, &subs_bufs).unwrap();
+            rctx.set_keep();
+        }
+    }
+
+    #[test]
+    fn report_triggered_by_liveness_deadline() {
+        // With no changes at all, a subscription still becomes reportable once
+        // it enters the "liveness" window (within half of `max_int` of the
+        // deadline).
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+        // max_int = 20s → half of max_int = 10s → becomes report-due at now+10s.
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 20);
+            rctx.set_keep();
+        }
+
+        // Short of the liveness window: not due.
+        let short = now + Duration::from_secs(5);
+        assert!(subs.report(short, 0, &subs_bufs).is_none());
+
+        // At the liveness window: due even without any attr/event change.
+        let long = now + Duration::from_secs(11);
+        {
+            let mut rctx = subs.report(long, 0, &subs_bufs).unwrap();
+            assert!(rctx.should_send_if_empty());
+            rctx.set_keep();
+        }
+    }
+
+    #[test]
+    fn is_expired_uses_max_int() {
+        // `Subscription::is_expired` returns true once `max_int` has elapsed
+        // since the last reported_at.
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let base = Instant::now();
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, base, 1, 10, 1, 5);
+            rctx.set_keep();
+        }
+
+        // Before max_int: not expired. Use the `remove` predicate as a probe
+        // because we have no other way to observe per-sub `is_expired` through
+        // the public API.
+        let before = base + Duration::from_secs(2);
+        assert!(!subs.remove(&subs_bufs, |sub| sub
+            .is_expired(before)
+            .then_some("expired")));
+
+        // Past max_int: expired — removal fires.
+        let after = base + Duration::from_secs(10);
+        assert!(subs.remove(&subs_bufs, |sub| sub.is_expired(after).then_some("expired")));
+    }
+
+    #[test]
+    fn remove_invokes_predicate_and_frees_slots() {
+        // `Subscriptions::remove` drains every matching entry (not just one),
+        // returns whether anything was removed, and frees the slots so that
+        // subsequent `add` calls succeed up to the capacity `N`.
+        let subs: Subscriptions<3> = Subscriptions::new();
+        let pool = TestPool::<4>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<4>, 3> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+        for peer in [100_u64, 101, 102] {
+            let fab_idx = if peer == 102 { 2 } else { 1 };
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, fab_idx, peer, 1, 60);
+            rctx.set_keep();
+        }
+        // Table is full: a 4th add must be rejected.
+        assert!(subs
+            .add(
+                now,
+                fab(1),
+                200,
+                0,
+                1,
+                60,
+                0,
+                pool.get_immediate().unwrap(),
+                &subs_bufs
+            )
+            .is_none());
+
+        // Remove every fab(1) subscription (2 of them).
+        let mut seen_peers: std::vec::Vec<u64> = std::vec::Vec::new();
+        let removed = subs.remove(&subs_bufs, |sub| {
+            if sub.ids().fab_idx == fab(1) {
+                seen_peers.push(sub.ids().peer_node_id);
+                Some("fabric 1 removed")
+            } else {
+                None
+            }
+        });
+        assert!(removed);
+        seen_peers.sort();
+        assert_eq!(seen_peers, std::vec![100_u64, 101]);
+
+        // A second identical remove is a no-op and returns false.
+        assert!(!subs.remove(&subs_bufs, |sub| (sub.ids().fab_idx == fab(1))
+            .then_some("fabric 1 removed")));
+
+        // Two slots were freed: we can add two more subs.
+        {
+            let mut r1 = add_sub(&subs, &subs_bufs, &pool, now, 3, 300, 1, 60);
+            r1.set_keep();
+            let mut r2 = add_sub(&subs, &subs_bufs, &pool, now, 3, 301, 1, 60);
+            r2.set_keep();
+        }
+        // And a third add is rejected again (back at capacity).
+        assert!(subs
+            .add(
+                now,
+                fab(3),
+                302,
+                0,
+                1,
+                60,
+                0,
+                pool.get_immediate().unwrap(),
+                &subs_bufs
+            )
+            .is_none());
+    }
+
+    #[test]
+    fn remove_on_empty_table_returns_false() {
+        let subs: Subscriptions<2> = Subscriptions::new();
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 2> = SubscriptionsBuffers::new();
+        assert!(!subs.remove(&subs_bufs, |_| Some("never called on empty")));
+    }
+
+    #[test]
+    fn purge_reported_changes_keeps_entries_until_all_subs_catch_up() {
+        // `purge_reported_changes` must only drop table entries every
+        // subscription has already reported on: the slowest subscriber's
+        // `max_seen_attr_change_id` acts as a floor.
+        let subs: Subscriptions<2> = Subscriptions::new();
+        let pool = TestPool::<3>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<3>, 2> = SubscriptionsBuffers::new();
+
+        let base = Instant::now();
+
+        // Two priming adds. Both start at watermark = 0 (no changes yet).
+        // `ReportContext::next_max_seen_attr_change_id` is captured as 0 by
+        // `add`, so dropping either rctx with keep commits max_seen = 0.
+        {
+            let mut r1 = add_sub(&subs, &subs_bufs, &pool, base, 1, 100, 1, 60);
+            r1.set_keep();
+            let mut r2 = add_sub(&subs, &subs_bufs, &pool, base, 1, 101, 1, 60);
+            r2.set_keep();
+        }
+
+        // Record two changes. Watermark becomes 2.
+        subs.notify_attribute_changed(1, 2, 3); // id 1
+        subs.notify_attribute_changed(1, 2, 4); // id 2
+
+        // Advance both subs to watermark 2 via two `report` + keep cycles.
+        let later = base + Duration::from_secs(2);
+        for _ in 0..2 {
+            let mut rctx = subs.report(later, 0, &subs_bufs).unwrap();
+            assert!(rctx.should_report_attr(1, 2, 3));
+            assert!(rctx.should_report_attr(1, 2, 4));
+            rctx.set_keep();
+        }
+
+        // Both subs have max_seen = 2; purge is safe and removes the stale
+        // entries. The next report should now find nothing pending (same
+        // instant, no new changes, min_int elapsed but not half of max_int).
+        subs.purge_reported_changes();
+        assert!(subs.report(later, 0, &subs_bufs).is_none());
+
+        // A brand new change becomes pending again post-purge.
+        subs.notify_attribute_changed(5, 6, 7);
+        let even_later = later + Duration::from_secs(2);
+        {
+            let mut rctx = subs.report(even_later, 0, &subs_bufs).unwrap();
+            assert!(rctx.should_report_attr(5, 6, 7));
+            // Previously-purged entries are no longer visible through the
+            // sub's filter either.
+            assert!(!rctx.should_report_attr(1, 2, 3));
+            rctx.set_keep();
+        }
+    }
+
+    #[test]
+    fn update_max_seen_event_number_is_monotonic() {
+        // The setter advances the watermark but panics on regression
+        // (asserted in `update_max_seen_event_number`). We only exercise the
+        // monotonic-advance path here to avoid a deliberate panic in tests.
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+        let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 60);
+        assert_eq!(rctx.max_seen_event_number(), 0);
+        rctx.update_max_seen_event_number(3);
+        assert_eq!(rctx.max_seen_event_number(), 3);
+        rctx.update_max_seen_event_number(3); // equal is allowed
+        assert_eq!(rctx.max_seen_event_number(), 3);
+        rctx.update_max_seen_event_number(42);
+        assert_eq!(rctx.max_seen_event_number(), 42);
+    }
+}

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -732,9 +732,9 @@ impl ChangedAttrs {
     /// Returns the newly assigned change ID.
     fn record_wildcard(&mut self, endpoint: Option<EndptId>, cluster: Option<ClusterId>) -> u64 {
         self.record_raw(ChangedAttr {
-            endpoint,
-            cluster,
-            attr: None,
+            endpoint: endpoint.unwrap_or(WILDCARD_ENDPOINT),
+            cluster: cluster.unwrap_or(WILDCARD_CLUSTER),
+            attr: WILDCARD_ATTR,
             change_id: 0,
         })
     }
@@ -842,9 +842,9 @@ impl ChangedAttrs {
                 self.entries.clear();
 
                 unwrap!(self.entries.push(ChangedAttr {
-                    endpoint: None,
-                    cluster: None,
-                    attr: None,
+                    endpoint: WILDCARD_ENDPOINT,
+                    cluster: WILDCARD_CLUSTER,
+                    attr: WILDCARD_ATTR,
                     change_id: new.change_id,
                 }));
 
@@ -902,76 +902,144 @@ impl ChangedAttrs {
     }
 }
 
+/// Sentinel value for "any endpoint" inside a [`ChangedAttr`] entry.
+///
+/// Matter endpoint ids are `u16`; the Matter Core Specification caps practical
+/// endpoint numbering well below `0xFFFF`, and the CHIP reference SDK
+/// (`kInvalidEndpointId` in `src/lib/core/DataModelTypes.h`) adopts the same
+/// convention, so we can repurpose `u16::MAX` as an internal "wildcard" marker.
+const WILDCARD_ENDPOINT: EndptId = EndptId::MAX;
+
+/// Sentinel value for "any cluster" inside a [`ChangedAttr`] entry.
+///
+/// Matter cluster ids are Manufacturer Extensible Identifiers (MEIs, Core Spec
+/// §7.18.2): `(vendor_prefix << 16) | suffix` with `0xFFFF` reserved as an
+/// invalid vendor prefix. `0xFFFF_FFFF` therefore cannot be a legitimate
+/// cluster id and is safe to use as an internal "wildcard" marker. The CHIP
+/// reference SDK uses the same value as `kInvalidClusterId`.
+const WILDCARD_CLUSTER: ClusterId = ClusterId::MAX;
+
+/// Sentinel value for "any attribute" inside a [`ChangedAttr`] entry.
+///
+/// Same MEI argument as [`WILDCARD_CLUSTER`]: `0xFFFF_FFFF` cannot be a
+/// legitimate attribute id and matches CHIP's `kInvalidAttributeId`.
+const WILDCARD_ATTR: AttrId = AttrId::MAX;
+
 /// A record of one recently changed attribute.
 ///
-/// A `None` field acts as a wildcard. Wildcards appear only as a result of
-/// "promotion" when the `changed_attrs` table becomes full and several
-/// concrete entries need to be coalesced into a coarser one.
+/// A field holding its corresponding `WILDCARD_*` sentinel acts as a wildcard
+/// on that axis. Wildcards appear only as a result of "promotion" when the
+/// `changed_attrs` table becomes full and several concrete entries need to be
+/// coalesced into a coarser one.
+///
+/// Rust is free to reorder these fields under the default `repr(Rust)`, and
+/// it does so to minimize size: on 64-bit targets `size_of::<ChangedAttr>()`
+/// is 24 bytes (the `u64` change_id forces 8-byte alignment; the rest packs
+/// into the remaining 16 bytes). The previous `Option<u16> / Option<u32> /
+/// Option<u32>` encoding took 32 bytes per entry because `u16` / `u32` have
+/// no niche for `Option`. See `changed_attr_size_is_compact`.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct ChangedAttr {
-    endpoint: Option<EndptId>,
-    cluster: Option<ClusterId>,
-    attr: Option<AttrId>,
+    endpoint: EndptId,
+    cluster: ClusterId,
+    attr: AttrId,
     change_id: u64,
 }
 
 impl ChangedAttr {
     const fn concrete(endpoint: EndptId, cluster: ClusterId, attr: AttrId, change_id: u64) -> Self {
         Self {
-            endpoint: Some(endpoint),
-            cluster: Some(cluster),
-            attr: Some(attr),
+            endpoint,
+            cluster,
+            attr,
             change_id,
         }
+    }
+
+    #[inline]
+    const fn is_endpoint_wildcard(&self) -> bool {
+        self.endpoint == WILDCARD_ENDPOINT
+    }
+
+    #[inline]
+    const fn is_cluster_wildcard(&self) -> bool {
+        self.cluster == WILDCARD_CLUSTER
+    }
+
+    #[inline]
+    const fn is_attr_wildcard(&self) -> bool {
+        self.attr == WILDCARD_ATTR
     }
 
     /// Whether this record covers the concrete attribute triple
     /// `(endpoint, cluster, attr)`.
     fn matches(&self, endpoint: EndptId, cluster: ClusterId, attr: AttrId) -> bool {
-        self.endpoint.map(|x| x == endpoint).unwrap_or(true)
-            && self.cluster.map(|x| x == cluster).unwrap_or(true)
-            && self.attr.map(|x| x == attr).unwrap_or(true)
+        (self.is_endpoint_wildcard() || self.endpoint == endpoint)
+            && (self.is_cluster_wildcard() || self.cluster == cluster)
+            && (self.is_attr_wildcard() || self.attr == attr)
     }
 
     /// Whether `other` is semantically covered by `self` (i.e. `self` is as
     /// coarse as or coarser than `other` on every axis).
     fn covers(&self, other: &ChangedAttr) -> bool {
-        fn cov<T: Eq>(a: Option<T>, b: Option<T>) -> bool {
-            match (a, b) {
-                (None, _) => true,        // self wildcard covers anything
-                (Some(_), None) => false, // concrete doesn't cover wildcard
-                (Some(a), Some(b)) => a == b,
+        #[inline]
+        fn cov<T: Eq>(a: T, a_wild: bool, b: T, b_wild: bool) -> bool {
+            if a_wild {
+                true // self wildcard covers anything
+            } else if b_wild {
+                false // concrete doesn't cover wildcard
+            } else {
+                a == b
             }
         }
-        cov(self.endpoint, other.endpoint)
-            && cov(self.cluster, other.cluster)
-            && cov(self.attr, other.attr)
+        cov(
+            self.endpoint,
+            self.is_endpoint_wildcard(),
+            other.endpoint,
+            other.is_endpoint_wildcard(),
+        ) && cov(
+            self.cluster,
+            self.is_cluster_wildcard(),
+            other.cluster,
+            other.is_cluster_wildcard(),
+        ) && cov(
+            self.attr,
+            self.is_attr_wildcard(),
+            other.attr,
+            other.is_attr_wildcard(),
+        )
     }
 
     /// Build the coarsened wildcard entry representing `pivot`'s group at the
     /// given level. Returns `None` if `pivot` cannot be promoted at that level
     /// (e.g. its endpoint is already a wildcard for level 1 or 2).
     fn coarsen(&self, level: u8) -> Option<Self> {
-        let (endpoint, cluster) = match level {
-            1 => (self.endpoint?, self.cluster?),
-            2 => {
-                return Some(Self {
-                    endpoint: Some(self.endpoint?),
-                    cluster: None,
-                    attr: None,
+        match level {
+            1 => {
+                if self.is_endpoint_wildcard() || self.is_cluster_wildcard() {
+                    return None;
+                }
+                Some(Self {
                     change_id: 0,
+                    cluster: self.cluster,
+                    attr: WILDCARD_ATTR,
+                    endpoint: self.endpoint,
+                })
+            }
+            2 => {
+                if self.is_endpoint_wildcard() {
+                    return None;
+                }
+                Some(Self {
+                    change_id: 0,
+                    cluster: WILDCARD_CLUSTER,
+                    attr: WILDCARD_ATTR,
+                    endpoint: self.endpoint,
                 })
             }
             _ => unreachable!(),
-        };
-
-        Some(Self {
-            endpoint: Some(endpoint),
-            cluster: Some(cluster),
-            attr: None,
-            change_id: 0,
-        })
+        }
     }
 }
 
@@ -1170,7 +1238,7 @@ mod tests {
         assert!(attrs
             .entries
             .iter()
-            .any(|e| e.endpoint == Some(1) && e.cluster == Some(2) && e.attr.is_none()));
+            .any(|e| e.endpoint == 1 && e.cluster == 2 && e.is_attr_wildcard()));
         assert!(attrs.contains_since(1, 3, 20, 0));
     }
 
@@ -1295,14 +1363,14 @@ mod tests {
         let wild_11 = attrs
             .entries
             .iter()
-            .filter(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_none())
+            .filter(|e| e.endpoint == 1 && e.cluster == 1 && e.is_attr_wildcard())
             .count();
         assert_eq!(wild_11, 1);
         // No concrete (1, 1, _) entries survived.
         let concrete_11 = attrs
             .entries
             .iter()
-            .filter(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_some())
+            .filter(|e| e.endpoint == 1 && e.cluster == 1 && !e.is_attr_wildcard())
             .count();
         assert_eq!(concrete_11, 0);
         // Singletons on (1, k, 0) for k=2..=6 remain concrete.
@@ -1310,9 +1378,7 @@ mod tests {
             let n = attrs
                 .entries
                 .iter()
-                .filter(|e| {
-                    e.endpoint == Some(1) && e.cluster == Some(cluster) && e.attr == Some(0)
-                })
+                .filter(|e| e.endpoint == 1 && e.cluster == cluster && e.attr == 0)
                 .count();
             assert_eq!(n, 1, "singleton (1, {}, 0) should remain concrete", cluster);
         }
@@ -1320,7 +1386,7 @@ mod tests {
         assert!(attrs
             .entries
             .iter()
-            .any(|e| e.endpoint == Some(2) && e.cluster == Some(2) && e.attr == Some(2)));
+            .any(|e| e.endpoint == 2 && e.cluster == 2 && e.attr == 2));
 
         // All original triples still report as changed.
         for attr in 0..10u32 {
@@ -1355,11 +1421,11 @@ mod tests {
         let a_wild = attrs
             .entries
             .iter()
-            .any(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_none());
+            .any(|e| e.endpoint == 1 && e.cluster == 1 && e.is_attr_wildcard());
         let b_wild = attrs
             .entries
             .iter()
-            .any(|e| e.endpoint == Some(2) && e.cluster == Some(2) && e.attr.is_none());
+            .any(|e| e.endpoint == 2 && e.cluster == 2 && e.is_attr_wildcard());
         assert!(
             a_wild ^ b_wild,
             "expected exactly one of the groups to be collapsed (A: {}, B: {})",
@@ -1370,12 +1436,12 @@ mod tests {
         let a_concrete = attrs
             .entries
             .iter()
-            .filter(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_some())
+            .filter(|e| e.endpoint == 1 && e.cluster == 1 && !e.is_attr_wildcard())
             .count();
         let b_concrete = attrs
             .entries
             .iter()
-            .filter(|e| e.endpoint == Some(2) && e.cluster == Some(2) && e.attr.is_some())
+            .filter(|e| e.endpoint == 2 && e.cluster == 2 && !e.is_attr_wildcard())
             .count();
         assert!(
             (a_wild && a_concrete == 0 && b_concrete == 8)
@@ -1403,24 +1469,26 @@ mod tests {
         let lvl1_wild = attrs
             .entries
             .iter()
-            .filter(|e| e.endpoint.is_some() && e.cluster.is_some() && e.attr.is_none())
+            .filter(|e| {
+                !e.is_endpoint_wildcard() && !e.is_cluster_wildcard() && e.is_attr_wildcard()
+            })
             .count();
         assert_eq!(lvl1_wild, 0);
         // Exactly one level-2 wildcard on endpoint 1 or 2 was produced.
         let ep1_wild = attrs
             .entries
             .iter()
-            .any(|e| e.endpoint == Some(1) && e.cluster.is_none() && e.attr.is_none());
+            .any(|e| e.endpoint == 1 && e.is_cluster_wildcard() && e.is_attr_wildcard());
         let ep2_wild = attrs
             .entries
             .iter()
-            .any(|e| e.endpoint == Some(2) && e.cluster.is_none() && e.attr.is_none());
+            .any(|e| e.endpoint == 2 && e.is_cluster_wildcard() && e.is_attr_wildcard());
         assert!(ep1_wild ^ ep2_wild);
         // No global wildcard was produced either.
         assert!(!attrs
             .entries
             .iter()
-            .any(|e| e.endpoint.is_none() && e.cluster.is_none() && e.attr.is_none()));
+            .any(|e| e.is_endpoint_wildcard() && e.is_cluster_wildcard() && e.is_attr_wildcard()));
 
         // All originals still visible.
         for cluster in 0..8u32 {
@@ -1444,7 +1512,9 @@ mod tests {
         attrs.record(100, 200, 300);
         assert_eq!(attrs.entries.len(), 1);
         let only = &attrs.entries[0];
-        assert!(only.endpoint.is_none() && only.cluster.is_none() && only.attr.is_none());
+        assert!(
+            only.is_endpoint_wildcard() && only.is_cluster_wildcard() && only.is_attr_wildcard()
+        );
 
         // Every previously-recorded triple is still covered.
         for i in 0..MAX_CHANGED_ATTRS as u16 {
@@ -1467,7 +1537,7 @@ mod tests {
         let wild = attrs
             .entries
             .iter()
-            .find(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_none())
+            .find(|e| e.endpoint == 1 && e.cluster == 1 && e.is_attr_wildcard())
             .expect("(1, 1, *) wildcard was produced");
         assert_eq!(wild.change_id, max_before);
 
@@ -1498,7 +1568,7 @@ mod tests {
         let wild = attrs
             .entries
             .iter()
-            .find(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_none())
+            .find(|e| e.endpoint == 1 && e.cluster == 1 && e.is_attr_wildcard())
             .unwrap();
         assert_eq!(wild.change_id, new_id);
     }
@@ -1569,7 +1639,7 @@ mod tests {
         assert!(attrs
             .entries
             .iter()
-            .any(|e| e.endpoint == Some(1) && e.cluster == Some(1) && e.attr.is_none()));
+            .any(|e| e.endpoint == 1 && e.cluster == 1 && e.is_attr_wildcard()));
 
         // Keep feeding: eventually we must fall back to level-2 or global
         // without breaking correctness.
@@ -1591,21 +1661,21 @@ mod tests {
     fn changed_attr_covers_wildcards() {
         let concrete = ChangedAttr::concrete(1, 2, 3, 1);
         let any_attr = ChangedAttr {
-            endpoint: Some(1),
-            cluster: Some(2),
-            attr: None,
+            endpoint: 1,
+            cluster: 2,
+            attr: WILDCARD_ATTR,
             change_id: 1,
         };
         let any_cluster = ChangedAttr {
-            endpoint: Some(1),
-            cluster: None,
-            attr: None,
+            endpoint: 1,
+            cluster: WILDCARD_CLUSTER,
+            attr: WILDCARD_ATTR,
             change_id: 1,
         };
         let global = ChangedAttr {
-            endpoint: None,
-            cluster: None,
-            attr: None,
+            endpoint: WILDCARD_ENDPOINT,
+            cluster: WILDCARD_CLUSTER,
+            attr: WILDCARD_ATTR,
             change_id: 1,
         };
 
@@ -1622,6 +1692,16 @@ mod tests {
         assert!(any_attr.matches(1, 2, 99));
         assert!(!any_attr.matches(1, 9, 99));
         assert!(global.matches(99, 99, 99));
+    }
+
+    #[test]
+    fn changed_attr_size_is_compact() {
+        // `ChangedAttr` must stay at 24 bytes on 64-bit targets: `u64` change_id
+        // forces 8-byte alignment, and the `(u32, u32, u16)` path tuple fits in
+        // the remaining 16 bytes (4 + 4 + 2 + 6 padding). Regressing back to an
+        // `Option<u16> / Option<u32> / Option<u32>` encoding would bump this to
+        // 32 bytes per entry, i.e. +128 bytes per `Subscriptions` table.
+        assert_eq!(core::mem::size_of::<ChangedAttr>(), 24);
     }
 
     // ---------- Subscriptions ----------

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -224,19 +224,6 @@ impl<const N: usize> Subscriptions<N> {
     where
         B: BufferAccess<IMBuffer> + 'a,
     {
-        // REVIEW: `next_max_seen_attr_change_id` is hard-coded to `0` here,
-        // but the matching path in `report()` uses `changed_attrs.watermark()`.
-        // For `add()` the value doesn't actually matter (the subscription is
-        // freshly constructed below with `max_seen_attr_change_id =
-        // changed_attrs.watermark()`, and `set_complete()` is what ultimately
-        // writes this field back via `report_complete`), but the asymmetry is
-        // confusing and means `set_complete()` called from the *priming*
-        // report path will overwrite `max_seen_attr_change_id` with 0,
-        // effectively resetting the subscription's `since` watermark to 0 on
-        // its very first commit.  Changes that occurred *during* the priming
-        // report will then be re-emitted in the next incremental report, but
-        // changes that happened between `add()` and the start of priming will
-        // be replayed twice.
         let (sub, buf, next_max_seen_attr_change_id) = self.with(buffers, |state, buffers| {
             let (sub, buf) = state.add::<B>(
                 fabric_idx,
@@ -411,7 +398,7 @@ struct SubscriptionsInner<const N: usize> {
     next_subscription_id: u32,
     subscriptions_count: usize,
     subscriptions: Vec<Subscription, N>,
-    changed_attrs: ChangedAttributes,
+    changed_attrs: ChangedAttrs,
 }
 
 impl<const N: usize> SubscriptionsInner<N> {
@@ -422,7 +409,7 @@ impl<const N: usize> SubscriptionsInner<N> {
             next_subscription_id: 1,
             subscriptions_count: 0,
             subscriptions: Vec::new(),
-            changed_attrs: ChangedAttributes::new(),
+            changed_attrs: ChangedAttrs::new(),
         }
     }
 
@@ -432,7 +419,7 @@ impl<const N: usize> SubscriptionsInner<N> {
             next_subscription_id: 1,
             subscriptions_count: 0,
             subscriptions <- Vec::init(),
-            changed_attrs <- ChangedAttributes::init(),
+            changed_attrs <- ChangedAttrs::init(),
         })
     }
 
@@ -645,7 +632,7 @@ impl Subscription {
         &self,
         now: Instant,
         rx: &[u8],
-        changed_attrs: &ChangedAttributes,
+        changed_attrs: &ChangedAttrs,
         max_event_number: EventNumber,
     ) -> bool {
         if self.is_expired(now) || !self.is_report_allowed(now) {
@@ -675,7 +662,7 @@ impl Subscription {
             .unwrap_or(true)
     }
 
-    fn is_affected_by_attr_changes(&self, _rx: &[u8], changes: &ChangedAttributes) -> bool {
+    fn is_affected_by_attr_changes(&self, _rx: &[u8], changes: &ChangedAttrs) -> bool {
         changes.any_since(self.max_seen_attr_change_id)
     }
 
@@ -699,7 +686,7 @@ impl Subscription {
 /// affected subscriptions to emit a slightly wider set of attributes on their
 /// next report, but this is a bounded loss of precision that preserves
 /// correctness.
-pub(crate) struct ChangedAttributes {
+pub(crate) struct ChangedAttrs {
     /// Monotonically increasing ID assigned to every recorded change.
     /// The first assigned ID is 1; `0` is reserved as the "no change seen yet"
     /// sentinel used by fresh subscriptions.
@@ -709,7 +696,7 @@ pub(crate) struct ChangedAttributes {
     entries: Vec<ChangedAttr, MAX_CHANGED_ATTRS>,
 }
 
-impl ChangedAttributes {
+impl ChangedAttrs {
     /// Create the instance.
     #[inline(always)]
     const fn new() -> Self {
@@ -1087,7 +1074,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_starts_empty() {
-        let attrs = ChangedAttributes::new();
+        let attrs = ChangedAttrs::new();
         assert_eq!(attrs.watermark(), 0);
         assert!(!attrs.any_since(0));
         assert!(!attrs.contains_since(1, 2, 3, 0));
@@ -1095,7 +1082,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_record_assigns_monotonic_ids() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         let id1 = attrs.record(1, 2, 3);
         let id2 = attrs.record(1, 2, 4);
         let id3 = attrs.record(2, 2, 3);
@@ -1107,7 +1094,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_contains_since_and_any_since() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         attrs.record(1, 2, 3);
         attrs.record(1, 2, 4);
 
@@ -1125,7 +1112,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_duplicate_refreshes_change_id() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         attrs.record(1, 2, 3);
         attrs.record(1, 2, 4);
         // Same triple as first record - should refresh, not add a new entry.
@@ -1141,7 +1128,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_record_wildcard_cluster_covers_every_attr() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         let id = attrs.record_wildcard(Some(7), Some(42));
 
         // Any concrete attribute on that (endpoint, cluster) is now covered.
@@ -1156,7 +1143,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_record_wildcard_endpoint_covers_every_cluster() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         attrs.record_wildcard(Some(5), None);
 
         assert!(attrs.contains_since(5, 1, 1, 0));
@@ -1166,7 +1153,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_record_wildcard_absorbs_existing_concrete_entries() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         // Seed three concrete attrs on (1, 2).
         attrs.record(1, 2, 10);
         attrs.record(1, 2, 11);
@@ -1189,7 +1176,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_record_wildcard_is_refreshed_when_already_covered() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         // Endpoint-wide wildcard covers any cluster on that endpoint.
         attrs.record_wildcard(Some(1), None);
         let before_len = attrs.entries.len();
@@ -1204,7 +1191,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_purge_up_to_removes_old_entries() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         attrs.record(1, 2, 3); // id 1
         attrs.record(1, 2, 4); // id 2
         attrs.record(2, 2, 3); // id 3
@@ -1222,7 +1209,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_clear_empties_table_but_keeps_watermark() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         attrs.record(1, 2, 3);
         attrs.record(1, 2, 4);
         let wm_before = attrs.watermark();
@@ -1236,7 +1223,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_promotion_on_overflow_same_cluster() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         // Fill the table with distinct concrete entries on the same (endpoint, cluster).
         for attr in 0..MAX_CHANGED_ATTRS as u32 {
             attrs.record(1, 2, attr);
@@ -1267,7 +1254,7 @@ mod tests {
 
     #[test]
     fn changed_attrs_promotion_to_global_wildcard() {
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         // Entries spread across many endpoints/clusters/attrs to force promotion
         // past the (endpoint, cluster, *) and (endpoint, *, *) levels.
         for i in 0..(MAX_CHANGED_ATTRS as u16 + 5) {
@@ -1289,7 +1276,7 @@ mod tests {
         // (= 15 entries total). One extra record fills the table, then an
         // overflowing record forces exactly ONE level-1 promotion which must
         // collapse the big (1, 1, *) group while leaving singletons concrete.
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         for attr in 0..10u32 {
             attrs.record(1, 1, attr);
         }
@@ -1350,7 +1337,7 @@ mod tests {
     fn promotion_is_minimal_only_one_group_collapsed_per_overflow() {
         // Two big level-1 groups of equal size. A single overflow must collapse
         // only ONE of them, not both (minimal promotion).
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         // Group A: (1, 1, 0..8) = 8 entries
         for attr in 0..8u32 {
             attrs.record(1, 1, attr);
@@ -1400,7 +1387,7 @@ mod tests {
     fn promotion_falls_back_to_level_2_when_no_level_1_group() {
         // All (endpoint, cluster) pairs are unique (level-1 groups are all
         // singletons) but endpoints repeat, so level-2 groups are non-trivial.
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         for cluster in 0..8u32 {
             attrs.record(1, cluster, 0);
         }
@@ -1448,7 +1435,7 @@ mod tests {
         // All-distinct endpoints AND (endpoint, cluster) pairs: no level-1 or
         // level-2 group has >=2 entries. Overflow must collapse everything to
         // a single global wildcard.
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         for i in 0..MAX_CHANGED_ATTRS as u16 {
             attrs.record(i, i as u32, i as u32);
         }
@@ -1470,7 +1457,7 @@ mod tests {
     fn promotion_preserves_max_change_id_in_coarsened_entry() {
         // After collapsing a (1, 1, *) group, the resulting wildcard's
         // change_id must equal the max change_id of the collapsed entries.
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         for attr in 0..MAX_CHANGED_ATTRS as u32 {
             attrs.record(1, 1, attr);
         }
@@ -1494,7 +1481,7 @@ mod tests {
         // Build a state where (1, 1, *) wildcard already exists via a forced
         // promotion. Recording another (1, 1, k) must refresh that wildcard's
         // change_id without producing any new entry.
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         for attr in 0..MAX_CHANGED_ATTRS as u32 {
             attrs.record(1, 1, attr);
         }
@@ -1521,7 +1508,7 @@ mod tests {
         // Sustained mixed churn must never let the table exceed its capacity,
         // and every freshly-recorded triple must remain visible immediately
         // after recording.
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         for i in 0..1000u32 {
             let endpoint = (i % 7) as u16;
             let cluster = i % 13;
@@ -1544,7 +1531,7 @@ mod tests {
     fn promotion_iterated_into_same_existing_wildcard() {
         // Once (1, 1, *) exists, repeated inserts on that group must never
         // grow the table, and never trigger further promotion.
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         for attr in 0..MAX_CHANGED_ATTRS as u32 {
             attrs.record(1, 1, attr);
         }
@@ -1564,7 +1551,7 @@ mod tests {
         // (freeing 1 slot), but the table is still full once the new record
         // tries to be inserted on a fresh singleton location. Subsequent
         // overflows must escalate to level-2 / global.
-        let mut attrs = ChangedAttributes::new();
+        let mut attrs = ChangedAttrs::new();
         // 2 entries sharing (1, 1, *) -- a single level-1 group of size 2.
         attrs.record(1, 1, 0);
         attrs.record(1, 1, 1);

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -254,17 +254,18 @@ impl<const N: usize> Subscriptions<N> {
         })
     }
 
-    // REVIEW: a subscription that is currently being reported on has been
-    // `swap_remove`d from `state.subscriptions` (see `SubscriptionsInner::report`)
-    // and only lives inside its `ReportContext`. `remove` scans
-    // `state.subscriptions` only, so an in-flight subscription is *invisible*
-    // to `remove` and will silently survive any removal request (e.g. a
-    // `keep_subs=false` Subscribe handled by another task, or a session
-    // removal). It is put back verbatim by `Drop` via `report_complete`.
-    // This is a correctness regression vs. the pre-refactor code and probably
-    // deserves either a "pending removal" flag on `ReportContext` or holding
-    // the subscription in place during reporting (e.g. with a `reporting`
-    // marker) so `remove` can still act on it.
+    /// Remove every subscription for which `f` returns `Some(reason)`.
+    ///
+    /// A subscription that is currently being reported on has been moved out
+    /// of `state.subscriptions` into its `ReportContext` (see
+    /// [`SubscriptionsInner::report`]). To keep such an in-flight subscription
+    /// observable, [`SubscriptionsInner::report`] also leaves a clone of it in
+    /// `state.reporting`. If the predicate matches that clone, we flip
+    /// `state.reporting_cancelled` so that [`SubscriptionsInner::report_complete`]
+    /// drops the subscription on `Drop` of its `ReportContext` instead of
+    /// re-inserting it. The count invariant is preserved: either the Vec path
+    /// decrements `subscriptions_count` now, or `report_complete` does it
+    /// later — never both for the same subscription.
     pub(crate) fn remove<B, F>(&self, buffers: &SubscriptionsBuffers<'_, B, N>, mut f: F) -> bool
     where
         B: BufferAccess<IMBuffer>,
@@ -295,6 +296,25 @@ impl<const N: usize> Subscriptions<N> {
                 info!("Removed subscription {:?}, reason: {}", ids, reason);
 
                 removed = true;
+            }
+
+            // Consider the in-flight subscription (if any). It is not in
+            // `state.subscriptions`; only a snapshot clone lives in
+            // `state.reporting`. If the predicate matches and we have not
+            // already flagged it for cancellation, request that
+            // `report_complete` drop it.
+            if state.reporting_cancelled.is_none() {
+                if let Some(sub) = state.reporting.as_ref() {
+                    if let Some(reason) = f(sub) {
+                        info!(
+                            "Marked in-flight subscription {:?} for removal, reason: {}",
+                            sub.ids(),
+                            reason
+                        );
+                        state.reporting_cancelled = Some(reason);
+                        removed = true;
+                    }
+                }
             }
 
             removed
@@ -399,6 +419,19 @@ struct SubscriptionsInner<const N: usize> {
     subscriptions_count: usize,
     subscriptions: Vec<Subscription, N>,
     changed_attrs: ChangedAttrs,
+    /// Snapshot of the subscription currently being reported on (i.e. the
+    /// one that has been `swap_remove`d into a `ReportContext`). `None` when
+    /// no report is in flight. This is a frozen clone captured at `report()`
+    /// time; mutations made by `ReportContext` (e.g. to
+    /// `max_seen_event_number`) are NOT visible here. The slot exists so
+    /// that `Subscriptions::remove` can still observe and cancel an
+    /// in-flight subscription.
+    reporting: Option<Subscription>,
+    /// Set by `Subscriptions::remove` when its predicate matched
+    /// `reporting`. Consumed by `report_complete`, which then drops the
+    /// subscription (and decrements `subscriptions_count`) regardless of the
+    /// `keep` flag on the `ReportContext`.
+    reporting_cancelled: Option<&'static str>,
 }
 
 impl<const N: usize> SubscriptionsInner<N> {
@@ -410,6 +443,8 @@ impl<const N: usize> SubscriptionsInner<N> {
             subscriptions_count: 0,
             subscriptions: Vec::new(),
             changed_attrs: ChangedAttrs::new(),
+            reporting: None,
+            reporting_cancelled: None,
         }
     }
 
@@ -420,12 +455,19 @@ impl<const N: usize> SubscriptionsInner<N> {
             subscriptions_count: 0,
             subscriptions <- Vec::init(),
             changed_attrs <- ChangedAttrs::init(),
+            reporting: None,
+            reporting_cancelled: None,
         })
     }
 
     fn clear(&mut self) {
         self.subscriptions.clear();
         self.subscriptions_count = 0;
+        // If a report is in flight, make sure `report_complete` drops it
+        // rather than pushing it back into an otherwise-empty table.
+        if self.reporting.is_some() {
+            self.reporting_cancelled = Some("subscriptions cleared");
+        }
     }
 
     /// Add a subscription with the given parameters.
@@ -502,11 +544,22 @@ impl<const N: usize> SubscriptionsInner<N> {
     where
         B: BufferAccess<IMBuffer> + 'a,
     {
+        // `reporting` must be vacant: callers only start a new report after
+        // the previous `ReportContext` has been dropped (which clears the
+        // slot via `report_complete`).
+        debug_assert!(self.reporting.is_none());
+        debug_assert!(self.reporting_cancelled.is_none());
+
         if let Some(index) = self.find_reportable::<B>(now, max_event_number, buffers) {
             let sub = self.subscriptions.swap_remove(index);
             let buf = buffers.swap_remove(index);
 
             info!("About to report on subscription {:?}", sub.ids());
+
+            // Leave a snapshot clone behind so that `Subscriptions::remove`
+            // can still match and cancel this subscription while the report
+            // is in flight.
+            self.reporting = Some(sub.clone());
 
             Some((sub, buf))
         } else {
@@ -523,7 +576,18 @@ impl<const N: usize> SubscriptionsInner<N> {
     ) where
         B: BufferAccess<IMBuffer> + 'a,
     {
-        if keep {
+        // Always clear the reporting slot; it was populated in `report()`.
+        self.reporting = None;
+        let cancelled = self.reporting_cancelled.take();
+
+        if let Some(reason) = cancelled {
+            info!(
+                "In-flight subscription {:?} cancelled during reporting: {}",
+                sub.ids(),
+                reason
+            );
+            self.subscriptions_count -= 1;
+        } else if keep {
             unwrap!(self.subscriptions.push(sub));
             unwrap!(buffers.push(buffer).map_err(|_| ()));
         } else {
@@ -2111,6 +2175,98 @@ mod tests {
         let subs: Subscriptions<2> = Subscriptions::new();
         let subs_bufs: SubscriptionsBuffers<TestPool<2>, 2> = SubscriptionsBuffers::new();
         assert!(!subs.remove(&subs_bufs, |_| Some("never called on empty")));
+    }
+
+    #[test]
+    fn remove_cancels_in_flight_subscription() {
+        // A subscription that has been moved into a `ReportContext` is still
+        // observable to `remove` via `SubscriptionsInner::reporting`. Matching
+        // it must cause `report_complete` to drop the subscription on Drop
+        // rather than re-inserting it, even when `set_keep` was called.
+        let subs: Subscriptions<2> = Subscriptions::new();
+        let pool = TestPool::<3>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<3>, 2> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+
+        // Prime a subscription so it lives in the table.
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 100, 1, 60);
+            rctx.set_keep();
+        }
+        assert_eq!(subs.state.lock(|s| s.borrow().subscriptions_count), 1);
+
+        // Start an incremental report and, while it is "in flight", issue
+        // a `remove` that matches the in-flight subscription. Also flip
+        // `set_keep` to verify the cancel flag wins over `keep`.
+        subs.notify_attribute_changed(1, 2, 3);
+        let later = now + Duration::from_secs(2);
+        {
+            let mut rctx = subs.report(later, 0, &subs_bufs).unwrap();
+
+            // The in-flight sub is currently absent from `state.subscriptions`
+            // but must still be visible to `remove` through the `reporting`
+            // slot.
+            let mut matched_peers: std::vec::Vec<u64> = std::vec::Vec::new();
+            let removed = subs.remove(&subs_bufs, |sub| {
+                matched_peers.push(sub.ids().peer_node_id);
+                (sub.ids().peer_node_id == 100).then_some("test-cancel")
+            });
+            assert!(removed);
+            assert!(matched_peers.contains(&100));
+
+            // Even though we ask to keep, the cancel flag must force a drop.
+            rctx.set_keep();
+        }
+
+        // After `ReportContext::drop` the subscription must be gone and the
+        // slot freed.
+        subs.state.lock(|s| {
+            let s = s.borrow();
+            assert_eq!(s.subscriptions_count, 0);
+            assert!(s.subscriptions.is_empty());
+            assert!(s.reporting.is_none());
+            assert!(s.reporting_cancelled.is_none());
+        });
+
+        // Slot is free: a new sub can be added.
+        let mut r = add_sub(&subs, &subs_bufs, &pool, now, 1, 101, 1, 60);
+        r.set_keep();
+    }
+
+    #[test]
+    fn remove_not_matching_in_flight_leaves_it_intact() {
+        // If `remove`'s predicate matches neither the in-flight subscription
+        // nor anything in the table, the in-flight subscription must still
+        // be re-inserted on `ReportContext::drop` when `set_keep` is called.
+        let subs: Subscriptions<2> = Subscriptions::new();
+        let pool = TestPool::<3>::new(0);
+        let subs_bufs: SubscriptionsBuffers<TestPool<3>, 2> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 100, 1, 60);
+            rctx.set_keep();
+        }
+
+        subs.notify_attribute_changed(1, 2, 3);
+        let later = now + Duration::from_secs(2);
+        {
+            let mut rctx = subs.report(later, 0, &subs_bufs).unwrap();
+            let removed = subs.remove(&subs_bufs, |sub| {
+                (sub.ids().peer_node_id == 999).then_some("no-match")
+            });
+            assert!(!removed);
+            rctx.set_keep();
+        }
+
+        subs.state.lock(|s| {
+            let s = s.borrow();
+            assert_eq!(s.subscriptions_count, 1);
+            assert_eq!(s.subscriptions.len(), 1);
+            assert!(s.reporting.is_none());
+            assert!(s.reporting_cancelled.is_none());
+        });
     }
 
     #[test]

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -41,7 +41,8 @@ pub const DEFAULT_MAX_SUBSCRIPTIONS: usize = MAX_FABRICS * 3;
 /// wildcards so that new changes can always be recorded.
 pub const MAX_CHANGED_ATTRS: usize = 16;
 
-// REVIEW: `SubscriptionsBuffers` is a thin wrapper around a second
+/// A struct for the RX buffers containing the read requests of the tracked subscriptions.
+// NOTE: `SubscriptionsBuffers` is a thin wrapper around a second
 // `Mutex<RefCell<Vec<..>>>` that is *always* locked in lockstep with
 // `Subscriptions::state` (see `Subscriptions::with`). As long as that lock
 // order is respected the pair is safe, but the two locks let someone (now or
@@ -58,25 +59,18 @@ where
     buffers: Mutex<RefCell<SubscriptionsBuffersInner<'a, B, N>>>,
 }
 
-impl<'a, B, const N: usize> Default for SubscriptionsBuffers<'a, B, N>
-where
-    B: BufferAccess<IMBuffer> + 'a,
-{
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<'a, B, const N: usize> SubscriptionsBuffers<'a, B, N>
 where
     B: BufferAccess<IMBuffer> + 'a,
 {
+    /// Create the instance.
     pub const fn new() -> Self {
         Self {
             buffers: Mutex::new(RefCell::new(Vec::new())),
         }
     }
 
+    /// Return an in-place initializer for the instance.
     pub fn init() -> impl Init<Self> {
         init!(Self {
             buffers <- Mutex::init(RefCell::init(Vec::init())),
@@ -91,10 +85,20 @@ where
     }
 }
 
+impl<'a, B, const N: usize> Default for SubscriptionsBuffers<'a, B, N>
+where
+    B: BufferAccess<IMBuffer> + 'a,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A type alias for the inner buffer vector of `SubscriptionsBuffers`.
 type SubscriptionsBuffersInner<'a, B, const N: usize> =
     Vec<<B as BufferAccess<IMBuffer>>::Buffer<'a>, N>;
 
-/// A utility for tracking subscriptions accepted by the data model.
+/// A type for tracking subscriptions accepted by the data model.
 ///
 /// The `N` type parameter specifies the maximum number of subscriptions that can be tracked at the same time.
 /// Additional subscriptions are rejected by the data model with a "resource exhausted" IM status message.
@@ -192,6 +196,10 @@ impl<const N: usize> Subscriptions<N> {
         self.notification.notify();
     }
 
+    /// Notify the instance that a new event has been emitted and that it should
+    /// re-evaluate the subscriptions and report on those that are interested in the new event.
+    ///
+    /// Public for the integration tests.
     pub fn notify_event_emitted(
         &self,
         _endpoint_id: EndptId,
@@ -204,10 +212,14 @@ impl<const N: usize> Subscriptions<N> {
         self.notification.notify();
     }
 
+    /// Clear all subscriptions and pending changes.
+    /// Used when initializing a new data model.
     pub(crate) fn clear(&self) {
         self.state.lock(|state| state.borrow_mut().clear());
     }
 
+    /// Add a new subscription with the given parameters.
+    /// Returns a context for the initial report if successful, or `None` if the subscription table is full.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn add<'a, 's, B>(
         &'s self,
@@ -327,6 +339,9 @@ impl<const N: usize> Subscriptions<N> {
         removed
     }
 
+    /// Begin a report for the subscription with the given parameters.
+    /// Returns a context capturing the subscription's current state if successful, or `None`
+    /// if no subscription is currently reportable.
     pub(crate) fn report<'a, 's, B>(
         &'s self,
         now: Instant,
@@ -359,6 +374,8 @@ impl<const N: usize> Subscriptions<N> {
             .lock(|state| state.borrow_mut().purge_reported_changes())
     }
 
+    /// Complete a report by updating the subscription's watermark and last-reported timestamp,
+    /// and re-inserting it into the table if the `keep` flag is set on the context.
     fn report_complete<'a, B>(&self, report: &mut ReportContext<'a, '_, B, N>)
     where
         B: BufferAccess<IMBuffer> + 'a,
@@ -414,10 +431,22 @@ impl<const N: usize> AttrChangeNotifier for Subscriptions<N> {
 
 impl<const N: usize> DynBase for Subscriptions<N> {}
 
+/// The inner state of `Subscriptions`, protected by a mutex.
+/// See `Subscriptions` for the public API and invariants.
 struct SubscriptionsInner<const N: usize> {
+    /// Monotonically increasing ID assigned to every accepted subscription.
+    /// The first assigned ID is 1; `0` is reserved as the "no subscription" sentinel used by `reporting`.
     next_subscription_id: u32,
+    /// The total number of accepted subscriptions, including any currently
+    /// in-flight one (i.e. one whose `Subscription` has been moved into a
+    /// `ReportContext` and is therefore temporarily not in `subscriptions`).
+    /// Used to enforce the `N` capacity bound in `add`.
     subscriptions_count: usize,
+    /// The active subscriptions. Does NOT include a subscription that is
+    /// currently being reported on; see `reporting` for the snapshot of the
+    /// in-flight one.
     subscriptions: Vec<Subscription, N>,
+    /// The changed attributes that subscriptions are consulting to decide whether and what they need to report.
     changed_attrs: ChangedAttrs,
     /// Snapshot of the subscription currently being reported on (i.e. the
     /// one that has been `swap_remove`d into a `ReportContext`). `None` when
@@ -467,6 +496,10 @@ impl<const N: usize> SubscriptionsInner<N> {
         // rather than pushing it back into an otherwise-empty table.
         if self.reporting.is_some() {
             self.reporting_cancelled = Some("subscriptions cleared");
+            // The in-flight subscription is still counted in
+            // `subscriptions_count` until `report_complete` runs; restore
+            // that so the decrement there balances.
+            self.subscriptions_count = 1;
         }
     }
 
@@ -592,7 +625,6 @@ impl<const N: usize> SubscriptionsInner<N> {
             unwrap!(buffers.push(buffer).map_err(|_| ()));
         } else {
             warn!("Subscription {:?} removed during reporting", sub.ids());
-
             self.subscriptions_count -= 1;
         }
     }
@@ -628,6 +660,7 @@ impl<const N: usize> SubscriptionsInner<N> {
     }
 }
 
+/// The IDs of a subscription, used to identify it across the system and to route reports to it.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SubscriptionIds {
@@ -667,15 +700,17 @@ pub struct Subscription {
 }
 
 impl Subscription {
+    /// Return the IDs of the subscription.
     pub const fn ids(&self) -> &SubscriptionIds {
         &self.ids
     }
 
-    /// The session ID on which this subscription was accepted.
+    /// Return the session ID on which this subscription was accepted.
     pub const fn session_id(&self) -> u32 {
         self.session_id
     }
 
+    /// Return `true` if the subscription is expired and should be removed, or `false` if it is still active.
     pub fn is_expired(&self, now: Instant) -> bool {
         self.reported_at
             .checked_add(embassy_time::Duration::from_secs(self.max_int_secs as _))
@@ -683,15 +718,7 @@ impl Subscription {
             .unwrap_or(false)
     }
 
-    // REVIEW: `is_expired(now)` returning `true` here *prevents* the
-    // subscription from being picked up for reporting. That's a correctness
-    // problem: the expected flow for an expired subscription is to be removed
-    // (by `Subscriptions::remove` with an `is_expired` reason — which is
-    // indeed what `dm.rs` does). But if the reporter task wakes up on the
-    // change notification path and races past the `remove` pass, the expired
-    // subscription will be silently starved instead of being removed or
-    // reported. Consider dropping the `is_expired` check here entirely — the
-    // "remove expired" step in `dm.rs` is the single source of truth.
+    /// Return `true` if the subscription is due for a report based on the given parameters, or `false` if it is not.
     fn is_reportable(
         &self,
         now: Instant,
@@ -699,7 +726,7 @@ impl Subscription {
         changed_attrs: &ChangedAttrs,
         max_event_number: EventNumber,
     ) -> bool {
-        if self.is_expired(now) || !self.is_report_allowed(now) {
+        if !self.is_report_allowed(now) {
             return false;
         }
 
@@ -708,6 +735,7 @@ impl Subscription {
             || self.is_affected_by_new_events(rx, max_event_number)
     }
 
+    /// Return `true` if the subscription is allowed to report based on the min interval, or `false` if it is still in the quiet period since the last report.
     fn is_report_allowed(&self, now: Instant) -> bool {
         self.reported_at
             .checked_add(embassy_time::Duration::from_secs(self.min_int_secs as _))
@@ -715,6 +743,7 @@ impl Subscription {
             .unwrap_or(true)
     }
 
+    /// Return `true` if the subscription is due for a report based on the max interval, or `false` if it is not yet due.
     fn is_report_due(&self, now: Instant) -> bool {
         self.reported_at
             .checked_add(embassy_time::Duration::from_secs(self.max_int_secs as _))
@@ -726,11 +755,23 @@ impl Subscription {
             .unwrap_or(true)
     }
 
+    /// Return `true` if the subscription is affected by changes to the attribute triple `(endpoint, cluster, attr)` based on the subscription's RX and the given table of changed attributes, or `false` if it is not affected.
     fn is_affected_by_attr_changes(&self, _rx: &[u8], changes: &ChangedAttrs) -> bool {
+        // NOTE: we could consult the subscription's RX here to skip the check if the subscription
+        // is not interested in the changed path at all, but that would require parsing the RX at every report check,
+        // which is anyway done later during reporting and the report is canceled if empty
+        //
+        // Therefore and for now do not to this here
         changes.any_since(self.max_seen_attr_change_id)
     }
 
+    /// Return `true` if the subscription is affected by new events based on the subscription's RX and the given max event number, or `false` if it is not affected.
     fn is_affected_by_new_events(&self, _rx: &[u8], max_event_number: EventNumber) -> bool {
+        // NOTE: we could consult the subscription's RX here to skip the check if the subscription
+        // is not interested in events at all, but that would require parsing the RX at every report check,
+        // which is anyway done later during reporting and the report is canceled if empty
+        //
+        // Therefore and for now do not to this here
         self.max_seen_event_number < max_event_number
     }
 }
@@ -1012,6 +1053,7 @@ struct ChangedAttr {
 }
 
 impl ChangedAttr {
+    /// Create a concrete (non-wildcard) entry with the given parameters and change ID.
     const fn concrete(endpoint: EndptId, cluster: ClusterId, attr: AttrId, change_id: u64) -> Self {
         Self {
             endpoint,
@@ -1021,16 +1063,19 @@ impl ChangedAttr {
         }
     }
 
+    /// Return `true` if this entry is a wildcard on the endpoint axis, or `false` if it is concrete.
     #[inline]
     const fn is_endpoint_wildcard(&self) -> bool {
         self.endpoint == WILDCARD_ENDPOINT
     }
 
+    /// Return `true` if this entry is a wildcard on the cluster axis, or `false` if it is concrete.
     #[inline]
     const fn is_cluster_wildcard(&self) -> bool {
         self.cluster == WILDCARD_CLUSTER
     }
 
+    /// Return `true` if this entry is a wildcard on the attribute axis, or `false` if it is concrete.
     #[inline]
     const fn is_attr_wildcard(&self) -> bool {
         self.attr == WILDCARD_ATTR
@@ -1112,12 +1157,30 @@ pub struct ReportContext<'a, 's, B, const N: usize>
 where
     B: BufferAccess<IMBuffer> + 'a,
 {
+    /// A reference to the global subscriptions table, used to return the subscription on
+    /// successful completion of the report
     subscriptions: &'s Subscriptions<N>,
+    /// A reference to the global subscription buffers, used to return the subscription buffer on
+    /// successful completion of the report
     subscriptions_buffers: &'s SubscriptionsBuffers<'a, B, N>,
+    /// The subscription being reported on.
     subscription: Option<Subscription>,
+    /// The RX buffer with report data associated with the subscription being reported on.
     subscription_buffer: Option<B::Buffer<'a>>,
+    /// The next maximum seen attribute change ID for the subscription
+    /// to be updated into it upon returning the subscription to the table.
+    ///
+    /// This is captured here because the subscription's own `max_seen_attr_change_id`
+    /// is not updated until the report completes as it is until then still used.
     next_max_seen_attr_change_id: u64,
+    /// The next reported timestamp for the subscription,
+    /// to be updated into it upon returning the subscription to the table.
+    ///
+    /// This is captured here because the subscription's own `next_reported_at`
+    /// is not updated until the report completes as it is until then still used.
     next_reported_at: Instant,
+    /// Whether the subscription should be kept in the table after the report completes.
+    /// Set by the report handler if the other peer acknowledges the data reported by the subscription.
     keep: bool,
 }
 
@@ -1125,14 +1188,18 @@ impl<'a, 's, B, const N: usize> ReportContext<'a, 's, B, N>
 where
     B: BufferAccess<IMBuffer> + 'a,
 {
+    /// Return a reference to the subscription being reported on.
     pub fn subscription(&self) -> &Subscription {
         unwrap!(self.subscription.as_ref())
     }
 
+    /// Return a reference to the RX buffer associated with the subscription being reported on.
     pub fn rx(&self) -> &[u8] {
         unwrap!(self.subscription_buffer.as_ref()).as_ref()
     }
 
+    /// Return `true` if the report should be sent even if it turns out to be empty
+    /// (i.e. no attributes or events to report), or `false` if it can be skipped in that case.
     pub fn should_send_if_empty(&self) -> bool {
         // A fresh subscription has `reported_at == Instant::MAX`, which makes
         // `is_report_due` return `true` via its overflow-to-`unwrap_or(true)`
@@ -1141,6 +1208,8 @@ where
         unwrap!(self.subscription.as_ref()).is_report_due(self.next_reported_at)
     }
 
+    /// Return `true` if the subscription should report the attribute
+    /// identified by the given triple, or `false` if it can skip it.
     pub fn should_report_attr(
         &self,
         endpoint_id: EndptId,
@@ -1167,10 +1236,12 @@ where
         })
     }
 
+    /// Return the maximum event number the subscription has seen so far.
     pub fn max_seen_event_number(&self) -> EventNumber {
         unwrap!(self.subscription.as_ref()).max_seen_event_number
     }
 
+    /// Update the maximum event number the subscription has seen so far to the given value.
     pub fn update_max_seen_event_number(&mut self, max_seen_event_number: EventNumber) {
         let sub = unwrap!(self.subscription.as_mut());
 
@@ -1178,6 +1249,8 @@ where
         sub.max_seen_event_number = max_seen_event_number;
     }
 
+    /// Mark the subscription to be kept in the table after the report completes,
+    /// meaning the other peer acknowledged our report.
     pub fn set_keep(&mut self) {
         self.keep = true;
     }

--- a/rs-matter/src/dm/types/dataver.rs
+++ b/rs-matter/src/dm/types/dataver.rs
@@ -21,6 +21,7 @@ use core::num::Wrapping;
 
 use rand_core::RngCore;
 
+use crate::dm::{AttrChangeNotifier, AttrId, ClusterId, EndptId};
 use crate::utils::sync::blocking::Mutex;
 
 pub struct Dataver(Mutex<Cell<Wrapping<u32>>>);
@@ -44,6 +45,51 @@ impl Dataver {
 
             state.get().0
         })
+    }
+
+    /// Bump the cluster data version and notify any subscribers that the
+    /// given attribute has changed.
+    ///
+    /// This is the preferred way to signal an attribute mutation that happens
+    /// outside the normal write/invoke dispatch path (e.g. from a timer, an
+    /// async I/O completion, or a state-machine transition), because it keeps
+    /// the cluster data version and the subscription notification in lockstep.
+    ///
+    /// For mutations that happen *inside* the normal write/invoke dispatch
+    /// path, the generated `HandlerAdaptor` already bumps the data version;
+    /// call [`AttrChangeNotifier::notify_attr_changed`] directly in that case.
+    pub fn changed_and_notify_attr<N>(
+        &self,
+        notifier: N,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        attr_id: AttrId,
+    ) -> u32
+    where
+        N: AttrChangeNotifier,
+    {
+        let v = self.changed();
+        notifier.notify_attr_changed(endpoint_id, cluster_id, attr_id);
+        v
+    }
+
+    /// Bump the cluster data version and notify any subscribers that every
+    /// attribute on the given cluster may have changed.
+    ///
+    /// Use this when a single operation mutates many attributes of the same
+    /// cluster and enumerating them would be cumbersome or error-prone.
+    pub fn changed_and_notify_cluster<N>(
+        &self,
+        notifier: N,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+    ) -> u32
+    where
+        N: AttrChangeNotifier,
+    {
+        let v = self.changed();
+        notifier.notify_cluster_changed(endpoint_id, cluster_id);
+        v
     }
 }
 

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -51,6 +51,31 @@ pub trait AttrChangeNotifier {
     /// - `cluster_id`: The cluster ID of the cluster that has changed.
     /// - `attr_id`: The attribute ID of the attribute that has changed.
     fn notify_attr_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId, attr_id: AttrId);
+
+    /// Notify that every attribute of the given cluster may have changed.
+    ///
+    /// Use this when a single operation mutates many attributes of the same
+    /// cluster and enumerating them would be cumbersome or error-prone (e.g.
+    /// commissioning-window transitions, cluster-wide resets).
+    ///
+    /// Subscriptions whose interest paths intersect `(endpoint_id, cluster_id)`
+    /// at any attribute will be re-reported.
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId);
+
+    /// Notify that every attribute on every cluster of the given endpoint may
+    /// have changed.
+    ///
+    /// Typically used when the endpoint's composition changes (dynamic
+    /// endpoints being enabled/disabled, bridge device add/remove, etc.).
+    fn notify_endpoint_changed(&self, endpoint_id: EndptId);
+
+    /// Notify that every attribute on every cluster on every endpoint may
+    /// have changed.
+    ///
+    /// This is the coarsest possible notification and should be used sparingly
+    /// (e.g. global resets, factory reset, etc.). Every active subscription
+    /// will be flagged for re-report.
+    fn notify_all_changed(&self);
 }
 
 impl<T> AttrChangeNotifier for &T
@@ -60,11 +85,79 @@ where
     fn notify_attr_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId, attr_id: AttrId) {
         (**self).notify_attr_changed(endpoint_id, cluster_id, attr_id)
     }
+
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        (**self).notify_cluster_changed(endpoint_id, cluster_id)
+    }
+
+    fn notify_endpoint_changed(&self, endpoint_id: EndptId) {
+        (**self).notify_endpoint_changed(endpoint_id)
+    }
+
+    fn notify_all_changed(&self) {
+        (**self).notify_all_changed()
+    }
 }
 
 impl AttrChangeNotifier for () {
     fn notify_attr_changed(&self, _endpt: EndptId, _clust: ClusterId, _attr: AttrId) {
         // No-op
+    }
+
+    fn notify_cluster_changed(&self, _endpt: EndptId, _clust: ClusterId) {
+        // No-op
+    }
+
+    fn notify_endpoint_changed(&self, _endpt: EndptId) {
+        // No-op
+    }
+
+    fn notify_all_changed(&self) {
+        // No-op
+    }
+}
+
+/// A trait for notifying the data model that the state of an attribute has changed.
+/// Typically implemented on types that have a notion of a "current" endpoint and a "current" cluster, so that the caller doesn't have to specify them again.
+pub trait OwnAttrChangeNotifier {
+    /// Notify that the state of an attribute has changed.
+    ///
+    /// # Arguments
+    /// - `attr_id`: The attribute ID of the attribute that has changed.
+    fn notify_own_attr_changed(&self, attr_id: AttrId);
+
+    /// Notify that every attribute of our own cluster may have changed.
+    ///
+    /// Use this when a single operation mutates many attributes of the same
+    /// cluster and enumerating them would be cumbersome or error-prone (e.g.
+    /// commissioning-window transitions, cluster-wide resets).
+    ///
+    /// Subscriptions whose interest paths intersect `(endpoint_id, cluster_id)`
+    /// at any attribute will be re-reported.
+    fn notify_own_cluster_changed(&self);
+
+    /// Notify that every attribute on every cluster of our own endpoint may
+    /// have changed.
+    ///
+    /// Typically used when the endpoint's composition changes (dynamic
+    /// endpoints being enabled/disabled, bridge device add/remove, etc.).
+    fn notify_own_endpoint_changed(&self);
+}
+
+impl<T> OwnAttrChangeNotifier for &T
+where
+    T: OwnAttrChangeNotifier,
+{
+    fn notify_own_attr_changed(&self, attr_id: AttrId) {
+        (**self).notify_own_attr_changed(attr_id)
+    }
+
+    fn notify_own_cluster_changed(&self) {
+        (**self).notify_own_cluster_changed()
+    }
+
+    fn notify_own_endpoint_changed(&self) {
+        (**self).notify_own_endpoint_changed()
     }
 }
 
@@ -214,7 +307,7 @@ where
 }
 
 /// A context super-type that is passed to the handler when processing an attribute read/write or a command invoke operation.
-pub trait OperationContext: HandlerContext + OwnEventEmitter {
+pub trait OperationContext: HandlerContext + OwnAttrChangeNotifier + OwnEventEmitter {
     /// Return the exchange object that is associated with this operation.
     fn exchange(&self) -> &Exchange<'_>;
 
@@ -376,6 +469,18 @@ where
         self.context
             .notify_attr_changed(endpoint_id, cluster_id, attr_id);
     }
+
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        self.context.notify_cluster_changed(endpoint_id, cluster_id);
+    }
+
+    fn notify_endpoint_changed(&self, endpoint_id: EndptId) {
+        self.context.notify_endpoint_changed(endpoint_id);
+    }
+
+    fn notify_all_changed(&self) {
+        self.context.notify_all_changed();
+    }
 }
 
 impl<C> EventEmitter for ReadContextInstance<'_, C>
@@ -412,6 +517,23 @@ where
 
     fn cluster(&self) -> ClusterId {
         self.attr.cluster_id
+    }
+}
+
+impl<C> OwnAttrChangeNotifier for ReadContextInstance<'_, C>
+where
+    C: HandlerContext,
+{
+    fn notify_own_attr_changed(&self, attr_id: AttrId) {
+        self.notify_attr_changed(self.endpt(), self.cluster(), attr_id);
+    }
+
+    fn notify_own_cluster_changed(&self) {
+        self.notify_cluster_changed(self.endpt(), self.cluster());
+    }
+
+    fn notify_own_endpoint_changed(&self) {
+        self.notify_endpoint_changed(self.endpt());
     }
 }
 
@@ -509,6 +631,18 @@ where
         self.context
             .notify_attr_changed(endpoint_id, cluster_id, attr_id);
     }
+
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        self.context.notify_cluster_changed(endpoint_id, cluster_id);
+    }
+
+    fn notify_endpoint_changed(&self, endpoint_id: EndptId) {
+        self.context.notify_endpoint_changed(endpoint_id);
+    }
+
+    fn notify_all_changed(&self) {
+        self.context.notify_all_changed();
+    }
 }
 
 impl<C> EventEmitter for WriteContextInstance<'_, C>
@@ -545,6 +679,23 @@ where
 
     fn cluster(&self) -> ClusterId {
         self.attr.cluster_id
+    }
+}
+
+impl<C> OwnAttrChangeNotifier for WriteContextInstance<'_, C>
+where
+    C: HandlerContext,
+{
+    fn notify_own_attr_changed(&self, attr_id: AttrId) {
+        self.notify_attr_changed(self.endpt(), self.cluster(), attr_id);
+    }
+
+    fn notify_own_cluster_changed(&self) {
+        self.notify_cluster_changed(self.endpt(), self.cluster());
+    }
+
+    fn notify_own_endpoint_changed(&self) {
+        self.notify_endpoint_changed(self.endpt());
     }
 }
 
@@ -646,6 +797,18 @@ where
         self.context
             .notify_attr_changed(endpoint_id, cluster_id, attr_id);
     }
+
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        self.context.notify_cluster_changed(endpoint_id, cluster_id);
+    }
+
+    fn notify_endpoint_changed(&self, endpoint_id: EndptId) {
+        self.context.notify_endpoint_changed(endpoint_id);
+    }
+
+    fn notify_all_changed(&self) {
+        self.context.notify_all_changed();
+    }
 }
 
 impl<C> EventEmitter for InvokeContextInstance<'_, C>
@@ -682,6 +845,23 @@ where
 
     fn cluster(&self) -> ClusterId {
         self.cmd.cluster_id
+    }
+}
+
+impl<C> OwnAttrChangeNotifier for InvokeContextInstance<'_, C>
+where
+    C: HandlerContext,
+{
+    fn notify_own_attr_changed(&self, attr_id: AttrId) {
+        self.notify_attr_changed(self.endpt(), self.cluster(), attr_id);
+    }
+
+    fn notify_own_cluster_changed(&self) {
+        self.notify_cluster_changed(self.endpt(), self.cluster());
+    }
+
+    fn notify_own_endpoint_changed(&self) {
+        self.notify_endpoint_changed(self.endpt());
     }
 }
 

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -56,11 +56,14 @@ impl<'a> Node<'a> {
     /// accessible by the accessor and whether they should be served based on the
     /// fabric filtering and dataver filtering rules and filter out the inaccessible ones (wildcard reads)
     /// or report an error status for the non-wildcard ones.
-    pub fn read<'m>(
+    pub fn read<'m, F>(
         &'m self,
         req: &'m ReportDataReq,
         accessor: &'m Accessor<'m>,
+        filter: F,
     ) -> Result<impl Iterator<Item = Result<Result<AttrDetails<'m>, AttrStatus>, Error>> + 'm, Error>
+    where
+        F: FnMut(EndptId, ClusterId, u32) -> bool + 'm,
     {
         let dataver_filters = req.dataver_filters()?;
         let fabric_filtered = req.fabric_filtered()?;
@@ -78,6 +81,7 @@ impl<'a> Node<'a> {
                     })
                 })
             }),
+            filter,
         ))
     }
 
@@ -101,6 +105,7 @@ impl<'a> Node<'a> {
             accessor,
             req.timed_request()?,
             Some(req.write_requests()?.into_iter()),
+            |_, _, _| true,
         ))
     }
 
@@ -124,6 +129,7 @@ impl<'a> Node<'a> {
             accessor,
             req.timed_request()?,
             req.inv_requests()?.map(move |reqs| reqs.into_iter()),
+            |_, _, _| true,
         ))
     }
 
@@ -478,7 +484,7 @@ impl<'a> PathExpansionItem<'a> for CmdData<'a> {
 /// While the iterator can be (and used to be) implemented by using monadic combinators,
 /// this implementation is done in a more imperative way to avoid the overhead of monadic
 /// combinators in terms of memory size.
-struct PathExpander<'a, T, I>
+struct PathExpander<'a, T, I, F>
 where
     I: Iterator<Item = Result<T, Error>>,
 {
@@ -498,12 +504,15 @@ where
     cluster_index: u16,
     /// The current leaf index.
     leaf_index: u16,
+    /// Filter the expanded item or not
+    filter: F,
 }
 
-impl<'a, T, I> PathExpander<'a, T, I>
+impl<'a, T, I, F> PathExpander<'a, T, I, F>
 where
     I: Iterator<Item = Result<T, Error>>,
     T: PathExpansionItem<'a>,
+    F: FnMut(EndptId, ClusterId, u32) -> bool,
 {
     /// Create a new path expander with the given node, accessor, and paths.
     pub const fn new(
@@ -511,6 +520,7 @@ where
         accessor: &'a Accessor<'a>,
         timed: bool,
         paths: Option<I>,
+        filter: F,
     ) -> Self {
         Self {
             node,
@@ -521,6 +531,7 @@ where
             endpoint_index: 0,
             cluster_index: 0,
             leaf_index: 0,
+            filter,
         }
     }
 
@@ -577,49 +588,65 @@ where
                             };
 
                             if path.leaf.is_none() || path.leaf == Some(leaf_id as _) {
-                                // Leaf found, check its access rights
+                                // Leaf found, filter and check its access rights
 
-                                let check = if matches!(T::OPERATION, Operation::Invoke) {
-                                    cluster.check_cmd_access(
-                                        self.accessor,
-                                        self.timed,
-                                        GenericPath::new(
-                                            Some(endpoint.id),
-                                            Some(cluster.id),
-                                            Some(leaf_id),
-                                        ),
-                                        unwrap!(cluster
-                                            .commands()
-                                            .map(|cmd| cmd.id)
-                                            .nth(self.leaf_index as usize)),
-                                    )
+                                let check = if (self.filter)(endpoint.id, cluster.id, leaf_id) {
+                                    if matches!(T::OPERATION, Operation::Invoke) {
+                                        cluster.check_cmd_access(
+                                            self.accessor,
+                                            self.timed,
+                                            GenericPath::new(
+                                                Some(endpoint.id),
+                                                Some(cluster.id),
+                                                Some(leaf_id),
+                                            ),
+                                            unwrap!(cluster
+                                                .commands()
+                                                .map(|cmd| cmd.id)
+                                                .nth(self.leaf_index as usize)),
+                                        )
+                                    } else {
+                                        // TODO: Need to also check that the code is not trying to access an element of an array
+                                        // when the attribute is not an array
+
+                                        cluster.check_attr_access(
+                                            self.accessor,
+                                            self.timed,
+                                            GenericPath::new(
+                                                Some(endpoint.id),
+                                                Some(cluster.id),
+                                                Some(leaf_id),
+                                            ),
+                                            matches!(T::OPERATION, Operation::Write),
+                                            unwrap!(cluster
+                                                .attributes()
+                                                .map(|attr| attr.id)
+                                                .nth(self.leaf_index as usize)),
+                                        )
+                                    }
+                                    .map(|_| true)
                                 } else {
-                                    // TODO: Need to also check that the code is not trying to access an element of an array
-                                    // when the attribute is not an array
-
-                                    cluster.check_attr_access(
-                                        self.accessor,
-                                        self.timed,
-                                        GenericPath::new(
-                                            Some(endpoint.id),
-                                            Some(cluster.id),
-                                            Some(leaf_id),
-                                        ),
-                                        matches!(T::OPERATION, Operation::Write),
-                                        unwrap!(cluster
-                                            .attributes()
-                                            .map(|attr| attr.id)
-                                            .nth(self.leaf_index as usize)),
-                                    )
+                                    Ok(false)
                                 };
 
                                 match check {
-                                    Ok(()) => {
+                                    Ok(true) => {
                                         // Because on the next call we should start from the next leaf or if leaves
                                         // are over, from the next cluster and so on
                                         self.leaf_index += 1;
 
                                         return Ok(Some((endpoint.id, cluster.id, leaf_id)));
+                                    }
+                                    Ok(false) => {
+                                        // Filtered out. For a non-wildcard path the
+                                        // leaf exists but the filter explicitly rejected
+                                        // it - treat this as "no output" rather than
+                                        // reporting `UnsupportedAttribute`/`UnsupportedCommand`.
+                                        if !path.is_wildcard() {
+                                            self.leaf_index += 1;
+                                            return Ok(None);
+                                        }
+                                        // Else: just skip it and continue scanning
                                     }
                                     Err(status) => {
                                         if !path.is_wildcard() {
@@ -666,10 +693,11 @@ where
     }
 }
 
-impl<'a, T, I> Iterator for PathExpander<'a, T, I>
+impl<'a, T, I, F> Iterator for PathExpander<'a, T, I, F>
 where
     I: Iterator<Item = Result<T, Error>>,
     T: PathExpansionItem<'a>,
+    F: FnMut(EndptId, ClusterId, u32) -> bool,
 {
     type Item = Result<Result<T::Expanded<'a>, T::Status>, Error>;
 
@@ -794,11 +822,27 @@ mod test {
         input: &[GenericPath],
         expected: &[Result<Result<GenericPath, IMStatusCode>, ErrorCode>],
     ) {
+        test_with_filter(node, input, |_, _, _| true, expected)
+    }
+
+    /// Compare an input of paths against their expanded expectations,
+    /// using the provided per-(endpoint, cluster, leaf) filter.
+    fn test_with_filter(
+        node: &Node,
+        input: &[GenericPath],
+        filter: impl FnMut(EndptId, ClusterId, u32) -> bool,
+        expected: &[Result<Result<GenericPath, IMStatusCode>, ErrorCode>],
+    ) {
         let matter = test_matter();
         let accessor = Accessor::new(0, AccessorSubjects::new(0), Some(AuthMode::Pase), &matter);
 
-        let expander =
-            PathExpander::new(node, &accessor, false, Some(input.iter().cloned().map(Ok)));
+        let expander = PathExpander::new(
+            node,
+            &accessor,
+            false,
+            Some(input.iter().cloned().map(Ok)),
+            filter,
+        );
 
         assert_eq!(
             expander
@@ -1054,6 +1098,96 @@ mod test {
                 Ok(Ok(GenericPath::new(Some(5), Some(20), Some(20)))),
                 Ok(Err(IMStatusCode::UnsupportedAttribute)),
             ],
+        );
+    }
+
+    #[test]
+    fn test_filter() {
+        static NODE: Node = Node::new(&[
+            Endpoint::new(
+                0,
+                &[DeviceType { dtype: 0, drev: 0 }],
+                &[Cluster::new(
+                    1,
+                    1,
+                    0,
+                    &[
+                        Attribute::new(1, Access::all(), Quality::all()),
+                        Attribute::new(2, Access::all(), Quality::all()),
+                    ],
+                    &[Command::new(1, None, Access::all())],
+                    &[],
+                    |_, _, _| true,
+                    |_, _, _| true,
+                    |_, _, _| true,
+                )],
+            ),
+            Endpoint::new(
+                5,
+                &[DeviceType { dtype: 0, drev: 0 }],
+                &[Cluster::new(
+                    1,
+                    1,
+                    0,
+                    &[Attribute::new(1, Access::all(), Quality::all())],
+                    &[Command::new(1, None, Access::all())],
+                    &[],
+                    |_, _, _| true,
+                    |_, _, _| true,
+                    |_, _, _| true,
+                )],
+            ),
+        ]);
+
+        // Non-wildcard path, leaf exists but is filtered out: the expander
+        // must yield nothing for this input (neither an expansion nor an
+        // `UnsupportedAttribute` status).
+        test_with_filter(
+            &NODE,
+            &[GenericPath::new(Some(0), Some(1), Some(1))],
+            |_, _, _| false,
+            &[],
+        );
+
+        // Non-wildcard path, leaf does not exist: filter must not be consulted
+        // and the expander must still produce `UnsupportedAttribute`.
+        test_with_filter(
+            &NODE,
+            &[GenericPath::new(Some(0), Some(1), Some(99))],
+            |_, _, _| true,
+            &[Ok(Err(IMStatusCode::UnsupportedAttribute))],
+        );
+
+        // Wildcard path, filter rejects everything: empty output, no errors.
+        test_with_filter(
+            &NODE,
+            &[GenericPath::new(None, None, None)],
+            |_, _, _| false,
+            &[],
+        );
+
+        // Wildcard path, filter rejects some leaves: the accepted ones are
+        // yielded and the rejected ones are silently skipped.
+        test_with_filter(
+            &NODE,
+            &[GenericPath::new(None, None, None)],
+            |_, _, leaf| leaf == 1,
+            &[
+                Ok(Ok(GenericPath::new(Some(0), Some(1), Some(1)))),
+                Ok(Ok(GenericPath::new(Some(5), Some(1), Some(1)))),
+            ],
+        );
+
+        // Mixed: a non-wildcard filtered-out path followed by a wildcard
+        // should only yield items from the wildcard.
+        test_with_filter(
+            &NODE,
+            &[
+                GenericPath::new(Some(0), Some(1), Some(1)),
+                GenericPath::new(None, None, None),
+            ],
+            |_ep, _cl, leaf| leaf != 1,
+            &[Ok(Ok(GenericPath::new(Some(0), Some(1), Some(2))))],
         );
     }
 }

--- a/rs-matter/src/dm/types/reply.rs
+++ b/rs-matter/src/dm/types/reply.rs
@@ -16,7 +16,7 @@
  */
 
 use crate::acl::Accessor;
-use crate::dm::{AsyncHandler, HandlerContext, Node};
+use crate::dm::{AsyncHandler, EventNumber, HandlerContext, Node};
 use crate::error::{Error, ErrorCode};
 use crate::im::{
     AttrDataTag, AttrPath, AttrResp, AttrRespTag, AttrStatus, CmdDataTag, CmdPath, CmdResp,
@@ -180,7 +180,19 @@ where
                 let result = self.write(attr, data).await;
 
                 match result {
-                    Ok(()) => Ok(attr.status(IMStatusCode::Success)),
+                    Ok(()) => {
+                        // A write that was accepted by the cluster handler
+                        // counts as an attribute change for subscription
+                        // reporting purposes. Notify generically here so that
+                        // cluster handlers do not each need to call
+                        // `notify_attr_changed` from every attribute setter.
+                        self.context.notify_attr_changed(
+                            attr.endpoint_id,
+                            attr.cluster_id,
+                            attr.attr_id,
+                        );
+                        Ok(attr.status(IMStatusCode::Success))
+                    }
                     Err(err) if err.code() != ErrorCode::NoSpace => {
                         error!("Error writing attribute: {}", err);
 
@@ -295,15 +307,19 @@ where
     }
 }
 
-pub struct EventReader<'a> {
-    /// On construction - a reference to the minimum event number that should be emitted to the subscriber. This is updated after each event is emitted, so it always reflects the minimum event number that should be processed / appended to the writer.
-    /// After each successive call to `process_read`, this is updated to the biggest event number seen during the processing.
-    min_event_number: &'a mut u64,
+pub struct EventReader {
+    max_seen_event_number: u64,
 }
 
-impl<'a> EventReader<'a> {
-    pub const fn new(min_event_number: &'a mut u64) -> Self {
-        Self { min_event_number }
+impl EventReader {
+    pub const fn new(max_seen_event_number: u64) -> Self {
+        Self {
+            max_seen_event_number,
+        }
+    }
+
+    pub const fn max_seen_event_number(&self) -> EventNumber {
+        self.max_seen_event_number
     }
 
     pub fn process_read<T: TLVWrite>(
@@ -316,7 +332,13 @@ impl<'a> EventReader<'a> {
         mut tw: T,
     ) -> Result<(), Error> {
         let event_number = event.event_number;
-        if event_number < *self.min_event_number {
+        // `max_seen_event_number` is stored as the *next* event number the
+        // caller expects to receive (i.e. one past the largest already
+        // delivered). A fresh reader initialised with `0` must therefore
+        // still deliver event `0`, which is why the comparison is strictly
+        // less than, and the field is advanced to `event_number + 1` after
+        // a successful emit.
+        if event_number < self.max_seen_event_number {
             // This event has already been seen by the caller, skip
             return Ok(());
         }
@@ -329,7 +351,7 @@ impl<'a> EventReader<'a> {
             // If there was an error, rewind to the tail so we don't write any data.
             tw.rewind_to(tail);
         } else {
-            *self.min_event_number = event_number.wrapping_add(1);
+            self.max_seen_event_number = event_number.wrapping_add(1);
         }
 
         result

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -510,8 +510,7 @@ impl<'a> Matter<'a> {
         notify: &dyn AttrChangeNotifier,
     ) -> Result<(), Error> {
         let notify_mdns = || self.notify_mdns_changed();
-        let notify_change =
-            |endpt_id, clust_id, attr_id| notify.notify_attr_changed(endpt_id, clust_id, attr_id);
+        let notify_change = |endpt_id, clust_id| notify.notify_cluster_changed(endpt_id, clust_id);
 
         self.with_state(|state| {
             let mut rand = crypto.rand()?;
@@ -539,8 +538,7 @@ impl<'a> Matter<'a> {
     /// The method will return Ok(false) if there is no active PASE commissioning window to close.
     pub fn close_comm_window(&self, notify: &dyn AttrChangeNotifier) -> Result<bool, Error> {
         let notify_mdns = || self.notify_mdns_changed();
-        let notify_change =
-            |endpt_id, clust_id, attr_id| notify.notify_attr_changed(endpt_id, clust_id, attr_id);
+        let notify_change = |endpt_id, clust_id| notify.notify_cluster_changed(endpt_id, clust_id);
 
         self.with_state(|state| state.pase.close_comm_window(notify_mdns, notify_change))
     }

--- a/rs-matter/src/sc/pase.rs
+++ b/rs-matter/src/sc/pase.rs
@@ -29,7 +29,7 @@ use spake2p::Spake2pVerifierData;
 use crate::dm::clusters::adm_comm::{self};
 use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::error::{Error, ErrorCode};
-use crate::im::{AttrId, ClusterId, EndptId};
+use crate::im::{ClusterId, EndptId};
 use crate::sc::pase::spake2p::{
     Spake2pVerifierPasswordRef, Spake2pVerifierSaltRef, Spake2pVerifierStrRef,
 };
@@ -52,6 +52,15 @@ pub(crate) mod spake2p;
 pub const MIN_COMM_WINDOW_TIMEOUT_SECS: u16 = 3 * 60;
 /// Maximal commissioning window timeout in seconds, as per the Matter Core Spec
 pub const MAX_COMM_WINDOW_TIMEOUT_SECS: u16 = 15 * 60;
+
+/// Notify that the externally-visible attributes of the Administrator
+/// Commissioning cluster may have changed. Called whenever the commissioning
+/// window is opened or closed: `WindowStatus`, `AdminFabricIndex` and
+/// `AdminVendorId` all transition together, so we mark the entire cluster
+/// dirty with a single call.
+fn notify_adm_comm_window_attrs_changed(notify_change: &mut impl FnMut(EndptId, ClusterId)) {
+    notify_change(ROOT_ENDPOINT_ID, adm_comm::FULL_CLUSTER.id);
+}
 
 /// The type of commissioning window
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -209,7 +218,7 @@ impl Pase {
     pub fn check_comm_window_timeout(
         &mut self,
         notify_mdns: impl FnMut(),
-        notify_change: impl FnMut(EndptId, ClusterId, AttrId),
+        notify_change: impl FnMut(EndptId, ClusterId),
     ) -> Result<bool, Error> {
         let expired = self
             .comm_window
@@ -257,7 +266,7 @@ impl Pase {
         timeout_secs: u16,
         opener: Option<CommWindowOpener>,
         mut notify_mdns: impl FnMut(),
-        mut notify_change: impl FnMut(EndptId, ClusterId, AttrId),
+        mut notify_change: impl FnMut(EndptId, ClusterId),
     ) -> Result<(), Error> {
         if self.comm_window.is_some() {
             Err(ErrorCode::Busy)?;
@@ -280,11 +289,7 @@ impl Pase {
             )));
 
         notify_mdns();
-        notify_change(
-            ROOT_ENDPOINT_ID,
-            adm_comm::FULL_CLUSTER.id,
-            adm_comm::AttributeId::WindowStatus as _,
-        );
+        notify_adm_comm_window_attrs_changed(&mut notify_change);
 
         info!("PASE Basic Commissioning Window opened");
 
@@ -318,7 +323,7 @@ impl Pase {
         timeout_secs: u16,
         opener: Option<CommWindowOpener>,
         mut notify_mdns: impl FnMut(),
-        mut notify_change: impl FnMut(EndptId, ClusterId, AttrId),
+        mut notify_change: impl FnMut(EndptId, ClusterId),
     ) -> Result<(), Error> {
         if self.comm_window.is_some() {
             Err(ErrorCode::Busy)?;
@@ -341,11 +346,7 @@ impl Pase {
         )));
 
         notify_mdns();
-        notify_change(
-            ROOT_ENDPOINT_ID,
-            adm_comm::FULL_CLUSTER.id,
-            adm_comm::AttributeId::WindowStatus as _,
-        );
+        notify_adm_comm_window_attrs_changed(&mut notify_change);
 
         info!("PASE Commissioning Window opened");
 
@@ -363,17 +364,13 @@ impl Pase {
     pub fn close_comm_window(
         &mut self,
         mut notify_mdns: impl FnMut(),
-        mut notify_change: impl FnMut(EndptId, ClusterId, AttrId),
+        mut notify_change: impl FnMut(EndptId, ClusterId),
     ) -> Result<bool, Error> {
         if self.comm_window.is_some() {
             self.comm_window.clear();
 
             notify_mdns();
-            notify_change(
-                ROOT_ENDPOINT_ID,
-                adm_comm::FULL_CLUSTER.id,
-                adm_comm::AttributeId::WindowStatus as _,
-            );
+            notify_adm_comm_window_attrs_changed(&mut notify_change);
 
             info!("PASE Commissioning Window closed");
 

--- a/rs-matter/src/sc/pase/responder.rs
+++ b/rs-matter/src/sc/pase/responder.rs
@@ -113,10 +113,8 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
         let mut count = 0;
 
         let notify_mdns = || exchange.matter().notify_mdns_changed();
-        let notify_change = |endpt_id, cluster_id, attr_id| {
-            self.notify
-                .notify_attr_changed(endpt_id, cluster_id, attr_id)
-        };
+        let notify_change =
+            |endpt_id, cluster_id| self.notify.notify_cluster_changed(endpt_id, cluster_id);
 
         let has_comm_window = {
             exchange.with_state(|state| {
@@ -208,10 +206,8 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
         let mut cb = HMAC_HASH_ZEROED;
 
         let notify_mdns = || exchange.matter().notify_mdns_changed();
-        let notify_change = |endpt_id, cluster_id, attr_id| {
-            self.notify
-                .notify_attr_changed(endpt_id, cluster_id, attr_id)
-        };
+        let notify_change =
+            |endpt_id, cluster_id| self.notify.notify_cluster_changed(endpt_id, cluster_id);
 
         let has_comm_window = {
             exchange.with_state(|state| {


### PR DESCRIPTION
This PR addresses https://github.com/project-chip/rs-matter/issues/166 

Essentially, the PR implements a table (`ChangedAttributes`) that tracks all changed attributes.
I suspect (and the AI confirmed) that the table is very similar to the way changesets are tracked in the Matter C++ SDK as well.

I also took the opportunity to tighten up a bit the subscriptions' code by moving a lot of code from `dm` to `subscriptions`.
