### PR TITLE
Follow-up fixes related to the TCP protocol support

### DIFF
--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -71,9 +71,6 @@ fn main() -> Result<(), Error> {
     // Create the Matter object
     let mut matter = Matter::new_default(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, MATTER_PORT);
 
-    // Need to call this once
-    matter.initialize_transport_buffers();
-
     // Create the events
     let mut events: Events = Events::new_default();
 

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -113,9 +113,6 @@ fn main() -> Result<(), Error> {
         MATTER_PORT,
     ));
 
-    // Need to call this once
-    matter.initialize_transport_buffers();
-
     // Create the event queue
     let events = EVENTS.uninit().init_with(Events::init_default());
 

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -130,9 +130,6 @@ fn run() -> Result<(), Error> {
         MATTER_PORT,
     ));
 
-    // Need to call this once
-    matter.initialize_transport_buffers();
-
     // Create the event queue
     let events = EVENTS.uninit().init_with(Events::init_default());
 

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -90,9 +90,6 @@ fn main() -> Result<(), Error> {
     // Create the Matter object
     let mut matter = Matter::new_default(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, MATTER_PORT);
 
-    // Need to call this once
-    matter.initialize_transport_buffers();
-
     // Create the event queue
     let mut events: Events = Events::new_default();
 

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -106,9 +106,6 @@ fn run() -> Result<(), Error> {
         MATTER_PORT,
     ));
 
-    // Need to call this once
-    matter.initialize_transport_buffers();
-
     // Persistence
     let kv_buf = KV_BUF.uninit().init_zeroed().as_mut_slice();
     let mut kv = DirKvBlobStore::new_default();

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -124,9 +124,6 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
     // Create the Matter object
     let mut matter = Matter::new_default(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, MATTER_PORT);
 
-    // Need to call this once
-    matter.initialize_transport_buffers();
-
     // A storage for the Wifi networks
     let mut networks = WifiNetworks::<3>::new();
 

--- a/examples/src/bin/onoff_light_work_stealing.rs
+++ b/examples/src/bin/onoff_light_work_stealing.rs
@@ -111,9 +111,6 @@ fn run() -> Result<(), Error> {
         MATTER_PORT,
     ));
 
-    // Need to call this once
-    matter.initialize_transport_buffers();
-
     // Create the events
     let events = EVENTS.uninit().init_with(Events::init_default());
 

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -67,9 +67,6 @@ fn main() -> Result<(), Error> {
     // Create the Matter object
     let mut matter = Matter::new_default(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, MATTER_PORT);
 
-    // Need to call this once
-    matter.initialize_transport_buffers();
-
     // Create the event queue
     let mut events: Events = Events::new_default();
 

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -63,7 +63,7 @@ mod types;
 /// write requests per-transaction will be supported.
 const MAX_WRITE_ATTRS_IN_ONE_TRANS: usize = 15;
 
-pub type IMBuffer = heapless::Vec<u8, MAX_EXCHANGE_RX_BUF_SIZE>;
+pub type IMBuffer = crate::utils::storage::Vec<u8, MAX_EXCHANGE_RX_BUF_SIZE>;
 
 /// An `ExchangeHandler` implementation capable of handling responder exchanges for the Interaction Model protocol.
 /// The implementation needs a `DataModelHandler` instance to interact with the underlying clusters of the data model.

--- a/rs-matter/src/im/client.rs
+++ b/rs-matter/src/im/client.rs
@@ -111,8 +111,13 @@ impl<'a> InvokeRequestBuilder<'a> {
     /// Create a new InvokeRequestBuilder
     pub const fn new(invoke_requests: &'a [CmdData<'a>], timed: bool) -> Self {
         Self {
-            suppress_response: None,
-            timed_request: if timed { Some(true) } else { None },
+            // Matter 1.5 Core spec §8.8.5: `SuppressResponse` and
+            // `TimedRequest` are mandatory fields of `InvokeRequestMessage`
+            // and MUST be present on the wire. Encode them explicitly so
+            // strictly-validating peers (e.g. SmartThings) accept the
+            // request instead of rejecting it with `INVALID_ACTION`.
+            suppress_response: Some(false),
+            timed_request: Some(timed),
             invoke_requests,
         }
     }
@@ -786,6 +791,40 @@ impl ImClient {
             .await?;
 
         exchange.recv_fetch().await?;
+
+        // Servers MAY reply with a plain `StatusResponse` instead of a full
+        // `InvokeResponse` for commands whose return is `DefaultSuccess`
+        // (empty response body). Accept both.
+        let opcode = exchange.rx()?.meta().proto_opcode;
+
+        if opcode == OpCode::StatusResponse as u8 {
+            // Parse status from the RX buffer, then ACK.
+            let status = {
+                let rx = exchange.rx()?;
+                let element = TLVElement::new(rx.payload());
+                StatusResp::from_tlv(&element)?.status
+            };
+
+            exchange.acknowledge().await?;
+
+            if status == IMStatusCode::Success {
+                return Ok(CmdResp::status_new(
+                    CmdPath {
+                        endpoint: Some(endpoint),
+                        cluster: Some(cluster),
+                        cmd: Some(cmd),
+                    },
+                    IMStatusCode::Success,
+                    None,
+                ));
+            } else {
+                error!("Invoke reply: StatusResponse({:?})", status);
+                return Err(status
+                    .to_error_code()
+                    .unwrap_or(ErrorCode::InvalidData)
+                    .into());
+            }
+        }
 
         // Check opcode and more_chunks before acknowledging
         {

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -346,11 +346,6 @@ impl<'a> Matter<'a> {
         )
     }
 
-    /// Initialize the transport buffers if using the `large-buffers` feature flag.
-    pub fn initialize_transport_buffers(&mut self) {
-        self.transport.initialize_buffers()
-    }
-
     pub fn dev_det(&self) -> &BasicInfoConfig<'_> {
         self.dev_det
     }

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -46,9 +46,6 @@ use packet::PacketHdr;
 use proto_hdr::ProtoHdr;
 use session::{Session, Sessions};
 
-#[cfg(all(feature = "large-buffers", feature = "alloc"))]
-extern crate alloc;
-
 mod dedup;
 
 pub mod exchange;
@@ -66,14 +63,14 @@ const MAX_GROUP_ADDRS: usize = MAX_FABRICS * MAX_GROUPS_PER_FABRIC;
 
 const ACCEPT_TIMEOUT_MS: u64 = 1000;
 
-#[cfg(all(feature = "large-buffers", feature = "alloc"))]
+#[cfg(feature = "large-buffers")]
 pub(crate) const MAX_RX_BUF_SIZE: usize = network::MAX_RX_LARGE_PACKET_SIZE;
-#[cfg(all(feature = "large-buffers", feature = "alloc"))]
+#[cfg(feature = "large-buffers")]
 pub(crate) const MAX_TX_BUF_SIZE: usize = network::MAX_TX_LARGE_PACKET_SIZE;
 
-#[cfg(not(all(feature = "large-buffers", feature = "alloc")))]
+#[cfg(not(feature = "large-buffers"))]
 pub(crate) const MAX_RX_BUF_SIZE: usize = network::MAX_RX_PACKET_SIZE;
-#[cfg(not(all(feature = "large-buffers", feature = "alloc")))]
+#[cfg(not(feature = "large-buffers"))]
 pub(crate) const MAX_TX_BUF_SIZE: usize = network::MAX_TX_PACKET_SIZE;
 
 /// Represents the state of the transport layer of a `Matter` instance.
@@ -118,32 +115,6 @@ impl Transport {
             device_sai: dev_det.sai,
             device_sii: dev_det.sii,
         })
-    }
-
-    /// Initialize the transport buffers if using the `large-buffers` feature flag.
-    #[cfg(all(feature = "large-buffers", feature = "alloc"))]
-    pub fn initialize_buffers(&mut self) {
-        use crate::utils::init::InitMaybeUninit;
-
-        let rx = self.rx.get_mut();
-        let tx = self.tx.get_mut();
-
-        if rx.buf.buffer.is_none() {
-            let mut b = alloc::boxed::Box::new_uninit();
-            b.init_with(crate::utils::storage::Vec::init());
-            rx.buf.buffer = Some(unsafe { b.assume_init() });
-        }
-
-        if tx.buf.buffer.is_none() {
-            let mut b = alloc::boxed::Box::new_uninit();
-            b.init_with(crate::utils::storage::Vec::init());
-            tx.buf.buffer = Some(unsafe { b.assume_init() });
-        }
-    }
-
-    #[cfg(not(all(feature = "large-buffers", feature = "alloc")))]
-    pub fn initialize_buffers(&mut self) {
-        // No-op, as buffers are allocated inline
     }
 
     /// Reset the transport state by clearing the RX buffer and the TX buffer
@@ -1537,71 +1508,36 @@ impl defmt::Format for DetailedPacketInfo<'_> {
     }
 }
 
-// The buffer used inside the pair of RX and TX `Packet` instances
-// When the `alloc` and `large-buffers` features are enabled, the buffer payload is allocated on the heap
+// The buffer used inside the pair of RX and TX `Packet` instances.
+//
+// The payload is allocated inline. With `large-buffers` enabled the inner
+// `Vec` is ~1 MiB, so prefer constructing the buffer in place via
+// [`PacketBuffer::init`].
+// Constructing one by value with `new()` works too, as long as the resulting
+// `Matter` is not moved through a small stack.
 //
 // This type is only known and used by the `transport` and the `exchange` modules
-#[cfg(all(feature = "large-buffers", feature = "alloc"))]
-pub(crate) struct PacketBuffer<const N: usize> {
-    buffer: Option<alloc::boxed::Box<crate::utils::storage::Vec<u8, N>>>,
-}
-
-// The buffer used inside the pair of RX and TX `Packet` instances
-// When the either of the `alloc` and `large-buffers` features is not enabled, the buffer payload is allocated inline
-//
-// This type is only known and used by the `transport` and the `exchange` modules
-#[cfg(not(all(feature = "large-buffers", feature = "alloc")))]
 pub(crate) struct PacketBuffer<const N: usize> {
     buffer: crate::utils::storage::Vec<u8, N>,
 }
 
 impl<const N: usize> PacketBuffer<N> {
-    #[cfg(all(feature = "large-buffers", feature = "alloc"))]
-    pub const fn new() -> Self {
-        Self { buffer: None }
-    }
-
-    #[cfg(not(all(feature = "large-buffers", feature = "alloc")))]
     pub const fn new() -> Self {
         Self {
             buffer: crate::utils::storage::Vec::new(),
         }
     }
 
-    #[cfg(all(feature = "large-buffers", feature = "alloc"))]
-    pub fn init() -> impl Init<Self> {
-        init!(Self { buffer: None })
-    }
-
-    #[cfg(not(all(feature = "large-buffers", feature = "alloc")))]
     pub fn init() -> impl Init<Self> {
         init!(Self {
             buffer <- crate::utils::storage::Vec::init(),
         })
     }
 
-    #[cfg(all(feature = "large-buffers", feature = "alloc"))]
-    pub fn buf_mut(&mut self) -> &mut crate::utils::storage::Vec<u8, N> {
-        unwrap!(
-            self.buffer.as_deref_mut(),
-            "Buffer is not allocated. Did you forget to call `initialize_buffers`?"
-        )
-    }
-
-    #[cfg(not(all(feature = "large-buffers", feature = "alloc")))]
     pub fn buf_mut(&mut self) -> &mut crate::utils::storage::Vec<u8, N> {
         &mut self.buffer
     }
 
-    #[cfg(all(feature = "large-buffers", feature = "alloc"))]
-    pub fn buf_ref(&self) -> &crate::utils::storage::Vec<u8, N> {
-        unwrap!(
-            self.buffer.as_deref(),
-            "Buffer is not allocated. Did you forget to call `initialize_buffers`?"
-        )
-    }
-
-    #[cfg(not(all(feature = "large-buffers", feature = "alloc")))]
     pub fn buf_ref(&self) -> &crate::utils::storage::Vec<u8, N> {
         &self.buffer
     }

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -41,11 +41,22 @@ use super::session::{Session, SessionMode};
 use super::{PacketAccess, MAX_RX_BUF_SIZE, MAX_TX_BUF_SIZE};
 
 /// Minimum buffer which should be allocated by user code that wants to pull RX messages via `Exchange::recv_into`
-// TODO: Revisit with large packets
+///
+/// When the `large-buffers` feature is enabled, this tracks the larger TCP-capable packet
+/// size, so that IM-level buffers (e.g. `IMBuffer`) can absorb a full Matter-over-TCP
+/// message. Otherwise it stays at the UDP-sized default.
+#[cfg(feature = "large-buffers")]
+pub const MAX_EXCHANGE_RX_BUF_SIZE: usize = network::MAX_RX_LARGE_PACKET_SIZE;
+#[cfg(not(feature = "large-buffers"))]
 pub const MAX_EXCHANGE_RX_BUF_SIZE: usize = network::MAX_RX_PACKET_SIZE;
 
 /// Maximum buffer which should be allocated and used by user code that wants to send messages via `Exchange::send`
-// TODO: Revisit with large packets
+///
+/// Mirrors `MAX_EXCHANGE_RX_BUF_SIZE` with respect to the `large-buffers` feature.
+#[cfg(feature = "large-buffers")]
+pub const MAX_EXCHANGE_TX_BUF_SIZE: usize =
+    network::MAX_TX_LARGE_PACKET_SIZE - PacketHdr::HDR_RESERVE - PacketHdr::TAIL_RESERVE;
+#[cfg(not(feature = "large-buffers"))]
 pub const MAX_EXCHANGE_TX_BUF_SIZE: usize =
     network::MAX_TX_PACKET_SIZE - PacketHdr::HDR_RESERVE - PacketHdr::TAIL_RESERVE;
 

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -1118,17 +1118,23 @@ impl Sessions {
         peer_node_id: u64,
         secure: bool,
     ) -> Option<&mut Session> {
-        let mut session = self
+        // Prefer a TCP-backed session (larger payloads, no MRP fragmentation
+        // limits) over UDP when both are available for the same peer. This
+        // is required e.g. for the WebRTC Transport Provider's outbound
+        // `Answer(sdp)` invoke whose payload can easily exceed a UDP MTU.
+        let idx = self
             .sessions
-            .iter_mut()
-            // Expired sessions are not allowed to initiate new exchanges
-            .find(|sess| !sess.expired && sess.is_for_node(fabric_idx, peer_node_id, secure));
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| !s.expired && s.is_for_node(fabric_idx, peer_node_id, secure))
+            .max_by_key(|(_, s)| i32::from(s.peer_addr.is_tcp()))
+            .map(|(i, _)| i)?;
 
-        if let Some(session) = session.as_mut() {
-            session.update_last_used(self.epoch);
-        }
+        let session = &mut self.sessions[idx];
 
-        session
+        session.update_last_used(self.epoch);
+
+        Some(session)
     }
 
     pub(crate) fn get_for_rx(

--- a/rs-matter/src/utils/init.rs
+++ b/rs-matter/src/utils/init.rs
@@ -98,3 +98,15 @@ impl<T> InitMaybeUninit<T> for MaybeUninit<T> {
         }
     }
 }
+
+/// A trait for types that have a canonical, stack-safe, in-place default initializer.
+///
+/// This is the in-place initialization analogue of `Default`: unlike `Default::default()`
+/// which returns `Self` by value (potentially materializing a large value on the stack),
+/// `init_default()` returns an `Init<Self>` that writes the value directly into its
+/// final memory location. This is essential for large types (e.g. buffers sized in MiB)
+/// whose on-stack construction would overflow the stack.
+pub trait InitDefault: Sized {
+    /// Returns a canonical in-place initializer for `Self`.
+    fn init_default() -> impl Init<Self>;
+}

--- a/rs-matter/src/utils/storage/pooled.rs
+++ b/rs-matter/src/utils/storage/pooled.rs
@@ -24,7 +24,7 @@ use embassy_futures::select::{select, Either};
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_time::{Duration, Timer};
 
-use crate::utils::init::{init, Init, UnsafeCellInit};
+use crate::utils::init::{init, Init, InitDefault, UnsafeCellInit};
 use crate::utils::sync::blocking::raw::MatterRawMutex;
 use crate::utils::sync::Signal;
 
@@ -108,12 +108,15 @@ where
 
     fn init_buffers(pool: &UnsafeCell<crate::utils::storage::Vec<T, N>>)
     where
-        T: Default + Clone,
+        T: InitDefault,
     {
         let buffers = unwrap!(unsafe { pool.get().as_mut() });
 
-        if buffers.len() < N {
-            unwrap!(buffers.resize_default(N));
+        while buffers.len() < N {
+            // In-place initialization: each slot is written directly via pinned-init,
+            // never materializing a full `T` value on the stack. This is essential when
+            // `T` is a large buffer (e.g. 1 MiB) that would otherwise overflow the stack.
+            unwrap!(buffers.push_init_unchecked(T::init_default()));
         }
     }
 }
@@ -134,7 +137,7 @@ where
 
 impl<const N: usize, T, M> BufferAccess<T> for PooledBuffers<N, T, M>
 where
-    T: Default + Clone,
+    T: InitDefault,
     M: RawMutex,
 {
     type Buffer<'b>

--- a/rs-matter/src/utils/storage/vec.rs
+++ b/rs-matter/src/utils/storage/vec.rs
@@ -34,7 +34,7 @@ use core::{
     slice,
 };
 
-use crate::utils::init::{init_from_closure, Init};
+use crate::utils::init::{init_from_closure, Init, InitDefault};
 
 /// A fixed capacity [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html)
 ///
@@ -112,7 +112,6 @@ impl<T, const N: usize> Vec<T, N> {
     }
 
     /// Constructs a new vector with a fixed capacity of `N` and fills it
-    /// with the provided slice.
     ///
     /// This is equivalent to the following code:
     ///
@@ -908,6 +907,12 @@ impl<T, const N: usize> Vec<T, N> {
 impl<T, const N: usize> Default for Vec<T, N> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<T, const N: usize> InitDefault for Vec<T, N> {
+    fn init_default() -> impl Init<Self> {
+        Self::init()
     }
 }
 

--- a/rs-matter/tests/case.rs
+++ b/rs-matter/tests/case.rs
@@ -97,13 +97,10 @@ fn test_case_handshake() {
 
         // ---- 2. Set up two Matter instances ----
 
-        let mut device_matter =
-            Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, sys_epoch, 0);
-        device_matter.initialize_transport_buffers();
+        let device_matter = Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, sys_epoch, 0);
 
-        let mut controller_matter =
+        let controller_matter =
             Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, sys_epoch, 0);
-        controller_matter.initialize_transport_buffers();
 
         // ---- 3. Populate both FabricMgrs with matching fabric ----
 

--- a/rs-matter/tests/commissioning.rs
+++ b/rs-matter/tests/commissioning.rs
@@ -195,7 +195,6 @@ macro_rules! commissioning_test {
                 sys_epoch,
                 MATTER_PORT,
             ));
-            device_matter.initialize_transport_buffers();
 
             let device_crypto = test_only_crypto();
             let mut rand = device_crypto.rand()?;
@@ -242,7 +241,6 @@ macro_rules! commissioning_test {
                 sys_epoch,
                 0,
             ));
-            ctrl_matter.initialize_transport_buffers();
             let ctrl_crypto = test_only_crypto();
 
             let transport_label = if $use_tcp { "TCP" } else { "UDP" };

--- a/rs-matter/tests/common/e2e.rs
+++ b/rs-matter/tests/common/e2e.rs
@@ -225,7 +225,7 @@ impl<C: Crypto> E2eRunner<C> {
         #[cfg(not(feature = "std"))]
         use rs_matter::utils::rand::dummy_rand as rand;
 
-        let mut matter = Matter::new(
+        let matter = Matter::new(
             &TEST_DEV_DET,
             TEST_DEV_COMM,
             &TEST_DEV_ATT,
@@ -236,8 +236,6 @@ impl<C: Crypto> E2eRunner<C> {
         matter.with_state(|state| {
             state.fabrics.add_with_post_init(|_| Ok(())).unwrap();
         });
-
-        matter.initialize_transport_buffers();
 
         matter
     }

--- a/rs-matter/tests/exchange.rs
+++ b/rs-matter/tests/exchange.rs
@@ -52,13 +52,10 @@ fn test_unsecured_exchange_over_udp() {
 
     futures_lite::future::block_on(async {
         // Create device-side and controller-side Matter instances
-        let mut device_matter =
-            Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, sys_epoch, 0);
-        device_matter.initialize_transport_buffers();
+        let device_matter = Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, sys_epoch, 0);
 
-        let mut controller_matter =
+        let controller_matter =
             Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, sys_epoch, 0);
-        controller_matter.initialize_transport_buffers();
 
         let crypto = test_only_crypto();
 

--- a/rs-matter/tests/pase.rs
+++ b/rs-matter/tests/pase.rs
@@ -52,13 +52,10 @@ fn test_pase_handshake() {
     init_env_logger();
 
     futures_lite::future::block_on(async {
-        let mut device_matter =
-            Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, sys_epoch, 0);
-        device_matter.initialize_transport_buffers();
+        let device_matter = Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, sys_epoch, 0);
 
-        let mut controller_matter =
+        let controller_matter =
             Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, sys_epoch, 0);
-        controller_matter.initialize_transport_buffers();
 
         let crypto = test_only_crypto();
 


### PR DESCRIPTION
These are a set of follow-up fixes related to the introduction of the TCP protocol support.
All of these are from testing the TCP protocol for-real with the Matter 1.5 camera stuff / WebRTC and Smart Things, which is so far the only commercial controller which supports Matter 1.5 cameras ATM.

Basically, they fix small stuff elsewhere in `rs-matter` so that the whole stack can work fine on top of TCP.

In particular:

- `PooledBuffers` needed to allocate large buffers when the `large-buffers` feature is enabled. There was even a TODO for that

- I also realized that we don't need `alloc` as a dependency on the `large-buffers` feature, because the large buffers can be pre-allocated statically, just like the small (UDP) buffers. Moreover, with `const fn new` and especially with `pinned-init` that we now support, this pre-allocation can be done very efficiently, without any stack blowups. Hence, the `Matter::initialize_transport_buffers` call the user had to explicitly call at least when large buffers are enabled was no longer necessary and was therefore removed.

- `ImClient` had a small buglet where it could not invoke commands that return a status code

- And probably the one which is a tad controversial: in `sessions`, we now have a piece of code that - when finding a session for a node id - prefers to return a TCP over a UDP session (that is, if there is a TCP one in the first place). I'm not convinced this is ideal, but it won't do any harm either, if TCP is not enabled.