### PR TITLE
Make sure the examples run on Windows

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -54,7 +54,7 @@ embassy-sync = "0.7"
 embassy-time = { version = "0.5", features = ["std"] }
 embassy-time-queue-utils = { version = "0.3", features = ["generic-queue-64"] }
 static_cell = "1"
-nix = { version = "0.27", features = ["net"] }
+if-addrs = "0.15"
 async-io = "2"
 async-compat = "0.2"
 futures-lite = "2"

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -38,7 +38,7 @@ use rs_matter::dm::devices::{DEV_TYPE_AGGREGATOR, DEV_TYPE_BRIDGED_NODE, DEV_TYP
 use rs_matter::dm::endpoints;
 use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
-use rs_matter::dm::networks::unix::UnixNetifs;
+use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver, EmptyHandler, Endpoint,
@@ -211,7 +211,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
         endpoints::with_eth_sys(
             &false,
             &(),
-            &UnixNetifs,
+            &SysNetifs,
             rand,
             EmptyHandler
                 // The next chain is the handler for the "aggregator" endpoint 1.

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -49,7 +49,7 @@ use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
-use rs_matter::dm::networks::unix::UnixNetifs;
+use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
@@ -245,8 +245,13 @@ fn main() -> Result<(), Error> {
         matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
     }
 
-    // Listen to SIGTERM because at the end of the test we'll receive it
+    // Listen to SIGTERM (or Ctrl-C on Windows, where SIGTERM is not
+    // supported by `async-signal`) because at the end of the test we'll
+    // receive it.
+    #[cfg(not(windows))]
     let mut term_signal = Signals::new([Signal::Term])?;
+    #[cfg(windows)]
+    let mut term_signal = Signals::new([Signal::Int])?;
     let mut term = pin!(async {
         term_signal.next().await;
         Ok(())
@@ -318,7 +323,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
         endpoints::with_eth_sys(
             &false,
             &(),
-            &UnixNetifs,
+            &SysNetifs,
             rand,
             EmptyHandler
                 // Clusters for Endpoint 1

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -49,7 +49,7 @@ use rs_matter::dm::devices::DEV_TYPE_DIMMABLE_LIGHT;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
-use rs_matter::dm::networks::unix::UnixNetifs;
+use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::IMBuffer;
 use rs_matter::dm::{
@@ -226,8 +226,13 @@ fn run() -> Result<(), Error> {
         matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
     }
 
-    // Listen to SIGTERM because at the end of the test we'll receive it
+    // Listen to SIGTERM (or Ctrl-C on Windows, where SIGTERM is not
+    // supported by `async-signal`) because at the end of the test we'll
+    // receive it.
+    #[cfg(not(windows))]
     let mut term_signal = Signals::new([Signal::Term])?;
+    #[cfg(windows)]
+    let mut term_signal = Signals::new([Signal::Int])?;
     let mut term = pin!(async {
         term_signal.next().await;
         Ok(())
@@ -273,7 +278,7 @@ fn dm_handler<'a, LH: LevelControlHooks, OH: OnOffHooks>(
         endpoints::with_eth_sys(
             &false,
             &(),
-            &UnixNetifs,
+            &SysNetifs,
             rand,
             EmptyHandler
                 .chain(

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -61,7 +61,7 @@ use rs_matter::dm::devices::DEV_TYPE_CASTING_VIDEO_PLAYER;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
-use rs_matter::dm::networks::unix::UnixNetifs;
+use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
     ArrayAttributeRead, Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver,
@@ -193,7 +193,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
         endpoints::with_eth_sys(
             &false,
             &(),
-            &UnixNetifs,
+            &SysNetifs,
             rand,
             EmptyHandler
                 .chain(

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -38,7 +38,7 @@ use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::events::NoEvents;
 use rs_matter::dm::networks::eth::EthNetwork;
-use rs_matter::dm::networks::unix::UnixNetifs;
+use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::IMBuffer;
 use rs_matter::dm::{
@@ -216,7 +216,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
         endpoints::with_eth_sys(
             &false,
             &(),
-            &UnixNetifs,
+            &SysNetifs,
             rand,
             EmptyHandler
                 .chain(

--- a/examples/src/bin/onoff_light_work_stealing.rs
+++ b/examples/src/bin/onoff_light_work_stealing.rs
@@ -38,7 +38,7 @@ use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints::{self, EthSysHandler};
 use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
-use rs_matter::dm::networks::unix::UnixNetifs;
+use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::IMBuffer;
 use rs_matter::dm::{Async, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node};
@@ -257,7 +257,7 @@ fn dm_handler<'a>(
     endpoints::with_eth_sys(
         &false,
         &(),
-        &UnixNetifs,
+        &SysNetifs,
         rand,
         EmptyHandler
             .chain(

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -38,7 +38,7 @@ use rs_matter::dm::devices::DEV_TYPE_SMART_SPEAKER;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::eth::EthNetwork;
-use rs_matter::dm::networks::unix::UnixNetifs;
+use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
     Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
@@ -188,7 +188,7 @@ fn dm_handler<'a, LH: LevelControlHooks, OH: OnOffHooks>(
         endpoints::with_eth_sys(
             &false,
             &(),
-            &UnixNetifs,
+            &SysNetifs,
             rand,
             EmptyHandler
                 .chain(

--- a/examples/src/common/mdns.rs
+++ b/examples/src/common/mdns.rs
@@ -70,49 +70,62 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
     use rs_matter::transport::network::{Ipv4Addr, Ipv6Addr};
 
     // NOTE:
-    // Replace with your own network initialization for e.g. `no_std` environments
+    // Replace with your own network initialization for e.g. `no_std` environments.
+    //
+    // Uses the cross-platform `if-addrs` crate to enumerate interfaces so the
+    // examples work on Linux, macOS and Windows.
     #[inline(never)]
     fn initialize_network() -> Result<(Ipv4Addr, Ipv6Addr, u32), Error> {
         use log::error;
-        use nix::{net::if_::InterfaceFlags, sys::socket::SockaddrIn6};
         use rs_matter::error::ErrorCode;
-        let interfaces = || {
-            nix::ifaddrs::getifaddrs().unwrap().filter(|ia| {
-                ia.flags
-                    .contains(InterfaceFlags::IFF_UP | InterfaceFlags::IFF_BROADCAST)
-                    && !ia
-                        .flags
-                        .intersects(InterfaceFlags::IFF_LOOPBACK | InterfaceFlags::IFF_POINTOPOINT)
-            })
+
+        let all = if_addrs::get_if_addrs().map_err(|_| ErrorCode::StdIoError)?;
+
+        // A quick and dirty way to pick the interface we want: find one that
+        // has both an IPv6 address AND a non-loopback IPv4 address assigned.
+        // Prefer link-local (fe80::/10) IPv6 addresses — most likely that's
+        // the "real" LAN interface we need, as opposed to all the
+        // docker/libvirt/virtual interfaces that might be present on the
+        // machine and which typically are IPv4-only.
+        //
+        // On Windows the `if_addrs` crate may omit link-local IPv6 addresses,
+        // so we fall back to accepting any non-loopback IPv6 address paired
+        // with an IPv4 address on the same interface.
+        let find_candidate = |ipv6_filter: fn(std::net::Ipv6Addr) -> bool| {
+            all.iter()
+                .filter(|ia| !ia.is_loopback())
+                .filter_map(|ia| match ia.addr {
+                    if_addrs::IfAddr::V6(ref v6) if ipv6_filter(v6.ip) => {
+                        Some((ia.name.clone(), v6.ip, ia.index.unwrap_or(0)))
+                    }
+                    _ => None,
+                })
+                .find_map(|(iname, ipv6, index)| {
+                    all.iter()
+                        .filter(|ia2| ia2.name == iname)
+                        .find_map(|ia2| match ia2.addr {
+                            if_addrs::IfAddr::V4(ref v4) => {
+                                Some((iname.clone(), v4.ip, ipv6, index))
+                            }
+                            _ => None,
+                        })
+                })
         };
 
-        // A quick and dirty way to get a network interface that has a link-local IPv6 address assigned as well as a non-loopback IPv4
-        // Most likely, this is the interface we need
-        // (as opposed to all the docker and libvirt interfaces that might be assigned on the machine and which seem by default to be IPv4 only)
-        let (iname, ip, ipv6) = interfaces()
-            .filter_map(|ia| {
-                ia.address
-                    .and_then(|addr| addr.as_sockaddr_in6().map(SockaddrIn6::ip))
-                    .map(|ipv6| (ia.interface_name, ipv6))
-            })
-            .filter_map(|(iname, ipv6)| {
-                interfaces()
-                    .filter(|ia2| ia2.interface_name == iname)
-                    .find_map(|ia2| {
-                        ia2.address
-                            .and_then(|addr| addr.as_sockaddr_in().map(|addr| addr.ip().into()))
-                            .map(|ip: std::net::Ipv4Addr| (iname.clone(), ip, ipv6))
-                    })
-            })
-            .next()
+        // Prefer an interface with a link-local IPv6 address …
+        let candidate = find_candidate(|ip| (ip.segments()[0] & 0xffc0) == 0xfe80)
+            // … otherwise accept any non-loopback IPv6 address
+            .or_else(|| find_candidate(|_| true))
             .ok_or_else(|| {
                 error!("Cannot find network interface suitable for mDNS broadcasting");
                 ErrorCode::StdIoError
             })?;
 
-        info!("Will use network interface {iname} with {ip}/{ipv6} for mDNS",);
+        let (iname, ip, ipv6, index) = candidate;
 
-        Ok((ip.octets().into(), ipv6.octets().into(), 0 as _))
+        info!("Will use network interface {iname} with {ip}/{ipv6} for mDNS");
+
+        Ok((ip.octets().into(), ipv6.octets().into(), index))
     }
 
     let (ipv4_addr, ipv6_addr, interface) = initialize_network()?;

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -117,7 +117,7 @@ max-btp-sessions-1 = [] # default
 astro-dnssd = ["os", "dep:astro-dnssd"]
 zeroconf = ["os", "dep:zeroconf"]
 zbus = ["dep:zbus", "os", "futures-lite", "libc", "uuid", "async-channel"]
-os = ["std", "backtrace", "async-io", "critical-section/std", "embassy-sync/std", "embassy-time/std"]
+os = ["std", "backtrace", "async-io", "critical-section/std", "embassy-sync/std", "embassy-time/std", "dep:if-addrs"]
 std = ["alloc", "rand"]
 backtrace = []
 alloc = ["defmt?/alloc"]
@@ -196,6 +196,7 @@ libc = { version = "0.2", optional = true }
 futures-lite = { version = "2", optional = true }
 astro-dnssd = { version = "0.3", optional = true }
 zeroconf = { version = "0.15", optional = true }
+if-addrs = { version = "0.15", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "espidf")))'.dependencies]
 bitflags = "2"

--- a/rs-matter/src/dm/networks.rs
+++ b/rs-matter/src/dm/networks.rs
@@ -20,9 +20,24 @@
 use core::future::Future;
 
 pub mod eth;
+#[cfg(feature = "os")]
+pub mod generic;
 #[cfg(all(unix, feature = "os", not(target_os = "espidf")))]
 pub mod unix;
 pub mod wireless;
+
+#[cfg(all(feature = "os", not(all(unix, not(target_os = "espidf")))))]
+pub use generic::GenericNetifs as SysNetifs;
+/// A platform-appropriate alias for the default OS-backed `NetifDiag` /
+/// `NetChangeNotif` implementation:
+///
+/// - On Unix (non-ESP-IDF) it resolves to [`unix::UnixNetifs`], which uses
+///   `nix` and reports MAC addresses and link-local IPv6 addresses.
+/// - On other platforms (notably Windows) it resolves to
+///   [`generic::GenericNetifs`], a portable `if-addrs`-backed fallback that
+///   does not report MAC addresses.
+#[cfg(all(unix, feature = "os", not(target_os = "espidf")))]
+pub use unix::UnixNetifs as SysNetifs;
 
 /// A generic trait for network change notifications.
 pub trait NetChangeNotif {
@@ -37,4 +52,30 @@ where
     fn wait_changed(&self) -> impl Future<Output = ()> {
         (*self).wait_changed()
     }
+}
+
+/// Polling interval used by the polling-based [`NetChangeNotif`]
+/// implementations of [`unix::UnixNetifs`] and [`generic::GenericNetifs`].
+#[cfg(feature = "os")]
+pub const NETIF_POLL_INTERVAL: embassy_time::Duration = embassy_time::Duration::from_secs(5);
+
+/// A polling-based [`NetChangeNotif::wait_changed`] helper that simply waits
+/// for [`NETIF_POLL_INTERVAL`] and then unconditionally reports a change.
+///
+/// This intentionally does NOT compare interface snapshots itself, because:
+/// - A snapshot-comparing helper would only observe changes that happen
+///   while it is being awaited; any change occurring between two consecutive
+///   `wait_changed` calls would be missed.
+/// - Callers of [`NetChangeNotif`] are expected to re-read the interface
+///   state after `wait_changed` returns and diff it against the previously
+///   observed state, so doing the same diff inside `wait_changed` would be
+///   redundant.
+///
+/// The trade-off is that callers will be woken up every
+/// [`NETIF_POLL_INTERVAL`] even when nothing has changed; for an OS-level
+/// `NetChangeNotif`, [`NETIF_POLL_INTERVAL`] should therefore be kept large
+/// enough to keep that overhead negligible.
+#[cfg(feature = "os")]
+pub(crate) async fn poll_netifs_changed() {
+    embassy_time::Timer::after(NETIF_POLL_INTERVAL).await;
 }

--- a/rs-matter/src/dm/networks/generic.rs
+++ b/rs-matter/src/dm/networks/generic.rs
@@ -1,0 +1,144 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! A cross-platform `NetifDiag` and `NetChangeNotif` implementation backed by
+//! the `if-addrs` crate. Suitable as a fallback on platforms (notably
+//! Windows) where the richer [`super::unix::UnixNetifs`] implementation is
+//! not available. Unlike the `unix` module, this implementation does not
+//! report a hardware address (MAC).
+
+use core::net::{Ipv4Addr, Ipv6Addr};
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::dm::clusters::gen_diag::{InterfaceTypeEnum, NetifDiag, NetifInfo};
+use crate::error::{Error, ErrorCode};
+use crate::utils::sync::DynBase;
+
+use super::NetChangeNotif;
+
+/// `GenericNetifs` enumerates all operational network interfaces in a
+/// cross-platform way using the `if-addrs` crate.
+///
+/// It is a simple implementation of the [`NetifDiag`] trait suitable as a
+/// fallback on platforms where the richer [`super::unix::UnixNetifs`]
+/// implementation is not available (notably Windows). On Unix platforms,
+/// prefer [`super::unix::UnixNetifs`], which additionally reports the
+/// hardware (MAC) address.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct GenericNetifs;
+
+impl GenericNetifs {
+    /// Get all network interfaces.
+    pub fn get(&self) -> Result<Vec<GenericNetif>, Error> {
+        let mut netifs: Vec<GenericNetif> = Vec::new();
+
+        for ia in if_addrs::get_if_addrs().map_err(|_| ErrorCode::NoNetworkInterface)? {
+            let netif_index = ia.index.unwrap_or(0);
+
+            let entry = if let Some(entry) = netifs.iter_mut().find(|n| n.name == ia.name) {
+                entry
+            } else {
+                netifs.push(GenericNetif {
+                    name: ia.name.clone(),
+                    hw_addr: [0; 8],
+                    ipv4addrs: Vec::new(),
+                    ipv6addrs: Vec::new(),
+                    operational: true,
+                    netif_index,
+                });
+                netifs.last_mut().unwrap()
+            };
+
+            if entry.netif_index == 0 {
+                entry.netif_index = netif_index;
+            }
+
+            match ia.addr {
+                if_addrs::IfAddr::V4(v4) => entry.ipv4addrs.push(v4.ip),
+                if_addrs::IfAddr::V6(v6) => entry.ipv6addrs.push(v6.ip),
+            }
+        }
+
+        Ok(netifs)
+    }
+}
+
+impl DynBase for GenericNetifs {}
+
+impl NetifDiag for GenericNetifs {
+    fn netifs(&self, f: &mut dyn FnMut(&NetifInfo) -> Result<(), Error>) -> Result<(), Error> {
+        for netif in self.get()? {
+            f(&netif.to_netif_info())?;
+        }
+
+        Ok(())
+    }
+}
+
+impl NetChangeNotif for GenericNetifs {
+    /// Wait until the set of network interfaces (or their addresses) may have
+    /// changed.
+    ///
+    /// NOTE: The `if-addrs` crate does not expose OS-specific change
+    /// notifications, so this is a polling-based fallback that simply waits
+    /// for [`super::NETIF_POLL_INTERVAL`] and then returns; it does not
+    /// actually detect changes. Callers are expected to re-read the
+    /// interface state after this returns and diff it against the previously
+    /// observed one.
+    async fn wait_changed(&self) {
+        super::poll_netifs_changed().await;
+    }
+}
+
+/// A single network interface as reported by [`GenericNetifs`].
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct GenericNetif {
+    /// Interface name
+    pub name: String,
+    /// Hardware address (always zero - not provided by `if-addrs`)
+    pub hw_addr: [u8; 8],
+    /// IPv4 addresses
+    pub ipv4addrs: Vec<Ipv4Addr>,
+    /// IPv6 addresses
+    pub ipv6addrs: Vec<Ipv6Addr>,
+    /// Operational status (always `true` - `if-addrs` only reports interfaces
+    /// that have an address assigned, which we treat as operational).
+    pub operational: bool,
+    /// Interface index
+    pub netif_index: u32,
+}
+
+impl GenericNetif {
+    /// Convert to [`NetifInfo`].
+    pub fn to_netif_info(&self) -> NetifInfo<'_> {
+        NetifInfo {
+            name: &self.name,
+            operational: self.operational,
+            offprem_svc_reachable_ipv4: None,
+            offprem_svc_reachable_ipv6: None,
+            hw_addr: &self.hw_addr,
+            ipv4_addrs: &self.ipv4addrs,
+            ipv6_addrs: &self.ipv6addrs,
+            netif_type: InterfaceTypeEnum::Unspecified,
+            netif_index: self.netif_index,
+        }
+    }
+}

--- a/rs-matter/src/dm/networks/unix.rs
+++ b/rs-matter/src/dm/networks/unix.rs
@@ -85,8 +85,17 @@ impl NetifDiag for UnixNetifs {
 }
 
 impl NetChangeNotif for UnixNetifs {
+    /// Wait until the set of network interfaces (or their addresses) may have
+    /// changed.
+    ///
+    /// NOTE: This is a polling-based fallback that simply waits for
+    /// [`super::NETIF_POLL_INTERVAL`] and then returns; it does not actually
+    /// detect changes. Callers are expected to re-read the interface state
+    /// after this returns and diff it against the previously observed one.
+    /// A future improvement would use OS-specific notifications (e.g.
+    /// `RTNETLINK` on Linux) for instant change detection.
     async fn wait_changed(&self) {
-        core::future::pending().await // TODO
+        super::poll_netifs_changed().await;
     }
 }
 


### PR DESCRIPTION
Subject says it all - addresses #346

- One issue is the `nix`-based interface enumerator, now replaced with `if-addrs` on Windows specifically
- Another was the use of the SIGTERM signal in two of the examples (the ones used as test drivers for the Python/YAML tests) which is not available on Windows
- ~~I suspect there is also a problem with mDNS, we'll see shortly.~~