### PR TITLE
Add test TC_IDM_2_2

### DIFF
--- a/.github/workflows/chiptool-tests.yml
+++ b/.github/workflows/chiptool-tests.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run YAML Integration Tests (with RustCrypto by default))
         run: |
-          cargo xtask itest
+          cargo xtask itest --skip-setup
 
       # TODO: Enable once mbedtls-rs-sys built removes the installation step
       # - name: Run One YAML Integration Test with MbedTLS
@@ -77,12 +77,12 @@ jobs:
 
       - name: Run One YAML Integration Test with OpenSSL
         run: |
-          cargo xtask itest --features openssl TestBasicInformation
+          cargo xtask itest --skip-setup --features openssl TestBasicInformation
 
       - name: Run LevelControl and OnOff YAML Integration Tests for dimmable_light
         run: |
           # TODO: Specify this test list inside of itest instead of here & re-add Test_TC_LVL_4_1, Test_TC_LVL_9_1, Test_TC_OO_2_7
-          cargo xtask itest --target dimmable_light --timeout 500 --features chip-test Test_TC_LVL_2_1 Test_TC_LVL_2_2 Test_TC_LVL_3_1 Test_TC_LVL_5_1 Test_TC_LVL_6_1 Test_TC_LVL_7_1 Test_TC_OO_2_1 Test_TC_OO_2_2 Test_TC_OO_2_4 Test_TC_OO_2_6
+          cargo xtask itest --skip-setup --target dimmable_light --timeout 500 --features chip-test Test_TC_LVL_2_1 Test_TC_LVL_2_2 Test_TC_LVL_3_1 Test_TC_LVL_5_1 Test_TC_LVL_6_1 Test_TC_LVL_7_1 Test_TC_OO_2_1 Test_TC_OO_2_2 Test_TC_OO_2_4 Test_TC_OO_2_6
 
       - name: Upload test results on failure
         if: failure()

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -303,8 +303,7 @@ const NODE: Node<'static> = Node {
             clusters: clusters!(
                 desc::DescHandler::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
-                TestOnOffDeviceLogic::CLUSTER,
-                UnitTestingHandler::CLUSTER
+                TestOnOffDeviceLogic::CLUSTER
             ),
         },
     ],

--- a/examples/src/common/mdns.rs
+++ b/examples/src/common/mdns.rs
@@ -65,7 +65,7 @@ pub async fn run_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(), E
 async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(), Error> {
     use std::net::UdpSocket;
 
-    use log::info;
+    use log::{debug, error, info, warn};
 
     use rs_matter::transport::network::{Ipv4Addr, Ipv6Addr};
 
@@ -76,10 +76,10 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
     // examples work on Linux, macOS and Windows.
     #[inline(never)]
     fn initialize_network() -> Result<(Ipv4Addr, Ipv6Addr, u32), Error> {
-        use log::error;
         use rs_matter::error::ErrorCode;
 
         let all = if_addrs::get_if_addrs().map_err(|_| ErrorCode::StdIoError)?;
+        debug!("Available network interfaces: {:?}", all);
 
         // A quick and dirty way to pick the interface we want: find one that
         // has both an IPv6 address AND a non-loopback IPv4 address assigned.
@@ -91,7 +91,7 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
         // On Windows the `if_addrs` crate may omit link-local IPv6 addresses,
         // so we fall back to accepting any non-loopback IPv6 address paired
         // with an IPv4 address on the same interface.
-        let find_candidate = |ipv6_filter: fn(std::net::Ipv6Addr) -> bool| {
+        let find_ipv6_candidate = |ipv6_filter: fn(std::net::Ipv6Addr) -> bool| {
             all.iter()
                 .filter(|ia| !ia.is_loopback())
                 .filter_map(|ia| match ia.addr {
@@ -112,10 +112,40 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
                 })
         };
 
-        // Prefer an interface with a link-local IPv6 address …
-        let candidate = find_candidate(|ip| (ip.segments()[0] & 0xffc0) == 0xfe80)
-            // … otherwise accept any non-loopback IPv6 address
-            .or_else(|| find_candidate(|_| true))
+        // Last-resort fallback trying to find the ethernet interface even if it doesn't have an IPv6 address assigned.
+        let find_fallback_candidate = || {
+            all.iter()
+                .filter(|ia| !ia.is_loopback())
+                .filter(|ia| ia.name.starts_with("eth") || ia.name.starts_with("eno"))
+                .map(|ia| match ia.addr {
+                    if_addrs::IfAddr::V4(ref v4) => (
+                        ia.name.clone(),
+                        v4.ip,
+                        std::net::Ipv6Addr::UNSPECIFIED,
+                        ia.index.unwrap_or(0),
+                    ),
+                    if_addrs::IfAddr::V6(ref v6) => (
+                        ia.name.clone(),
+                        std::net::Ipv4Addr::UNSPECIFIED,
+                        v6.ip,
+                        ia.index.unwrap_or(0),
+                    ),
+                })
+                .next()
+        };
+
+        // Prefer an interface with a link-local IPv6 address
+        let candidate = find_ipv6_candidate(|ip| ip.is_unicast_link_local())
+            // otherwise accept any non-loopback IPv6 address
+            .or_else(|| find_ipv6_candidate(|_| true))
+            // otherwise do one last fallback: accept an interface named "eth*" or "eno*" with a non-loopback IPv4 address
+            // even if it doesn't have an IPv6 address assigned.
+            //
+            // This is a common scenario in VMs and containers where the host might not provide an IPv6 address - including GH actions.
+            .or_else(|| {
+                warn!("No network interface with a suitable IPv6 address found");
+                find_fallback_candidate()
+            })
             .ok_or_else(|| {
                 error!("Cannot find network interface suitable for mDNS broadcasting");
                 ErrorCode::StdIoError

--- a/rs-matter/src/cert.rs
+++ b/rs-matter/src/cert.rs
@@ -209,7 +209,13 @@ impl<'a> Extension<'a> {
                 Self::encode_extension_end(w)?;
             }
             Extension::FutureExtensions(t) => {
-                error!("Future Extensions Not Yet Supported: {}", Bytes(t.0))
+                // Per Matter Spec 6.5.11.5, the `future-extensions` TLV field
+                // carries one or more ASN.1 DER-encoded X.509 `Extension`
+                // structures verbatim. They MUST be reproduced byte-for-byte
+                // inside the TBS extensions SEQUENCE so that the
+                // signature-over-TBS verification matches what the issuer
+                // actually signed.
+                w.raw("Future Extensions", t.0)?;
             }
         }
 
@@ -832,6 +838,13 @@ pub trait CertConsumer {
     fn end_ctx(&mut self) -> Result<(), Error>;
     fn oid(&mut self, tag: &str, oid: &[u8]) -> Result<(), Error>;
     fn utctime(&mut self, tag: &str, epoch: u64) -> Result<(), Error>;
+    /// Emit raw, pre-encoded DER bytes into the output stream verbatim.
+    ///
+    /// This is used to carry through TLV `future-extensions`, whose payload is
+    /// already a fully DER-encoded X.509 Extension (or a sequence of them) and
+    /// must be reproduced byte-for-byte for the TBS hash to match the signed
+    /// data.
+    fn raw(&mut self, tag: &str, data: &[u8]) -> Result<(), Error>;
 }
 
 #[cfg(test)]

--- a/rs-matter/src/cert/asn1_writer.rs
+++ b/rs-matter/src/cert/asn1_writer.rs
@@ -302,4 +302,11 @@ impl CertConsumer for ASN1Writer<'_> {
             self.write_str(0x17, time_str.as_bytes())
         }
     }
+
+    fn raw(&mut self, _tag: &str, data: &[u8]) -> Result<(), Error> {
+        self.append_with(data.len(), |t| {
+            let end_offset = t.offset + data.len();
+            t.buf[t.offset..end_offset].copy_from_slice(data);
+        })
+    }
 }

--- a/rs-matter/src/cert/printer.rs
+++ b/rs-matter/src/cert/printer.rs
@@ -133,4 +133,8 @@ impl CertConsumer for CertPrinter<'_, '_> {
         let _ = writeln!(self.f, "{} {} {:?}", SPACE[self.level], tag, dt);
         Ok(())
     }
+    fn raw(&mut self, tag: &str, data: &[u8]) -> Result<(), Error> {
+        let _ = writeln!(self.f, "{} {} {:x?}", SPACE[self.level], tag, data);
+        Ok(())
+    }
 }

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -30,9 +30,9 @@ use crate::dm::events::EventTLVWrite;
 use crate::dm::subscriptions::SubscriptionsBuffers;
 use crate::error::{Error, ErrorCode};
 use crate::im::{
-    EventPriority, EventResp, EventStatus, IMStatusCode, InvReq, InvRespTag, OpCode, ReadReq,
-    ReportDataReq, ReportDataRespTag, StatusResp, SubscribeReq, SubscribeResp, TimedReq, WriteReq,
-    WriteRespTag, PROTO_ID_INTERACTION_MODEL,
+    AttrPath, EventPriority, EventResp, EventStatus, IMStatusCode, InvReq, InvRespTag, OpCode,
+    ReadReq, ReportDataReq, ReportDataRespTag, StatusResp, SubscribeReq, SubscribeResp, TimedReq,
+    WriteReq, WriteRespTag, PROTO_ID_INTERACTION_MODEL,
 };
 use crate::persist::KvBlobStoreAccess;
 use crate::respond::ExchangeHandler;
@@ -267,6 +267,11 @@ where
         let read_req = ReadReq::new(TLVElement::new(&rx));
         debug!("IM: Read request: {:?}", read_req);
 
+        if let Err(err) = Self::validate_read(&read_req) {
+            error!("Invalid read request: {:?}", err);
+            return Self::send_status(exchange, err.code().into()).await;
+        }
+
         let req = ReportDataReq::Read(&read_req);
 
         let mut wb = WriteBuf::new(&mut tx);
@@ -284,6 +289,35 @@ where
         );
 
         resp.respond(&mut wb, true, true, |_, _, _| true).await?;
+
+        Ok(())
+    }
+
+    /// Validate a `ReadReq` request prior to processing.
+    fn validate_read(req: &ReadReq<'_>) -> Result<(), Error> {
+        if let Some(attr_requests) = req.attr_requests()? {
+            for attr_req in attr_requests {
+                Self::validate_attr_wildcard_path(&attr_req?)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Per-spec validation of an `AttrPath` that may contain wildcards.
+    ///
+    /// Per Matter spec section 8.9.2.3, when a path uses a wildcard cluster
+    /// but specifies a concrete attribute id, that attribute id must be a
+    /// global (system) attribute. Any other combination must be rejected with
+    /// `INVALID_ACTION`.
+    fn validate_attr_wildcard_path(path: &AttrPath) -> Result<(), Error> {
+        if path.cluster.is_none() {
+            if let Some(attr_id) = path.attr {
+                if !Attribute::is_system_attr(attr_id) {
+                    return Err(ErrorCode::InvalidAction.into());
+                }
+            }
+        }
 
         Ok(())
     }
@@ -463,7 +497,9 @@ where
             for attr_req in attr_requests {
                 let path = attr_req?;
 
-                if !path.is_wildcard() {
+                if path.is_wildcard() {
+                    Self::validate_attr_wildcard_path(&path)?;
+                } else {
                     node.validate_attr_path(&path, false, false, accessor)
                         .map_err(|_| ErrorCode::InvalidAction)?;
                 }

--- a/rs-matter/src/dm/types/reply.rs
+++ b/rs-matter/src/dm/types/reply.rs
@@ -115,7 +115,7 @@ where
                 match result {
                     Ok(()) => Ok(None),
                     Err(e) if e.code() != ErrorCode::NoSpace => {
-                        error!("Error reading attribute: {:?}", e);
+                        error!("Error reading attribute: {}", e);
 
                         tw.rewind_to(pos);
 

--- a/rs-matter/tests/data_model/attributes.rs
+++ b/rs-matter/tests/data_model/attributes.rs
@@ -67,13 +67,17 @@ fn test_read_success() {
 
 #[test]
 fn test_read_unsupported_fields() {
-    // 6 reads
+    // 5 reads
     // - endpoint doesn't exist - UnsupportedEndpoint
     // - cluster doesn't exist - UnsupportedCluster
     // - cluster doesn't exist and endpoint is wildcard - Silently ignore
     // - attribute doesn't exist - UnsupportedAttribute
     // - attribute doesn't exist and endpoint is wildcard - Silently ignore
-    // - attribute doesn't exist and cluster is wildcard - Silently ignore
+    //
+    // Note: a path with a wildcard cluster and a concrete non-global
+    // attribute id is rejected at the request level with InvalidAction
+    // (per Matter spec section 8.9.2.3) and is therefore covered by a
+    // dedicated integration test rather than this per-path test.
     init_env_logger();
 
     let invalid_endpoint = GenericPath::new(
@@ -94,14 +98,12 @@ fn test_read_unsupported_fields() {
     let invalid_attribute = GenericPath::new(Some(0), Some(echo_cluster::ID), Some(0x1234));
     let invalid_attribute_wc_endpoint =
         GenericPath::new(None, Some(echo_cluster::ID), Some(0x1234));
-    let invalid_attribute_wc_cluster = GenericPath::new(Some(0), None, Some(0x1234));
     let input = &[
         AttrPath::from_gp(&invalid_endpoint),
         AttrPath::from_gp(&invalid_cluster),
         AttrPath::from_gp(&invalid_cluster_wc_endpoint),
         AttrPath::from_gp(&invalid_attribute),
         AttrPath::from_gp(&invalid_attribute_wc_endpoint),
-        AttrPath::from_gp(&invalid_attribute_wc_cluster),
     ];
 
     let expected = &[

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -33,6 +33,9 @@ use log::{debug, info, warn};
 /// in `src/python_testing/`. All other names are YAML test suites
 /// dispatched to `scripts/tests/run_test_suite.py`.
 const DEFAULT_TESTS: &[&str] = &[
+    //
+    // YAML tests
+    //
     "Test_AddNewFabricFromExistingFabric",
     "TestAccessControlCluster",
     "TestAccessControlConstraints",
@@ -73,6 +76,11 @@ const DEFAULT_TESTS: &[&str] = &[
     // "TestSystemCommands", // TODO: Error attempting to start secondary device
     // "TestUserLabelCluster",  // TODO: specific cluster, to be implemented with all others
     // "TestUserLabelClusterConstraints",  // TODO: specific cluster, to be implemented with all others
+
+    //
+    // Python tests
+    //
+    "TC_IDM_2_2",
 ];
 
 /// The directory where the Chip repository will be cloned


### PR DESCRIPTION
This is the first Python test that we have and which passes.

It is primarily testing the IM/DM, but as a side effect is also testing the commissioning path.

EDIT: Looks like the Python test runner is not establishing a dedicated (Ipv6) network for running the app and the test? 
Instead, the GH action runner's ipv4-only network is used, so `chip_tool_tests` had to get some hacks in the network interface detector for mDNS (rest of the stack runs fine with ipv4-only).
