### PR TITLE
Fix a regression - in certain cases a subscription might enter an endless reporting loop

### DIFF
--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -284,7 +284,7 @@ where
             &node,
             None,
             HandlerInvoker::new(exchange, self),
-            EventReader::new(0),
+            EventReader::new(0, u64::MAX),
             self.events,
         );
 
@@ -578,13 +578,14 @@ where
 
             // Now report while there are subscriptions which are due for reporting
 
-            let max_event_number = self.events.watermark();
+            let event_numbers_watermark = self.events.watermark();
 
             loop {
-                let Some(mut rctx) =
-                    self.subscriptions
-                        .report(now, max_event_number, &self.subscriptions_buffers)
-                else {
+                let Some(mut rctx) = self.subscriptions.report(
+                    now,
+                    event_numbers_watermark,
+                    &self.subscriptions_buffers,
+                ) else {
                     break;
                 };
 
@@ -728,7 +729,10 @@ where
             &node,
             Some(rctx.subscription().ids().id),
             HandlerInvoker::new(exchange, self),
-            EventReader::new(rctx.max_seen_event_number()),
+            EventReader::new(
+                rctx.max_seen_event_number(),
+                rctx.next_max_seen_event_number(),
+            ),
             self.events,
         );
 
@@ -737,9 +741,8 @@ where
                 rctx.should_report_attr(e, c, a)
             })
             .await?;
-        if sub_valid {
-            rctx.update_max_seen_event_number(resp.event_reader.max_seen_event_number());
-        } else {
+
+        if !sub_valid {
             warn!(
                 "Subscription {:?} removed during reporting",
                 rctx.subscription().ids()
@@ -1134,8 +1137,6 @@ where
             for event_req in event_reqs.iter() {
                 let path = event_req?;
 
-                *empty = false;
-
                 if !path.is_wildcard() {
                     if let Err(status) = self.node.validate_event_path(&path, &accessor) {
                         if matches!(status, IMStatusCode::UnsupportedEvent) {
@@ -1144,6 +1145,8 @@ where
                             // Seems we should not error out in that case?
                             continue;
                         }
+
+                        *empty = false;
 
                         let resp = EventResp::Status(EventStatus::new(path, status, None));
 
@@ -1188,7 +1191,9 @@ where
                             }
                         }
 
-                        result?;
+                        if result? {
+                            *empty = false;
+                        }
                     }
 
                     Ok(true)

--- a/rs-matter/src/dm/events.rs
+++ b/rs-matter/src/dm/events.rs
@@ -132,7 +132,8 @@ impl<const N: usize> Events<N> {
     }
 
     pub(crate) fn watermark(&self) -> EventNumber {
-        self.inner.lock(|state| state.borrow().next_event_number)
+        self.inner
+            .lock(|state| state.borrow().next_event_number.wrapping_sub(1))
     }
 
     /// Push a new event into the event queue.
@@ -213,6 +214,8 @@ struct EventsInner<const N: usize> {
     buf_debug: EventsBuf<N>,
     buf_info: EventsBuf<N>,
     buf_critical: EventsBuf<N>,
+    /// The first assigned event number is 1; `0` is reserved as the "no events seen yet"
+    /// sentinel used by fresh subscriptions.
     next_event_number: EventNumber,
 }
 
@@ -222,7 +225,7 @@ impl<const N: usize> EventsInner<N> {
             buf_debug: EventsBuf::new(),
             buf_info: EventsBuf::new(),
             buf_critical: EventsBuf::new(),
-            next_event_number: 0,
+            next_event_number: 1,
         }
     }
 
@@ -231,7 +234,7 @@ impl<const N: usize> EventsInner<N> {
             buf_debug <- EventsBuf::init(),
             buf_info <- EventsBuf::init(),
             buf_critical <- EventsBuf::init(),
-            next_event_number: 0,
+            next_event_number: 1,
         })
     }
 
@@ -239,7 +242,7 @@ impl<const N: usize> EventsInner<N> {
         self.buf_debug.reset();
         self.buf_info.reset();
         self.buf_critical.reset();
-        self.next_event_number = 0;
+        self.next_event_number = 1;
     }
 
     /// Remove persisted state from the given key-value store.
@@ -330,16 +333,20 @@ impl<const N: usize> EventsInner<N> {
     {
         let event_number = self.next_event_number;
 
-        if event_number.is_multiple_of(EVENT_NUMBER_EPOCH_SIZE) {
+        if event_number == 1 || event_number.is_multiple_of(EVENT_NUMBER_EPOCH_SIZE) {
             // We're at an epoch start boundary. Therefore, we need to persist the new epoch to storage
             // so we don't lose it on reboot and end up reusing event numbers.
             persist.store_tlv(
                 EVENT_EPOCH_KEY,
-                event_number.wrapping_add(EVENT_NUMBER_EPOCH_SIZE),
+                if event_number == 1 {
+                    EVENT_NUMBER_EPOCH_SIZE
+                } else {
+                    event_number.wrapping_add(EVENT_NUMBER_EPOCH_SIZE).max(1)
+                },
             )?;
         }
 
-        self.next_event_number = event_number.wrapping_add(1);
+        self.next_event_number = event_number.wrapping_add(1).max(1);
 
         Ok(event_number)
     }

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -229,7 +229,7 @@ impl<const N: usize> Subscriptions<N> {
         session_id: u32,
         min_int_secs: u16,
         max_int_secs: u16,
-        max_event_number: EventNumber,
+        event_numbers_watermark: EventNumber,
         buffer: B::Buffer<'a>,
         buffers: &'s SubscriptionsBuffers<'a, B, N>,
     ) -> Option<ReportContext<'a, 's, B, N>>
@@ -243,7 +243,6 @@ impl<const N: usize> Subscriptions<N> {
                 session_id,
                 min_int_secs,
                 max_int_secs,
-                max_event_number,
                 buffer,
                 buffers,
             )?;
@@ -261,6 +260,7 @@ impl<const N: usize> Subscriptions<N> {
             subscription: Some(sub),
             subscription_buffer: Some(buf),
             next_max_seen_attr_change_id,
+            next_max_seen_event_number: event_numbers_watermark,
             next_reported_at: now,
             keep: false,
         })
@@ -345,16 +345,19 @@ impl<const N: usize> Subscriptions<N> {
     pub(crate) fn report<'a, 's, B>(
         &'s self,
         now: Instant,
-        max_event_number: EventNumber,
+        event_numbers_watermark: EventNumber,
         buffers: &'s SubscriptionsBuffers<'a, B, N>,
     ) -> Option<ReportContext<'a, 's, B, N>>
     where
         B: BufferAccess<IMBuffer> + 'a,
     {
         let (sub, buf, next_max_seen_attr_change_id) = self.with(buffers, |state, buffers| {
-            let (sub, buf) = state.report::<B>(now, max_event_number, buffers)?;
+            let (sub, buf) = state.report::<B>(now, event_numbers_watermark, buffers)?;
+            let attr_change_ids_watermark = state.changed_attrs.watermark();
 
-            Some((sub, buf, state.changed_attrs.watermark()))
+            info!("About to report on subscription {:?}, details: max_seen_attr_change_id: {}, max_seen_event_number: {}, attr_change_ids_watermark: {}, event_numbers_watermark: {}", sub.ids(), sub.max_seen_attr_change_id, sub.max_seen_event_number, attr_change_ids_watermark, event_numbers_watermark);
+
+            Some((sub, buf, attr_change_ids_watermark))
         })?;
 
         Some(ReportContext {
@@ -363,6 +366,7 @@ impl<const N: usize> Subscriptions<N> {
             subscription: Some(sub),
             subscription_buffer: Some(buf),
             next_max_seen_attr_change_id,
+            next_max_seen_event_number: event_numbers_watermark,
             next_reported_at: now,
             keep: false,
         })
@@ -384,6 +388,7 @@ impl<const N: usize> Subscriptions<N> {
         let buf = unwrap!(report.subscription_buffer.take());
 
         sub.max_seen_attr_change_id = report.next_max_seen_attr_change_id;
+        sub.max_seen_event_number = report.next_max_seen_event_number;
         sub.reported_at = report.next_reported_at;
 
         let keep = report.keep;
@@ -514,7 +519,6 @@ impl<const N: usize> SubscriptionsInner<N> {
         session_id: u32,
         min_int_secs: u16,
         max_int_secs: u16,
-        _max_event_number: EventNumber,
         buffer: B::Buffer<'a>,
         _buffers: &mut SubscriptionsBuffersInner<'a, B, N>,
     ) -> Option<(Subscription, B::Buffer<'a>)>
@@ -571,7 +575,7 @@ impl<const N: usize> SubscriptionsInner<N> {
     fn report<'a, B>(
         &mut self,
         now: Instant,
-        max_event_number: EventNumber,
+        event_numbers_watermark: EventNumber,
         buffers: &mut SubscriptionsBuffersInner<'a, B, N>,
     ) -> Option<(Subscription, B::Buffer<'a>)>
     where
@@ -583,7 +587,7 @@ impl<const N: usize> SubscriptionsInner<N> {
         debug_assert!(self.reporting.is_none());
         debug_assert!(self.reporting_cancelled.is_none());
 
-        if let Some(index) = self.find_reportable::<B>(now, max_event_number, buffers) {
+        if let Some(index) = self.find_reportable::<B>(now, event_numbers_watermark, buffers) {
             let sub = self.subscriptions.swap_remove(index);
             let buf = buffers.swap_remove(index);
 
@@ -621,6 +625,8 @@ impl<const N: usize> SubscriptionsInner<N> {
             );
             self.subscriptions_count -= 1;
         } else if keep {
+            info!("Subscription {:?} kept after reporting; max-attr-change-id: {}, max-seen-event-number: {}", sub.ids(), sub.max_seen_attr_change_id, sub.max_seen_event_number);
+
             unwrap!(self.subscriptions.push(sub));
             unwrap!(buffers.push(buffer).map_err(|_| ()));
         } else {
@@ -632,7 +638,7 @@ impl<const N: usize> SubscriptionsInner<N> {
     fn find_reportable<'a, B>(
         &self,
         now: Instant,
-        max_event_number: EventNumber,
+        event_numbers_watermark: EventNumber,
         buffers: &SubscriptionsBuffersInner<'a, B, N>,
     ) -> Option<usize>
     where
@@ -642,7 +648,9 @@ impl<const N: usize> SubscriptionsInner<N> {
             .iter()
             .enumerate()
             .map(|(index, sub)| (sub, &buffers[index]))
-            .position(|(sub, rx)| sub.is_reportable(now, rx, &self.changed_attrs, max_event_number))
+            .position(|(sub, rx)| {
+                sub.is_reportable(now, rx, &self.changed_attrs, event_numbers_watermark)
+            })
     }
 
     /// Remove entries that every subscription has already reported on.
@@ -724,7 +732,7 @@ impl Subscription {
         now: Instant,
         rx: &[u8],
         changed_attrs: &ChangedAttrs,
-        max_event_number: EventNumber,
+        event_numbers_watermark: EventNumber,
     ) -> bool {
         if !self.is_report_allowed(now) {
             return false;
@@ -732,7 +740,7 @@ impl Subscription {
 
         self.is_report_due(now)
             || self.is_affected_by_attr_changes(rx, changed_attrs)
-            || self.is_affected_by_new_events(rx, max_event_number)
+            || self.is_affected_by_new_events(rx, event_numbers_watermark)
     }
 
     /// Return `true` if the subscription is allowed to report based on the min interval, or `false` if it is still in the quiet period since the last report.
@@ -765,14 +773,14 @@ impl Subscription {
         changes.any_since(self.max_seen_attr_change_id)
     }
 
-    /// Return `true` if the subscription is affected by new events based on the subscription's RX and the given max event number, or `false` if it is not affected.
-    fn is_affected_by_new_events(&self, _rx: &[u8], max_event_number: EventNumber) -> bool {
+    /// Return `true` if the subscription is affected by new events based on the subscription's RX and the given event numbers watermark, or `false` if it is not affected.
+    fn is_affected_by_new_events(&self, _rx: &[u8], event_numbers_watermark: EventNumber) -> bool {
         // NOTE: we could consult the subscription's RX here to skip the check if the subscription
         // is not interested in events at all, but that would require parsing the RX at every report check,
         // which is anyway done later during reporting and the report is canceled if empty
         //
         // Therefore and for now do not to this here
-        self.max_seen_event_number < max_event_number
+        self.max_seen_event_number < event_numbers_watermark
     }
 }
 
@@ -1173,6 +1181,12 @@ where
     /// This is captured here because the subscription's own `max_seen_attr_change_id`
     /// is not updated until the report completes as it is until then still used.
     next_max_seen_attr_change_id: u64,
+    /// The next maximum seen event number for the subscription
+    /// to be updated into it upon returning the subscription to the table.
+    ///
+    /// This is captured here because the subscription's own `max_seen_event_number`
+    /// is not updated until the report completes as it is until then still used.
+    next_max_seen_event_number: EventNumber,
     /// The next reported timestamp for the subscription,
     /// to be updated into it upon returning the subscription to the table.
     ///
@@ -1241,12 +1255,9 @@ where
         unwrap!(self.subscription.as_ref()).max_seen_event_number
     }
 
-    /// Update the maximum event number the subscription has seen so far to the given value.
-    pub fn update_max_seen_event_number(&mut self, max_seen_event_number: EventNumber) {
-        let sub = unwrap!(self.subscription.as_mut());
-
-        assert!(sub.max_seen_event_number <= max_seen_event_number);
-        sub.max_seen_event_number = max_seen_event_number;
+    /// Return the next maximum event number to be updated into the subscription upon returning it to the table.
+    pub fn next_max_seen_event_number(&self) -> EventNumber {
+        self.next_max_seen_event_number
     }
 
     /// Mark the subscription to be kept in the table after the report completes,
@@ -1957,7 +1968,8 @@ mod tests {
     //   * `find_report_due_events_pending_receives_subscription_watermark` —
     //     the old `events_pending` callback no longer exists; the
     //     subscription's `max_seen_event_number` is now compared directly
-    //     against the `max_event_number` passed to `Subscriptions::report`.
+    //     against the `event_numbers_watermark` passed to
+    //     `Subscriptions::report`.
     //   * `find_removed_session_matches_predicate` — `session_id` tracking
     //     was dropped in the refactor (see REVIEW on `SubscriptionsInner::add`).
     //     Predicate-based removal is covered by `remove_invokes_predicate_*`.
@@ -1983,7 +1995,7 @@ mod tests {
             /* session_id */ 0,
             min_int,
             max_int,
-            /* max_event_number */ 0,
+            /* event_numbers_watermark */ 0,
             pool.get_immediate().unwrap(),
             subs_bufs,
         )
@@ -2076,8 +2088,8 @@ mod tests {
 
     #[test]
     fn report_triggered_by_new_events() {
-        // A bump in `max_event_number` (i.e. a newly emitted event) makes the
-        // subscription reportable even without attribute changes.
+        // A bump in `event_numbers_watermark` (i.e. a newly emitted event)
+        // makes the subscription reportable even without attribute changes.
         let subs: Subscriptions<1> = Subscriptions::new();
         let pool = TestPool::<2>::new(0);
         let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
@@ -2088,7 +2100,7 @@ mod tests {
             rctx.set_keep();
         }
 
-        // Same instant, no new events (max_event_number = 0 same as sub's
+        // Same instant, no new events (watermark = 0 same as sub's
         // max_seen), min_int not elapsed → nothing to report.
         assert!(subs.report(now, 0, &subs_bufs).is_none());
 
@@ -2097,21 +2109,24 @@ mod tests {
         // Still no new events at `later` (min_int elapsed though).
         assert!(subs.report(later, 0, &subs_bufs).is_none());
 
-        // A new event bumps max_event_number → sub is reportable.
+        // A new event bumps the watermark → sub is reportable. The captured
+        // `next_max_seen_event_number` mirrors the watermark and is the
+        // value that will be committed on `set_keep`.
         {
             let mut rctx = subs.report(later, 5, &subs_bufs).unwrap();
             assert_eq!(rctx.max_seen_event_number(), 0);
-            rctx.update_max_seen_event_number(5);
-            assert_eq!(rctx.max_seen_event_number(), 5);
+            assert_eq!(rctx.next_max_seen_event_number(), 5);
             rctx.set_keep();
         }
 
-        // After reporting, max_event_number=5 is no longer "new" for this sub.
+        // After reporting, watermark=5 is no longer "new" for this sub.
         assert!(subs.report(later, 5, &subs_bufs).is_none());
         // But a further bump does trigger again (past min_int is needed).
         let even_later = later + Duration::from_secs(2);
         {
             let mut rctx = subs.report(even_later, 6, &subs_bufs).unwrap();
+            assert_eq!(rctx.max_seen_event_number(), 5);
+            assert_eq!(rctx.next_max_seen_event_number(), 6);
             rctx.set_keep();
         }
     }
@@ -2396,22 +2411,56 @@ mod tests {
     }
 
     #[test]
-    fn update_max_seen_event_number_is_monotonic() {
-        // The setter advances the watermark but panics on regression
-        // (asserted in `update_max_seen_event_number`). We only exercise the
-        // monotonic-advance path here to avoid a deliberate panic in tests.
+    fn next_max_seen_event_number_captured_at_report_time() {
+        // The captured `next_max_seen_event_number` reflects the
+        // `event_numbers_watermark` passed to `add` / `report` and is what
+        // gets committed to the subscription on `set_keep`. The committed
+        // value advances even if no events were actually emitted during the
+        // report — this is what prevents the "endless reporting loop" for
+        // subscriptions that are not interested in events but receive an
+        // event-triggered report.
         let subs: Subscriptions<1> = Subscriptions::new();
         let pool = TestPool::<2>::new(0);
         let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
 
         let now = Instant::now();
-        let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 60);
-        assert_eq!(rctx.max_seen_event_number(), 0);
-        rctx.update_max_seen_event_number(3);
-        assert_eq!(rctx.max_seen_event_number(), 3);
-        rctx.update_max_seen_event_number(3); // equal is allowed
-        assert_eq!(rctx.max_seen_event_number(), 3);
-        rctx.update_max_seen_event_number(42);
-        assert_eq!(rctx.max_seen_event_number(), 42);
+
+        // Priming report sees the watermark passed to `add` (0 here).
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 60);
+            assert_eq!(rctx.max_seen_event_number(), 0);
+            assert_eq!(rctx.next_max_seen_event_number(), 0);
+            rctx.set_keep();
+        }
+
+        let later = now + Duration::from_secs(2);
+
+        // First incremental report at watermark=7: the captured "next" is 7,
+        // and the previous watermark (the sub's `max_seen_event_number`) is
+        // still 0 until commit.
+        {
+            let mut rctx = subs.report(later, 7, &subs_bufs).unwrap();
+            assert_eq!(rctx.max_seen_event_number(), 0);
+            assert_eq!(rctx.next_max_seen_event_number(), 7);
+            rctx.set_keep();
+        }
+
+        // After commit the sub's `max_seen_event_number` has advanced to 7
+        // — even though we never recorded a single emitted event during
+        // this report. A second call at the same watermark is therefore a
+        // no-op (no new events to deliver).
+        assert!(subs.report(later, 7, &subs_bufs).is_none());
+
+        let even_later = later + Duration::from_secs(2);
+
+        // Bumping the watermark to 42 makes the sub reportable again; the
+        // previous max-seen is the 7 we just committed, the captured next
+        // is the new watermark.
+        {
+            let mut rctx = subs.report(even_later, 42, &subs_bufs).unwrap();
+            assert_eq!(rctx.max_seen_event_number(), 7);
+            assert_eq!(rctx.next_max_seen_event_number(), 42);
+            rctx.set_keep();
+        }
     }
 }

--- a/rs-matter/src/dm/types/reply.rs
+++ b/rs-matter/src/dm/types/reply.rs
@@ -16,7 +16,7 @@
  */
 
 use crate::acl::Accessor;
-use crate::dm::{AsyncHandler, EventNumber, HandlerContext, Node};
+use crate::dm::{AsyncHandler, HandlerContext, Node};
 use crate::error::{Error, ErrorCode};
 use crate::im::{
     AttrDataTag, AttrPath, AttrResp, AttrRespTag, AttrStatus, CmdDataTag, CmdPath, CmdResp,
@@ -309,17 +309,15 @@ where
 
 pub struct EventReader {
     max_seen_event_number: u64,
+    next_max_seen_event_number: u64,
 }
 
 impl EventReader {
-    pub const fn new(max_seen_event_number: u64) -> Self {
+    pub const fn new(max_seen_event_number: u64, next_max_seen_event_number: u64) -> Self {
         Self {
             max_seen_event_number,
+            next_max_seen_event_number,
         }
-    }
-
-    pub const fn max_seen_event_number(&self) -> EventNumber {
-        self.max_seen_event_number
     }
 
     pub fn process_read<T: TLVWrite>(
@@ -330,17 +328,13 @@ impl EventReader {
         node: &Node<'_>,
         accessor: &Accessor<'_>,
         mut tw: T,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         let event_number = event.event_number;
-        // `max_seen_event_number` is stored as the *next* event number the
-        // caller expects to receive (i.e. one past the largest already
-        // delivered). A fresh reader initialised with `0` must therefore
-        // still deliver event `0`, which is why the comparison is strictly
-        // less than, and the field is advanced to `event_number + 1` after
-        // a successful emit.
-        if event_number < self.max_seen_event_number {
-            // This event has already been seen by the caller, skip
-            return Ok(());
+        if !(event_number > self.max_seen_event_number
+            && event_number <= self.next_max_seen_event_number)
+        {
+            // This event is outside the range of interest, skip
+            return Ok(false);
         }
 
         let tail = tw.get_tail();
@@ -348,10 +342,16 @@ impl EventReader {
         let result = self.do_process_read(event, paths, event_filters, node, accessor, &mut tw);
 
         if result.is_err() {
-            // If there was an error, rewind to the tail so we don't write any data.
+            // If there was an error, rewind to the tail so we don't write any data
+            // and leave `max_seen_event_number` untouched so this event will be
+            // retried on the next chunk.
             tw.rewind_to(tail);
         } else {
-            self.max_seen_event_number = event_number.wrapping_add(1);
+            // The event was considered (whether or not it actually matched the
+            // path/filter/access checks). Advance the local watermark so that
+            // chunked reads do not re-consider the same event again on
+            // continuation, and so that the iteration converges.
+            self.max_seen_event_number = event_number;
         }
 
         result
@@ -365,14 +365,16 @@ impl EventReader {
         node: &Node<'_>,
         accessor: &Accessor<'_>,
         mut tw: T,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         if Self::matches_paths(&event, paths, node, accessor)?
             && Self::matches_filters(&event, event_filters)?
             && Self::matches_access(&event, node, accessor)?
         {
-            EventResp::Data(event).to_tlv(&TagType::Anonymous, &mut tw)
+            EventResp::Data(event).to_tlv(&TagType::Anonymous, &mut tw)?;
+
+            Ok(true)
         } else {
-            Ok(())
+            Ok(false)
         }
     }
 

--- a/rs-matter/tests/data_model/events.rs
+++ b/rs-matter/tests/data_model/events.rs
@@ -60,7 +60,7 @@ fn test_read_event_filtered() {
     push_events(
         &im,
         &[
-            // Event no set to 0 on all, because Events will assign these, starting at zero
+            // Event no set to 0 on all, because Events will assign these, starting at one
             event_data_req!(ep0_event1, 0, EventPriority::Critical, Some(&0x41u8)),
             event_data_req!(ep0_event1, 0, EventPriority::Critical, Some(&0x42u8)),
             event_data_req!(ep0_event1, 0, EventPriority::Critical, Some(&0x43u8)),
@@ -76,11 +76,11 @@ fn test_read_event_filtered() {
         TLVTest::read_events(
             &[WILDCARD_PATH.clone()],
             &[
-                event_data_path!(ep0_event1, 0, EventPriority::Critical, Some(&0x41u8)),
-                event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&0x42u8)),
-                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x43u8)),
-                event_data_path!(ep1_event1, 3, EventPriority::Critical, Some(&0x44u8)),
-                event_data_path!(ep1_event2, 4, EventPriority::Critical, Some(&0x45u8)),
+                event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&0x41u8)),
+                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x42u8)),
+                event_data_path!(ep0_event1, 3, EventPriority::Critical, Some(&0x43u8)),
+                event_data_path!(ep1_event1, 4, EventPriority::Critical, Some(&0x44u8)),
+                event_data_path!(ep1_event2, 5, EventPriority::Critical, Some(&0x45u8)),
             ],
         ),
     );
@@ -92,15 +92,15 @@ fn test_read_event_filtered() {
             TestReadReq {
                 event_filters: Some(&[EventFilter {
                     node: None,
-                    event_min: Some(2),
+                    event_min: Some(3),
                 }]),
                 ..TestReadReq::event_reqs(&[WILDCARD_PATH.clone()])
             },
             TestReportDataMsg::event_reports(&[
                 // n.b. first two events excluded
-                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x43u8)),
-                event_data_path!(ep1_event1, 3, EventPriority::Critical, Some(&0x44u8)),
-                event_data_path!(ep1_event2, 4, EventPriority::Critical, Some(&0x45u8)),
+                event_data_path!(ep0_event1, 3, EventPriority::Critical, Some(&0x43u8)),
+                event_data_path!(ep1_event1, 4, EventPriority::Critical, Some(&0x44u8)),
+                event_data_path!(ep1_event2, 5, EventPriority::Critical, Some(&0x45u8)),
             ]),
             ReplyProcessor::none,
         ),
@@ -121,9 +121,9 @@ fn test_read_event_filtered() {
             },
             TestReportDataMsg::event_reports(&[
                 // n.b. events that aren't from endpoint 0 are excluded
-                event_data_path!(ep0_event1, 0, EventPriority::Critical, Some(&0x41u8)),
-                event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&0x42u8)),
-                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x43u8)),
+                event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&0x41u8)),
+                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x42u8)),
+                event_data_path!(ep0_event1, 3, EventPriority::Critical, Some(&0x43u8)),
             ]),
             ReplyProcessor::none,
         ),
@@ -144,10 +144,10 @@ fn test_read_event_filtered() {
             },
             TestReportDataMsg::event_reports(&[
                 // n.b. only events with id 1
-                event_data_path!(ep0_event1, 0, EventPriority::Critical, Some(&0x41u8)),
-                event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&0x42u8)),
-                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x43u8)),
-                event_data_path!(ep1_event1, 3, EventPriority::Critical, Some(&0x44u8)),
+                event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&0x41u8)),
+                event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&0x42u8)),
+                event_data_path!(ep0_event1, 3, EventPriority::Critical, Some(&0x43u8)),
+                event_data_path!(ep1_event1, 4, EventPriority::Critical, Some(&0x44u8)),
             ]),
             ReplyProcessor::none,
         ),
@@ -228,7 +228,7 @@ fn test_subscribe_events() {
                     subscription_id: Some(1),
                     event_reports: Some(&[event_data_path!(
                         ep0_event1,
-                        0,
+                        1,
                         EventPriority::Critical,
                         Some(&0x41u8)
                     )]),
@@ -257,7 +257,7 @@ fn test_subscribe_events() {
                 },
                 TestReportDataMsg::event_reports(&[event_data_path!(
                     ep0_event1,
-                    0,
+                    1,
                     EventPriority::Critical,
                     Some(&0x41u8)
                 )]),
@@ -285,7 +285,7 @@ fn test_subscribe_events() {
                     subscription_id: Some(1),
                     event_reports: Some(&[event_data_path!(
                         ep0_event1,
-                        1,
+                        2,
                         EventPriority::Critical,
                         Some(&0x42u8)
                     )]),
@@ -328,8 +328,8 @@ fn test_long_read_events() {
                 TestReadReq::event_reqs(&[WILDCARD_PATH.clone()]),
                 TestReportDataMsg {
                     event_reports: Some(&[
-                        event_data_path!(ep0_event1, 0, EventPriority::Critical, Some(&[1u8; 256])),
-                        event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&[2u8; 256])),
+                        event_data_path!(ep0_event1, 1, EventPriority::Critical, Some(&[1u8; 256])),
+                        event_data_path!(ep0_event1, 2, EventPriority::Critical, Some(&[2u8; 256])),
                     ]),
                     more_chunks: Some(true),
                     ..Default::default()
@@ -343,7 +343,7 @@ fn test_long_read_events() {
                 TestReportDataMsg {
                     event_reports: Some(&[event_data_path!(
                         ep0_event1,
-                        2,
+                        3,
                         EventPriority::Critical,
                         Some(&[3u8; 256])
                     )]),


### PR DESCRIPTION
The TL;DR of the bug is that in certain cases (triggered by the new upcoming Python tests) it was possible for a subscription to enter an endless loop of reporting which happened under the following conditions:
- There is at least one event in the Events buffer, which the subscription had not "seen" yet
- The subscription is - however - NOT interested in any events (its events requests during priming were empty)

The result was, the last seen event number of the subscription was never updated because the subscription - during reporting - does not even get to "see" the events in the events buffer as it does not contain event requests in the first place. And so next time the subscription is polled whether it is due to reporting, true was returned because - again - the sub had a "seen event number smaller than the actual one.

The fix was to preserve and update the last seen event number in the subscription in an identical way how the attributes change id watermark is preserved. 

Additionally, I made it so that event numbers start from 1, which matches what we do for attribute changes, and makes the overall code a bit clearer and symmetric.
