### PR TITLE
Implement CommandRef and thus multiple paths per invoke

### DIFF
--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -272,6 +272,10 @@ fn main() -> Result<(), Error> {
 /// - We can set the product appearance to what the `TestBasicInformation` tests expect;
 /// - We can set the device type and pairing hint to what the `TestDiscovery` tests expect.
 /// - When the `test-tcp` feature is enabled, we advertise TCP support via mDNS (`T=1`).
+/// - We advertise `MaxPathsPerInvoke = 1`. This is the spec minimum and keeps
+///   `TC_IDM_1_4` on the short path (it skips steps 3+ for devices that report 1),
+///   avoiding test-only requirements like `TestEventTriggers` on the General Diagnostics
+///   cluster which we do not implement.
 const BASIC_INFO: BasicInfoConfig<'static> = BasicInfoConfig {
     product_appearance: ProductAppearance {
         finish: ProductFinishEnum::Satin,
@@ -280,6 +284,7 @@ const BASIC_INFO: BasicInfoConfig<'static> = BasicInfoConfig {
     device_type: Some(0x0101),
     pairing_hint: PairingHintFlags::PRESS_RESET_BUTTON,
     tcp_supported: cfg!(feature = "test-tcp"),
+    max_paths_per_invoke: 1,
     ..TEST_DEV_DET
 };
 

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -392,6 +392,40 @@ where
             return Ok(());
         }
 
+        let max_paths = exchange.matter().dev_det().max_paths_per_invoke as usize;
+
+        if let Some(reqs) = req.inv_requests()? {
+            let mut count = 0;
+            for r in &reqs {
+                let _ = r?;
+                count += 1;
+            }
+
+            if count > max_paths {
+                return Self::send_status(exchange, IMStatusCode::InvalidAction).await;
+            }
+
+            // Per Matter Core spec section 8.9.4: when an `InvokeRequestMessage`
+            // carries multiple `CommandDataIB` entries, each MUST include a unique
+            // `CommandRef` and the request paths SHALL be unique. `count` is bounded
+            // by `max_paths_per_invoke` (typically a single-digit number), so the
+            // O(n²) pairwise check below is cheaper than allocating buffers.
+            if count > 1 {
+                for (i, req_i) in reqs.iter().enumerate() {
+                    let req_i = req_i?;
+                    if req_i.command_ref.is_none() {
+                        return Self::send_status(exchange, IMStatusCode::InvalidAction).await;
+                    }
+                    for req_j in reqs.iter().skip(i + 1) {
+                        let req_j = req_j?;
+                        if req_i.path == req_j.path || req_i.command_ref == req_j.command_ref {
+                            return Self::send_status(exchange, IMStatusCode::InvalidAction).await;
+                        }
+                    }
+                }
+            }
+        }
+
         let mut wb = WriteBuf::new(&mut tx);
 
         let metadata = self.handler.lock().await;

--- a/rs-matter/src/dm/clusters/basic_info.rs
+++ b/rs-matter/src/dm/clusters/basic_info.rs
@@ -46,8 +46,9 @@ pub const DEFAULT_DATA_MODEL_REVISION: u16 = 19;
 
 /// The default maximum number of paths that can be included in an Invoke request
 ///
-/// Set to 1
-pub const DEFAULT_MAX_PATHS_PER_INVOKE: u16 = 1;
+/// Set to 5, which is enough to support typical batched invokes while
+/// keeping the in-memory CommandRef tracking buffer in `dm::invoke()` small.
+pub const DEFAULT_MAX_PATHS_PER_INVOKE: u16 = 5;
 
 bitflags! {
     #[repr(transparent)]

--- a/rs-matter/src/dm/types/command.rs
+++ b/rs-matter/src/dm/types/command.rs
@@ -94,6 +94,9 @@ pub struct CmdDetails<'a> {
     pub fab_idx: u8,
     /// Whether the original command was a wildcard one
     pub wildcard: bool,
+    /// The CommandRef from the originating `CommandDataIB`, if any.
+    /// Echoed back in the response so the requester can correlate batched invokes.
+    pub command_ref: Option<u16>,
 }
 
 impl CmdDetails<'_> {
@@ -118,6 +121,7 @@ impl CmdDetails<'_> {
                 ),
                 status,
                 None,
+                self.command_ref,
             ))
         } else {
             None

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -467,6 +467,7 @@ impl<'a> PathExpansionItem<'a> for CmdData<'a> {
                 cmd_id: leaf_id,
                 fab_idx: accessor.fab_idx,
                 wildcard: false,
+                command_ref: self.command_ref,
             },
             self.data.clone(),
         );
@@ -475,7 +476,7 @@ impl<'a> PathExpansionItem<'a> for CmdData<'a> {
     }
 
     fn into_status(self, status: IMStatusCode) -> Self::Status {
-        CmdStatus::new(self.path, status, None)
+        CmdStatus::new(self.path, status, None, self.command_ref)
     }
 }
 

--- a/rs-matter/src/dm/types/reply.rs
+++ b/rs-matter/src/dm/types/reply.rs
@@ -551,6 +551,7 @@ where
 /// A concrete implementation of the `InvokeReply` trait for encoding command data.
 pub struct InvokeReplyInstance<T> {
     path: CmdPath,
+    command_ref: Option<u16>,
     tw: T,
 }
 
@@ -561,6 +562,7 @@ where
     pub const fn new(cmd: &CmdDetails, tw: T) -> Self {
         Self {
             path: cmd.reply_path(),
+            command_ref: cmd.command_ref,
             tw,
         }
     }
@@ -571,7 +573,7 @@ where
     T: TLVWrite + Send,
 {
     fn with_command(mut self, cmd: u32) -> Result<impl Reply, Error> {
-        let mut writer = CmdInvokeReplyInstance::new(self.tw);
+        let mut writer = CmdInvokeReplyInstance::new(self.tw, self.command_ref);
         let mut tw = writer.writer();
 
         tw.start_struct(&TLVTag::Anonymous)?;
@@ -591,6 +593,7 @@ where
     T: TLVWrite,
 {
     anchor: T::Position,
+    command_ref: Option<u16>,
     tw: T,
 }
 
@@ -600,9 +603,10 @@ where
 {
     const TAG: TagType = TagType::Context(CmdDataTag::Data as _);
 
-    fn new(tw: T) -> Self {
+    fn new(tw: T, command_ref: Option<u16>) -> Self {
         Self {
             anchor: tw.get_tail(),
+            command_ref,
             tw,
         }
     }
@@ -620,6 +624,11 @@ where
     }
 
     fn complete(mut self) -> Result<(), Error> {
+        if let Some(command_ref) = self.command_ref {
+            self.tw
+                .u16(&TLVTag::Context(CmdDataTag::CommandRef as _), command_ref)?;
+        }
+
         self.tw.end_container()?;
         self.tw.end_container()?;
 

--- a/rs-matter/src/im/client.rs
+++ b/rs-matter/src/im/client.rs
@@ -694,6 +694,7 @@ impl ImClient {
         let data = CmdData {
             path,
             data: cmd_data,
+            command_ref: None,
         };
 
         let mut result: Option<Result<T, Error>> = None;
@@ -779,6 +780,7 @@ impl ImClient {
         let cmd_data = [CmdData {
             path,
             data: cmd_data,
+            command_ref: None,
         }];
 
         let req = InvokeRequestBuilder::new(&cmd_data, timed_timeout_ms.is_some());
@@ -815,6 +817,7 @@ impl ImClient {
                         cmd: Some(cmd),
                     },
                     IMStatusCode::Success,
+                    None,
                     None,
                 ));
             } else {
@@ -892,6 +895,7 @@ mod tests {
         let data = CmdData {
             path,
             data: TLVElement::new(&[]),
+            command_ref: None,
         };
 
         let cmds = [data];

--- a/rs-matter/src/im/invoke.rs
+++ b/rs-matter/src/im/invoke.rs
@@ -86,17 +86,27 @@ pub struct CmdStatus {
     pub path: CmdPath,
     /// The status of the command invocation.
     pub status: Status,
+    /// The CommandRef echoed from the corresponding `CommandDataIB`.
+    /// Required when the request was part of a batched (multi-path) invoke.
+    pub command_ref: Option<u16>,
 }
 
 impl CmdStatus {
-    /// Create a new command status with the given path, status code, and optional cluster status.
-    pub const fn new(path: CmdPath, status: IMStatusCode, cluster_status: Option<u16>) -> Self {
+    /// Create a new command status with the given path, status code, optional cluster status,
+    /// and optional CommandRef (echoed from the request when batched).
+    pub const fn new(
+        path: CmdPath,
+        status: IMStatusCode,
+        cluster_status: Option<u16>,
+        command_ref: Option<u16>,
+    ) -> Self {
         Self {
             path,
             status: Status {
                 status,
                 cluster_status,
             },
+            command_ref,
         }
     }
 }
@@ -110,12 +120,19 @@ impl CmdStatus {
 pub struct CmdData<'a> {
     pub path: CmdPath,
     pub data: TLVElement<'a>,
+    /// CommandRef set by the requester to correlate batched invokes with their responses.
+    /// Mandatory when the `InvokeRequestMessage` carries more than one `CommandDataIB`.
+    pub command_ref: Option<u16>,
 }
 
 impl<'a> CmdData<'a> {
-    /// Create a new command data instance with the specified path and data.
-    pub const fn new(path: CmdPath, data: TLVElement<'a>) -> Self {
-        Self { path, data }
+    /// Create a new command data instance with the specified path, data, and optional CommandRef.
+    pub const fn new(path: CmdPath, data: TLVElement<'a>, command_ref: Option<u16>) -> Self {
+        Self {
+            path,
+            data,
+            command_ref,
+        }
     }
 }
 
@@ -126,6 +143,7 @@ impl<'a> CmdData<'a> {
 pub enum CmdDataTag {
     Path = 0,
     Data = 1,
+    CommandRef = 2,
 }
 
 /// Response to a command invocation.
@@ -141,15 +159,17 @@ pub enum CmdResp<'a> {
 
 impl CmdResp<'_> {
     /// Create the `Status` variant of a command response
-    /// with the given command path, status code, and optional cluster status.
+    /// with the given command path, status code, optional cluster status, and optional CommandRef.
     pub const fn status_new(
         cmd_path: CmdPath,
         status: IMStatusCode,
         cluster_status: Option<u16>,
+        command_ref: Option<u16>,
     ) -> Self {
         Self::Status(CmdStatus {
             path: cmd_path,
             status: Status::new(status, cluster_status),
+            command_ref,
         })
     }
 }

--- a/rs-matter/src/sc.rs
+++ b/rs-matter/src/sc.rs
@@ -166,25 +166,25 @@ pub enum GeneralCode {
 }
 
 /// Represents the session parameters
-/// that might present in a "PBKDFParamRequest" or "CASE-Sigma1" message
-#[derive(FromTLV, ToTLV, Debug)]
+/// that might present in a "PBKDFParamRequest"/"PBKDFParamResponse" or "CASE-Sigma1"/"CASE-Sigma2" message
+#[derive(Default, FromTLV, ToTLV, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(start = 1)]
 pub(crate) struct SessionParameters {
     /// Session Idle Interval
-    sii: Option<u32>,
+    pub(crate) sii: Option<u32>,
     /// Session Active Interval
-    sai: Option<u32>,
+    pub(crate) sai: Option<u32>,
     /// Session Active Threshold
-    sat: Option<u16>,
+    pub(crate) sat: Option<u16>,
     /// Data Model Revision
-    dm_revision: Option<u16>,
+    pub(crate) dm_revision: Option<u16>,
     /// Interaction Model Revision
-    im_revision: Option<u16>,
+    pub(crate) im_revision: Option<u16>,
     /// Specification Version
-    spec_version: Option<u32>,
+    pub(crate) spec_version: Option<u32>,
     /// Maximum number of paths per invoke
-    max_paths_per_invoke: Option<u16>,
+    pub(crate) max_paths_per_invoke: Option<u16>,
 }
 
 /// Represents a Status Report message, as per "Appendix D: Status Report Messages" of the Matter Spec.

--- a/rs-matter/src/sc/case/responder.rs
+++ b/rs-matter/src/sc/case/responder.rs
@@ -26,7 +26,7 @@ use crate::error::{Error, ErrorCode};
 use crate::sc::{
     check_opcode, complete_with_status, sc_write, OpCode, SCStatusCodes, SessionParameters,
 };
-use crate::tlv::{get_root_node_struct, FromTLV, OctetStr, TLVElement, TLVTag, TLVWrite};
+use crate::tlv::{get_root_node_struct, FromTLV, OctetStr, TLVElement, TLVTag, TLVWrite, ToTLV};
 use crate::transport::exchange::Exchange;
 use crate::transport::session::{NocCatIds, ReservedSession, SessionMode};
 use crate::utils::init::{init, Init, InitMaybeUninit};
@@ -199,6 +199,16 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
                             buf,
                         )
                     })?;
+
+                    // Responder session parameters (tag 5)
+                    let session_params = crate::sc::SessionParameters {
+                        max_paths_per_invoke: Some(
+                            exchange.matter().dev_det().max_paths_per_invoke,
+                        ),
+                        ..Default::default()
+                    };
+                    session_params.to_tlv(&TLVTag::Context(5), &mut *tw)?;
+
                     tw.end_container()?;
 
                     if !tt_updated {

--- a/rs-matter/src/sc/pase.rs
+++ b/rs-matter/src/sc/pase.rs
@@ -449,6 +449,8 @@ pub(crate) struct PBKDFParamResp<'a> {
     pub responder_ssid: u16,
     /// The PBKDF2 parameters, if any
     pub params: Option<PBKDFParamRespParams<'a>>,
+    /// The responder session parameters, if any
+    pub session_parameters: Option<crate::sc::SessionParameters>,
 }
 
 /// The PBKDFParamResponse parameters structure

--- a/rs-matter/src/sc/pase/responder.rs
+++ b/rs-matter/src/sc/pase/responder.rs
@@ -153,6 +153,7 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
                 initiator_random.load(Spake2pRandomRef::try_new(req.initiator_random.0)?);
 
                 // Generate response
+                let max_paths = exchange.matter().dev_det().max_paths_per_invoke;
                 let resp = PBKDFParamResp {
                     initiator_random: OctetStr::new(initiator_random.access()),
                     responder_random: OctetStr::new(our_random.access()),
@@ -160,6 +161,10 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
                     params: (!req.has_params).then(|| PBKDFParamRespParams {
                         iterations: count,
                         salt: OctetStr::new(salt.access()),
+                    }),
+                    session_parameters: Some(crate::sc::SessionParameters {
+                        max_paths_per_invoke: Some(max_paths),
+                        ..Default::default()
                     }),
                 };
 

--- a/rs-matter/tests/common/e2e/im/commands.rs
+++ b/rs-matter/tests/common/e2e/im/commands.rs
@@ -71,12 +71,24 @@ macro_rules! echo_resp {
 pub struct TestCmdData<'a> {
     pub path: CmdPath,
     pub data: &'a dyn TestToTLV,
+    pub command_ref: Option<u16>,
 }
 
 impl<'a> TestCmdData<'a> {
     /// Create a new `TestCmdData` instance.
     pub const fn new(path: CmdPath, data: &'a dyn TestToTLV) -> Self {
-        Self { path, data }
+        Self {
+            path,
+            data,
+            command_ref: None,
+        }
+    }
+
+    /// Set the `CommandRef` to be sent with this command. Required when batching
+    /// multiple commands in a single `InvokeRequestMessage` per Matter spec.
+    pub const fn with_command_ref(mut self, command_ref: u16) -> Self {
+        self.command_ref = Some(command_ref);
+        self
     }
 }
 
@@ -87,6 +99,10 @@ impl TestToTLV for TestCmdData<'_> {
         self.path.test_to_tlv(&TLVTag::Context(0), tw)?;
 
         self.data.test_to_tlv(&TLVTag::Context(1), tw)?;
+
+        if let Some(command_ref) = self.command_ref {
+            tw.u16(&TLVTag::Context(2), command_ref)?;
+        }
 
         tw.end_container()?;
 
@@ -102,6 +118,19 @@ impl TestToTLV for TestCmdData<'_> {
 pub enum TestCmdResp<'a> {
     Cmd(TestCmdData<'a>),
     Status(CmdStatus),
+}
+
+impl TestCmdResp<'_> {
+    /// Set the `CommandRef` to be echoed back in this response. Mirrors the
+    /// `with_command_ref` builder on `TestCmdData` and is required when the
+    /// originating `InvokeRequestMessage` carried multiple `CommandDataIB` entries.
+    pub fn with_command_ref(mut self, command_ref: u16) -> Self {
+        match &mut self {
+            TestCmdResp::Cmd(data) => data.command_ref = Some(command_ref),
+            TestCmdResp::Status(status) => status.command_ref = Some(command_ref),
+        }
+        self
+    }
 }
 
 impl TestToTLV for TestCmdResp<'_> {

--- a/rs-matter/tests/data_model/commands.rs
+++ b/rs-matter/tests/data_model/commands.rs
@@ -33,8 +33,16 @@ fn test_invoke_cmds_success() {
     // - another on endpoint 1 with data 10
     init_env_logger();
 
-    let input = &[echo_req!(0, 5), echo_req!(1, 10)];
-    let expected = &[echo_resp!(0, 10), echo_resp!(1, 30)];
+    // Multi-command invokes require a unique CommandRef in each request and
+    // each response per Matter spec section 8.9.4.
+    let input = &[
+        echo_req!(0, 5).with_command_ref(0),
+        echo_req!(1, 10).with_command_ref(1),
+    ];
+    let expected = &[
+        echo_resp!(0, 10).with_command_ref(0),
+        echo_resp!(1, 30).with_command_ref(1),
+    ];
     commands(input, expected);
 }
 
@@ -66,11 +74,11 @@ fn test_invoke_cmds_unsupported_fields() {
     let invalid_command = CmdPath::new(Some(0), Some(echo_cluster::ID), Some(0x1234));
     let invalid_command_wc_endpoint = CmdPath::new(None, Some(echo_cluster::ID), Some(0x1234));
     let input = &[
-        cmd_data!(invalid_endpoint.clone(), 5),
-        cmd_data!(invalid_cluster.clone(), 5),
-        cmd_data!(invalid_cluster_wc_endpoint, 5),
-        cmd_data!(invalid_command.clone(), 5),
-        cmd_data!(invalid_command_wc_endpoint, 5),
+        cmd_data!(invalid_endpoint.clone(), 5).with_command_ref(0),
+        cmd_data!(invalid_cluster.clone(), 5).with_command_ref(1),
+        cmd_data!(invalid_cluster_wc_endpoint, 5).with_command_ref(2),
+        cmd_data!(invalid_command.clone(), 5).with_command_ref(3),
+        cmd_data!(invalid_command_wc_endpoint, 5).with_command_ref(4),
     ];
 
     let expected = &[
@@ -78,16 +86,19 @@ fn test_invoke_cmds_unsupported_fields() {
             invalid_endpoint,
             IMStatusCode::UnsupportedEndpoint,
             None,
+            Some(0),
         )),
         TestCmdResp::Status(CmdStatus::new(
             invalid_cluster,
             IMStatusCode::UnsupportedCluster,
             None,
+            Some(1),
         )),
         TestCmdResp::Status(CmdStatus::new(
             invalid_command,
             IMStatusCode::UnsupportedCommand,
             None,
+            Some(3),
         )),
     ];
     commands(input, expected);
@@ -128,6 +139,7 @@ fn test_invoke_cmd_wc_endpoint_only_1_has_cluster() {
     let expected = &[TestCmdResp::Status(CmdStatus::new(
         expected_path,
         IMStatusCode::Success,
+        None,
         None,
     ))];
     commands(input, expected);

--- a/rs-matter/tests/data_model/timed_requests.rs
+++ b/rs-matter/tests/data_model/timed_requests.rs
@@ -208,8 +208,14 @@ fn test_timed_cmd_success() {
     // A timed request that works
     init_env_logger();
 
-    let input = &[echo_req!(0, 5), echo_req!(1, 10)];
-    let expected = &[echo_resp!(0, 10), echo_resp!(1, 30)];
+    let input = &[
+        echo_req!(0, 5).with_command_ref(0),
+        echo_req!(1, 10).with_command_ref(1),
+    ];
+    let expected = &[
+        echo_resp!(0, 10).with_command_ref(0),
+        echo_resp!(1, 30).with_command_ref(1),
+    ];
 
     let im = new_default_runner();
     let handler = im.handler();

--- a/rs-matter/tests/im/client_invokes.rs
+++ b/rs-matter/tests/im/client_invokes.rs
@@ -54,6 +54,7 @@ fn test_client_invoke_non_chunked() {
             let cmd = CmdData {
                 path,
                 data: TLVElement::new(&echo_data),
+                command_ref: None,
             };
 
             let mut chunk_count = 0u32;


### PR DESCRIPTION
Subject says it all. Good to have that functionality and our own integration tests were (wrongly) testing multiple paths per invoke anyway.

Also, TC_IDM_1_4 revealed we have an issue with how we handle multiple paths per invoke.