### PR TITLE
Enable most/all IDM, ACE and ACL Python tests

### DIFF
--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -669,6 +669,15 @@ impl AclEntry {
                             Err(ErrorCode::ConstraintError)?;
                         }
 
+                        if matches!(auth_mode, AccessControlEntryAuthModeEnum::Group) {
+                            // Per Matter Core spec section 9.10.5.1: for Group auth mode, the
+                            // subject SHALL be a valid 16-bit Group ID. Group ID 0 is reserved
+                            // and MUST NOT be used; values larger than `u16::MAX` are also invalid.
+                            if subject == 0 || subject > u16::MAX as u64 {
+                                Err(ErrorCode::ConstraintError)?;
+                            }
+                        }
+
                         // As per spec, on too many subjects we should return a FAILURE status code
                         // `ErrorCode::BufferTooSmall` translates to a generic FAILURE status code
                         esubjects

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -323,7 +323,7 @@ impl defmt::Format for AccessorSubjects {
 /// The Accessor Object
 pub struct Accessor<'a> {
     /// The fabric index of the accessor
-    pub fab_idx: u8,
+    pub(crate) fab_idx: u8,
     /// Accessor's subject: could be node-id, NoC CAT, group id
     subjects: AccessorSubjects,
     /// The auth mode of this session. Might be `None` for plain-text sessions
@@ -386,13 +386,17 @@ impl<'a> Accessor<'a> {
         }
     }
 
+    pub fn fab_idx(&self) -> Result<NonZeroU8, Error> {
+        NonZeroU8::new(self.fab_idx).ok_or(ErrorCode::UnsupportedAccess.into())
+    }
+
     /// Return the subjects of the accessor
-    pub fn subjects(&self) -> &AccessorSubjects {
+    pub const fn subjects(&self) -> &AccessorSubjects {
         &self.subjects
     }
 
     /// Return the auth mode of the accessor
-    pub fn auth_mode(&self) -> Option<AuthMode> {
+    pub const fn auth_mode(&self) -> Option<AuthMode> {
         self.auth_mode
     }
 
@@ -429,6 +433,20 @@ impl<'a> Accessor<'a> {
 
         self.matter
             .with_state(|state| state.fabrics.get(fab_idx).map(|fabric| fabric.node_id()))
+    }
+
+    /// Return the peer node ID (admin node ID) for CASE sessions, or None for PASE/other sessions.
+    pub fn peer_node_id(&self) -> Option<u64> {
+        if matches!(self.auth_mode, Some(AuthMode::Case)) {
+            let id = self.subjects.0[0];
+            if is_node(id) {
+                Some(id)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
     }
 }
 

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -29,7 +29,7 @@ use crate::dm::clusters::acl::{
     AccessControlAuxiliaryTypeEnum, AccessControlEntryAuthModeEnum,
     AccessControlEntryPrivilegeEnum, AccessControlEntryStruct, AccessControlEntryStructBuilder,
 };
-use crate::dm::{Access, ClusterId, EndptId, NodeId, Privilege};
+use crate::dm::{Access, ClusterId, DeviceType, EndptId, NodeId, Privilege};
 use crate::error::{Error, ErrorCode};
 use crate::im::GenericPath;
 use crate::tlv::{FromTLV, Nullable, TLVBuilderParent, TLVElement, TLVTag, TLVWrite, ToTLV, TLV};
@@ -453,7 +453,7 @@ impl<'a> Accessor<'a> {
 /// Access Descriptor Object
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct AccessDesc {
+pub struct AccessDesc<'a> {
     /// The object to be acted upon
     path: GenericPath,
     /// The target permissions
@@ -461,6 +461,10 @@ pub struct AccessDesc {
     // The operation being done
     // TODO: Currently this is Access, but we need a way to represent the 'invoke' somehow too
     operation: Access,
+    /// The device types of the endpoint hosting `path`. Used by ACL `Target`
+    /// entries that filter by `DeviceType` (Matter Core spec section 9.10.5.4).
+    /// Empty when the access target's endpoint is unknown / not yet expanded.
+    device_types: &'a [DeviceType],
 }
 
 /// Access Request Object
@@ -468,21 +472,37 @@ pub struct AccessReq<'a> {
     /// The accessor requesting access
     accessor: &'a Accessor<'a>,
     /// The object being accessed
-    object: AccessDesc,
+    object: AccessDesc<'a>,
 }
 
 impl<'a> AccessReq<'a> {
-    /// Create an access request object
+    /// Create an access request object.
     ///
     /// An access request specifies the _accessor_ attempting to access _path_
-    /// with _operation_
-    pub fn new(accessor: &'a Accessor, path: GenericPath, operation: Access) -> Self {
+    /// with _operation_. `device_types` lists the device types declared by
+    /// the endpoint that hosts `path`; pass an empty slice when this is not
+    /// applicable (e.g. for unit tests that don't exercise `DeviceType` ACL
+    /// targets).
+    pub const fn new(accessor: &'a Accessor, path: GenericPath, operation: Access) -> Self {
+        Self::new_with_device_types(accessor, path, operation, &[])
+    }
+
+    /// Create an access request object that also carries the device types of
+    /// the access target's endpoint, so that ACL entries with a `Target` of
+    /// kind `DeviceType` can be evaluated.
+    pub const fn new_with_device_types(
+        accessor: &'a Accessor,
+        path: GenericPath,
+        operation: Access,
+        device_types: &'a [DeviceType],
+    ) -> Self {
         AccessReq {
             accessor,
             object: AccessDesc {
                 path,
                 target_perms: None,
                 operation,
+                device_types,
             },
         }
     }
@@ -670,11 +690,16 @@ impl AclEntry {
 
                         let target = target?;
 
-                        if
-                            // As per spec, either the device type or the endpoint/cluster shuld be set, but not all
-                            target.device_type()?.is_some() && (target.endpoint()?.is_some() || target.cluster()?.is_some())
-                            // As per spec, at least one of device type, endpoint or cluster should be set
-                            || target.device_type()?.is_none() && target.endpoint()?.is_none() && target.cluster()?.is_none()
+                        // Matter Core spec section 9.10.5.4 (AccessControlTargetStruct):
+                        // - At least one of cluster, endpoint or deviceType SHALL be present.
+                        // - If endpoint is present, deviceType SHALL NOT be present (and vice
+                        //   versa). cluster may be combined with either endpoint or deviceType.
+                        let has_endpoint = target.endpoint()?.is_some();
+                        let has_cluster = target.cluster()?.is_some();
+                        let has_device_type = target.device_type()?.is_some();
+
+                        if (!has_endpoint && !has_cluster && !has_device_type)
+                            || (has_endpoint && has_device_type)
                         {
                             Err(ErrorCode::ConstraintError)?;
                         }
@@ -836,8 +861,19 @@ impl AclEntry {
             // Otherwise, check if the target matches any of the ACL entry's targets
             targets.is_empty()
                 || targets.iter().any(|t| {
-                    (t.endpoint.is_none() || t.endpoint == object.path.endpoint)
-                        && (t.cluster.is_none() || t.cluster == object.path.cluster)
+                    let endpoint_match = t.endpoint.is_none() || t.endpoint == object.path.endpoint;
+                    let cluster_match = t.cluster.is_none() || t.cluster == object.path.cluster;
+                    // When `Target.device_type` is set, the access target's endpoint
+                    // must declare a matching device type in its `DeviceTypeList`
+                    // (Matter Core spec section 9.10.5.4).
+                    let device_type_match = match t.device_type {
+                        Some(dt) => object
+                            .device_types
+                            .iter()
+                            .any(|endpoint_dt| endpoint_dt.dtype as u32 == dt),
+                        None => true,
+                    };
+                    endpoint_match && cluster_match && device_type_match
                 })
         });
 

--- a/rs-matter/src/cert.rs
+++ b/rs-matter/src/cert.rs
@@ -22,7 +22,6 @@ use num_derive::FromPrimitive;
 
 use crate::crypto::{Crypto, PublicKey};
 use crate::error::{Error, ErrorCode};
-use crate::fmt::Bytes;
 use crate::tlv::{FromTLV, Octets, TLVArray, TLVElement, TLVList, ToTLV};
 use crate::utils::epoch::MATTER_CERT_DOESNT_EXPIRE;
 use crate::utils::iter::TryFindIterator;
@@ -798,12 +797,6 @@ impl<'a, C: Crypto> CertVerifier<'a, C> {
                 .verify(asn1, self.cert.signature()?.try_into()?)?;
 
             if !result {
-                error!(
-                    "Verification of certificate signature failed: {:?} by {:?}",
-                    self.cert.get_subject_key_id().map(Bytes),
-                    parent.get_subject_key_id().map(Bytes)
-                );
-
                 Err(ErrorCode::InvalidSignature)?;
             }
         }

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -279,12 +279,17 @@ where
         let metadata = self.handler.lock().await;
         let node = metadata.node();
 
+        // Honor the `fabricFiltered` flag on the originating Read request.
+        // When set, fabric-sensitive events emitted on other fabrics are
+        // dropped before they reach the wire (Matter Core spec section 8.5.2).
+        let fabric_filtered = req.fabric_filtered().unwrap_or(true);
+
         let mut resp = ReportDataResponder::new(
             &req,
             &node,
             None,
             HandlerInvoker::new(exchange, self),
-            EventReader::new(0, u64::MAX),
+            EventReader::new(0, u64::MAX, fabric_filtered),
             self.events,
         );
 
@@ -762,6 +767,11 @@ where
         let metadata = self.handler.lock().await;
         let node = metadata.node();
 
+        // Honor the `fabricFiltered` flag on the originating Subscribe request.
+        // When set, fabric-sensitive events emitted on other fabrics are
+        // dropped before they reach the wire (Matter Core spec section 8.5.2).
+        let fabric_filtered = req.fabric_filtered().unwrap_or(true);
+
         let mut resp = ReportDataResponder::new(
             &req,
             &node,
@@ -770,6 +780,7 @@ where
             EventReader::new(
                 rctx.max_seen_event_number(),
                 rctx.next_max_seen_event_number(),
+                fabric_filtered,
             ),
             self.events,
         );

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -533,6 +533,10 @@ where
 
                 if path.is_wildcard() {
                     Self::validate_attr_wildcard_path(&path)?;
+
+                    if !node.has_accessible_attr(&path, accessor) {
+                        return Err(ErrorCode::InvalidAction.into());
+                    }
                 } else {
                     node.validate_attr_path(&path, false, false, accessor)
                         .map_err(|_| ErrorCode::InvalidAction)?;

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -194,9 +194,104 @@ impl ClusterHandler for AclHandler {
 
         let fab_idx = NonZeroU8::new(ctx.attr().fab_idx).ok_or(ErrorCode::UnsupportedAccess)?;
 
+        // We emit `AccessControlEntryChanged` events while still holding the
+        // matter state lock so that we can compare the *old* and *new* ACL
+        // contents and produce one event per entry change. `Events::push` (used
+        // by the emit path) takes its own independent lock, so this is safe.
         ctx.exchange().with_state(|state| {
             let fabric = state.fabrics.fabric_mut(fab_idx)?;
-            self.set_acl(fabric, value)?;
+
+            match value {
+                ArrayAttributeWrite::Replace(list) => {
+                    // Snapshot old entries so we can diff against the new list per index
+                    // (Matter Core spec section 9.10.7 mandates one event per entry change,
+                    // with `LatestValue` populated). `MAX_ACL_ENTRIES_PER_FABRIC` is small
+                    // (default 4), so a stack-allocated snapshot is cheap.
+                    let mut old_entries: heapless::Vec<AclEntry, MAX_ACL_ENTRIES_PER_FABRIC> =
+                        heapless::Vec::new();
+                    for e in fabric.acl_iter() {
+                        let _ = old_entries.push(e.clone());
+                    }
+
+                    self.set_acl(fabric, ArrayAttributeWrite::Replace(list))?;
+
+                    let new_count = fabric.acl_iter().count();
+                    let old_count = old_entries.len();
+
+                    // Per-index Changed (overlap) and Added (new tail) events.
+                    for (i, entry) in fabric.acl_iter().enumerate() {
+                        let change = if i < old_count {
+                            ChangeTypeEnum::Changed
+                        } else {
+                            ChangeTypeEnum::Added
+                        };
+                        emit_acl_entry_changed(
+                            &ctx,
+                            admin_node_id.clone(),
+                            admin_passcode_id.clone(),
+                            change,
+                            entry,
+                            fab_idx.get(),
+                        )?;
+                    }
+
+                    // Removed events for entries that fell off the end of the list.
+                    // `LatestValue` for a removal is the entry's contents just before removal.
+                    for old_entry in old_entries.iter().skip(new_count) {
+                        emit_acl_entry_changed(
+                            &ctx,
+                            admin_node_id.clone(),
+                            admin_passcode_id.clone(),
+                            ChangeTypeEnum::Removed,
+                            old_entry,
+                            fab_idx.get(),
+                        )?;
+                    }
+                }
+                ArrayAttributeWrite::Add(entry) => {
+                    let old_count = fabric.acl_iter().count();
+                    self.set_acl(fabric, ArrayAttributeWrite::Add(entry))?;
+                    if let Some(new_entry) = fabric.acl_iter().nth(old_count) {
+                        emit_acl_entry_changed(
+                            &ctx,
+                            admin_node_id.clone(),
+                            admin_passcode_id.clone(),
+                            ChangeTypeEnum::Added,
+                            new_entry,
+                            fab_idx.get(),
+                        )?;
+                    }
+                }
+                ArrayAttributeWrite::Update(index, entry) => {
+                    let idx = index as usize;
+                    self.set_acl(fabric, ArrayAttributeWrite::Update(index, entry))?;
+                    if let Some(new_entry) = fabric.acl_iter().nth(idx) {
+                        emit_acl_entry_changed(
+                            &ctx,
+                            admin_node_id.clone(),
+                            admin_passcode_id.clone(),
+                            ChangeTypeEnum::Changed,
+                            new_entry,
+                            fab_idx.get(),
+                        )?;
+                    }
+                }
+                ArrayAttributeWrite::Remove(index) => {
+                    let idx = index as usize;
+                    let removed = fabric.acl_iter().nth(idx).cloned();
+                    self.set_acl(fabric, ArrayAttributeWrite::Remove(index))?;
+                    if let Some(old_entry) = removed {
+                        emit_acl_entry_changed(
+                            &ctx,
+                            admin_node_id.clone(),
+                            admin_passcode_id.clone(),
+                            ChangeTypeEnum::Removed,
+                            &old_entry,
+                            fab_idx.get(),
+                        )?;
+                    }
+                }
+            }
 
             // NOTE: Not sure this is a spec-compliant behavor:
             // If the failsafe is armed for our fabric, we'll NOT persist the groups changes until commissioning is complete.
@@ -208,20 +303,7 @@ impl ClusterHandler for AclHandler {
             Ok(())
         })?;
 
-        persist.run()?;
-
-        AccessControlEntryChanged::emit(&ctx, |tw| {
-            tw.admin_node_id(admin_node_id)?
-                .admin_passcode_id(admin_passcode_id)?
-                .change_type(ChangeTypeEnum::Changed)?
-                .latest_value()?
-                .null()?
-                .fabric_index(Some(fab_idx.get()))?
-                .end()
-        })
-        .unwrap();
-
-        Ok(())
+        persist.run()
     }
 
     fn handle_review_fabric_restrictions<P: TLVBuilderParent>(
@@ -233,6 +315,48 @@ impl ClusterHandler for AclHandler {
         // Only necessary with MNGD feature (ManagedDevice)
         unimplemented!()
     }
+}
+
+/// Emit one `AccessControlEntryChanged` event with the given change type and
+/// the entry's contents serialized into `LatestValue`.
+///
+/// Callers pass in the `admin_node_id` / `admin_passcode_id` derived from the
+/// requesting accessor (CASE → node id, PASE → passcode id 0). For changes
+/// originating from internal flows that do not have a requester (e.g. the
+/// auto-created admin entry on AddNOC, which runs over PASE), pass null/0.
+///
+/// The event is emitted on endpoint 0 (the AccessControl cluster always lives
+/// there), via `emit_for` so the helper can be used from cluster handlers
+/// other than ACL itself (e.g. from the OperationalCredentials handler when
+/// AddNOC seeds the initial admin entry).
+pub(crate) fn emit_acl_entry_changed<E>(
+    emitter: E,
+    admin_node_id: Nullable<u64>,
+    admin_passcode_id: Nullable<u16>,
+    change_type: ChangeTypeEnum,
+    entry: &AclEntry,
+    fab_idx: u8,
+) -> Result<(), Error>
+where
+    E: crate::dm::EventEmitter,
+{
+    AccessControlEntryChanged::emit_for(emitter, 0, |tw| {
+        let inner = tw
+            .admin_node_id(admin_node_id)?
+            .admin_passcode_id(admin_passcode_id)?
+            .change_type(change_type)?
+            .latest_value()?
+            .non_null()?;
+
+        // `read_into` populates the full `AccessControlEntryStruct` for the
+        // requested fabric. We pass `fab_idx == fab_idx` so that all
+        // fabric-sensitive fields are included in the event payload.
+        let parent = entry.read_into(fab_idx, Some(fab_idx), inner)?;
+
+        parent.fabric_index(Some(fab_idx))?.end()
+    })?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -19,14 +19,14 @@
 
 use core::num::NonZeroU8;
 
-use crate::acl::{self, AclEntry, MAX_ACL_ENTRIES_PER_FABRIC};
+use crate::acl::{self, AclEntry, AuthMode, MAX_ACL_ENTRIES_PER_FABRIC};
 use crate::dm::{
     ArrayAttributeRead, ArrayAttributeWrite, AttrDetails, Cluster, Dataver, InvokeContext,
     ReadContext, WriteContext,
 };
 use crate::error::{Error, ErrorCode};
 use crate::fabric::{Fabric, FabricPersist, Fabrics};
-use crate::tlv::{TLVArray, TLVBuilderParent};
+use crate::tlv::{Nullable, TLVArray, TLVBuilderParent};
 use crate::utils::init::stack_try_pin_init;
 use crate::with;
 
@@ -180,8 +180,21 @@ impl ClusterHandler for AclHandler {
     ) -> Result<(), Error> {
         let mut persist = FabricPersist::new(ctx.kv());
 
+        let accessor = ctx.exchange().accessor()?;
+        let admin_node_id: Nullable<u64> = match accessor.peer_node_id() {
+            Some(id) => Nullable::some(id),
+            None => Nullable::none(),
+        };
+        let admin_passcode_id: Nullable<u16> =
+            if matches!(accessor.auth_mode(), Some(AuthMode::Pase)) {
+                Nullable::some(0u16)
+            } else {
+                Nullable::none()
+            };
+
+        let fab_idx = NonZeroU8::new(ctx.attr().fab_idx).ok_or(ErrorCode::UnsupportedAccess)?;
+
         ctx.exchange().with_state(|state| {
-            let fab_idx = NonZeroU8::new(ctx.attr().fab_idx).ok_or(ErrorCode::Invalid)?;
             let fabric = state.fabrics.fabric_mut(fab_idx)?;
             self.set_acl(fabric, value)?;
 
@@ -195,7 +208,20 @@ impl ClusterHandler for AclHandler {
             Ok(())
         })?;
 
-        persist.run()
+        persist.run()?;
+
+        AccessControlEntryChanged::emit(&ctx, |tw| {
+            tw.admin_node_id(admin_node_id)?
+                .admin_passcode_id(admin_passcode_id)?
+                .change_type(ChangeTypeEnum::Changed)?
+                .latest_value()?
+                .null()?
+                .fabric_index(Some(fab_idx.get()))?
+                .end()
+        })
+        .unwrap();
+
+        Ok(())
     }
 
     fn handle_review_fabric_restrictions<P: TLVBuilderParent>(

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -26,6 +26,7 @@ use crate::dm::{Cluster, Dataver, InvokeContext, OperationContext, ReadContext, 
 use crate::error::{Error, ErrorCode};
 use crate::fabric::FabricPersist;
 use crate::persist::{Persist, BASIC_INFO_KEY, NETWORKS_KEY};
+use crate::sc::pase::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use crate::tlv::TLVBuilderParent;
 use crate::utils::sync::DynBase;
 use crate::{with, MatterState};
@@ -118,7 +119,13 @@ impl CommPolicy for bool {
     }
 
     fn failsafe_max_cml_secs(&self) -> u16 {
-        120
+        // Aligned with the Matter reference SDK example implementations and
+        // with `MAX_COMM_WINDOW_TIMEOUT_SECS` in `sc::pase`. Some Python tests
+        // (e.g. TC_ACL_2_9) read this attribute and reuse it as the
+        // `commissioning_timeout` for `OpenCommissioningWindow`, which the spec
+        // bounds at [180, 900] seconds; reporting 900 keeps such tests within
+        // the valid range while still being a reasonable upper bound.
+        MAX_COMM_WINDOW_TIMEOUT_SECS
     }
 
     fn regulatory_config(&self) -> RegulatoryLocationTypeEnum {

--- a/rs-matter/src/dm/clusters/groups.rs
+++ b/rs-matter/src/dm/clusters/groups.rs
@@ -92,9 +92,7 @@ impl ClusterHandler for GroupsHandler {
         request: AddGroupRequest<'_>,
         response: AddGroupResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx =
-            NonZeroU8::new(ctx.exchange().accessor()?.fab_idx).ok_or(ErrorCode::Invalid)?;
-
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
         let group_id = request.group_id()?;
         let group_name: &str = request.group_name()?;
 
@@ -149,9 +147,7 @@ impl ClusterHandler for GroupsHandler {
         request: ViewGroupRequest<'_>,
         response: ViewGroupResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx =
-            NonZeroU8::new(ctx.exchange().accessor()?.fab_idx).ok_or(ErrorCode::Invalid)?;
-
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
         let group_id = request.group_id()?;
 
         // Validate constraints
@@ -192,9 +188,7 @@ impl ClusterHandler for GroupsHandler {
         request: GetGroupMembershipRequest<'_>,
         response: GetGroupMembershipResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx =
-            NonZeroU8::new(ctx.exchange().accessor()?.fab_idx).ok_or(ErrorCode::Invalid)?;
-
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
         let request_group_list = request.group_list()?;
 
         ctx.exchange().with_state(|state| {
@@ -234,8 +228,7 @@ impl ClusterHandler for GroupsHandler {
         request: RemoveGroupRequest<'_>,
         response: RemoveGroupResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx =
-            NonZeroU8::new(ctx.exchange().accessor()?.fab_idx).ok_or(ErrorCode::Invalid)?;
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
         let group_id = request.group_id()?;
         let endpoint_id = ctx.cmd().endpoint_id;
 
@@ -272,8 +265,7 @@ impl ClusterHandler for GroupsHandler {
     }
 
     fn handle_remove_all_groups(&self, ctx: impl InvokeContext) -> Result<(), Error> {
-        let fab_idx =
-            NonZeroU8::new(ctx.exchange().accessor()?.fab_idx).ok_or(ErrorCode::Invalid)?;
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
         let endpoint_id = ctx.cmd().endpoint_id;
 
         let mut persist = FabricPersist::new(ctx.kv());

--- a/rs-matter/src/dm/clusters/grp_key_mgmt.rs
+++ b/rs-matter/src/dm/clusters/grp_key_mgmt.rs
@@ -181,7 +181,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         ctx: impl WriteContext,
         value: ArrayAttributeWrite<TLVArray<'_, GroupKeyMapStruct<'_>>, GroupKeyMapStruct<'_>>,
     ) -> Result<(), Error> {
-        let fab_idx = NonZeroU8::new(ctx.attr().fab_idx).ok_or(ErrorCode::Invalid)?;
+        let fab_idx = NonZeroU8::new(ctx.attr().fab_idx).ok_or(ErrorCode::UnsupportedAccess)?;
 
         let mut persist = FabricPersist::new(ctx.kv());
 
@@ -253,9 +253,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         ctx: impl InvokeContext,
         request: KeySetWriteRequest<'_>,
     ) -> Result<(), Error> {
-        let fab_idx =
-            NonZeroU8::new(ctx.exchange().accessor()?.fab_idx).ok_or(ErrorCode::Invalid)?;
-
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
         let key_set = request.group_key_set()?;
 
         let group_key_set_id = key_set.group_key_set_id()?;
@@ -421,9 +419,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         request: KeySetReadRequest<'_>,
         response: KeySetReadResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx =
-            NonZeroU8::new(ctx.exchange().accessor()?.fab_idx).ok_or(ErrorCode::Invalid)?;
-
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
         let group_key_set_id = request.group_key_set_id()?;
 
         ctx.exchange().with_state(|state| {
@@ -470,9 +466,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         ctx: impl InvokeContext,
         request: KeySetRemoveRequest<'_>,
     ) -> Result<(), Error> {
-        let fab_idx =
-            NonZeroU8::new(ctx.exchange().accessor()?.fab_idx).ok_or(ErrorCode::Invalid)?;
-
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
         let group_key_set_id = request.group_key_set_id()?;
 
         // KeySetRemove of ID 0 (IPK) is not allowed
@@ -509,8 +503,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         ctx: impl InvokeContext,
         response: KeySetReadAllIndicesResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx =
-            NonZeroU8::new(ctx.exchange().accessor()?.fab_idx).ok_or(ErrorCode::Invalid)?;
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
 
         ctx.exchange().with_state(|state| {
             let fabric = state.fabrics.fabric(fab_idx)?;

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -21,8 +21,10 @@ use core::cell::Cell;
 use core::mem::MaybeUninit;
 use core::num::NonZeroU8;
 
+use crate::acl::AclEntry;
 use crate::cert::CertRef;
 use crate::crypto::{CanonPkcSignature, Crypto, SigningSecretKey};
+use crate::dm::clusters::acl::{emit_acl_entry_changed, ChangeTypeEnum};
 use crate::dm::clusters::dev_att::DeviceAttestation;
 use crate::dm::clusters::gen_comm::GenCommHandler;
 use crate::dm::{ArrayAttributeRead, Cluster, Dataver, InvokeContext, ReadContext};
@@ -430,6 +432,10 @@ impl ClusterHandler for NocHandler {
             .filter(|icac| !icac.is_empty());
 
         let mut added_fab_idx = None;
+        // Captured inside the closure so we can emit `AccessControlEntryChanged`
+        // for the auto-created admin ACL entry *after* the failsafe-armed
+        // closure unwinds successfully (Matter Core spec section 9.10.7).
+        let mut admin_acl_entry: Option<AclEntry> = None;
 
         let buf = response.writer().available_space();
 
@@ -452,6 +458,10 @@ impl ClusterHandler for NocHandler {
                 )?;
 
                 let fab_idx = fabric.fab_idx();
+                // Snapshot the freshly seeded admin ACL entry while we still
+                // hold the state lock; we'll emit the event once we're sure
+                // the fabric stays committed (i.e. no rollback happened).
+                let captured_admin_entry = fabric.acl_iter().next().cloned();
                 let succeeded = Cell::new(false);
 
                 let _fab_guard = scopeguard::guard(fab_idx, |fab_idx| {
@@ -471,6 +481,7 @@ impl ClusterHandler for NocHandler {
 
                 succeeded.set(true);
                 added_fab_idx = Some(fab_idx.get());
+                admin_acl_entry = captured_admin_entry;
 
                 Ok(())
             },
@@ -478,6 +489,21 @@ impl ClusterHandler for NocHandler {
 
         // AddNOC mutates NOCs, Fabrics, CommissionedFabrics, TrustedRootCerts, etc.
         ctx.notify_own_cluster_changed();
+
+        // Emit the `AccessControlEntryChanged` event for the auto-created admin
+        // entry. AddNOC happens over PASE during commissioning, so per Matter
+        // Core spec 9.10.7 the event has `adminNodeID = null` and
+        // `adminPasscodeID = 0`.
+        if let (Some(fab_idx), Some(entry)) = (added_fab_idx, &admin_acl_entry) {
+            emit_acl_entry_changed(
+                &ctx,
+                crate::tlv::Nullable::none(),
+                crate::tlv::Nullable::some(0u16),
+                ChangeTypeEnum::Added,
+                entry,
+                fab_idx,
+            )?;
+        }
 
         response
             .status_code(status)?

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -355,7 +355,7 @@ impl<const N: usize> Subscriptions<N> {
             let (sub, buf) = state.report::<B>(now, event_numbers_watermark, buffers)?;
             let attr_change_ids_watermark = state.changed_attrs.watermark();
 
-            info!("About to report on subscription {:?}, details: max_seen_attr_change_id: {}, max_seen_event_number: {}, attr_change_ids_watermark: {}, event_numbers_watermark: {}", sub.ids(), sub.max_seen_attr_change_id, sub.max_seen_event_number, attr_change_ids_watermark, event_numbers_watermark);
+            debug!("About to report on subscription {:?}, details: max_seen_attr_change_id: {}, max_seen_event_number: {}, attr_change_ids_watermark: {}, event_numbers_watermark: {}", sub.ids(), sub.max_seen_attr_change_id, sub.max_seen_event_number, attr_change_ids_watermark, event_numbers_watermark);
 
             Some((sub, buf, attr_change_ids_watermark))
         })?;
@@ -591,7 +591,7 @@ impl<const N: usize> SubscriptionsInner<N> {
             let sub = self.subscriptions.swap_remove(index);
             let buf = buffers.swap_remove(index);
 
-            info!("About to report on subscription {:?}", sub.ids());
+            debug!("About to report on subscription {:?}", sub.ids());
 
             // Leave a snapshot clone behind so that `Subscriptions::remove`
             // can still match and cancel this subscription while the report

--- a/rs-matter/src/dm/types/cluster.rs
+++ b/rs-matter/src/dm/types/cluster.rs
@@ -143,18 +143,22 @@ impl<'a> Cluster<'a> {
     /// designated by the provided path.
     ///
     /// if `write` is true, the operation is a write operation, otherwise it is a read operation.
+    /// `device_types` lists the device types declared by the endpoint hosting `path`,
+    /// so ACL entries with a `Target` of kind `DeviceType` can be evaluated correctly.
     pub(crate) fn check_attr_access(
         &self,
         accessor: &Accessor,
         timed: bool,
         path: GenericPath,
+        device_types: &[DeviceType],
         write: bool,
         attr_id: AttrId,
     ) -> Result<(), IMStatusCode> {
-        let mut access_req = AccessReq::new(
+        let mut access_req = AccessReq::new_with_device_types(
             accessor,
             path,
             if write { Access::WRITE } else { Access::READ },
+            device_types,
         );
 
         let target_perms = self
@@ -186,14 +190,17 @@ impl<'a> Cluster<'a> {
 
     /// Check if the accessor has the required permissions to access the command
     /// designated by the provided path.
+    /// `device_types` lists the device types declared by the endpoint hosting `path`.
     pub(crate) fn check_cmd_access(
         &self,
         accessor: &Accessor,
         timed: bool,
         path: GenericPath,
+        device_types: &[DeviceType],
         cmd_id: CmdId,
     ) -> Result<(), IMStatusCode> {
-        let mut access_req = AccessReq::new(accessor, path, Access::WRITE);
+        let mut access_req =
+            AccessReq::new_with_device_types(accessor, path, Access::WRITE, device_types);
 
         let target_perms = self
             .commands
@@ -216,13 +223,16 @@ impl<'a> Cluster<'a> {
 
     /// Check if the accessor has the required permissions to access the event
     /// designated by the provided path.
+    /// `device_types` lists the device types declared by the endpoint hosting `path`.
     pub(crate) fn check_event_access(
         &self,
         accessor: &Accessor,
         path: GenericPath,
+        device_types: &[DeviceType],
         event_id: EventId,
     ) -> Result<(), IMStatusCode> {
-        let mut access_req = AccessReq::new(accessor, path, Access::READ);
+        let mut access_req =
+            AccessReq::new_with_device_types(accessor, path, Access::READ, device_types);
 
         let target_perms = self
             .events

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -157,6 +157,45 @@ impl<'a> Node<'a> {
         cluster.check_attr_access(accessor, timed, gp, write, attr.id)
     }
 
+    /// Return `true` if at least one attribute matching the (potentially wildcard) path
+    /// is accessible to the given accessor. Used for subscription validation.
+    pub(crate) fn has_accessible_attr(&self, path: &AttrPath, accessor: &Accessor<'_>) -> bool {
+        for endpoint in self.endpoints.iter() {
+            if let Some(ep_id) = path.endpoint {
+                if endpoint.id != ep_id {
+                    continue;
+                }
+            }
+
+            for cluster in endpoint.clusters.iter() {
+                if let Some(cluster_id) = path.cluster {
+                    if cluster.id != cluster_id {
+                        continue;
+                    }
+                }
+
+                for attr in cluster.attributes.iter() {
+                    if let Some(attr_id) = path.attr {
+                        if attr.id != attr_id {
+                            continue;
+                        }
+                    }
+
+                    let gp = GenericPath::new(Some(endpoint.id), Some(cluster.id), Some(attr.id));
+
+                    if cluster
+                        .check_attr_access(accessor, false, gp, false, attr.id)
+                        .is_ok()
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
     pub(crate) fn validate_event_path(
         &self,
         path: &EventPath,

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -146,7 +146,7 @@ impl<'a> Node<'a> {
 
         let gp = path.to_gp();
 
-        let Some((cluster, attr_id)) = self.validate_cluster_path(&gp)? else {
+        let Some((endpoint, cluster, attr_id)) = self.validate_cluster_path(&gp)? else {
             return Ok(());
         };
 
@@ -154,7 +154,7 @@ impl<'a> Node<'a> {
             return Err(IMStatusCode::UnsupportedAttribute);
         };
 
-        cluster.check_attr_access(accessor, timed, gp, write, attr.id)
+        cluster.check_attr_access(accessor, timed, gp, endpoint.device_types, write, attr.id)
     }
 
     /// Return `true` if at least one attribute matching the (potentially wildcard) path
@@ -184,7 +184,14 @@ impl<'a> Node<'a> {
                     let gp = GenericPath::new(Some(endpoint.id), Some(cluster.id), Some(attr.id));
 
                     if cluster
-                        .check_attr_access(accessor, false, gp, false, attr.id)
+                        .check_attr_access(
+                            accessor,
+                            false,
+                            gp,
+                            endpoint.device_types,
+                            false,
+                            attr.id,
+                        )
                         .is_ok()
                     {
                         return true;
@@ -207,7 +214,7 @@ impl<'a> Node<'a> {
 
         let gp = path.to_gp();
 
-        let Some((cluster, event_id)) = self.validate_cluster_path(&gp)? else {
+        let Some((endpoint, cluster, event_id)) = self.validate_cluster_path(&gp)? else {
             return Ok(());
         };
 
@@ -215,7 +222,7 @@ impl<'a> Node<'a> {
             return Err(IMStatusCode::UnsupportedEvent);
         };
 
-        cluster.check_event_access(accessor, gp, event.id)
+        cluster.check_event_access(accessor, gp, endpoint.device_types, event.id)
     }
 
     fn validate_node_id(
@@ -237,7 +244,7 @@ impl<'a> Node<'a> {
     fn validate_cluster_path(
         &self,
         path: &GenericPath,
-    ) -> Result<Option<(&Cluster<'_>, u32)>, IMStatusCode> {
+    ) -> Result<Option<(&Endpoint<'_>, &Cluster<'_>, u32)>, IMStatusCode> {
         let Some(endpoint_id) = path.endpoint else {
             return Ok(None);
         };
@@ -260,7 +267,7 @@ impl<'a> Node<'a> {
             return Ok(None);
         };
 
-        Ok(Some((cluster, leaf_id)))
+        Ok(Some((endpoint, cluster, leaf_id)))
     }
 }
 
@@ -640,6 +647,7 @@ where
                                                 Some(cluster.id),
                                                 Some(leaf_id),
                                             ),
+                                            endpoint.device_types,
                                             unwrap!(cluster
                                                 .commands()
                                                 .map(|cmd| cmd.id)
@@ -657,6 +665,7 @@ where
                                                 Some(cluster.id),
                                                 Some(leaf_id),
                                             ),
+                                            endpoint.device_types,
                                             matches!(T::OPERATION, Operation::Write),
                                             unwrap!(cluster
                                                 .attributes()

--- a/rs-matter/src/dm/types/privilege.rs
+++ b/rs-matter/src/dm/types/privilege.rs
@@ -29,11 +29,19 @@ bitflags! {
         const O = 0x02;
         const M = 0x04;
         const A = 0x08;
+        // ProxyView (kProxyView=2 in `AccessControlEntryPrivilegeEnum`).
+        // Stored as a non-hierarchical flag because, per the Matter spec,
+        // ProxyView is implementation-defined and SHALL NOT affect normal
+        // device operation. With no corresponding `NEED_*` bit in `Access`,
+        // an ACL entry with ProxyView grants no rights for non-proxy
+        // operations but still round-trips correctly across read/write.
+        const P = 0x10;
 
         const VIEW = Self::V.bits();
         const OPERATE = Self::V.bits() | Self::O.bits();
         const MANAGE = Self::V.bits() | Self::O.bits() | Self::M.bits();
         const ADMIN = Self::V.bits() | Self::O.bits() | Self::M.bits() | Self::A.bits();
+        const PROXYVIEW = Self::P.bits();
     }
 }
 
@@ -66,6 +74,8 @@ impl From<Privilege> for AccessControlEntryPrivilegeEnum {
             AccessControlEntryPrivilegeEnum::Operate
         } else if value.contains(Privilege::V) {
             AccessControlEntryPrivilegeEnum::View
+        } else if value.contains(Privilege::P) {
+            AccessControlEntryPrivilegeEnum::ProxyView
         } else {
             unreachable!()
         }
@@ -79,7 +89,7 @@ impl From<AccessControlEntryPrivilegeEnum> for Privilege {
             AccessControlEntryPrivilegeEnum::Manage => Privilege::MANAGE,
             AccessControlEntryPrivilegeEnum::Operate => Privilege::OPERATE,
             AccessControlEntryPrivilegeEnum::Administer => Privilege::ADMIN,
-            _ => Privilege::empty(),
+            AccessControlEntryPrivilegeEnum::ProxyView => Privilege::PROXYVIEW,
         }
     }
 }

--- a/rs-matter/src/dm/types/reply.rs
+++ b/rs-matter/src/dm/types/reply.rs
@@ -16,7 +16,7 @@
  */
 
 use crate::acl::Accessor;
-use crate::dm::{AsyncHandler, HandlerContext, Node};
+use crate::dm::{AsyncHandler, GlobalElements, HandlerContext, Node};
 use crate::error::{Error, ErrorCode};
 use crate::im::{
     AttrDataTag, AttrPath, AttrResp, AttrRespTag, AttrStatus, CmdDataTag, CmdPath, CmdResp,
@@ -310,13 +310,23 @@ where
 pub struct EventReader {
     max_seen_event_number: u64,
     next_max_seen_event_number: u64,
+    /// Whether the originating Read/Subscribe request had `fabricFiltered=true`.
+    /// When set, fabric-sensitive events (those whose payload carries a
+    /// `FabricIndex` context-tag 254) are dropped if their fabric index does
+    /// not match the accessor's. See Matter Core spec section 8.5.2.
+    fabric_filtered: bool,
 }
 
 impl EventReader {
-    pub const fn new(max_seen_event_number: u64, next_max_seen_event_number: u64) -> Self {
+    pub const fn new(
+        max_seen_event_number: u64,
+        next_max_seen_event_number: u64,
+        fabric_filtered: bool,
+    ) -> Self {
         Self {
             max_seen_event_number,
             next_max_seen_event_number,
+            fabric_filtered,
         }
     }
 
@@ -366,6 +376,10 @@ impl EventReader {
         accessor: &Accessor<'_>,
         mut tw: T,
     ) -> Result<bool, Error> {
+        if self.fabric_filtered && !Self::matches_fabric(&event, accessor) {
+            return Ok(false);
+        }
+
         if Self::matches_paths(&event, paths, node, accessor)?
             && Self::matches_filters(&event, event_filters)?
             && Self::matches_access(&event, node, accessor)?
@@ -375,6 +389,33 @@ impl EventReader {
             Ok(true)
         } else {
             Ok(false)
+        }
+    }
+
+    /// Per Matter Core spec section 8.5.2 (Fabric-Sensitive Reporting):
+    /// When `fabricFiltered=true`, fabric-sensitive events (those whose payload
+    /// carries a `FabricIndex` field at context tag 254) SHALL only be reported
+    /// to the requesting fabric.
+    ///
+    /// Events without a `FabricIndex` field are not fabric-sensitive and pass
+    /// through unfiltered. Events with a `FabricIndex` field that matches the
+    /// accessor's fabric are reported as well.
+    fn matches_fabric(event: &EventData<'_>, accessor: &Accessor<'_>) -> bool {
+        // Inspect the event payload struct for context tag 254 (FabricIndex).
+        let Ok(payload) = event.data.structure() else {
+            // Not a struct payload — treat as non-fabric-sensitive.
+            return true;
+        };
+
+        let Ok(elem) = payload.find_ctx(GlobalElements::FabricIndex as u8) else {
+            // No `FabricIndex` field — non-fabric-sensitive, allow.
+            return true;
+        };
+
+        match elem.non_empty().and_then(|e| e.u8().ok()) {
+            Some(fab_idx) => fab_idx == accessor.fab_idx,
+            // Field present but unreadable / null — be conservative and allow.
+            None => true,
         }
     }
 

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -1011,7 +1011,7 @@ impl Fabrics {
             return true;
         }
 
-        let Some(fab_idx) = NonZeroU8::new(req.accessor().fab_idx) else {
+        let Ok(fab_idx) = req.accessor().fab_idx() else {
             return false;
         };
 

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -138,6 +138,8 @@ pub enum MatterMdnsService {
         id: u64,
         /// The discriminator to be communicated over mDNS
         discriminator: u16,
+        /// Whether this is an enhanced (ECM) commissioning window (`CM=2`) vs basic (`CM=1`)
+        enhanced: bool,
     },
 }
 

--- a/rs-matter/src/sc/pase.rs
+++ b/rs-matter/src/sc/pase.rs
@@ -169,6 +169,7 @@ impl CommWindow {
         MatterMdnsService::Commissionable {
             id: self.mdns_id,
             discriminator: self.discriminator,
+            enhanced: matches!(self.comm_window_type(), CommWindowType::Enhanced),
         }
     }
 }

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -734,10 +734,37 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                 );
             }
             Err(e) if matches!(e.code(), ErrorCode::NoSession) => {
+                // Per Matter Core spec section 4.7.1.3, when a session-bearing
+                // message arrives for which we have no matching secure session
+                // (e.g. after a reboot has wiped the session table while the
+                // peer still believes the old session is alive), we reply with
+                // an unsecured `SessionNotFound` Status Report on the Secure
+                // Channel protocol. This nudges the peer to drop its stale
+                // session and re-establish CASE, instead of waiting for MRP
+                // retries to exhaust on its side.
                 warn!(
-                    "\n>>RCV {}\n      => No valid session found, dropping",
+                    "\n>>RCV {}\n      => No valid session found, replying with SessionNotFound",
                     packet
                 );
+
+                // `write_packet` with `session = None` requires the incoming
+                // header to look like an unsecured, non-reliable, source-tagged
+                // packet (see its preconditions). Clear `sess_id` so it is not
+                // considered encrypted, drop the reliable/ack flags since we
+                // are not party to any exchange, and stamp a placeholder
+                // `src_nodeid` (echoed as the response's `dst_nodeid` — UDP
+                // peer addressing is what actually routes the reply).
+                packet.header.plain.sess_id = 0;
+                packet.header.plain.set_src_nodeid(Some(0));
+                packet.header.proto.unset_reliable();
+                packet.header.proto.set_ack(None);
+
+                self.write_packet(packet, None, None, true, |wb| {
+                    sc_write(wb, SCStatusCodes::SessionNotFound, &[])
+                })?;
+
+                Self::netw_send(send, packet.peer, &packet.buf[packet.payload_start..], true)
+                    .await?;
             }
             Err(e) => {
                 error!("\n>>RCV {}\n      => Error ({:?}), dropping", packet, e);

--- a/rs-matter/src/transport/network/mdns.rs
+++ b/rs-matter/src/transport/network/mdns.rs
@@ -556,7 +556,11 @@ impl Service<'_> {
                 })
                 .await
             }
-            MatterMdnsService::Commissionable { discriminator, .. } => {
+            MatterMdnsService::Commissionable {
+                discriminator,
+                enhanced,
+                ..
+            } => {
                 // "_L{u16}""
                 let mut discr_svc_str = heapless::String::<7>::new();
                 // "_S{u16}""
@@ -590,7 +594,7 @@ impl Service<'_> {
                 write_unwrap!(discr_str, "{}", *discriminator);
                 unwrap!(txt_kvs.push(("D", discr_str.as_str())));
 
-                unwrap!(txt_kvs.push(("CM", "1")));
+                unwrap!(txt_kvs.push(("CM", if *enhanced { "2" } else { "1" })));
 
                 write_unwrap!(&mut vp_str, "{}+{}", dev_det.vid, dev_det.pid);
                 unwrap!(txt_kvs.push(("VP", &vp_str)));

--- a/xtask/src/common.rs
+++ b/xtask/src/common.rs
@@ -209,11 +209,19 @@ impl ChipBuilder {
         let runner = chip_dir.join("scripts/run_in_build_env.sh");
         let cmd_line = "./scripts/build_python.sh -i .environment/pigweed-venv -c no -d false";
 
+        // PW_ACTIVATE_SKIP_CHECKS=1 bypasses the `pw doctor` health check in
+        // activate.sh which fails when the `pw` CLI isn't on PATH (e.g. when
+        // bazelisk is absent). The PATH/PYTHONPATH setup that precedes the
+        // check in activate.sh is still applied, so gn/ninja remain usable.
+        //
         // Note: if this step fails in CI, temporarily flip the third arg to
         // `false` (or re-run with `-v`) to surface stderr — the wheel build
         // has many native deps and errors are otherwise invisible.
         run_command_with(
-            Command::new(&runner).current_dir(chip_dir).arg(cmd_line),
+            Command::new(&runner)
+                .current_dir(chip_dir)
+                .env("PW_ACTIVATE_SKIP_CHECKS", "1")
+                .arg(cmd_line),
             self.print_cmd_output,
             !self.print_cmd_output,
         )?;

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -85,7 +85,6 @@ const DEFAULT_TESTS: &[&str] = &[
     "TC_IDM_1_2",
     "TC_IDM_1_4",
     "TC_IDM_4_2",
-
     //
     // Python tests — Access Control (system cluster)
     //

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -99,7 +99,7 @@ const DEFAULT_TESTS: &[&str] = &[
     // "TC_ACL_2_5", // Skipped: tests the optional `AccessControlExtension` feature (Extension attribute), not implemented by rs-matter.
     "TC_ACL_2_6",
     // "TC_ACL_2_7", // Skipped: tests the optional `AccessControlExtension` feature (Extension attribute), not implemented by rs-matter.
-    // "TC_ACL_2_8", // TODO: requires fabric-scoped event filtering (`fabricFiltered=True` on `ReadEvent` should drop events whose `fabricIndex` differs from the requester's fabric). rs-matter does not implement this.
+    // "TC_ACL_2_8", // Skipped: the test re-runs itself internally with legacy list encoding after the modern-encoding pass. The Python framework's between-runs controller cleanup is buggy (`object NoneType can't be used in 'await' expression`) and leaves stale fabrics on the DUT, so the second commissioning fails with `Incorrect state`. The modern-encoding pass — including fabric-scoped event filtering — is exercised end-to-end and passes.
     // "TC_ACL_2_9", // TODO: not yet verified
     // "TC_ACL_2_10", // TODO: not yet verified
     // "TC_ACL_2_11", // TODO: not yet verified

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -101,7 +101,7 @@ const DEFAULT_TESTS: &[&str] = &[
     // "TC_ACL_2_7", // Skipped: tests the optional `AccessControlExtension` feature (Extension attribute), not implemented by rs-matter.
     // "TC_ACL_2_8", // Skipped: the test re-runs itself internally with legacy list encoding after the modern-encoding pass. The Python framework's between-runs controller cleanup is buggy (`object NoneType can't be used in 'await' expression`) and leaves stale fabrics on the DUT, so the second commissioning fails with `Incorrect state`. The modern-encoding pass — including fabric-scoped event filtering — is exercised end-to-end and passes.
     "TC_ACL_2_9",
-    // "TC_ACL_2_10", // TODO: post-reboot session handling. The test reboots the DUT mid-flow; afterwards the controller still uses its pre-reboot session ID. rs-matter silently drops those packets ("No valid session found, dropping") instead of replying with a status report (Matter Core spec section 4.7), so the controller times out. Needs a transport-layer fix.
+    "TC_ACL_2_10",
     // "TC_ACL_2_11", // Skipped: tests the provisional `ManagedAclRestrictions` feature (ARL attribute) and requires manufacturer-specific access restrictions to be pre-configured. rs-matter does not implement this feature.
 
     //

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -34,7 +34,7 @@ use log::{debug, info, warn};
 /// dispatched to `scripts/tests/run_test_suite.py`.
 const DEFAULT_TESTS: &[&str] = &[
     //
-    // YAML tests
+    // YAML tests — general Matter protocol & system clusters
     //
     "Test_AddNewFabricFromExistingFabric",
     "TestAccessControlCluster",
@@ -42,7 +42,7 @@ const DEFAULT_TESTS: &[&str] = &[
     "TestArmFailSafe",
     "TestAttributesById",
     "TestBasicInformation",
-    // "TestBinding", // TODO: specific cluster, to be implemented with all others
+    // "TestBinding", // TODO: Binding cluster not yet implemented
     "TestCASERecovery",
     "TestCluster",
     "TestClusterComplexTypes",
@@ -53,8 +53,8 @@ const DEFAULT_TESTS: &[&str] = &[
     "TestConfigVariables",
     "TestConstraints",
     "TestDelayCommands",
-    //"TestDescriptorCluster", // TODO: Assumes a Power Source device type and expects a lot of clusters to be there
-    // "TestDiagnosticLogs", // TODO: specific cluster, to be implemented with all others
+    // "TestDescriptorCluster", // TODO: Assumes a Power Source device type and expects a lot of clusters to be there
+    // "TestDiagnosticLogs", // TODO: Diagnostic Logs cluster not yet implemented
     "TestDiscovery",
     "TestEqualities",
     "TestEvents",
@@ -64,23 +64,124 @@ const DEFAULT_TESTS: &[&str] = &[
     "TestGroupMessaging",
     "TestGroupsCluster",
     "TestGroupKeyManagementCluster",
-    // "TestIdentifyCluster", // TODO: specific cluster, to be implemented with all others
+    // "TestIdentifyCluster", // TODO: Identify cluster not yet implemented
     "TestLogCommands",
     "TestMultiAdmin",
     "TestOperationalCredentialsCluster",
-    // "TestOperationalState", // TODO: specific cluster, to be implemented with all others
+    // "TestOperationalState", // TODO: Operational State cluster not yet implemented
     "TestReadNoneSubscribeNone",
+    // "TestSaveAs", // TODO: not yet verified
     "TestSelfFabricRemoval",
     "TestSubscribe_AdministratorCommissioning",
     "TestSubscribe_OnOff",
     // "TestSystemCommands", // TODO: Error attempting to start secondary device
-    // "TestUserLabelCluster",  // TODO: specific cluster, to be implemented with all others
-    // "TestUserLabelClusterConstraints",  // TODO: specific cluster, to be implemented with all others
+    // "TestUserLabelCluster", // TODO: User Label cluster not yet implemented
+    // "TestUserLabelClusterConstraints", // TODO: User Label cluster not yet implemented
 
     //
-    // Python tests
+    // Python tests — Interaction Data Model (general Matter protocol)
     //
     "TC_IDM_2_2",
+    "TC_IDM_1_2",
+    "TC_IDM_1_4",
+    "TC_IDM_4_2",
+
+    //
+    // Python tests — Access Control (system cluster)
+    //
+    "TC_ACE_1_2",
+    // "TC_ACE_1_3", // TODO: not yet verified
+    // "TC_ACE_1_4", // TODO: not yet verified
+    // "TC_ACE_1_5", // TODO: not yet verified
+    // "TC_ACL_2_2", // TODO: not yet verified
+    // "TC_ACL_2_3", // TODO: not yet verified
+    // "TC_ACL_2_4", // TODO: not yet verified
+    // "TC_ACL_2_5", // TODO: not yet verified
+    // "TC_ACL_2_6", // TODO: not yet verified
+    // "TC_ACL_2_7", // TODO: not yet verified
+    // "TC_ACL_2_8", // TODO: not yet verified
+    // "TC_ACL_2_9", // TODO: not yet verified
+    // "TC_ACL_2_10", // TODO: not yet verified
+    // "TC_ACL_2_11", // TODO: not yet verified
+
+    //
+    // Python tests — General & Administrator Commissioning (system clusters)
+    //
+    // "TC_CADMIN_1_3_4", // TODO: not yet verified
+    // "TC_CADMIN_1_5",   // TODO: not yet verified
+    // "TC_CADMIN_1_9",   // TODO: not yet verified
+    // "TC_CADMIN_1_11",  // TODO: not yet verified
+    // "TC_CADMIN_1_15",  // TODO: not yet verified
+    // "TC_CADMIN_1_19",  // TODO: not yet verified
+    // "TC_CADMIN_1_22",  // TODO: not yet verified
+    // "TC_CADMIN_1_25",  // TODO: not yet verified
+    // "TC_CADMIN_1_27",  // TODO: not yet verified
+    // "TC_CADMIN_1_28",  // TODO: not yet verified
+    // "TC_CGEN_2_1",     // TODO: not yet verified
+    // "TC_CGEN_2_2",     // TODO: not yet verified
+    // "TC_CGEN_2_4",     // TODO: not yet verified
+    // "TC_CGEN_2_5",     // TODO: not yet verified
+    // "TC_CGEN_2_6",     // TODO: not yet verified
+    // "TC_CGEN_2_7",     // TODO: not yet verified
+    // "TC_CGEN_2_8",     // TODO: not yet verified
+    // "TC_CGEN_2_9",     // TODO: not yet verified
+    // "TC_CGEN_2_10",    // TODO: not yet verified
+    // "TC_CGEN_2_11",    // TODO: not yet verified
+
+    //
+    // Python tests — Operational Credentials (system cluster)
+    //
+    // "TC_OPCREDS_3_1", // TODO: not yet verified
+    // "TC_OPCREDS_3_2", // TODO: not yet verified
+    // "TC_OPCREDS_3_4", // TODO: not yet verified
+    // "TC_OPCREDS_3_5", // TODO: not yet verified
+    // "TC_OPCREDS_3_8", // TODO: not yet verified
+
+    //
+    // Python tests — Session/Commissioning (general Matter protocol)
+    //
+    // "TC_SC_3_4", // TODO: not yet verified
+    // "TC_SC_3_5", // TODO: not yet verified
+    // "TC_SC_3_6", // TODO: not yet verified
+    // "TC_SC_4_1", // TODO: not yet verified
+    // "TC_SC_4_3", // TODO: not yet verified
+    // "TC_SC_7_1", // TODO: not yet verified
+
+    //
+    // Python tests — Basic Information (system cluster)
+    //
+    // "TC_BINFO_3_2", // TODO: not yet verified
+
+    //
+    // Python tests — Groups (system cluster)
+    //
+    // "TC_G_2_2", // TODO: not yet verified
+
+    //
+    // Python tests — General Diagnostics (system cluster)
+    //
+    // "TC_DGGEN_2_4", // TODO: not yet verified
+    // "TC_DGGEN_3_2", // TODO: not yet verified
+
+    //
+    // Python tests — Device Attestation (commissioning)
+    //
+    // "TC_DA_1_2", // TODO: not yet verified
+    // "TC_DA_1_5", // TODO: not yet verified
+    // "TC_DA_1_7", // TODO: not yet verified
+    // "TC_DA_1_9", // TODO: not yet verified
+
+    //
+    // Python tests — Device Discovery (general)
+    //
+    // "TC_DD_1_16_17", // TODO: not yet verified
+    // "TC_DD_3_23",    // TODO: not yet verified
+
+    //
+    // Python tests — Device Composition / Conformance (general)
+    //
+    // "TC_DeviceBasicComposition", // TODO: not yet verified
+    // "TC_DeviceConformance",      // TODO: not yet verified
 ];
 
 /// The directory where the Chip repository will be cloned
@@ -315,8 +416,14 @@ impl ITests {
         // The Python test framework drives commissioning itself via
         // `--script-args`; the rs-matter test executable is launched
         // by `run_python_test.py` and passed via `--app`.
+        //
+        // `--storage-path` must be specified so that `--factory-reset` in
+        // `run_python_test.py` also deletes the controller-side fabric state.
+        // Without it, the Python SDK reuses stale fabric storage from previous
+        // runs while the device has been factory-reset, causing AddNOC to fail.
         let script_args = format!(
-            "--commissioning-method on-network --discriminator {discriminator} \
+            "--storage-path /tmp/rs_matter_python_test_storage.json \
+             --commissioning-method on-network --discriminator {discriminator} \
              --passcode {passcode} --endpoint 1 \
              --paa-trust-store-path credentials/development/paa-root-certs"
         );

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -100,9 +100,9 @@ const DEFAULT_TESTS: &[&str] = &[
     "TC_ACL_2_6",
     // "TC_ACL_2_7", // Skipped: tests the optional `AccessControlExtension` feature (Extension attribute), not implemented by rs-matter.
     // "TC_ACL_2_8", // Skipped: the test re-runs itself internally with legacy list encoding after the modern-encoding pass. The Python framework's between-runs controller cleanup is buggy (`object NoneType can't be used in 'await' expression`) and leaves stale fabrics on the DUT, so the second commissioning fails with `Incorrect state`. The modern-encoding pass — including fabric-scoped event filtering — is exercised end-to-end and passes.
-    // "TC_ACL_2_9", // TODO: not yet verified
-    // "TC_ACL_2_10", // TODO: not yet verified
-    // "TC_ACL_2_11", // TODO: not yet verified
+    "TC_ACL_2_9",
+    // "TC_ACL_2_10", // TODO: post-reboot session handling. The test reboots the DUT mid-flow; afterwards the controller still uses its pre-reboot session ID. rs-matter silently drops those packets ("No valid session found, dropping") instead of replying with a status report (Matter Core spec section 4.7), so the controller times out. Needs a transport-layer fix.
+    // "TC_ACL_2_11", // Skipped: tests the provisional `ManagedAclRestrictions` feature (ARL attribute) and requires manufacturer-specific access restrictions to be pre-configured. rs-matter does not implement this feature.
 
     //
     // Python tests — General & Administrator Commissioning (system clusters)

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -96,10 +96,10 @@ const DEFAULT_TESTS: &[&str] = &[
     "TC_ACL_2_2",
     // "TC_ACL_2_3", // Skipped: tests the optional `AccessControlExtension` feature (Extension attribute), not implemented by rs-matter.
     "TC_ACL_2_4",
-    // "TC_ACL_2_5", // TODO: not yet verified
-    // "TC_ACL_2_6", // TODO: not yet verified
-    // "TC_ACL_2_7", // TODO: not yet verified
-    // "TC_ACL_2_8", // TODO: not yet verified
+    // "TC_ACL_2_5", // Skipped: tests the optional `AccessControlExtension` feature (Extension attribute), not implemented by rs-matter.
+    "TC_ACL_2_6",
+    // "TC_ACL_2_7", // Skipped: tests the optional `AccessControlExtension` feature (Extension attribute), not implemented by rs-matter.
+    // "TC_ACL_2_8", // TODO: requires fabric-scoped event filtering (`fabricFiltered=True` on `ReadEvent` should drop events whose `fabricIndex` differs from the requester's fabric). rs-matter does not implement this.
     // "TC_ACL_2_9", // TODO: not yet verified
     // "TC_ACL_2_10", // TODO: not yet verified
     // "TC_ACL_2_11", // TODO: not yet verified
@@ -457,6 +457,13 @@ impl ITests {
                  --string-arg PIXIT.ACE.APPATTRIBUTE:OnOff \
                  --int-arg PIXIT.ACE.APPDEVTYPEID:256"
             }
+            // ACL tests target the AccessControl cluster which lives on
+            // endpoint 0. The default `--endpoint 1` we pass for application
+            // tests would route ancillary helpers like
+            // `get_latest_event_number` at endpoint 1, where there are no
+            // ACL events. argparse keeps the last `--endpoint`, so appending
+            // here wins.
+            "TC_ACL_2_6" | "TC_ACL_2_7" | "TC_ACL_2_8" => " --endpoint 0",
             _ => "",
         }
     }

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -92,10 +92,10 @@ const DEFAULT_TESTS: &[&str] = &[
     "TC_ACE_1_2",
     "TC_ACE_1_3",
     "TC_ACE_1_4",
-    // "TC_ACE_1_5", // TODO: not yet verified
-    // "TC_ACL_2_2", // TODO: not yet verified
-    // "TC_ACL_2_3", // TODO: not yet verified
-    // "TC_ACL_2_4", // TODO: not yet verified
+    "TC_ACE_1_5",
+    "TC_ACL_2_2",
+    // "TC_ACL_2_3", // Skipped: tests the optional `AccessControlExtension` feature (Extension attribute), not implemented by rs-matter.
+    "TC_ACL_2_4",
     // "TC_ACL_2_5", // TODO: not yet verified
     // "TC_ACL_2_6", // TODO: not yet verified
     // "TC_ACL_2_7", // TODO: not yet verified

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -90,8 +90,8 @@ const DEFAULT_TESTS: &[&str] = &[
     // Python tests — Access Control (system cluster)
     //
     "TC_ACE_1_2",
-    // "TC_ACE_1_3", // TODO: not yet verified
-    // "TC_ACE_1_4", // TODO: not yet verified
+    "TC_ACE_1_3",
+    "TC_ACE_1_4",
     // "TC_ACE_1_5", // TODO: not yet verified
     // "TC_ACL_2_2", // TODO: not yet verified
     // "TC_ACL_2_3", // TODO: not yet verified
@@ -421,11 +421,12 @@ impl ITests {
         // `run_python_test.py` also deletes the controller-side fabric state.
         // Without it, the Python SDK reuses stale fabric storage from previous
         // runs while the device has been factory-reset, causing AddNOC to fail.
+        let extra_args = Self::extra_python_script_args(test_name);
         let script_args = format!(
             "--storage-path /tmp/rs_matter_python_test_storage.json \
              --commissioning-method on-network --discriminator {discriminator} \
              --passcode {passcode} --endpoint 1 \
-             --paa-trust-store-path credentials/development/paa-root-certs"
+             --paa-trust-store-path credentials/development/paa-root-certs{extra_args}"
         );
 
         Ok(format!(
@@ -436,6 +437,28 @@ impl ITests {
             script_path.display(),
             script_args,
         ))
+    }
+
+    /// Test-specific extra `--script-args` for `run_python_test.py`.
+    ///
+    /// Some `MatterBaseTest`-style scripts require PIXIT/PICS values supplied
+    /// on the command line via the `--int-arg`, `--string-arg`, `--hex-arg`
+    /// flags. Map them here per test, keyed by file stem, so the rest of the
+    /// dispatch path stays uniform.
+    fn extra_python_script_args(test_name: &str) -> &'static str {
+        match test_name {
+            // TC_ACE_1_4 needs the PIXITs that point at the application
+            // endpoint/cluster/attribute exposed by `chip_tool_tests`. Endpoint 1
+            // hosts the OnOff cluster on a `DEV_TYPE_ON_OFF_LIGHT` (device type
+            // 0x0100 == 256).
+            "TC_ACE_1_4" => {
+                " --int-arg PIXIT.ACE.APPENDPOINT:1 \
+                 --string-arg PIXIT.ACE.APPCLUSTER:OnOff \
+                 --string-arg PIXIT.ACE.APPATTRIBUTE:OnOff \
+                 --int-arg PIXIT.ACE.APPDEVTYPEID:256"
+            }
+            _ => "",
+        }
     }
 
     fn build_test_exe<'a>(


### PR DESCRIPTION
There are a bunch of Python tests (in addition to the YAML ones). 
This PR enables some of those which are related to system clusters:
- The TC_IDM_* ones - these are generic tests exercising the Interaction/data model
- ACE and ACL -these tests exercise primarily the ACL as well as commissioning

(There would be separate PRs enabling Python & YAML tests for app-specific clusters, where the first one would be for the camera clusters.)


Stuff fixed with this PR:

##### ACLs

- Finally: device types handling in ACL. Closes #256 
- Proper error code when no fabric
  - Make sure we return UnsupportedAccess for incoming requests requiring a fabric (fab_idx 1= 0). We did return Invalid so far.
- ProxyView support in ACLs
- Emit ACL entry changed event

##### Commissioning Window

- We were not advertising the extended commissioning window when an extended one was opened

##### Events

- Fabric filtering when reporting on events was not implemented. Now it is.

##### Transport

- Send a Status Code `SessionNotFound` when the incoming session cannot be found so that the other peer can re-establish a session with us rather than retrying with MRP the packet. Previously, we did not send anything for unknown sessions, which - by itself - might be an even bigger problem if a reliable transport like TCP or BTP is used.