### PR TITLE
CADMIN Python tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target
 Cargo.lock
 .vscode
 .idea
+.claude
 
 # Nix
 .devenv/

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -361,6 +361,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use core::cell::Cell;
     use core::num::NonZeroU8;
 
     use crate::acl::{AclEntry, AuthMode};
@@ -546,6 +547,7 @@ mod tests {
                 fab_filter: false,
                 dataver: None,
                 wildcard: false,
+                cluster_status: Cell::new(0),
             };
 
             acl_read(&acl, &fabrics, &attr, &mut writebuf);
@@ -573,6 +575,7 @@ mod tests {
                 fab_filter: true,
                 dataver: None,
                 wildcard: false,
+                cluster_status: Cell::new(0),
             };
 
             acl_read(&acl, &fabrics, &attr, &mut writebuf);
@@ -599,6 +602,7 @@ mod tests {
                 fab_filter: true,
                 dataver: None,
                 wildcard: false,
+                cluster_status: Cell::new(0),
             };
 
             acl_read(&acl, &fabrics, &attr, &mut writebuf);

--- a/rs-matter/src/dm/clusters/adm_comm.rs
+++ b/rs-matter/src/dm/clusters/adm_comm.rs
@@ -21,7 +21,7 @@ use rand_core::RngCore;
 
 use crate::crypto::Crypto;
 use crate::dm::{Cluster, Dataver, InvokeContext, ReadContext};
-use crate::error::Error;
+use crate::error::{Error, ErrorCode};
 use crate::sc::pase::spake2p::SPAKE2P_VERIFIER_SALT_ZEROED;
 use crate::sc::pase::{CommWindowOpener, CommWindowType};
 use crate::tlv::Nullable;
@@ -30,6 +30,26 @@ use crate::MatterState;
 pub use crate::dm::clusters::decl::administrator_commissioning::*;
 use crate::transport::exchange::ExchangeId;
 use crate::transport::session::SessionMode;
+
+/// PAKE iteration count bounds (Matter Core spec section 11.18.6.1.4).
+const MIN_PBKDF_ITERATIONS: u32 = 1000;
+const MAX_PBKDF_ITERATIONS: u32 = 100_000;
+
+/// PAKE salt length bounds (Matter Core spec section 11.18.6.1.4 / 5.1.6.1).
+const MIN_PAKE_SALT_LEN: usize = 16;
+const MAX_PAKE_SALT_LEN: usize = 32;
+
+/// SPAKE2+ verifier length: W0 (32) || L (65) = 97 octets
+/// (Matter Core spec section 3.10).
+const PAKE_VERIFIER_LEN: usize = 97;
+
+/// Stash an `AdministratorCommissioning` cluster-specific status on the
+/// invoke context so the IM layer surfaces it in `StatusIB.clusterStatus`,
+/// then build the matching `Failure(0x01)` error to return from the handler.
+fn cluster_status_err(ctx: &impl InvokeContext, status: StatusCode) -> Error {
+    ctx.cmd().set_cluster_status(status as u8);
+    Error::new(ErrorCode::Failure)
+}
 
 /// The system implementation of a handler for the Administrative Commissioning Matter cluster.
 #[derive(Debug, Clone)]
@@ -148,6 +168,24 @@ impl ClusterHandler for AdminCommHandler {
         let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
         let notify_change = |_, _| ctx.notify_own_cluster_changed();
 
+        // Validate the PAKE parameters up front so we can surface
+        // `PAKEParameterError` as the cluster-specific status (Matter Core
+        // spec section 11.18.6.1.4).
+        let iterations = request.iterations()?;
+        if !(MIN_PBKDF_ITERATIONS..=MAX_PBKDF_ITERATIONS).contains(&iterations) {
+            return Err(cluster_status_err(&ctx, StatusCode::PAKEParameterError));
+        }
+
+        let salt = request.salt()?;
+        if !(MIN_PAKE_SALT_LEN..=MAX_PAKE_SALT_LEN).contains(&salt.0.len()) {
+            return Err(cluster_status_err(&ctx, StatusCode::PAKEParameterError));
+        }
+
+        let verifier = request.pake_passcode_verifier()?;
+        if verifier.0.len() != PAKE_VERIFIER_LEN {
+            return Err(cluster_status_err(&ctx, StatusCode::PAKEParameterError));
+        }
+
         ctx.exchange().with_state(|state| {
             state
                 .pase
@@ -157,17 +195,20 @@ impl ClusterHandler for AdminCommHandler {
 
             let mdns_id = ctx.crypto().rand()?.next_u64();
 
-            state.pase.open_comm_window(
-                mdns_id,
-                request.pake_passcode_verifier()?.0.try_into()?,
-                request.salt()?.0.try_into()?,
-                request.iterations()?,
-                request.discriminator()?,
-                request.commissioning_timeout()?,
-                opener,
-                notify_mdns,
-                notify_change,
-            )
+            state
+                .pase
+                .open_comm_window(
+                    mdns_id,
+                    verifier.0.try_into()?,
+                    salt.0.try_into()?,
+                    iterations,
+                    request.discriminator()?,
+                    request.commissioning_timeout()?,
+                    opener,
+                    notify_mdns,
+                    notify_change,
+                )
+                .map_err(|err| map_open_window_err(&ctx, err))
         })
     }
 
@@ -195,16 +236,19 @@ impl ClusterHandler for AdminCommHandler {
             let mut salt = SPAKE2P_VERIFIER_SALT_ZEROED;
             rand.fill_bytes(salt.access_mut());
 
-            state.pase.open_basic_comm_window(
-                mdns_id,
-                salt.reference(),
-                dev_comm.password.reference(),
-                dev_comm.discriminator,
-                request.commissioning_timeout()?,
-                opener,
-                notify_mdns,
-                notify_change,
-            )
+            state
+                .pase
+                .open_basic_comm_window(
+                    mdns_id,
+                    salt.reference(),
+                    dev_comm.password.reference(),
+                    dev_comm.discriminator,
+                    request.commissioning_timeout()?,
+                    opener,
+                    notify_mdns,
+                    notify_change,
+                )
+                .map_err(|err| map_open_window_err(&ctx, err))
         })
     }
 
@@ -212,11 +256,37 @@ impl ClusterHandler for AdminCommHandler {
         let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
         let notify_change = |_, _| ctx.notify_own_cluster_changed();
 
-        ctx.exchange()
-            .with_state(|state| state.pase.close_comm_window(notify_mdns, notify_change))?;
-
-        // TODO: Send status code if no commissioning window is open?
+        ctx.exchange().with_state(|state| {
+            state
+                .pase
+                .close_comm_window(notify_mdns, notify_change)
+                .map_err(|err| map_revoke_err(&ctx, err))
+        })?;
 
         Ok(())
+    }
+}
+
+/// Map errors returned by `Pase::open_*_comm_window` to
+/// `AdministratorCommissioning` cluster-specific status codes (Matter Core
+/// spec section 11.18.6). `Busy` is the only cluster status the open paths
+/// surface today; other transport-level errors (e.g. invalid timeout) bubble
+/// up unchanged so the IM layer turns them into the generic `InvalidCommand`.
+fn map_open_window_err(ctx: &impl InvokeContext, err: Error) -> Error {
+    if err.code() == ErrorCode::Busy {
+        cluster_status_err(ctx, StatusCode::Busy)
+    } else {
+        err
+    }
+}
+
+/// Same idea for `RevokeCommissioning`: per spec, attempting to revoke when
+/// no window is open SHALL return `WindowNotOpen`. `Pase::close_comm_window`
+/// reports this as `ErrorCode::Invalid`.
+fn map_revoke_err(ctx: &impl InvokeContext, err: Error) -> Error {
+    if matches!(err.code(), ErrorCode::Invalid) {
+        cluster_status_err(ctx, StatusCode::WindowNotOpen)
+    } else {
+        err
     }
 }

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -25,8 +25,10 @@ use crate::acl::AclEntry;
 use crate::cert::CertRef;
 use crate::crypto::{CanonPkcSignature, Crypto, SigningSecretKey};
 use crate::dm::clusters::acl::{emit_acl_entry_changed, ChangeTypeEnum};
+use crate::dm::clusters::adm_comm;
 use crate::dm::clusters::dev_att::DeviceAttestation;
 use crate::dm::clusters::gen_comm::GenCommHandler;
+use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::dm::{ArrayAttributeRead, Cluster, Dataver, InvokeContext, ReadContext};
 use crate::error::{Error, ErrorCode};
 use crate::fabric::{Fabric, FabricPersist, MAX_FABRICS};
@@ -614,7 +616,7 @@ impl ClusterHandler for NocHandler {
 
         let mut persist = FabricPersist::new(ctx.kv());
 
-        let status = ctx.exchange().with_state(|state| {
+        let (status, opener_fabric_removed) = ctx.exchange().with_state(|state| {
             let sess = ctx.exchange().id().session(&mut state.sessions);
 
             if state.fabrics.remove(fab_idx).is_ok() {
@@ -641,9 +643,20 @@ impl ClusterHandler for NocHandler {
 
                 info!("Removed operational fabric with local index {}", fab_idx);
 
-                Ok(NodeOperationalCertStatusEnum::OK)
+                // If the removed fabric was the one that opened the current
+                // commissioning window, `AdminFabricIndex` (and `AdminVendorId`)
+                // transition to null and subscribers must be notified — see
+                // Matter Core spec section 11.18.7.
+                let opener_fabric_removed = state
+                    .pase
+                    .comm_window()
+                    .and_then(|w| w.opener())
+                    .map(|opener| opener.fab_idx == fab_idx)
+                    .unwrap_or(false);
+
+                Ok::<_, Error>((NodeOperationalCertStatusEnum::OK, opener_fabric_removed))
             } else {
-                Ok(NodeOperationalCertStatusEnum::InvalidFabricIndex)
+                Ok((NodeOperationalCertStatusEnum::InvalidFabricIndex, false))
             }
         })?;
 
@@ -651,6 +664,10 @@ impl ClusterHandler for NocHandler {
 
         // RemoveFabric mutates NOCs, Fabrics, CommissionedFabrics, TrustedRootCerts
         ctx.notify_own_cluster_changed();
+
+        if opener_fabric_removed {
+            ctx.notify_cluster_changed(ROOT_ENDPOINT_ID, adm_comm::FULL_CLUSTER.id);
+        }
 
         response
             .status_code(status)?

--- a/rs-matter/src/dm/types/attribute.rs
+++ b/rs-matter/src/dm/types/attribute.rs
@@ -16,6 +16,7 @@
  */
 #![allow(clippy::bad_bit_mask)]
 
+use core::cell::Cell;
 use core::fmt::{self, Debug};
 
 use strum::FromRepr;
@@ -270,6 +271,17 @@ pub struct AttrDetails<'a> {
     pub dataver: Option<u32>,
     /// Whether the original attribute was a wildcard one
     pub wildcard: bool,
+    /// Cluster-specific status to stamp into the response `StatusIB.clusterStatus`
+    /// for this attribute read or write. `0` means "no cluster status" (the
+    /// reserved `kSuccess` value in Matter cluster-status enums).
+    ///
+    /// Mirrors the same field on `CmdDetails` — kept off `Error` so that
+    /// `Result<T, Error>` stays a compact 1-byte error payload across the
+    /// codebase. Cluster handlers set this via
+    /// `ReadContext::attr().set_cluster_status(...)` /
+    /// `WriteContext::attr().set_cluster_status(...)` before returning an
+    /// error.
+    pub cluster_status: Cell<u8>,
 }
 
 impl AttrDetails<'_> {
@@ -310,9 +322,29 @@ impl AttrDetails<'_> {
             })
     }
 
+    /// Stamp a cluster-specific status code onto this attribute access. The
+    /// value is echoed in `StatusIB.clusterStatus` when the read or write
+    /// returns `Err`. `0` is treated as "none" (Matter reserves it for
+    /// `kSuccess`).
+    pub fn set_cluster_status(&self, cluster_status: u8) {
+        self.cluster_status.set(cluster_status);
+    }
+
+    /// The currently stashed cluster-specific status, if any.
+    pub fn cluster_status(&self) -> Option<u16> {
+        match self.cluster_status.get() {
+            0 => None,
+            n => Some(n as u16),
+        }
+    }
+
     pub fn status(&self, status: IMStatusCode) -> Option<AttrStatus> {
         if self.should_report(status) {
-            Some(AttrStatus::new(self.reply_path(), status, None))
+            Some(AttrStatus::new(
+                self.reply_path(),
+                status,
+                self.cluster_status(),
+            ))
         } else {
             None
         }

--- a/rs-matter/src/dm/types/command.rs
+++ b/rs-matter/src/dm/types/command.rs
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+use core::cell::Cell;
 use core::fmt;
 
 use crate::im::{CmdPath, CmdStatus, IMStatusCode};
@@ -97,6 +98,55 @@ pub struct CmdDetails<'a> {
     /// The CommandRef from the originating `CommandDataIB`, if any.
     /// Echoed back in the response so the requester can correlate batched invokes.
     pub command_ref: Option<u16>,
+    /// Cluster-specific status to stamp into the response `StatusIB.clusterStatus`
+    /// when the handler returns `Err`. `0` means "no cluster status" (the
+    /// reserved `kSuccess` value in Matter cluster-status enums).
+    ///
+    /// Cluster handlers set this via `InvokeContext::set_cluster_status`
+    /// before returning an error. Stored here as a `Cell<u8>` rather than
+    /// on `Error` so that `Result<T, Error>` keeps its compact 1-byte error
+    /// payload across the codebase.
+    cluster_status: Cell<u8>,
+}
+
+impl<'a> CmdDetails<'a> {
+    /// Construct a new `CmdDetails`. Initializes `cluster_status` to `0`
+    /// (no cluster-specific status to report).
+    pub const fn new(
+        node: &'a Node<'a>,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        cmd_id: CmdId,
+        fab_idx: u8,
+        wildcard: bool,
+        command_ref: Option<u16>,
+    ) -> Self {
+        Self {
+            node,
+            endpoint_id,
+            cluster_id,
+            cmd_id,
+            fab_idx,
+            wildcard,
+            command_ref,
+            cluster_status: Cell::new(0),
+        }
+    }
+
+    /// Stamp a cluster-specific status code onto this invoke. The value is
+    /// echoed in `StatusIB.clusterStatus` when the handler returns `Err`.
+    /// `0` is treated as "none" (Matter reserves it for `kSuccess`).
+    pub fn set_cluster_status(&self, cluster_status: u8) {
+        self.cluster_status.set(cluster_status);
+    }
+
+    /// The currently stashed cluster-specific status, if any.
+    pub fn cluster_status(&self) -> Option<u16> {
+        match self.cluster_status.get() {
+            0 => None,
+            n => Some(n as u16),
+        }
+    }
 }
 
 impl CmdDetails<'_> {
@@ -111,7 +161,7 @@ impl CmdDetails<'_> {
         )
     }
 
-    pub const fn status(&self, status: IMStatusCode) -> Option<CmdStatus> {
+    pub fn status(&self, status: IMStatusCode) -> Option<CmdStatus> {
         if self.should_report(status) {
             Some(CmdStatus::new(
                 CmdPath::new(
@@ -120,7 +170,7 @@ impl CmdDetails<'_> {
                     Some(self.cmd_id),
                 ),
                 status,
-                None,
+                self.cluster_status(),
                 self.command_ref,
             ))
         } else {

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+use core::cell::Cell;
 use core::fmt;
 
 use crate::acl::Accessor;
@@ -433,6 +434,7 @@ impl<'a> PathExpansionItem<'a> for AttrReadPath<'a> {
             fab_idx: accessor.fab_idx,
             fab_filter: self.fabric_filtered,
             dataver: dataver(self.dataver_filters.as_ref(), endpoint_id, cluster_id)?,
+            cluster_status: Cell::new(0),
         })
     }
 
@@ -474,6 +476,7 @@ impl<'a> PathExpansionItem<'a> for AttrData<'a> {
                 // are assumed to be always fabric-filtered
                 fab_filter: true,
                 dataver: self.data_ver,
+                cluster_status: Cell::new(0),
             },
             self.data.clone(),
         );
@@ -506,15 +509,15 @@ impl<'a> PathExpansionItem<'a> for CmdData<'a> {
         leaf_id: u32,
     ) -> Result<Self::Expanded<'a>, Error> {
         let expanded = (
-            CmdDetails {
+            CmdDetails::new(
                 node,
                 endpoint_id,
                 cluster_id,
-                cmd_id: leaf_id,
-                fab_idx: accessor.fab_idx,
-                wildcard: false,
-                command_ref: self.command_ref,
-            },
+                leaf_id,
+                accessor.fab_idx,
+                false,
+                self.command_ref,
+            ),
             self.data.clone(),
         );
 

--- a/rs-matter/src/sc/pase.rs
+++ b/rs-matter/src/sc/pase.rs
@@ -94,6 +94,10 @@ pub struct CommWindow {
     opener: Option<CommWindowOpener>,
     /// The window expiry instant
     window_expiry: Duration,
+    /// Number of failed PAKE handshake attempts within this window.
+    /// Per Matter Core spec section 11.18.6.1.5, the window SHALL be
+    /// revoked after 20 unsuccessful handshakes.
+    pake_failures: u8,
 }
 
 impl CommWindow {
@@ -120,6 +124,7 @@ impl CommWindow {
             verifier <- Spake2pVerifierData::init_with_pw(password, salt),
             opener,
             window_expiry,
+            pake_failures: 0,
         })
     }
 
@@ -147,6 +152,7 @@ impl CommWindow {
             verifier <- Spake2pVerifierData::init(verifier, salt, count),
             opener,
             window_expiry,
+            pake_failures: 0,
         })
     }
 
@@ -350,6 +356,47 @@ impl Pase {
         notify_adm_comm_window_attrs_changed(&mut notify_change);
 
         info!("PASE Commissioning Window opened");
+
+        Ok(())
+    }
+
+    /// Record a failed PAKE handshake against the currently-open
+    /// commissioning window, and revoke the window if the limit is reached.
+    ///
+    /// Per Matter Core spec section 11.18.6.1.5, after 20 unsuccessful PAKE
+    /// attempts the device SHALL revoke the open commissioning window.
+    ///
+    /// Also clears the in-progress PASE establishment timeout so that the
+    /// next handshake attempt is not rejected as "another session in
+    /// progress" — without this, only the first wrong-passcode attempt would
+    /// be counted because subsequent attempts would be short-circuited at the
+    /// session-timeout gate.
+    ///
+    /// Has no effect on the failure counter if no window is open.
+    pub fn record_pake_failure(
+        &mut self,
+        notify_mdns: impl FnMut(),
+        notify_change: impl FnMut(EndptId, ClusterId),
+    ) -> Result<(), Error> {
+        const MAX_PAKE_FAILURES: u8 = 20;
+
+        self.session_timeout = None;
+
+        let revoke = if let Some(window) = self.comm_window.as_opt_mut() {
+            window.pake_failures = window.pake_failures.saturating_add(1);
+            warn!(
+                "PASE Commissioning Window: PAKE failure {} of {}",
+                window.pake_failures, MAX_PAKE_FAILURES
+            );
+            window.pake_failures >= MAX_PAKE_FAILURES
+        } else {
+            false
+        };
+
+        if revoke {
+            warn!("PASE Commissioning Window revoked after too many failed PAKE attempts");
+            self.close_comm_window(notify_mdns, notify_change)?;
+        }
 
         Ok(())
     }

--- a/rs-matter/src/sc/pase/responder.rs
+++ b/rs-matter/src/sc/pase/responder.rs
@@ -71,10 +71,39 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
     /// # Arguments
     /// - `exchange` - The exchange
     pub async fn handle(&mut self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
+        let result = self.handle_inner(exchange).await;
+
+        // Per Matter Core spec section 11.18.6.1.5, every unsuccessful PAKE
+        // handshake within the open commissioning window must be counted; the
+        // window SHALL be revoked after 20. We charge a failure for any path
+        // that errored mid-handshake or returned `Ok(false)` from
+        // `handle_inner` (PAKE3 verify failed). Successful handshakes and
+        // protocol-level rejections (e.g. "another PAKE session in progress",
+        // which is not a wrong-passcode attempt) return `Ok(true)` and
+        // therefore are not counted.
+        //
+        // We also unconditionally clear `session_timeout` so the next inbound
+        // PBKDFParamRequest isn't blocked by a stale "session in progress"
+        // marker left behind by an aborted handshake.
+        let pake_failed = matches!(result, Ok(false) | Err(_));
+
+        if pake_failed {
+            let notify_mdns = || exchange.matter().notify_mdns_changed();
+            let notify_change =
+                |endpt_id, cluster_id| self.notify.notify_cluster_changed(endpt_id, cluster_id);
+
+            let _ = exchange
+                .with_state(|state| state.pase.record_pake_failure(notify_mdns, notify_change));
+        }
+
+        result.map(|_| ())
+    }
+
+    async fn handle_inner(&mut self, exchange: &mut Exchange<'_>) -> Result<bool, Error> {
         let session = ReservedSession::reserve(exchange.matter(), &self.crypto).await?;
 
         if !self.update_session_timeout(exchange, true).await? {
-            return Ok(());
+            return Ok(true);
         }
 
         self.handle_pbkdfparamrequest(exchange).await?;
@@ -82,7 +111,7 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
         exchange.recv_fetch().await?;
 
         if !self.update_session_timeout(exchange, false).await? {
-            return Ok(());
+            return Ok(true);
         }
 
         self.handle_pasepake1(exchange).await?;
@@ -90,14 +119,16 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
         exchange.recv_fetch().await?;
 
         if !self.update_session_timeout(exchange, false).await? {
-            return Ok(());
+            return Ok(true);
         }
 
-        self.handle_pasepake3(exchange, session).await?;
+        let success = self.handle_pasepake3(exchange, session).await?;
 
         exchange.acknowledge().await?;
 
-        self.clear_session_timeout(exchange)
+        self.clear_session_timeout(exchange)?;
+
+        Ok(success)
     }
 
     /// Handle a PBKDFParamRequest message
@@ -262,14 +293,17 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
         &mut self,
         exchange: &mut Exchange<'_>,
         mut session: ReservedSession<'_>,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         check_opcode(exchange, OpCode::PASEPake3)?;
 
         let req = get_root_node_struct(exchange.rx()?.payload())?;
         let pake3 = Pake3::from_tlv(&req)?;
         let ca: HmacHashRef<'_> = pake3.ca.0.try_into()?;
 
-        let status = match self.spake2p.verify(ca) {
+        let verify_result = self.spake2p.verify(ca);
+        let success = verify_result.is_ok();
+
+        let status = match verify_result {
             Ok((local_sessid, peer_sessid, ke)) => {
                 // Get the keys
                 let mut session_keys = Spake2pSessionKeys::new(); // TODO: MEDIUM BUFFER
@@ -316,7 +350,9 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
             Err(status) => status,
         };
 
-        complete_with_status(exchange, status, &[]).await
+        complete_with_status(exchange, status, &[]).await?;
+
+        Ok(success)
     }
 
     /// Update the PASE session timeout tracker

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -1142,10 +1142,14 @@ impl Sessions {
         rx_peer: &Address,
         rx_plain: &PlainHdr,
     ) -> Option<&mut Session> {
+        // Per Matter Core spec section 4.7.1.3, an expired session must not
+        // accept new inbound messages. Skipping expired sessions here lets the
+        // caller surface a `SessionNotFound` to the peer rather than running
+        // the request through ACL checks against a removed fabric.
         let mut session = self
             .sessions
             .iter_mut()
-            .find(|sess| sess.is_for_rx(rx_peer, rx_plain));
+            .find(|sess| !sess.expired && sess.is_for_rx(rx_peer, rx_plain));
 
         if let Some(session) = session.as_mut() {
             session.update_last_used(self.epoch);

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -111,81 +111,80 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     //
     // Python tests — General & Administrator Commissioning (system clusters)
     //
-    // "TC_CADMIN_1_3_4", // TODO: not yet verified
-    // "TC_CADMIN_1_5",   // TODO: not yet verified
-    // "TC_CADMIN_1_9",   // TODO: not yet verified
-    // "TC_CADMIN_1_11",  // TODO: not yet verified
-    // "TC_CADMIN_1_15",  // TODO: not yet verified
-    // "TC_CADMIN_1_19",  // TODO: not yet verified
-    // "TC_CADMIN_1_22",  // TODO: not yet verified
-    // "TC_CADMIN_1_25",  // TODO: not yet verified
-    // "TC_CADMIN_1_27",  // TODO: not yet verified
-    // "TC_CADMIN_1_28",  // TODO: not yet verified
-    // "TC_CGEN_2_1",     // TODO: not yet verified
-    // "TC_CGEN_2_2",     // TODO: not yet verified
-    // "TC_CGEN_2_4",     // TODO: not yet verified
-    // "TC_CGEN_2_5",     // TODO: not yet verified
-    // "TC_CGEN_2_6",     // TODO: not yet verified
-    // "TC_CGEN_2_7",     // TODO: not yet verified
-    // "TC_CGEN_2_8",     // TODO: not yet verified
-    // "TC_CGEN_2_9",     // TODO: not yet verified
-    // "TC_CGEN_2_10",    // TODO: not yet verified
-    // "TC_CGEN_2_11",    // TODO: not yet verified
+    "TC_CADMIN_1_3_4",
+    "TC_CADMIN_1_5",
+    "TC_CADMIN_1_9",
+    "TC_CADMIN_1_11",
+    "TC_CADMIN_1_15",
+    // "TC_CADMIN_1_19",  // TODO: multi-fabric stress test commissions `SupportedFabrics` controllers back-to-back. Fails part-way with `Incorrect state` from the Python pairing controller. Likely needs deeper investigation of CASE setup between rapid commissioning rounds; not blocking other coverage.
+    "TC_CADMIN_1_22",
+    "TC_CADMIN_1_25",
+    // "TC_CADMIN_1_27",  // Skipped: requires the CHIP `jfc-server-app` (Joint Fabric Controller); rs-matter does not implement JF.
+    // "TC_CADMIN_1_28",  // Skipped: requires the CHIP `jfc-server-app` (Joint Fabric Controller); rs-matter does not implement JF.
+    "TC_CGEN_2_1",
+    // "TC_CGEN_2_2",  // TODO: after `AddTrustedRootCertificate` during a failsafe, the read-back of `TrustedRootCertificates` still reports the original size — the new root isn't surfaced. Likely an attribute-list issue in rs-matter's NOC handler.
+    // "TC_CGEN_2_4",  // TODO: `CommissioningComplete` returns an unexpected SDK error part on the negative paths exercised here (no fail-safe armed / wrong fabric). Needs alignment with the spec's expected error category.
+    // "TC_CGEN_2_5",  // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
+    // "TC_CGEN_2_6",  // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
+    // "TC_CGEN_2_7",  // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
+    // "TC_CGEN_2_8",  // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
+    // "TC_CGEN_2_9",  // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
+    // "TC_CGEN_2_10", // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
+    // "TC_CGEN_2_11", // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
 
     //
     // Python tests — Operational Credentials (system cluster)
     //
-    // "TC_OPCREDS_3_1", // TODO: not yet verified
-    // "TC_OPCREDS_3_2", // TODO: not yet verified
-    // "TC_OPCREDS_3_4", // TODO: not yet verified
-    // "TC_OPCREDS_3_5", // TODO: not yet verified
-    // "TC_OPCREDS_3_8", // TODO: not yet verified
+    // "TC_OPCREDS_3_1", // TODO: rs-matter accepts an `AddTrustedRootCertificate` payload with a malformed signature (the test expects this to be rejected). NOC handler needs to validate the RCAC's self-signature before accepting it.
+    "TC_OPCREDS_3_2",
+    // "TC_OPCREDS_3_4", // TODO: `UpdateNOC` returns `FailSafeRequired` / `NocMissingCsr` on the negative paths, but the test expects the spec's specific `NodeOperationalCertStatusEnum` values for each error condition. Needs alignment of error mapping.
+    // "TC_OPCREDS_3_5", // TODO: `UpdateNOC` returns `kMissingCsr` instead of `kOk` even on the valid happy path — looks like the CSR slot is being cleared too eagerly between the CSR request and the `UpdateNOC` call.
+    // "TC_OPCREDS_3_8", // TODO: a second-fabric NOC entry is not visible in the `NOCs` attribute when read non-fabric-filtered — likely a fabric-scoped attribute filter incorrectly applied to a non-fabric-filtered read.
 
     //
     // Python tests — Session/Commissioning (general Matter protocol)
     //
-    // "TC_SC_3_4", // TODO: not yet verified
-    // "TC_SC_3_5", // TODO: not yet verified
-    // "TC_SC_3_6", // TODO: not yet verified
-    // "TC_SC_4_1", // TODO: not yet verified
-    // "TC_SC_4_3", // TODO: not yet verified
-    // "TC_SC_7_1", // TODO: not yet verified
+    // "TC_SC_3_4", // TODO: a negative-path assertion expects `ChipStackError` to be raised but rs-matter accepts the request. Needs investigation of which validation step is missing.
+    // "TC_SC_3_5", // Skipped: requires the CHIP `all-clusters-app` (`--string-arg th_server_app_path`); rs-matter does not provide the secondary TH server app this test relies on.
+    // "TC_SC_3_6", // TODO: triggers an internal exception during the multi-fabric subscription scenario; needs investigation alongside the other multi-fabric stress tests.
+    // "TC_SC_4_1", // Skipped: must be invoked with `--qr-code`/`--manual-code` setup payloads instead of `--discriminator`/`--passcode`. The xtask wrapper passes the latter.
+    // "TC_SC_4_3", // TODO: the discovery PTR record `D4E76DDAABB4974F-0000000012344321` is not advertised on the loopback mDNS the test scrapes. Needs the rs-matter mDNS layer to publish the operational instance name in that test environment.
+    // "TC_SC_7_1", // Skipped: must be invoked with `--qr-code`/`--manual-code` setup payloads instead of `--discriminator`/`--passcode`. The xtask wrapper passes the latter.
 
     //
     // Python tests — Basic Information (system cluster)
     //
-    // "TC_BINFO_3_2", // TODO: not yet verified
+    // "TC_BINFO_3_2", // TODO: requires `BasicInformation::ConfigurationVersion` (1.5+ attribute); rs-matter returns `UnsupportedCluster` on the read. Add the attribute to the BINFO cluster.
 
     //
     // Python tests — Groups (system cluster)
     //
-    // "TC_G_2_2", // TODO: not yet verified
-
+    "TC_G_2_2",
     //
     // Python tests — General Diagnostics (system cluster)
     //
-    // "TC_DGGEN_2_4", // TODO: not yet verified
-    // "TC_DGGEN_3_2", // TODO: not yet verified
+    // "TC_DGGEN_2_4", // TODO: rs-matter does not advertise `GeneralDiagnostics::UpTime` (returns `UnsupportedAttribute`). Implement the attribute in the diagnostics cluster.
+    // "TC_DGGEN_3_2", // TODO: requires `BasicInformation::MaxPathsPerInvoke`; same gap as TC_BINFO_3_2 — needs the attribute exposed.
 
     //
     // Python tests — Device Attestation (commissioning)
     //
-    // "TC_DA_1_2", // TODO: not yet verified
-    // "TC_DA_1_5", // TODO: not yet verified
-    // "TC_DA_1_7", // TODO: not yet verified
+    // "TC_DA_1_2", // TODO: `AttestationRequest` invoke fails (likely needs an armed fail-safe or different access path in rs-matter). Needs attestation flow review.
+    // "TC_DA_1_5", // TODO: same setup issue as TC_DA_1_2 — DA test infrastructure needs the attestation invoke path to succeed before any of the cert-chain assertions can run.
+    // "TC_DA_1_7", // Skipped: requires two distinct discriminators (DUT + reference DUT). The xtask wrapper only commissions one device.
     // "TC_DA_1_9", // TODO: not yet verified
 
     //
     // Python tests — Device Discovery (general)
     //
-    // "TC_DD_1_16_17", // TODO: not yet verified
-    // "TC_DD_3_23",    // TODO: not yet verified
+    // "TC_DD_1_16_17", // Skipped: must be invoked with `--manual-code`. The xtask wrapper passes `--discriminator`/`--passcode` instead.
+    // "TC_DD_3_23",    // Skipped: requires PC/SC smart-card subsystem (`smartcard.pcsc`). Not available in the CI environment.
 
     //
     // Python tests — Device Composition / Conformance (general)
     //
-    // "TC_DeviceBasicComposition", // TODO: not yet verified
-    // "TC_DeviceConformance",      // TODO: not yet verified
+    // "TC_DeviceBasicComposition", // TODO: wildcard read returns `InvalidDataType`/`Failure` for some attribute on cluster 49 (NetworkCommissioning). Likely encoder gap on a specific attribute.
+    // "TC_DeviceConformance",      // TODO: device type revisions on the example endpoints don't match the spec-mandated values for the device types being advertised. Update the example apps' device-type revisions.
 ];
 
 /// Camera cluster tests — run against the `camera_tests` example.
@@ -403,6 +402,12 @@ impl ITests {
     ) -> anyhow::Result<()> {
         // TODO: Running test-by-test is slow. Turn this into a run-multiple-tests function.
 
+        // Some tests legitimately need more wall-clock time than the default
+        // (e.g. those that wait for a commissioning window to expire on its
+        // own). Allow per-test overrides while keeping the global `--timeout`
+        // as the floor for everything else.
+        let timeout_secs = Self::per_test_timeout_secs(test_name).unwrap_or(timeout_secs);
+
         info!("=> Running test `{test_name}` with timeout {timeout_secs}s...");
 
         let chip_dir = self.chip_builder.chip_dir();
@@ -542,6 +547,21 @@ impl ITests {
         ))
     }
 
+    /// Test-specific timeout override (in seconds) for tests that legitimately
+    /// need more wall-clock time than the default. Returning `None` falls
+    /// back to whatever `--timeout` was passed on the `cargo xtask itest`
+    /// command line.
+    fn per_test_timeout_secs(test_name: &str) -> Option<u32> {
+        match test_name {
+            // Several CADMIN tests open commissioning windows and then wait
+            // for them to expire on the device side, which takes 180s+ by
+            // construction.
+            "TC_CADMIN_1_3_4" | "TC_CADMIN_1_5" | "TC_CADMIN_1_9" | "TC_CADMIN_1_11"
+            | "TC_CADMIN_1_15" | "TC_CADMIN_1_22" | "TC_CADMIN_1_25" => Some(300),
+            _ => None,
+        }
+    }
+
     /// Test-specific extra `--script-args` for `run_python_test.py`.
     ///
     /// Some `MatterBaseTest`-style scripts require PIXIT/PICS values supplied
@@ -567,6 +587,43 @@ impl ITests {
             // ACL events. argparse keeps the last `--endpoint`, so appending
             // here wins.
             "TC_ACL_2_6" | "TC_ACL_2_7" | "TC_ACL_2_8" => " --endpoint 0",
+            // CADMIN (Administrator Commissioning) tests target the root
+            // endpoint via `@run_if_endpoint_matches(has_cluster(...))`.
+            "TC_CADMIN_1_3_4"
+            | "TC_CADMIN_1_5"
+            | "TC_CADMIN_1_9"
+            | "TC_CADMIN_1_11"
+            | "TC_CADMIN_1_15"
+            | "TC_CADMIN_1_22"
+            | "TC_CADMIN_1_25"
+            // CGEN (General Commissioning) tests target the root endpoint
+            // where the GeneralCommissioning cluster lives.
+            | "TC_CGEN_2_1"
+            // OPCREDS (Operational Credentials) tests live on the root
+            // endpoint.
+            | "TC_OPCREDS_3_1"
+            | "TC_OPCREDS_3_2"
+            | "TC_OPCREDS_3_4"
+            | "TC_OPCREDS_3_5"
+            | "TC_OPCREDS_3_8"
+            // SC (Secure Channel) tests target the root endpoint.
+            | "TC_SC_3_4"
+            | "TC_SC_3_6"
+            | "TC_SC_4_1"
+            | "TC_SC_4_3"
+            | "TC_SC_7_1"
+            // BINFO (Basic Information), DGGEN (General Diagnostics) live on
+            // the root endpoint.
+            | "TC_BINFO_3_2"
+            | "TC_DGGEN_2_4"
+            | "TC_DGGEN_3_2"
+            // Groups (TC_G_2_2) defaults to endpoint 0 if not provided.
+            | "TC_G_2_2"
+            // Device Attestation (DA) covers attestation primitives on the
+            // root endpoint.
+            | "TC_DA_1_2"
+            | "TC_DA_1_5"
+            | "TC_DA_1_7" => " --endpoint 0",
             _ => "",
         }
     }


### PR DESCRIPTION
A set of fixes so as to make most of the TC_CADMIN_* Python tests pass.

~~Most of the fixes are minor, the most controversial is the `Error` type extension with `cluster_error`. I haven't made my mind about this yet.~~

EDIT 1: Since the above change substantially increased the binary size, I implemented an alternative which leaves the `Error` type untouched

EDIT 2: Rather than enabling most of the tests in this PR, an assessment was done on the failing ones as for the root cause. The failing ones will be addressed with follow-up PRs.