### PR TITLE
More Pyhton integration tests - Operational Credentials cluster

### DIFF
--- a/.github/workflows/chiptool-tests.yml
+++ b/.github/workflows/chiptool-tests.yml
@@ -23,7 +23,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  yaml_integration_tests:
+  chip_integration_tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
 

--- a/.github/workflows/chiptool-tests.yml
+++ b/.github/workflows/chiptool-tests.yml
@@ -66,16 +66,16 @@ jobs:
         run: |
           cargo xtask itest-setup --gitref "${{ inputs.chip_ref || 'v1.5-branch' }}"
 
-      - name: Run System integration tests (with RustCrypto by default)
+      - name: Run System integration tests with RustCrypto
         run: |
           cargo xtask itest --skip-setup
 
       # TODO: Enable once mbedtls-rs-sys built removes the installation step
-      # - name: Run One YAML Integration Test with MbedTLS
+      # - name: Run one System integration test with MbedTLS
       #   run: |
       #     cargo xtask itest --features mbedtls TestBasicInformation
 
-      - name: Run One integration test with OpenSSL
+      - name: Run one System integration test with OpenSSL
         run: |
           cargo xtask itest --skip-setup --features openssl TestBasicInformation
 

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -216,7 +216,7 @@ const NOC_CAT_VERSION_MASK: u64 = 0xFFFF;
 const NODE_ID_RANGE: RangeInclusive<u64> = 1..=0xFFFF_FFEF_FFFF_FFFF;
 
 /// Is this identifier a NOC CAT
-fn is_noc_cat(id: u64) -> bool {
+pub(crate) fn is_noc_cat(id: u64) -> bool {
     ((id & NOC_CAT_SUBJECT_MASK) == NOC_CAT_SUBJECT_PREFIX)
         && ((id & (NOC_CAT_ID_MASK | NOC_CAT_VERSION_MASK)) > 0)
 }
@@ -238,7 +238,7 @@ pub fn gen_noc_cat(id: u16, version: u16) -> u32 {
 }
 
 /// Is this identifier a node id
-fn is_node(id: u64) -> bool {
+pub(crate) fn is_node(id: u64) -> bool {
     NODE_ID_RANGE.contains(&id)
 }
 

--- a/rs-matter/src/cert.rs
+++ b/rs-matter/src/cert.rs
@@ -688,6 +688,13 @@ impl<'a> CertRef<'a> {
         Ok(authority.is_some())
     }
 
+    /// Whether this certificate is self-signed (its `AuthorityKeyId` matches
+    /// its `SubjectKeyId`). Matter-issued RCACs are always self-signed; an
+    /// ICAC or NOC must not be (Matter Core spec section 6.5).
+    pub fn is_self_signed(&self) -> Result<bool, Error> {
+        self.is_authority(self)
+    }
+
     pub fn as_asn1(&self, buf: &mut [u8]) -> Result<usize, Error> {
         let mut w = ASN1Writer::new(buf);
         self.encode(&mut w)?;

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -179,6 +179,7 @@ where
             // Disarm the failsafe on timeout
             state.failsafe.check_failsafe_timeout(
                 &mut state.fabrics,
+                &mut state.sessions,
                 &self.networks,
                 &self.kv,
                 &mut notify_mdns,

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -182,6 +182,7 @@ where
                 &self.networks,
                 &self.kv,
                 &mut notify_mdns,
+                &mut notify_change,
             )?;
 
             // Close the commissioning window on timeout

--- a/rs-matter/src/dm/clusters/adm_comm.rs
+++ b/rs-matter/src/dm/clusters/adm_comm.rs
@@ -276,13 +276,21 @@ impl ClusterHandler for AdminCommHandler {
         //     don't confuse the commissioner across multiple rounds (see
         //     TC_CGEN_2_4, which iterates open / commission / revoke 8x).
         ctx.exchange().with_state(|state| {
-            state.failsafe.force_expiry(
-                &mut state.fabrics,
-                ctx.networks(),
-                ctx.kv(),
-                notify_mdns,
-            )?;
-            state.sessions.remove_pase();
+            state
+                .failsafe
+                .expire(&mut state.fabrics, ctx.networks(), ctx.kv(), notify_mdns)?;
+
+            // If RevokeCommissioning came in over a PASE session, don't
+            // drop it before we've sent the response — mark it as expired
+            // instead so it lingers just long enough for the in-flight
+            // exchange to complete, then can't accept new ones.
+            let sess = ctx.exchange().id().session(&mut state.sessions);
+            let expire_sess_id = matches!(
+                sess.get_session_mode(),
+                crate::transport::session::SessionMode::Pase { .. }
+            )
+            .then(|| sess.id());
+            state.sessions.remove_pase(expire_sess_id);
             ctx.exchange().matter().session_removed.notify();
             Ok::<_, Error>(())
         })?;

--- a/rs-matter/src/dm/clusters/adm_comm.rs
+++ b/rs-matter/src/dm/clusters/adm_comm.rs
@@ -256,6 +256,37 @@ impl ClusterHandler for AdminCommHandler {
         let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
         let notify_change = |_, _| ctx.notify_own_cluster_changed();
 
+        // Per Matter Core spec section 11.18.6.2 (and CHIP's
+        // `AdministratorCommissioningLogic::RevokeCommissioning`), revoking
+        // the commissioning window also:
+        //
+        //  1. Forces any in-flight fail-safe context to expire. Otherwise
+        //     stale state — e.g. the breadcrumb value an interrupted
+        //     commissioning attempt left behind — leaks into the next
+        //     `OpenCommissioningWindow` round and causes the commissioner to
+        //     skip past `ArmFailSafe` (it reads `breadcrumb > 0` and assumes
+        //     an in-progress commission, per the CHIP
+        //     `AutoCommissioner::GetNextCommissioningStageInternal` post-NOC
+        //     recovery path).
+        //
+        //  2. Tears down any PASE sessions that were established under that
+        //     commissioning window but never promoted to a fabric. CHIP ties
+        //     this to fail-safe expiry inside `CommissioningWindowManager`;
+        //     we do it explicitly here so accumulated dangling PASE sessions
+        //     don't confuse the commissioner across multiple rounds (see
+        //     TC_CGEN_2_4, which iterates open / commission / revoke 8x).
+        ctx.exchange().with_state(|state| {
+            state.failsafe.force_expiry(
+                &mut state.fabrics,
+                ctx.networks(),
+                ctx.kv(),
+                notify_mdns,
+            )?;
+            state.sessions.remove_pase();
+            ctx.exchange().matter().session_removed.notify();
+            Ok::<_, Error>(())
+        })?;
+
         ctx.exchange().with_state(|state| {
             state
                 .pase

--- a/rs-matter/src/dm/clusters/adm_comm.rs
+++ b/rs-matter/src/dm/clusters/adm_comm.rs
@@ -276,25 +276,28 @@ impl ClusterHandler for AdminCommHandler {
         //     don't confuse the commissioner across multiple rounds (see
         //     TC_CGEN_2_4, which iterates open / commission / revoke 8x).
         ctx.exchange().with_state(|state| {
-            state.failsafe.expire(
-                &mut state.fabrics,
-                ctx.networks(),
-                ctx.kv(),
-                notify_mdns,
-                notify_change,
-            )?;
-
             // If RevokeCommissioning came in over a PASE session, don't
             // drop it before we've sent the response — mark it as expired
             // instead so it lingers just long enough for the in-flight
             // exchange to complete, then can't accept new ones.
+            // `Failsafe::expire` does the actual `remove_pase` call.
             let sess = ctx.exchange().id().session(&mut state.sessions);
             let expire_sess_id = matches!(
                 sess.get_session_mode(),
                 crate::transport::session::SessionMode::Pase { .. }
             )
             .then(|| sess.id());
-            state.sessions.remove_pase(expire_sess_id);
+
+            state.failsafe.expire(
+                &mut state.fabrics,
+                &mut state.sessions,
+                expire_sess_id,
+                ctx.networks(),
+                ctx.kv(),
+                notify_mdns,
+                notify_change,
+            )?;
+
             ctx.exchange().matter().session_removed.notify();
             Ok::<_, Error>(())
         })?;

--- a/rs-matter/src/dm/clusters/adm_comm.rs
+++ b/rs-matter/src/dm/clusters/adm_comm.rs
@@ -276,9 +276,13 @@ impl ClusterHandler for AdminCommHandler {
         //     don't confuse the commissioner across multiple rounds (see
         //     TC_CGEN_2_4, which iterates open / commission / revoke 8x).
         ctx.exchange().with_state(|state| {
-            state
-                .failsafe
-                .expire(&mut state.fabrics, ctx.networks(), ctx.kv(), notify_mdns)?;
+            state.failsafe.expire(
+                &mut state.fabrics,
+                ctx.networks(),
+                ctx.kv(),
+                notify_mdns,
+                notify_change,
+            )?;
 
             // If RevokeCommissioning came in over a PASE session, don't
             // drop it before we've sent the response — mark it as expired

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -293,12 +293,10 @@ impl ClusterHandler for GenCommHandler<'_> {
             let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
 
             CommissioningErrorEnum::map(ctx.exchange().with_state(|state| {
-                let _ = state.failsafe.force_expiry(
-                    &mut state.fabrics,
-                    ctx.networks(),
-                    ctx.kv(),
-                    notify_mdns,
-                )?;
+                state
+                    .failsafe
+                    .expire(&mut state.fabrics, ctx.networks(), ctx.kv(), notify_mdns)?;
+
                 Ok(())
             }))?
         } else {

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -28,6 +28,7 @@ use crate::fabric::FabricPersist;
 use crate::persist::{Persist, BASIC_INFO_KEY, NETWORKS_KEY};
 use crate::sc::pase::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use crate::tlv::TLVBuilderParent;
+use crate::transport::session::SessionMode;
 use crate::utils::sync::DynBase;
 use crate::{with, MatterState};
 
@@ -294,8 +295,14 @@ impl ClusterHandler for GenCommHandler<'_> {
             let notify_change = |endpt_id, clust_id| ctx.notify_cluster_changed(endpt_id, clust_id);
 
             CommissioningErrorEnum::map(ctx.exchange().with_state(|state| {
+                let sess = ctx.exchange().id().session(&mut state.sessions);
+                let pase_sess_id =
+                    matches!(sess.get_session_mode(), SessionMode::Pase { .. }).then(|| sess.id());
+
                 state.failsafe.expire(
                     &mut state.fabrics,
+                    &mut state.sessions,
+                    pase_sess_id,
                     ctx.networks(),
                     ctx.kv(),
                     notify_mdns,
@@ -398,14 +405,35 @@ impl ClusterHandler for GenCommHandler<'_> {
         let status =
             CommissioningErrorEnum::map(Self::with_armed_failsafe(&ctx, |state, notify_mdns| {
                 let sess = ctx.exchange().id().session(&mut state.sessions);
+                // Spec V1.3 §5.5 / V1.4 §11.10.7.4: on
+                // `CommissioningComplete` the PASE session SHALL be
+                // terminated. The current command is being delivered over
+                // that PASE, so mark it `expired` (response can still go
+                // out, no further exchanges accepted) and let the LRU
+                // eviction reclaim the slot. Without this the promoted
+                // PASE leaks across commissioning rounds and eventually
+                // exhausts the session table — visible as `BUSY` on the
+                // next round's `PBKDFParamRequest` (TC_CADMIN_1_19 hit
+                // this on the 4th round of `SupportedFabrics` rounds).
+                // Modern controllers (CHIP SDK 1.4+) run a
+                // `FindOperationalForCommissioningComplete` step before
+                // sending `CommissioningComplete`, so this command
+                // typically arrives over the new operational CASE session
+                // rather than over PASE. In that case the current session
+                // doesn't need preserving and we just drop every PASE
+                // session unconditionally. (For legacy behaviour where the
+                // command does come over PASE we still preserve the
+                // current one.)
+                let pase_sess_id =
+                    matches!(sess.get_session_mode(), SessionMode::Pase { .. }).then(|| sess.id());
 
                 let fabric = state
                     .failsafe
                     .disarm(sess.get_session_mode(), &mut state.fabrics)?;
 
-                // As per section 5.5 of the Matter Core Spec V1.3 we have to terminate the PASE session
-                // upon completion of commissioning
                 state.pase.close_comm_window(notify_mdns, notify_change)?;
+                state.sessions.remove_pase(pase_sess_id);
+                ctx.exchange().matter().session_removed.notify();
 
                 // Finally, persist the fabric and the network settings, prior to sending the other party a "success" status
                 persist.store(fabric)?;

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -168,6 +168,24 @@ impl<'a> GenCommHandler<'a> {
         Self::with_armed_failsafe_ex(ctx, f)
     }
 
+    /// Return whether the supplied `NewRegulatoryConfig` value is allowed
+    /// given the device's `LocationCapability`. Mirrors the matrix in Matter
+    /// Core spec section 11.10.7.2.1.
+    fn is_regulatory_config_supported(
+        policy: &dyn CommPolicy,
+        new_config: RegulatoryLocationTypeEnum,
+    ) -> bool {
+        match policy.location_cap() {
+            RegulatoryLocationTypeEnum::Indoor => {
+                matches!(new_config, RegulatoryLocationTypeEnum::Indoor)
+            }
+            RegulatoryLocationTypeEnum::Outdoor => {
+                matches!(new_config, RegulatoryLocationTypeEnum::Outdoor)
+            }
+            RegulatoryLocationTypeEnum::IndoorOutdoor => true,
+        }
+    }
+
     /// Execute the provided closure after checking that the failsafe is armed for the
     /// fabric of this session.
     ///
@@ -292,8 +310,31 @@ impl ClusterHandler for GenCommHandler<'_> {
             return Err(ErrorCode::ConstraintError.into());
         }
 
-        let location_type = request.new_regulatory_config()?;
+        // Per Matter Core spec section 11.10.7.2.1, `NewRegulatoryConfig`
+        // SHALL be one of the values supported by the device's
+        // `LocationCapability`:
+        //
+        //   * `LocationCapability::Indoor`         -> only `Indoor`
+        //   * `LocationCapability::Outdoor`        -> only `Outdoor`
+        //   * `LocationCapability::IndoorOutdoor`  -> any of the three
+        //
+        // A request that violates this — including an enum value the device
+        // doesn't even recognise — must be rejected with the cluster-level
+        // `ValueOutsideRange` rather than a generic IM `Failure`. Decode the
+        // enum defensively because TLV decoding will reject an unknown
+        // variant before we ever see it (the test sends `3`).
+        let location_type = request.new_regulatory_config();
         let breadcrumb = request.breadcrumb()?;
+
+        let location_type = match location_type {
+            Ok(loc) if Self::is_regulatory_config_supported(self.commissioning_policy, loc) => loc,
+            _ => {
+                return response
+                    .error_code(CommissioningErrorEnum::ValueOutsideRange)?
+                    .debug_text("")?
+                    .end();
+            }
+        };
 
         let mut persist = Persist::new(ctx.kv());
 

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -291,11 +291,16 @@ impl ClusterHandler for GenCommHandler<'_> {
         // `Idle` and would leave the staged fabric committed.
         let status = if expiry_length_seconds == 0 {
             let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
+            let notify_change = |endpt_id, clust_id| ctx.notify_cluster_changed(endpt_id, clust_id);
 
             CommissioningErrorEnum::map(ctx.exchange().with_state(|state| {
-                state
-                    .failsafe
-                    .expire(&mut state.fabrics, ctx.networks(), ctx.kv(), notify_mdns)?;
+                state.failsafe.expire(
+                    &mut state.fabrics,
+                    ctx.networks(),
+                    ctx.kv(),
+                    notify_mdns,
+                    notify_change,
+                )?;
 
                 Ok(())
             }))?

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -275,21 +275,44 @@ impl ClusterHandler for GenCommHandler<'_> {
         request: ArmFailSafeRequest<'_>,
         response: ArmFailSafeResponseBuilder<P>,
     ) -> Result<P, Error> {
+        let expiry_length_seconds = request.expiry_length_seconds()?;
+
         info!(
             "Got Arm Fail Safe Request, expiry {}s",
-            request.expiry_length_seconds()?
+            expiry_length_seconds
         );
 
-        let status = CommissioningErrorEnum::map(ctx.exchange().with_state(|state| {
-            let sess = ctx.exchange().id().session(&mut state.sessions);
+        // `ArmFailSafe(0)` means "force-expire the fail-safe context" per
+        // Matter Core spec section 11.10.7.1: if the fail-safe is armed,
+        // the device SHALL roll back any uncommitted fabric / network state
+        // and reset the breadcrumb. Route through `force_expiry` so that
+        // in-flight `AddNOC` / `SetRegulatoryConfig` changes are reverted —
+        // the bare `failsafe.arm(0, ...)` path only flips the state to
+        // `Idle` and would leave the staged fabric committed.
+        let status = if expiry_length_seconds == 0 {
+            let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
 
-            state.failsafe.arm(
-                request.expiry_length_seconds()?,
-                request.breadcrumb()?,
-                sess.get_session_mode(),
-                &mut state.pase,
-            )
-        }))?;
+            CommissioningErrorEnum::map(ctx.exchange().with_state(|state| {
+                let _ = state.failsafe.force_expiry(
+                    &mut state.fabrics,
+                    ctx.networks(),
+                    ctx.kv(),
+                    notify_mdns,
+                )?;
+                Ok(())
+            }))?
+        } else {
+            CommissioningErrorEnum::map(ctx.exchange().with_state(|state| {
+                let sess = ctx.exchange().id().session(&mut state.sessions);
+
+                state.failsafe.arm(
+                    expiry_length_seconds,
+                    request.breadcrumb()?,
+                    sess.get_session_mode(),
+                    &mut state.pase,
+                )
+            }))?
+        };
 
         // Breadcrumb (and possibly failsafe-arm state) may have changed
         ctx.notify_own_cluster_changed();

--- a/rs-matter/src/dm/clusters/grp_key_mgmt.rs
+++ b/rs-matter/src/dm/clusters/grp_key_mgmt.rs
@@ -424,6 +424,28 @@ impl ClusterHandler for GrpKeyMgmtHandler {
 
         ctx.exchange().with_state(|state| {
             let fabric = state.fabrics.fabric(fab_idx)?;
+
+            // KeySet ID 0 is the IPK (Identity Protection Key); per Matter
+            // Core spec section 11.2.7.5 it is always present once the
+            // fabric has been added (`AddNOC`) and is reported here with
+            // its epoch keys redacted to null. The IPK isn't kept in the
+            // generic `key_sets` list — it lives on the fabric directly.
+            // Any other ID is looked up in the per-fabric `key_sets` map.
+            if group_key_set_id == 0 {
+                return response
+                    .group_key_set()?
+                    .group_key_set_id(0)?
+                    .group_key_security_policy(GroupKeySecurityPolicyEnum::TrustFirst)?
+                    .epoch_key_0(Nullable::<Octets<'_>>::none())?
+                    .epoch_start_time_0(Nullable::some(0))?
+                    .epoch_key_1(Nullable::<Octets<'_>>::none())?
+                    .epoch_start_time_1(Nullable::none())?
+                    .epoch_key_2(Nullable::<Octets<'_>>::none())?
+                    .epoch_start_time_2(Nullable::none())?
+                    .end()?
+                    .end();
+            }
+
             let entry = fabric
                 .groups()
                 .key_set_get(group_key_set_id)

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -229,27 +229,35 @@ impl ClusterHandler for NocHandler {
         ctx: impl ReadContext,
         builder: ArrayAttributeRead<OctetsArrayBuilder<P>, OctetsBuilder<P>>,
     ) -> Result<P, Error> {
-        let attr = ctx.attr();
-
         ctx.exchange().with_state(|state| {
-            let mut fabrics = state.fabrics.iter().filter(|fabric| {
-                (!attr.fab_filter || attr.fab_idx == fabric.fab_idx().get())
-                    && !fabric.root_ca().is_empty()
-            });
+            // `TrustedRootCertificates` is a plain `list[octet_string]`, not a
+            // fabric-scoped struct list, so fabric filtering does not apply
+            // here — every committed fabric's root cert is reported.
+            let fabric_certs = state
+                .fabrics
+                .iter()
+                .filter(|fabric| !fabric.root_ca().is_empty())
+                .map(|fabric| fabric.root_ca());
+
+            // While the fail-safe is armed, an `AddTrustedRootCertificate`
+            // command stages a root certificate that is not yet bound to a
+            // fabric. Per the Matter Core spec it must still appear in the
+            // `TrustedRootCertificates` list until the fail-safe expires or
+            // the cert is consumed by `AddNOC` / `UpdateNOC` (at which point
+            // the fabric table reports it).
+            let mut certs = fabric_certs.chain(state.failsafe.pending_root_ca());
 
             match builder {
                 ArrayAttributeRead::ReadAll(mut builder) => {
-                    for fabric in fabrics {
-                        builder = builder.push(Octets::new(fabric.root_ca()))?;
+                    for cert in certs {
+                        builder = builder.push(Octets::new(cert))?;
                     }
 
                     builder.end()
                 }
                 ArrayAttributeRead::ReadOne(index, builder) => {
-                    let fabric = fabrics.nth(index as _);
-
-                    if let Some(fabric) = fabric {
-                        builder.set(Octets::new(fabric.root_ca()))
+                    if let Some(cert) = certs.nth(index as _) {
+                        builder.set(Octets::new(cert))
                     } else {
                         Err(ErrorCode::ConstraintError.into())
                     }

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -379,10 +379,21 @@ impl ClusterHandler for NocHandler {
     ) -> Result<P, Error> {
         info!("Got CSR Request");
 
+        let is_for_update_noc = request.is_for_update_noc()?.unwrap_or(false);
+
         GenCommHandler::with_armed_failsafe(&ctx, |state, _| {
             let sess = ctx.exchange().id().session(&mut state.sessions);
 
-            let secret_key = if request.is_for_update_noc()?.unwrap_or(false) {
+            // Per Matter Core spec section 11.18.6.5 (`CSRRequest`),
+            // `isForUpdateNOC=true` is only valid over CASE — UpdateNOC
+            // can never run over PASE. A CSRRequest of that flavour over
+            // PASE is rejected with IM `INVALID_COMMAND` rather than
+            // bubbling up the generic auth failure as `Failure`.
+            if is_for_update_noc && !matches!(sess.get_session_mode(), SessionMode::Case { .. }) {
+                return Err(ErrorCode::InvalidCommand.into());
+            }
+
+            let secret_key = if is_for_update_noc {
                 state
                     .failsafe
                     .update_csr_req(ctx.crypto(), sess.get_session_mode())?

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -140,27 +140,26 @@ impl ClusterHandler for NocHandler {
                     && !fabric.root_ca().is_empty()
             });
 
+            // Outer `fabrics` iterator already drops entries the
+            // accessor isn't allowed to see when `fab_filter` is true;
+            // the inner-loop checks that used to gate every entry on
+            // `attr.fab_idx == fabric.fab_idx().get()` were therefore
+            // hiding non-accessing fabrics from a deliberately
+            // non-fabric-filtered read. Per Matter Core spec §11.18.5.1
+            // (NOCStruct, post-1.4.2) `noc` / `icac` are no longer
+            // fabric-sensitive, so a non-fabric-filtered read MUST return
+            // every fabric's NOC.
             match builder {
                 ArrayAttributeRead::ReadAll(mut builder) => {
                     for fabric in fabrics {
-                        if attr.fab_idx != fabric.fab_idx().get() {
-                            continue;
-                        }
-
                         builder = read_into(fabric, builder.push()?)?;
                     }
 
                     builder.end()
                 }
                 ArrayAttributeRead::ReadOne(index, builder) => {
-                    let fabric = fabrics.nth(index as _);
-
-                    if let Some(fabric) = fabric {
-                        if attr.fab_idx != fabric.fab_idx().get() {
-                            Err(ErrorCode::ConstraintError.into())
-                        } else {
-                            read_into(fabric, builder)
-                        }
+                    if let Some(fabric) = fabrics.nth(index as _) {
+                        read_into(fabric, builder)
                     } else {
                         Err(ErrorCode::ConstraintError.into())
                     }

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -49,7 +49,18 @@ impl NodeOperationalCertStatusEnum {
             Err(err) => match err.code() {
                 ErrorCode::NocFabricTableFull => Ok(Self::TableFull),
                 ErrorCode::NocInvalidFabricIndex => Ok(Self::InvalidFabricIndex),
-                ErrorCode::ConstraintError => Ok(Self::MissingCsr),
+                ErrorCode::NocFabricConflict => Ok(Self::FabricConflict),
+                ErrorCode::NocLabelConflict => Ok(Self::LabelConflict),
+                ErrorCode::NocInvalidNoc => Ok(Self::InvalidNOC),
+                ErrorCode::NocInvalidPublicKey => Ok(Self::InvalidPublicKey),
+                ErrorCode::NocInvalidAdminSubject => Ok(Self::InvalidAdminSubject),
+                ErrorCode::NocMissingCsr => Ok(Self::MissingCsr),
+                // Bare `ConstraintError` from `FailSafe::check_state`
+                // (e.g. "AddNOC received twice in the same fail-safe
+                // context", spec section 11.18.6.6) is reported as an
+                // IM-level status code per the spec, not as a
+                // `NodeOperationalCertStatusEnum` cluster status — let it
+                // propagate.
                 _ => Err(err),
             },
         }
@@ -580,13 +591,21 @@ impl ClusterHandler for NocHandler {
         let status = NodeOperationalCertStatusEnum::map(ctx.exchange().with_state(|state| {
             let sess = ctx.exchange().id().session(&mut state.sessions);
 
-            let SessionMode::Case { fab_idx, .. } = sess.get_session_mode() else {
-                return Err(ErrorCode::GennCommInvalidAuthentication.into());
-            };
+            // `UpdateFabricLabel` is fabric-scoped and the IM access-control
+            // check (see `cluster::check_cmd_access`) already rejects calls
+            // from a session with no associated fabric (PASE pre-AddNOC) with
+            // `UnsupportedAccess`. Anything that gets here therefore has an
+            // accessing fabric — and per the spec / CHIP reference impl,
+            // that includes a PASE session whose fab_idx was upgraded by
+            // `AddNOC` (`session.upgrade_fabric_idx`). So allow Case *and*
+            // Pase as long as fab_idx > 0; the `accessing_fab_idx()` helper
+            // returns 0 only for plain-text / un-upgraded PASE.
+            let fab_idx = NonZeroU8::new(sess.get_local_fabric_idx())
+                .ok_or(ErrorCode::GennCommInvalidAuthentication)?;
 
             let fabric = state
                 .fabrics
-                .update_label(*fab_idx, request.label()?)
+                .update_label(fab_idx, request.label()?)
                 .map_err(|e| {
                     if e.code() == ErrorCode::Invalid {
                         ErrorCode::NocLabelConflict.into()
@@ -691,12 +710,25 @@ impl ClusterHandler for NocHandler {
     ) -> Result<(), Error> {
         info!("Got Add Trusted Root Cert Request");
 
+        // Self-signature validation in `add_trusted_root_cert` re-encodes the
+        // RCAC into ASN.1 to feed it to ECDSA verify; sized to
+        // `MAX_CERT_ASN1_LEN` (the same bound `validate_certs` uses for the
+        // NOC chain).
+        // TODO XXX FIXME: LARGE BUFFER.
+        // We can avoid it if we had access to
+        // the output buffer (TX), but this is not possible yet for handler methods
+        // that are not expected to return command responses other than status result.
+        let mut buf = [0u8; crate::cert::MAX_CERT_ASN1_LEN];
+
         GenCommHandler::with_armed_failsafe(&ctx, |state, _| {
             let sess = ctx.exchange().id().session(&mut state.sessions);
 
-            state
-                .failsafe
-                .add_trusted_root_cert(sess.get_session_mode(), request.root_ca_certificate()?.0)
+            state.failsafe.add_trusted_root_cert(
+                ctx.crypto(),
+                sess.get_session_mode(),
+                request.root_ca_certificate()?.0,
+                &mut buf,
+            )
         })
     }
 

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -23,7 +23,7 @@ use core::num::NonZeroU8;
 
 use crate::acl::AclEntry;
 use crate::cert::CertRef;
-use crate::crypto::{CanonPkcSignature, Crypto, SigningSecretKey};
+use crate::crypto::{CanonPkcSignature, Crypto, SigningSecretKey, PKC_CANON_PUBLIC_KEY_LEN};
 use crate::dm::clusters::acl::{emit_acl_entry_changed, ChangeTypeEnum};
 use crate::dm::clusters::adm_comm;
 use crate::dm::clusters::dev_att::DeviceAttestation;
@@ -36,7 +36,7 @@ use crate::tlv::{
     Nullable, Octets, OctetsArrayBuilder, OctetsBuilder, TLVBuilder, TLVBuilderParent, TLVElement,
     TLVTag, TLVWrite,
 };
-use crate::transport::session::{AttChallengeRef, SessionMode};
+use crate::transport::session::{AttChallengeRef, SessionMode, ATT_CHALLENGE_LEN};
 use crate::utils::init::InitMaybeUninit;
 use crate::utils::storage::WriteBuf;
 
@@ -127,7 +127,7 @@ impl ClusterHandler for NocHandler {
                 .icac(Nullable::new(
                     (!fabric.icac().is_empty()).then(|| Octets::new(fabric.icac())),
                 ))?
-                .vvsc(None)?
+                .vvsc((!fabric.vvsc().is_empty()).then(|| Octets::new(fabric.vvsc())))?
                 .fabric_index(Some(fabric.fab_idx().get()))?
                 .end()
         }
@@ -190,7 +190,10 @@ impl ClusterHandler for NocHandler {
                 .fabric_id(fabric.fabric_id())?
                 .node_id(fabric.node_id())?
                 .label(fabric.label())?
-                .vid_verification_statement(None)?
+                .vid_verification_statement(
+                    (!fabric.vid_verification_statement().is_empty())
+                        .then(|| Octets::new(fabric.vid_verification_statement())),
+                )?
                 .fabric_index(Some(fabric.fab_idx().get()))?
                 .end()
         }
@@ -744,18 +747,208 @@ impl ClusterHandler for NocHandler {
 
     fn handle_set_vid_verification_statement(
         &self,
-        _ctx: impl InvokeContext,
-        _request: SetVIDVerificationStatementRequest<'_>,
+        ctx: impl InvokeContext,
+        request: SetVIDVerificationStatementRequest<'_>,
     ) -> Result<(), Error> {
-        Ok(()) // TODO
+        info!("Got Set VID Verification Statement Request");
+
+        let vendor_id = request.vendor_id()?;
+        let vvs = request.vid_verification_statement()?;
+        let vvsc = request.vvsc()?;
+
+        // Spec section 11.18.6.15 (`SetVIDVerificationStatement`): at
+        // least one field must be present, otherwise the command SHALL
+        // be rejected with `INVALID_COMMAND`.
+        if vendor_id.is_none() && vvs.is_none() && vvsc.is_none() {
+            return Err(ErrorCode::InvalidCommand.into());
+        }
+
+        // Per Matter Core spec section 6.2.1, valid VendorIDs are
+        // 0x0001..=0xFFF4. 0xFFF5..=0xFFFF are reserved or test/CSA
+        // values not allowed for SetVIDVerificationStatement.
+        if let Some(vid) = vendor_id {
+            if vid == 0 || vid > 0xFFF4 {
+                return Err(ErrorCode::ConstraintError.into());
+            }
+        }
+
+        // VID Verification Statement, when present, must be either
+        // empty (clearing) or exactly `VID_VERIFICATION_STATEMENT_LEN`
+        // bytes (cluster XML: `length="85" minLength="85"`).
+        if let Some(s) = &vvs {
+            if !s.0.is_empty() && s.0.len() != crate::fabric::VID_VERIFICATION_STATEMENT_LEN {
+                return Err(ErrorCode::ConstraintError.into());
+            }
+        }
+
+        // VVSC, when present, must fit in the shared `icac_or_vvsc`
+        // slot — see `Fabric::icac_or_vvsc` (capacity `MAX_CERT_TLV_LEN`,
+        // also the spec's 400-byte ceiling on the field). An empty VVSC
+        // clears the existing one.
+        if let Some(v) = &vvsc {
+            if v.0.len() > crate::cert::MAX_CERT_TLV_LEN {
+                return Err(ErrorCode::ConstraintError.into());
+            }
+        }
+
+        let fab_idx = NonZeroU8::new(ctx.cmd().fab_idx).ok_or(ErrorCode::UnsupportedAccess)?;
+
+        let mut persist = FabricPersist::new(ctx.kv());
+
+        ctx.exchange().with_state(|state| {
+            let fabric = state.fabrics.fabric_mut(fab_idx)?;
+
+            // A VVSC may only be present on a fabric whose chain has no
+            // ICAC (Matter Core spec section 6.5.7): the VVSC takes the
+            // ICAC's slot in the cert chain, the two are mutually
+            // exclusive. Reject any non-empty VVSC against a fabric
+            // that already carries an ICAC.
+            if let Some(v) = &vvsc {
+                if !v.0.is_empty() && !fabric.icac().is_empty() {
+                    return Err(ErrorCode::InvalidCommand.into());
+                }
+            }
+
+            fabric.set_vid_verification(
+                vendor_id,
+                vvs.as_ref().map(|s| s.0),
+                vvsc.as_ref().map(|v| v.0),
+            )?;
+
+            // Persist semantics (Matter Core spec section 11.18.6.15):
+            //   * If `AddNOC` / `UpdateNOC` was already received in this
+            //     fail-safe context, the VID-verification state is part
+            //     of the pending fabric mutation. Don't persist yet —
+            //     `CommissioningComplete` will persist; a fail-safe
+            //     expiry will roll back via the usual fabric remove /
+            //     reload path.
+            //   * Otherwise (no in-flight fabric mutation), the change
+            //     is immediately persistent and SHALL NOT be reverted
+            //     even if the caller later disarms the fail-safe.
+            let part_of_pending_fabric =
+                state.failsafe.is_armed() && state.failsafe.has_pending_noc_for(fab_idx);
+            if !part_of_pending_fabric {
+                persist.store(fabric)?;
+            }
+
+            Ok(())
+        })?;
+
+        persist.run()?;
+
+        // The mutation changed `NOCs.vvsc` and / or `Fabrics.vendorID`
+        // / `.vidVerificationStatement` on this cluster.
+        ctx.notify_own_cluster_changed();
+
+        Ok(())
     }
 
     fn handle_sign_vid_verification_request<P: TLVBuilderParent>(
         &self,
-        _ctx: impl InvokeContext,
-        _request: SignVIDVerificationRequestRequest<'_>,
-        _response: SignVIDVerificationResponseBuilder<P>,
+        ctx: impl InvokeContext,
+        request: SignVIDVerificationRequestRequest<'_>,
+        mut response: SignVIDVerificationResponseBuilder<P>,
     ) -> Result<P, Error> {
-        todo!()
+        info!("Got Sign VID Verification Request");
+
+        // Spec section 11.18.6.16: `FabricIndex` must be in [1..254];
+        // 0 / 255 are constraint errors.
+        let fab_idx_raw = request.fabric_index()?;
+        let fab_idx = NonZeroU8::new(fab_idx_raw)
+            .filter(|fi| fi.get() != u8::MAX)
+            .ok_or(ErrorCode::ConstraintError)?;
+
+        // `ClientChallenge` is fixed at 32 octets per cluster XML
+        // (`length="32" minLength="32"`). Anything else is a
+        // `CONSTRAINT_ERROR`.
+        let client_challenge = request.client_challenge()?.0;
+        if client_challenge.len() != VID_VERIFY_CLIENT_CHALLENGE_LEN {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+
+        ctx.exchange().with_state(|state| {
+            let sess = ctx.exchange().id().session(&mut state.sessions);
+            let attestation_challenge = sess.get_att_challenge().ok_or(ErrorCode::InvalidState)?;
+            let attestation_challenge_bytes: [u8; ATT_CHALLENGE_LEN] =
+                *attestation_challenge.access();
+
+            let fabric = state
+                .fabrics
+                .get(fab_idx)
+                .ok_or(ErrorCode::ConstraintError)?;
+
+            // Build VendorFabricBindingMessage (Matter Core spec
+            // section 6.5.6.2):
+            //   1B fabric_binding_version || 65B root_pub_key
+            //   || 8B fabric_id BE || 2B vendor_id BE
+            let root_ref = CertRef::new(TLVElement::new(fabric.root_ca()));
+            let root_pub_key = root_ref.pubkey()?;
+            if root_pub_key.len() != PKC_CANON_PUBLIC_KEY_LEN {
+                return Err(ErrorCode::InvalidData.into());
+            }
+
+            let fabric_id_be = fabric.fabric_id().to_be_bytes();
+            let vendor_id_be = fabric.vendor_id().to_be_bytes();
+
+            // Compute VIDVerificationTBS in a single contiguous buffer
+            // and feed it to the fabric's NOC private key.
+            //   1B fabric_binding_version || 32B client_challenge
+            //   || 32B attestation_challenge || 1B fabric_index
+            //   || vendor_fabric_binding_message (76B)
+            //   [|| vid_verification_statement (85B)]
+            //
+            // Borrow the response writer's unused tail as scratch — the TBS
+            // is consumed by `sign(...)` before any response field is
+            // written, so the bytes can safely be overwritten afterwards.
+            let tbs_buf = response.writer().available_space();
+            let mut len = 0usize;
+
+            tbs_buf[len] = FABRIC_BINDING_VERSION_1;
+            len += 1;
+            tbs_buf[len..len + client_challenge.len()].copy_from_slice(client_challenge);
+            len += client_challenge.len();
+            tbs_buf[len..len + attestation_challenge_bytes.len()]
+                .copy_from_slice(&attestation_challenge_bytes);
+            len += attestation_challenge_bytes.len();
+            tbs_buf[len] = fab_idx.get();
+            len += 1;
+            // VendorFabricBindingMessage starts here.
+            tbs_buf[len] = FABRIC_BINDING_VERSION_1;
+            len += 1;
+            tbs_buf[len..len + PKC_CANON_PUBLIC_KEY_LEN].copy_from_slice(root_pub_key);
+            len += PKC_CANON_PUBLIC_KEY_LEN;
+            tbs_buf[len..len + 8].copy_from_slice(&fabric_id_be);
+            len += 8;
+            tbs_buf[len..len + 2].copy_from_slice(&vendor_id_be);
+            len += 2;
+            // VIDVerificationStatement is appended only when set.
+            let vvs = fabric.vid_verification_statement();
+            if !vvs.is_empty() {
+                tbs_buf[len..len + vvs.len()].copy_from_slice(vvs);
+                len += vvs.len();
+            }
+
+            // TODO XXX FIXME: MEDIUM BUFFER
+            let mut signature = MaybeUninit::uninit();
+            let signature = signature.init_with(CanonPkcSignature::init());
+
+            ctx.crypto()
+                .secret_key(fabric.secret_key())?
+                .sign(&tbs_buf[..len], signature)?;
+
+            response
+                .fabric_index(fab_idx.get())?
+                .fabric_binding_version(FABRIC_BINDING_VERSION_1)?
+                .signature(Octets::new(signature.access()))?
+                .end()
+        })
     }
 }
+
+/// Matter Core spec section 6.5.6.2: `FabricBindingVersion` constant
+/// for V1 of the `VendorFabricBindingMessage` and `VIDVerificationTBS`.
+const FABRIC_BINDING_VERSION_1: u8 = 1;
+
+/// `ClientChallenge` is fixed at 32 octets (cluster XML
+/// `length="32" minLength="32"` on `SignVIDVerificationRequest`).
+const VID_VERIFY_CLIENT_CHALLENGE_LEN: usize = 32;

--- a/rs-matter/src/dm/types/cluster.rs
+++ b/rs-matter/src/dm/types/cluster.rs
@@ -213,6 +213,16 @@ impl<'a> Cluster<'a> {
             Err(IMStatusCode::NeedsTimedInteraction)?;
         }
 
+        // Per Matter Core spec section 8.9.4 (Invoke Interaction): "Else if
+        // the command in the path is fabric-scoped and there is no accessing
+        // fabric, a CommandStatusIB SHALL be generated with the
+        // UNSUPPORTED_ACCESS Status Code." This is the catch for fabric-scoped
+        // admin commands invoked over a PASE session that hasn't yet promoted
+        // its fabric index via AddNOC.
+        if target_perms.contains(Access::FAB_SCOPED) && accessor.fab_idx == 0 {
+            Err(IMStatusCode::UnsupportedAccess)?;
+        }
+
         access_req.set_target_perms(target_perms);
         if access_req.allow() {
             Ok(())

--- a/rs-matter/src/error.rs
+++ b/rs-matter/src/error.rs
@@ -101,11 +101,13 @@ pub enum ErrorCode {
     Utf8Fail,
     GennCommInvalidAuthentication,
     NocInvalidNoc,
+    NocInvalidPublicKey,
     NocMissingCsr,
     NocFabricTableFull,
     NocFabricConflict,
     NocLabelConflict,
     NocInvalidFabricIndex,
+    NocInvalidAdminSubject,
     Failure,
     // Certification Declaration errors
     CdInvalidFormat,

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -369,11 +369,18 @@ impl Fabric {
     ///
     /// This method is supposed to be called right after `Fabric::init` or
     /// when the NOC of the fabric needs to be updated.
+    ///
+    /// `root_ca` is `None` when called from the `UpdateNOC` flow — Matter
+    /// Core spec section 11.18.6.7 keeps the fabric's root cert unchanged
+    /// across `UpdateNOC`, and re-passing the existing bytes here would
+    /// require a (large) caller-side copy of `self.root_ca`. `Some(...)`
+    /// is used by the initial `AddNOC` flow, where the cert was just
+    /// staged in the fail-safe context.
     #[allow(clippy::too_many_arguments)]
     fn update<C: Crypto>(
         &mut self,
         crypto: C,
-        root_ca: &[u8],
+        root_ca: Option<&[u8]>,
         noc: &[u8],
         icac: &[u8],
         secret_key: CanonPkcSecretKeyRef<'_>,
@@ -381,17 +388,22 @@ impl Fabric {
         vendor_id: Option<u16>,
         case_admin_subject: Option<u64>,
     ) -> Result<(), Error> {
-        self.root_ca
-            .extend_from_slice(root_ca)
-            .map_err(|_| ErrorCode::BufferTooSmall)?;
+        if let Some(root_ca) = root_ca {
+            self.root_ca.clear();
+            self.root_ca
+                .extend_from_slice(root_ca)
+                .map_err(|_| ErrorCode::BufferTooSmall)?;
+        }
+        self.icac.clear();
         self.icac
             .extend_from_slice(icac)
             .map_err(|_| ErrorCode::BufferTooSmall)?;
+        self.noc.clear();
         self.noc
             .extend_from_slice(noc)
             .map_err(|_| ErrorCode::BufferTooSmall)?;
 
-        let root_cert = CertRef::new(TLVElement::new(root_ca));
+        let root_cert = CertRef::new(TLVElement::new(self.root_ca.as_slice()));
         let noc_cert = CertRef::new(TLVElement::new(noc));
 
         self.node_id = noc_cert.get_node_id()?;
@@ -881,7 +893,7 @@ impl Fabrics {
         self.add_with_post_init(|fabric| {
             fabric.update(
                 crypto,
-                root_ca,
+                Some(root_ca),
                 noc,
                 icac,
                 secret_key,
@@ -894,22 +906,25 @@ impl Fabrics {
 
     /// Update an existing fabric with the provided data (usually, as a result of an `UpdateNOC` IM command).
     ///
+    /// The fabric's existing root cert is preserved across this call —
+    /// `UpdateNOC` per Matter Core spec section 11.18.6.7 is not allowed
+    /// to change the root, and re-passing the bytes would force the
+    /// caller to take a (large) heap-less copy of `Fabric::root_ca`.
+    ///
     /// If this operation succeeds, the fabric immediately becomes operational.
     /// Note however, that the caller is expected to remove all sessions associated with the fabric, as they would
     /// contain invalid keys after the NOC update.
-    #[allow(clippy::too_many_arguments)]
     pub fn update<C: Crypto>(
         &mut self,
         crypto: C,
         fab_idx: NonZeroU8,
         secret_key: CanonPkcSecretKeyRef<'_>,
-        root_ca: &[u8],
         noc: &[u8],
         icac: &[u8],
     ) -> Result<&mut Fabric, Error> {
         let fabric = self.fabric_mut(fab_idx)?;
 
-        fabric.update(crypto, root_ca, noc, icac, secret_key, None, None, None)?;
+        fabric.update(crypto, None, noc, icac, secret_key, None, None, None)?;
 
         Ok(fabric)
     }

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -324,8 +324,16 @@ pub struct Fabric {
     /// This simplifies the implementation, but results in potentially multiple
     /// copies of the same Root CA used accross multiple fabrics.
     root_ca: Vec<u8, { MAX_CERT_TLV_LEN }>,
-    /// Intermediate CA certificate
-    icac: Vec<u8, { MAX_CERT_TLV_LEN }>,
+    /// Either the Intermediate CA certificate (`vvsc_set == false`) or the
+    /// Vendor Verification Signing Cert (`vvsc_set == true`). The two are
+    /// mutually exclusive in the cert chain (Matter Core spec section
+    /// 6.5.7) — a fabric with an ICAC cannot also carry a VVSC and vice
+    /// versa — so we share one buffer instead of paying for both. Empty
+    /// means neither is set; in that case `vvsc_set` is meaningless.
+    icac_or_vvsc: Vec<u8, { MAX_CERT_TLV_LEN }>,
+    /// Selector for what `icac_or_vvsc` holds: `false` for an ICAC,
+    /// `true` for a VVSC.
+    vvsc_set: bool,
     /// Node Operational Certificate
     noc: Vec<u8, { MAX_CERT_TLV_LEN }>,
     /// Identity Protection Key
@@ -336,7 +344,17 @@ pub struct Fabric {
     acl: Vec<AclEntry, { acl::MAX_ACL_ENTRIES_PER_FABRIC }>,
     /// Fabric group information
     groups: Groups,
+    /// VID Verification Statement (Matter Core spec section 6.2.4 / 11.18.6.15).
+    /// Either empty (not set) or exactly `VID_VERIFICATION_STATEMENT_LEN`
+    /// bytes long; the cluster XML enforces both bounds at the schema
+    /// level (`length="85" minLength="85"`).
+    vid_verification_statement: Vec<u8, VID_VERIFICATION_STATEMENT_LEN>,
 }
+
+/// Exact length of a non-empty VID Verification Statement.
+/// Matches `length="85" minLength="85"` on
+/// `OperationalCredentials::SetVIDVerificationStatement.vid_verification_statement`.
+pub const VID_VERIFICATION_STATEMENT_LEN: usize = 85;
 
 impl Fabric {
     /// Return an in-place-initializer for a Fabric type, with the
@@ -356,12 +374,14 @@ impl Fabric {
             compressed_fabric_id: 0,
             secret_key <- CanonPkcSecretKey::init(),
             root_ca <- Vec::init(),
-            icac <- Vec::init(),
+            icac_or_vvsc <- Vec::init(),
+            vvsc_set: false,
             noc <- Vec::init(),
             ipk <- KeySet::init(),
             label: String::new(),
             acl <- Vec::init(),
             groups <- Groups::init(),
+            vid_verification_statement <- Vec::init(),
         })
     }
 
@@ -394,10 +414,14 @@ impl Fabric {
                 .extend_from_slice(root_ca)
                 .map_err(|_| ErrorCode::BufferTooSmall)?;
         }
-        self.icac.clear();
-        self.icac
+        // `AddNOC` / `UpdateNOC` always replace the cert chain, so any
+        // previously-staged VVSC for this fabric is implicitly cleared
+        // here — the spec doesn't allow an ICAC and a VVSC to coexist.
+        self.icac_or_vvsc.clear();
+        self.icac_or_vvsc
             .extend_from_slice(icac)
             .map_err(|_| ErrorCode::BufferTooSmall)?;
+        self.vvsc_set = false;
         self.noc.clear();
         self.noc
             .extend_from_slice(noc)
@@ -551,8 +575,14 @@ impl Fabric {
     ///
     /// Note that this method might return an empty slice,
     /// which indicates that this fabric does not have an ICAC.
+    /// (The shared `icac_or_vvsc` slot may instead hold a VVSC; see
+    /// `vvsc()`.)
     pub fn icac(&self) -> &[u8] {
-        &self.icac
+        if self.vvsc_set {
+            &[]
+        } else {
+            &self.icac_or_vvsc
+        }
     }
 
     /// Return the fabric's NOC
@@ -573,6 +603,72 @@ impl Fabric {
     /// Return a mutable reference to the fabric's groups
     pub fn groups_mut(&mut self) -> &mut Groups {
         &mut self.groups
+    }
+
+    /// Return the fabric's VVSC bytes (Matter Core spec section 6.5.7).
+    /// Empty when `SetVIDVerificationStatement` has never been called with
+    /// a non-empty VVSC for this fabric, or when the fabric instead carries
+    /// an ICAC (see `icac()`) — VVSC and ICAC share storage and are
+    /// mutually exclusive per spec section 6.5.7.
+    pub fn vvsc(&self) -> &[u8] {
+        if self.vvsc_set {
+            &self.icac_or_vvsc
+        } else {
+            &[]
+        }
+    }
+
+    /// Return the fabric's VID Verification Statement bytes (Matter Core
+    /// spec section 6.2.4 / 11.18.6.15). Either empty (not set) or
+    /// exactly `VID_VERIFICATION_STATEMENT_LEN` bytes.
+    pub fn vid_verification_statement(&self) -> &[u8] {
+        &self.vid_verification_statement
+    }
+
+    /// Apply a `SetVIDVerificationStatement` mutation to the fabric. Each
+    /// field is `Some(slice)` for "replace with this value" (where an
+    /// empty slice clears the value), or `None` for "leave unchanged".
+    /// The caller is responsible for spec-level validation (size limits,
+    /// VVSC vs ICAC mutual exclusion, "all fields absent" → INVALID_COMMAND,
+    /// VendorID range, …); this method only enforces the storage
+    /// invariants (heapless `Vec` capacity).
+    pub fn set_vid_verification(
+        &mut self,
+        vendor_id: Option<u16>,
+        vid_verification_statement: Option<&[u8]>,
+        vvsc: Option<&[u8]>,
+    ) -> Result<(), Error> {
+        if let Some(vid) = vendor_id {
+            self.vendor_id = vid;
+        }
+
+        if let Some(vvs) = vid_verification_statement {
+            self.vid_verification_statement.clear();
+            self.vid_verification_statement
+                .extend_from_slice(vvs)
+                .map_err(|_| ErrorCode::BufferTooSmall)?;
+        }
+
+        if let Some(v) = vvsc {
+            // VVSC and ICAC share `icac_or_vvsc`. Clearing the VVSC must
+            // not stomp on an existing ICAC: per spec section 6.5.7 the
+            // two never coexist on the same fabric, so an empty-VVSC
+            // request against a fabric that holds an ICAC is a no-op
+            // here. The cluster handler still rejects a *non-empty* VVSC
+            // against such a fabric upstream.
+            if !v.is_empty() {
+                self.icac_or_vvsc.clear();
+                self.icac_or_vvsc
+                    .extend_from_slice(v)
+                    .map_err(|_| ErrorCode::BufferTooSmall)?;
+                self.vvsc_set = true;
+            } else if self.vvsc_set {
+                self.icac_or_vvsc.clear();
+                self.vvsc_set = false;
+            }
+        }
+
+        Ok(())
     }
 
     /// Return an iterator over the ACL entries of the fabric

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -20,8 +20,8 @@ use core::time::Duration;
 
 use crate::cert::{CertRef, MAX_CERT_TLV_LEN};
 use crate::crypto::{
-    CanonAeadKeyRef, CanonPkcSecretKey, CanonPkcSecretKeyRef, Crypto, SecretKey,
-    PKC_SECRET_KEY_ZEROED,
+    CanonAeadKeyRef, CanonPkcSecretKey, CanonPkcSecretKeyRef, Crypto, PublicKey, SecretKey,
+    SigningSecretKey, PKC_SECRET_KEY_ZEROED,
 };
 use crate::dm::clusters::net_comm::NetworksAccess;
 use crate::error::{Error, ErrorCode};
@@ -351,10 +351,12 @@ impl FailSafe {
         )
     }
 
-    pub fn add_trusted_root_cert(
+    pub fn add_trusted_root_cert<C: Crypto>(
         &mut self,
+        crypto: C,
         session_mode: &SessionMode,
         root_ca: &[u8],
+        buf: &mut [u8],
     ) -> Result<(), Error> {
         self.check_state(
             session_mode,
@@ -362,6 +364,20 @@ impl FailSafe {
             NocFlags::ADD_ROOT_CERT_RECVD,
             NocFlags::ADD_ROOT_CERT_RECVD,
         )?;
+
+        // Validate the candidate RCAC by checking its self-signature (a Matter
+        // RCAC is self-issued, so the certificate's own public key must verify
+        // the certificate's signature). Any decode or signature failure must
+        // surface as `INVALID_COMMAND` per Matter Core spec section 11.18.6.13
+        // (`AddTrustedRootCertificate`), not as the generic `Failure` we'd
+        // otherwise get from `ErrorCode::InvalidSignature`.
+        {
+            let root_ref = CertRef::new(TLVElement::new(root_ca));
+            root_ref
+                .verify_chain_start(&crypto)
+                .finalise(buf)
+                .map_err(|_| ErrorCode::InvalidCommand)?;
+        }
 
         self.root_ca.clear();
         self.root_ca
@@ -442,8 +458,24 @@ impl FailSafe {
             let icac_ref = icac.map(|icac| CertRef::new(TLVElement::new(icac)));
             let root_ref = CertRef::new(TLVElement::new(&self.root_ca));
 
-            // Validate the certs first
-            Self::validate_certs(&crypto, &noc_ref, icac_ref.as_ref(), &root_ref, buf)?;
+            // Validate the certs first. A chain that doesn't pass
+            // signature verification (or that doesn't chain back to the
+            // staged root) is reported as `kInvalidNOC` cluster status per
+            // Matter Core spec section 11.18.6.7 (`UpdateNOC`).
+            Self::validate_certs(&crypto, &noc_ref, icac_ref.as_ref(), &root_ref, buf)
+                .map_err(|_| ErrorCode::NocInvalidNoc)?;
+
+            // The NOC's public key must match the public key derived from
+            // the most recent `CSRRequest(isForUpdateNOC=true)` (Matter
+            // Core spec section 11.18.6.7).
+            let mut csr_pubkey = crate::crypto::CanonPkcPublicKey::new();
+            crypto
+                .secret_key(self.secret_key.reference())?
+                .pub_key()?
+                .write_canon(&mut csr_pubkey)?;
+            if csr_pubkey.access().as_slice() != noc_ref.pubkey()? {
+                Err(ErrorCode::NocInvalidPublicKey)?;
+            }
 
             // Check that the fabric ID and root cert pubkey in the NOC
             // match the ones of the fabric which is being updated
@@ -509,13 +541,38 @@ impl FailSafe {
             NocFlags::ADD_NOC_RECVD,
         )?;
 
+        // CaseAdminSubject must be either a valid Operational Node ID or a
+        // CASE Authenticated Tag (CAT) — Matter Core spec section 11.18.6.6
+        // (`AddNOC`). Anything else (most commonly 0) is reported as
+        // `kInvalidAdminSubject` cluster status.
+        if !crate::acl::is_node(case_admin_subject) && !crate::acl::is_noc_cat(case_admin_subject) {
+            Err(ErrorCode::NocInvalidAdminSubject)?;
+        }
+
         {
             let noc_ref = CertRef::new(TLVElement::new(noc));
             let icac_ref = icac.map(|icac| CertRef::new(TLVElement::new(icac)));
             let root_ref = CertRef::new(TLVElement::new(&self.root_ca));
 
-            // Validate the certs first
-            Self::validate_certs(&crypto, &noc_ref, icac_ref.as_ref(), &root_ref, buf)?;
+            // Validate the certs first. A chain that doesn't pass
+            // signature verification (or that doesn't chain back to the
+            // staged root) is reported as `kInvalidNOC` cluster status per
+            // Matter Core spec section 11.18.6.6 (`AddNOC`).
+            Self::validate_certs(&crypto, &noc_ref, icac_ref.as_ref(), &root_ref, buf)
+                .map_err(|_| ErrorCode::NocInvalidNoc)?;
+
+            // The NOC's public key must match the public key derived from
+            // the most recent `CSRRequest` (Matter Core spec section
+            // 11.18.6.6). The CSR's secret key is stashed in
+            // `self.secret_key` by `add_csr_req` / `update_csr_req`.
+            let mut csr_pubkey = crate::crypto::CanonPkcPublicKey::new();
+            crypto
+                .secret_key(self.secret_key.reference())?
+                .pub_key()?
+                .write_canon(&mut csr_pubkey)?;
+            if csr_pubkey.access().as_slice() != noc_ref.pubkey()? {
+                Err(ErrorCode::NocInvalidPublicKey)?;
+            }
 
             // Check that there is no fabric with the same fabric ID and root cert pubkey
             // as the one in the NOC, to avoid adding duplicate fabrics
@@ -593,7 +650,13 @@ impl FailSafe {
         let mut verifier = noc.verify_chain_start(crypto);
 
         if let Some(icac) = icac {
-            // If ICAC is present handle it
+            // If ICAC is present handle it. Reject the case where the
+            // commissioner re-uses the RCAC as the ICAC: Matter Core spec
+            // section 6.5 requires the ICAC to be a separate CA cert
+            // (i.e. not self-signed).
+            if icac.is_self_signed()? {
+                return Err(ErrorCode::InvalidData.into());
+            }
             verifier = verifier.add_cert(icac, buf)?;
         }
 

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -24,6 +24,8 @@ use crate::crypto::{
     SigningSecretKey, PKC_SECRET_KEY_ZEROED,
 };
 use crate::dm::clusters::net_comm::NetworksAccess;
+use crate::dm::endpoints::ROOT_ENDPOINT_ID;
+use crate::dm::{ClusterId, EndptId};
 use crate::error::{Error, ErrorCode};
 use crate::fabric::{Fabric, Fabrics};
 use crate::im::IMStatusCode;
@@ -126,6 +128,7 @@ impl FailSafe {
         networks: N,
         kv: S,
         mdns_notif: impl FnMut(),
+        notify_change: impl FnMut(EndptId, ClusterId),
     ) -> Result<bool, Error>
     where
         S: KvBlobStoreAccess,
@@ -134,7 +137,7 @@ impl FailSafe {
         if let State::Armed(ctx) = &self.state {
             let now = (self.epoch)();
             if now >= ctx.armed_at + Duration::from_secs(ctx.timeout_secs as u64) {
-                self.expire(fabrics, networks, kv, mdns_notif)?;
+                self.expire(fabrics, networks, kv, mdns_notif, notify_change)?;
                 return Ok(true);
             }
         }
@@ -151,6 +154,7 @@ impl FailSafe {
         networks: N,
         kv: S,
         mut mdns_notif: impl FnMut(),
+        mut notify_change: impl FnMut(EndptId, ClusterId),
     ) -> Result<bool, Error>
     where
         S: KvBlobStoreAccess,
@@ -188,6 +192,26 @@ impl FailSafe {
         self.breadcrumb = 0;
 
         mdns_notif();
+
+        // The rollback above restores attributes visible to subscribers —
+        // `OperationalCredentials::NOCs` / `Fabrics` (including `vvsc`,
+        // `VIDVerificationStatement`, `vendorID` mutated in-failsafe by
+        // `SetVIDVerificationStatement`) and `NetworkCommissioning::Networks`
+        // — to their persisted values. Notify so any active subscriptions
+        // re-report.
+        //
+        // TODO: this only flags subscriptions for re-reporting; it does
+        // *not* bump the affected clusters' data versions. `Failsafe`
+        // has no handle to the cluster meta needed to do that. Pre-existing
+        // limitation, not introduced by the timeout-vs-force-expiry path.
+        notify_change(
+            ROOT_ENDPOINT_ID,
+            crate::dm::clusters::decl::operational_credentials::FULL_CLUSTER.id,
+        );
+        notify_change(
+            ROOT_ENDPOINT_ID,
+            crate::dm::clusters::decl::network_commissioning::FULL_CLUSTER.id,
+        );
 
         Ok(true)
     }
@@ -318,6 +342,21 @@ impl FailSafe {
             State::Idle => false,
             State::Armed(ArmedCtx { fab_idx, .. }) => fab_idx == caller_fab_idx,
         }
+    }
+
+    /// Whether the current fail-safe context already has an in-flight
+    /// `AddNOC` or `UpdateNOC` for `caller_fab_idx`. Used by
+    /// `SetVIDVerificationStatement` to decide whether the VID-verification
+    /// mutation rides along with the pending fabric (and thus rolls back
+    /// on fail-safe expiry) or is committed to storage immediately.
+    pub fn has_pending_noc_for(&self, caller_fab_idx: NonZeroU8) -> bool {
+        let State::Armed(ctx) = &self.state else {
+            return false;
+        };
+        ctx.fab_idx == caller_fab_idx.get()
+            && ctx
+                .flags
+                .intersects(NocFlags::ADD_NOC_RECVD | NocFlags::UPDATE_NOC_RECVD)
     }
 
     pub fn check_armed(&self, session_mode: &SessionMode) -> Result<(), Error> {

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -80,6 +80,11 @@ impl From<IMStatusCode> for IMError {
     }
 }
 
+/// Default fail-safe expiry length used when the device implicitly arms the
+/// fail-safe (e.g. on PASE session establishment). Mirrors
+/// `CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC` from the reference SDK.
+pub const DEFAULT_FAILSAFE_EXPIRY_SECS: u16 = 60;
+
 pub struct FailSafe {
     state: State,
     secret_key: CanonPkcSecretKey,
@@ -254,6 +259,34 @@ impl FailSafe {
 
     pub fn is_armed(&self) -> bool {
         matches!(self.state, State::Armed(_))
+    }
+
+    /// Return the trusted root certificate that has been staged via
+    /// `AddTrustedRootCertificate` while the fail-safe is armed but has not
+    /// yet been bound to a fabric via `AddNOC` / `UpdateNOC`.
+    ///
+    /// Once `AddNOC` or `UpdateNOC` is processed the root certificate is
+    /// owned by the (new or updated) fabric and is reported through the
+    /// fabric table; until then it has no fabric association but the spec
+    /// still requires it to appear in the `TrustedRootCertificates` list
+    /// (Matter Core spec, NodeOperationalCredentials cluster).
+    pub fn pending_root_ca(&self) -> Option<&[u8]> {
+        let State::Armed(ctx) = &self.state else {
+            return None;
+        };
+
+        if !ctx.flags.contains(NocFlags::ADD_ROOT_CERT_RECVD) {
+            return None;
+        }
+
+        if ctx
+            .flags
+            .intersects(NocFlags::ADD_NOC_RECVD | NocFlags::UPDATE_NOC_RECVD)
+        {
+            return None;
+        }
+
+        (!self.root_ca.is_empty()).then_some(self.root_ca.as_slice())
     }
 
     pub fn is_armed_for(&self, caller_fab_idx: u8) -> bool {

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -125,47 +125,93 @@ impl FailSafe {
         fabrics: &mut Fabrics,
         networks: N,
         kv: S,
-        mut mdns_notif: impl FnMut(),
+        mdns_notif: impl FnMut(),
     ) -> Result<bool, Error>
     where
         S: KvBlobStoreAccess,
         N: NetworksAccess,
     {
-        if let State::Armed(ctx) = &mut self.state {
+        if let State::Armed(ctx) = &self.state {
             let now = (self.epoch)();
             if now >= ctx.armed_at + Duration::from_secs(ctx.timeout_secs as u64) {
-                warn!(
-                    "Fail-Safe timeout expired for fabric {}, disarming",
-                    ctx.fab_idx
-                );
-
-                kv.access(|mut kv, buf| {
-                    if let Some(fab_idx) = NonZeroU8::new(ctx.fab_idx) {
-                        fabrics.remove(fab_idx)?;
-                        fabrics.add_load(fab_idx.get(), &mut kv, buf)?;
-                    }
-
-                    networks.access(|networks| {
-                        let data = kv.load(NETWORKS_KEY, buf)?;
-
-                        if let Some(data) = data {
-                            networks.load(data)
-                        } else {
-                            networks.reset()
-                        }
-                    })
-                })?;
-
-                self.state = State::Idle;
-                self.breadcrumb = 0;
-
-                mdns_notif();
-
+                self.expire(fabrics, networks, kv, mdns_notif)?;
                 return Ok(true);
             }
         }
 
         Ok(false)
+    }
+
+    /// Force the fail-safe context to expire immediately, rolling back any
+    /// fabric / network changes that the in-flight commissioning had staged
+    /// and resetting the breadcrumb to 0. Mirrors CHIP's
+    /// `FailSafeContext::ForceFailSafeTimerExpiry`, used by
+    /// `RevokeCommissioning` to cancel a partially-completed commissioning
+    /// attempt.
+    pub fn force_expiry<S, N>(
+        &mut self,
+        fabrics: &mut Fabrics,
+        networks: N,
+        kv: S,
+        mdns_notif: impl FnMut(),
+    ) -> Result<bool, Error>
+    where
+        S: KvBlobStoreAccess,
+        N: NetworksAccess,
+    {
+        if matches!(self.state, State::Armed(_)) {
+            self.expire(fabrics, networks, kv, mdns_notif)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn expire<S, N>(
+        &mut self,
+        fabrics: &mut Fabrics,
+        networks: N,
+        kv: S,
+        mut mdns_notif: impl FnMut(),
+    ) -> Result<(), Error>
+    where
+        S: KvBlobStoreAccess,
+        N: NetworksAccess,
+    {
+        let State::Armed(ctx) = &self.state else {
+            return Ok(());
+        };
+
+        warn!(
+            "Fail-Safe timeout expired for fabric {}, disarming",
+            ctx.fab_idx
+        );
+
+        let fab_idx_raw = ctx.fab_idx;
+
+        kv.access(|mut kv, buf| {
+            if let Some(fab_idx) = NonZeroU8::new(fab_idx_raw) {
+                fabrics.remove(fab_idx)?;
+                fabrics.add_load(fab_idx.get(), &mut kv, buf)?;
+            }
+
+            networks.access(|networks| {
+                let data = kv.load(NETWORKS_KEY, buf)?;
+
+                if let Some(data) = data {
+                    networks.load(data)
+                } else {
+                    networks.reset()
+                }
+            })
+        })?;
+
+        self.state = State::Idle;
+        self.breadcrumb = 0;
+
+        mdns_notif();
+
+        Ok(())
     }
 
     pub fn arm(

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -125,6 +125,7 @@ impl FailSafe {
     pub fn check_failsafe_timeout<S, N>(
         &mut self,
         fabrics: &mut Fabrics,
+        sessions: &mut crate::transport::session::Sessions,
         networks: N,
         kv: S,
         mdns_notif: impl FnMut(),
@@ -137,7 +138,18 @@ impl FailSafe {
         if let State::Armed(ctx) = &self.state {
             let now = (self.epoch)();
             if now >= ctx.armed_at + Duration::from_secs(ctx.timeout_secs as u64) {
-                self.expire(fabrics, networks, kv, mdns_notif, notify_change)?;
+                // Timeout path: no caller exchange to preserve, so wipe
+                // every PASE session along with the fabric / networks
+                // rollback.
+                self.expire(
+                    fabrics,
+                    sessions,
+                    None,
+                    networks,
+                    kv,
+                    mdns_notif,
+                    notify_change,
+                )?;
                 return Ok(true);
             }
         }
@@ -148,9 +160,18 @@ impl FailSafe {
     /// Force the fail-safe context to expire immediately, rolling back any
     /// fabric / network changes that the in-flight commissioning had staged
     /// and resetting the breadcrumb to 0.
+    ///
+    /// `expire_sess_id` is the optional session ID of the exchange that
+    /// triggered the expiry — typically passed when the trigger arrived
+    /// over PASE, so the response can still be sent before the slot is
+    /// reclaimed. `None` for the timeout-driven path or when the trigger
+    /// arrived over CASE.
+    #[allow(clippy::too_many_arguments)]
     pub fn expire<S, N>(
         &mut self,
         fabrics: &mut Fabrics,
+        sessions: &mut crate::transport::session::Sessions,
+        expire_sess_id: Option<u32>,
         networks: N,
         kv: S,
         mut mdns_notif: impl FnMut(),
@@ -187,6 +208,15 @@ impl FailSafe {
                 }
             })
         })?;
+
+        // Any PASE session that was in flight under this fail-safe is
+        // now orphaned: its commissioning attempt was rolled back, so the
+        // session has nothing to do and should not stick around to fill
+        // the session table (same leak class fixed for
+        // `CommissioningComplete`). `Sessions::remove_pase` keeps
+        // `expire_sess_id` alive (marked expired) so any in-flight
+        // response can complete.
+        sessions.remove_pase(expire_sess_id);
 
         self.state = State::Idle;
         self.breadcrumb = 0;

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -144,42 +144,20 @@ impl FailSafe {
 
     /// Force the fail-safe context to expire immediately, rolling back any
     /// fabric / network changes that the in-flight commissioning had staged
-    /// and resetting the breadcrumb to 0. Mirrors CHIP's
-    /// `FailSafeContext::ForceFailSafeTimerExpiry`, used by
-    /// `RevokeCommissioning` to cancel a partially-completed commissioning
-    /// attempt.
-    pub fn force_expiry<S, N>(
-        &mut self,
-        fabrics: &mut Fabrics,
-        networks: N,
-        kv: S,
-        mdns_notif: impl FnMut(),
-    ) -> Result<bool, Error>
-    where
-        S: KvBlobStoreAccess,
-        N: NetworksAccess,
-    {
-        if matches!(self.state, State::Armed(_)) {
-            self.expire(fabrics, networks, kv, mdns_notif)?;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    fn expire<S, N>(
+    /// and resetting the breadcrumb to 0.
+    pub fn expire<S, N>(
         &mut self,
         fabrics: &mut Fabrics,
         networks: N,
         kv: S,
         mut mdns_notif: impl FnMut(),
-    ) -> Result<(), Error>
+    ) -> Result<bool, Error>
     where
         S: KvBlobStoreAccess,
         N: NetworksAccess,
     {
         let State::Armed(ctx) = &self.state else {
-            return Ok(());
+            return Ok(false);
         };
 
         warn!(
@@ -211,7 +189,7 @@ impl FailSafe {
 
         mdns_notif();
 
-        Ok(())
+        Ok(true)
     }
 
     pub fn arm(
@@ -446,17 +424,32 @@ impl FailSafe {
     ) -> Result<&'a mut Fabric, Error> {
         let fab_idx = Self::get_case_fab_idx(session_mode)?;
 
+        // `UpdateNOC` only requires the corresponding `CSRRequest` (with
+        // `isForUpdateNOC=true`) to have been processed in this fail-safe
+        // context. Per Matter Core spec section 11.18.6.7 it must NOT
+        // have been preceded by `AddTrustedRootCertificate`, `AddNOC`,
+        // `UpdateNOC`, or a CSRRequest of the wrong kind — those go in
+        // `absent`. `validate_certs` further down uses the *committed*
+        // root cert (`fabrics.fabric(fab_idx).root_ca()`), not anything
+        // staged via AddTrustedRootCertificate.
         self.check_state(
             session_mode,
-            NocFlags::ADD_ROOT_CERT_RECVD | NocFlags::UPDATE_CSR_REQ_RECVD,
-            NocFlags::ADD_NOC_RECVD | NocFlags::ADD_CSR_REQ_RECVD | NocFlags::UPDATE_NOC_RECVD,
+            NocFlags::UPDATE_CSR_REQ_RECVD,
+            NocFlags::ADD_ROOT_CERT_RECVD
+                | NocFlags::ADD_NOC_RECVD
+                | NocFlags::ADD_CSR_REQ_RECVD
+                | NocFlags::UPDATE_NOC_RECVD,
             NocFlags::UPDATE_NOC_RECVD,
         )?;
 
         {
             let noc_ref = CertRef::new(TLVElement::new(noc));
             let icac_ref = icac.map(|icac| CertRef::new(TLVElement::new(icac)));
-            let root_ref = CertRef::new(TLVElement::new(&self.root_ca));
+            // `UpdateNOC` re-uses the existing fabric's root cert; it does
+            // not consume one staged via `AddTrustedRootCertificate` (the
+            // `absent` constraint above ensures none was staged).
+            let fabric_root_ca = fabrics.fabric(fab_idx)?.root_ca();
+            let root_ref = CertRef::new(TLVElement::new(fabric_root_ca));
 
             // Validate the certs first. A chain that doesn't pass
             // signature verification (or that doesn't chain back to the
@@ -477,31 +470,25 @@ impl FailSafe {
                 Err(ErrorCode::NocInvalidPublicKey)?;
             }
 
-            // Check that the fabric ID and root cert pubkey in the NOC
-            // match the ones of the fabric which is being updated
+            // Check that the fabric ID in the NOC matches the fabric
+            // being updated. The root cert pubkey check is implicit: the
+            // chain validation above used the fabric's own root cert.
 
             let fabric_id = noc_ref.get_fabric_id()?;
-            let root_cert_pubkey = root_ref.pubkey()?;
-
             let fabric = fabrics.fabric(fab_idx)?;
 
             if fabric_id != fabric.fabric_id() {
                 Err(ErrorCode::NocFabricConflict)?;
             }
-
-            let f_root_ref = CertRef::new(TLVElement::new(fabric.root_ca()));
-            let f_root_pubkey = f_root_ref.pubkey()?;
-
-            if root_cert_pubkey != f_root_pubkey {
-                Err(ErrorCode::NocFabricConflict)?;
-            }
         }
 
+        // `Fabrics::update` keeps the existing root cert in place — no
+        // need (and no reason) to copy it out of the fabric just to pass
+        // it back in.
         let fabric = fabrics.update(
             &crypto,
             fab_idx,
             self.secret_key.reference(),
-            &self.root_ca,
             noc,
             icac.unwrap_or(&[]),
         )?;
@@ -697,14 +684,21 @@ impl FailSafe {
             }
 
             if !ctx.flags.contains(present) {
-                // State is not what is expected for that concrete command
-
-                if op == NocFlags::ADD_NOC_RECVD
-                    && !ctx.flags.contains(NocFlags::UPDATE_CSR_REQ_RECVD)
-                    || op == NocFlags::UPDATE_NOC_RECVD
-                        && !ctx.flags.contains(NocFlags::UPDATE_CSR_REQ_RECVD)
-                {
-                    // Return a more concrete error if the problem is that the CSR request is missing
+                // State is not what is expected for that concrete command.
+                //
+                // Disambiguate "no CSR at all" from "wrong CSR type" per
+                // Matter Core spec sections 11.18.6.6 (`AddNOC`) and
+                // 11.18.6.7 (`UpdateNOC`):
+                //   * No `CSRRequest` of either kind seen yet for this
+                //     fail-safe context → `kMissingCsr` cluster status.
+                //   * A CSR was issued but with the opposite
+                //     `isForUpdateNOC` flag from the command being
+                //     processed (e.g. `UpdateNOC` after a CSR for
+                //     `AddNOC`) → IM `CONSTRAINT_ERROR`.
+                let any_csr = ctx
+                    .flags
+                    .intersects(NocFlags::ADD_CSR_REQ_RECVD | NocFlags::UPDATE_CSR_REQ_RECVD);
+                if (op == NocFlags::ADD_NOC_RECVD || op == NocFlags::UPDATE_NOC_RECVD) && !any_csr {
                     Err(ErrorCode::NocMissingCsr)?;
                 }
 
@@ -712,17 +706,16 @@ impl FailSafe {
             }
 
             if !ctx.flags.intersection(absent).is_empty() {
-                // State is not what is expected for that concrete command
-
-                if op == NocFlags::ADD_NOC_RECVD
-                    && ctx.flags.contains(NocFlags::UPDATE_CSR_REQ_RECVD)
-                    || op == NocFlags::UPDATE_NOC_RECVD
-                        && ctx.flags.contains(NocFlags::ADD_CSR_REQ_RECVD)
-                {
-                    // Return a more concrete error if the problem is an add/update NOC mismatch
-                    Err(ErrorCode::NocFabricConflict)?;
-                }
-
+                // State is not what is expected for that concrete command.
+                //
+                // Two flavours both surface as IM `CONSTRAINT_ERROR` per
+                // Matter Core spec sections 11.18.6.6 (`AddNOC`) and
+                // 11.18.6.7 (`UpdateNOC`):
+                //   * the same `Add`/`UpdateNOC` was already received in
+                //     this fail-safe context
+                //   * the most recent `CSRRequest` had the wrong
+                //     `isForUpdateNOC` flag for the command being
+                //     processed (e.g. UpdateNOC after an AddNOC-style CSR)
                 Err(ErrorCode::ConstraintError)?;
             }
         } else {

--- a/rs-matter/src/sc/pase/responder.rs
+++ b/rs-matter/src/sc/pase/responder.rs
@@ -353,12 +353,12 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
                 exchange.with_state(|state| {
                     if !state.failsafe.is_armed() {
                         let session_mode = SessionMode::Pase { fab_idx: 0 };
-                        let _ = state.failsafe.arm(
+                        state.failsafe.arm(
                             crate::failsafe::DEFAULT_FAILSAFE_EXPIRY_SECS,
                             0,
                             &session_mode,
                             &mut state.pase,
-                        );
+                        )?;
                     }
 
                     Ok(())

--- a/rs-matter/src/sc/pase/responder.rs
+++ b/rs-matter/src/sc/pase/responder.rs
@@ -345,6 +345,25 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
                 // as reserved.
                 session.complete();
 
+                // Per CHIP `CommissioningWindowManager::OnSessionEstablished`,
+                // arm the fail-safe automatically once a PASE session is up so
+                // the commissioner can issue `AddTrustedRootCertificate` and
+                // friends without first sending `ArmFailSafe` itself. Mirrors
+                // `CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC` (60s default).
+                exchange.with_state(|state| {
+                    if !state.failsafe.is_armed() {
+                        let session_mode = SessionMode::Pase { fab_idx: 0 };
+                        let _ = state.failsafe.arm(
+                            crate::failsafe::DEFAULT_FAILSAFE_EXPIRY_SECS,
+                            0,
+                            &session_mode,
+                            &mut state.pase,
+                        );
+                    }
+
+                    Ok(())
+                })?;
+
                 SCStatusCodes::SessionEstablishmentSuccess
             }
             Err(status) => status,

--- a/rs-matter/src/transport/network/mdns/builtin/proto.rs
+++ b/rs-matter/src/transport/network/mdns/builtin/proto.rs
@@ -142,21 +142,47 @@ impl Host<'_> {
         self.add_ipv4(&mut answer, ttl_sec)?;
         self.add_ipv6(&mut answer, ttl_sec)?;
 
+        // The DNS broadcast packet has a fixed buffer (one Matter MTU) so
+        // a host with many services can overflow it — typically when more
+        // than ~4 commissioned fabrics are advertised at once
+        // (TC_CADMIN_1_19 hits this with 5). Treat overflow as
+        // "non-fatal": stop appending, keep whatever already fit, send
+        // that. Controllers that need a service we couldn't fit will
+        // still discover it via the per-instance query path
+        // (`Host::respond`), which only carries one service at a time.
+        //
+        // TODO: per RFC 6762 §17 we should split across multiple packets
+        // (with the TC bit set) and round-robin which services start each
+        // packet so no service is starved. The single-packet truncation
+        // below is the pragmatic fix that gets multi-fabric tests
+        // passing; it relies on solicited responses to fill the gap.
+        let mut overflowed = false;
         services.for_each(|service| {
-            service.add_service(&mut answer, self.hostname, ttl_sec)?;
-            service.add_service_type(&mut answer, ttl_sec)?;
-            service.add_dns_sd_service_type(&mut answer, ttl_sec)?;
-
-            // TODO: Apple commissioning - since Apple commissions > 1 fabric
-            // we are overflowing the DNS broadcast record.
-            // Temporarily comment out a few records to make it work.
-
-            //service.add_service_subtypes(&mut answer, ttl_sec)?;
-            //service.add_dns_sd_service_subtypes(&mut answer, ttl_sec)?;
-            //service.add_txt(&mut answer, ttl_sec)?;
-
-            Ok(())
+            if overflowed {
+                return Ok(());
+            }
+            let mut try_add = || -> Result<(), Error> {
+                service.add_service(&mut answer, self.hostname, ttl_sec)?;
+                service.add_service_type(&mut answer, ttl_sec)?;
+                service.add_dns_sd_service_type(&mut answer, ttl_sec)?;
+                Ok(())
+            };
+            if let Err(err) = try_add() {
+                if matches!(err.code(), ErrorCode::BufferTooSmall) {
+                    overflowed = true;
+                    Ok(())
+                } else {
+                    Err(err)
+                }
+            } else {
+                Ok(())
+            }
         })?;
+        if overflowed {
+            warn!(
+                "mDNS broadcast packet overflowed; some service records were dropped (will be served via direct queries)"
+            );
+        }
 
         let buf = answer.finish();
 

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -1205,6 +1205,26 @@ impl Sessions {
     pub fn iter(&self) -> impl Iterator<Item = &Session> {
         self.sessions.iter()
     }
+
+    /// Drop every PASE session that has not yet been promoted to a fabric
+    /// (i.e. `SessionMode::Pase { fab_idx: 0 }`). This is what
+    /// `RevokeCommissioning` and a fail-safe expiry over a PASE session need
+    /// to do per Matter Core spec section 11.18.6.2: when the commissioning
+    /// window is torn down, any in-flight PASE sessions associated with it
+    /// must be terminated.
+    pub fn remove_pase(&mut self) {
+        while let Some(index) = self
+            .sessions
+            .iter()
+            .position(|sess| matches!(sess.get_session_mode(), SessionMode::Pase { fab_idx: 0 }))
+        {
+            info!(
+                "Dropping unpromoted PASE session with ID {}",
+                self.sessions[index].id
+            );
+            self.sessions.swap_remove(index);
+        }
+    }
 }
 
 impl fmt::Display for Sessions {

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -1206,40 +1206,45 @@ impl Sessions {
         self.sessions.iter()
     }
 
-    /// Drop every PASE session that has not yet been promoted to a fabric
-    /// (i.e. `SessionMode::Pase { fab_idx: 0 }`). This is what
-    /// `RevokeCommissioning` and a fail-safe expiry over a PASE session need
-    /// to do per Matter Core spec section 11.18.6.2: when the commissioning
-    /// window is torn down, any in-flight PASE sessions associated with it
-    /// must be terminated.
+    /// Drop every PASE session, whether unpromoted (still
+    /// `SessionMode::Pase { fab_idx: 0 }`) or already promoted to a
+    /// fabric. Used by:
     ///
-    /// `expire_sess_id` is the optional ID of a session that should NOT be
-    /// removed immediately — typically the session that issued the
-    /// `RevokeCommissioning` command, so the response can still be sent.
-    /// That session is marked as `expired` instead, so it stops accepting
-    /// new exchanges but the in-flight one can complete.
+    /// * `RevokeCommissioning` and a fail-safe expiry over a PASE
+    ///   session (Matter Core spec section 11.18.6.2): when the
+    ///   commissioning window is torn down, any in-flight PASE sessions
+    ///   associated with it must be terminated. A PASE that was
+    ///   promoted via `AddNOC` is rolled back by the same fail-safe
+    ///   expiry, so its session must go too.
+    /// * `CommissioningComplete` (spec V1.3 section 5.5 / V1.4 section
+    ///   11.10.7.4): once the device transitions to operational state,
+    ///   all PASE sessions SHALL be terminated. Without this each
+    ///   commissioning round leaks the promoted PASE it ran on, and
+    ///   the session table eventually exhausts — visible as `BUSY` on
+    ///   the next round's `PBKDFParamRequest`.
+    ///
+    /// `expire_sess_id` is the optional ID of a session that should NOT
+    /// be removed immediately — typically the session that issued the
+    /// triggering command, so its response can still be sent. That
+    /// session is marked as `expired` instead, so it stops accepting
+    /// new exchanges but the in-flight one can complete; the transport
+    /// reclaims the slot via the usual LRU eviction path.
     pub fn remove_pase(&mut self, expire_sess_id: Option<u32>) {
         while let Some(index) = self.sessions.iter().position(|sess| {
-            matches!(sess.get_session_mode(), SessionMode::Pase { fab_idx: 0 })
+            matches!(sess.get_session_mode(), SessionMode::Pase { .. })
                 && Some(sess.id) != expire_sess_id
         }) {
-            info!(
-                "Dropping unpromoted PASE session with ID {}",
-                self.sessions[index].id
-            );
+            info!("Dropping PASE session with ID {}", self.sessions[index].id);
             self.sessions.swap_remove(index);
         }
 
         if let Some(expire_sess_id) = expire_sess_id {
             if let Some(sess) = self.sessions.iter_mut().find(|sess| {
                 sess.id == expire_sess_id
-                    && matches!(sess.get_session_mode(), SessionMode::Pase { fab_idx: 0 })
+                    && matches!(sess.get_session_mode(), SessionMode::Pase { .. })
             }) {
                 sess.expired = true;
-                info!(
-                    "Marking unpromoted PASE session with ID {} as expired",
-                    expire_sess_id
-                );
+                info!("Marking PASE session with ID {} as expired", expire_sess_id);
             }
         }
     }

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -1212,17 +1212,35 @@ impl Sessions {
     /// to do per Matter Core spec section 11.18.6.2: when the commissioning
     /// window is torn down, any in-flight PASE sessions associated with it
     /// must be terminated.
-    pub fn remove_pase(&mut self) {
-        while let Some(index) = self
-            .sessions
-            .iter()
-            .position(|sess| matches!(sess.get_session_mode(), SessionMode::Pase { fab_idx: 0 }))
-        {
+    ///
+    /// `expire_sess_id` is the optional ID of a session that should NOT be
+    /// removed immediately — typically the session that issued the
+    /// `RevokeCommissioning` command, so the response can still be sent.
+    /// That session is marked as `expired` instead, so it stops accepting
+    /// new exchanges but the in-flight one can complete.
+    pub fn remove_pase(&mut self, expire_sess_id: Option<u32>) {
+        while let Some(index) = self.sessions.iter().position(|sess| {
+            matches!(sess.get_session_mode(), SessionMode::Pase { fab_idx: 0 })
+                && Some(sess.id) != expire_sess_id
+        }) {
             info!(
                 "Dropping unpromoted PASE session with ID {}",
                 self.sessions[index].id
             );
             self.sessions.swap_remove(index);
+        }
+
+        if let Some(expire_sess_id) = expire_sess_id {
+            if let Some(sess) = self.sessions.iter_mut().find(|sess| {
+                sess.id == expire_sess_id
+                    && matches!(sess.get_session_mode(), SessionMode::Pase { fab_idx: 0 })
+            }) {
+                sess.expired = true;
+                info!(
+                    "Marking unpromoted PASE session with ID {} as expired",
+                    expire_sess_id
+                );
+            }
         }
     }
 }

--- a/xtask/src/common.rs
+++ b/xtask/src/common.rs
@@ -169,14 +169,23 @@ impl ChipBuilder {
     }
 
     /// Build and install the CHIP Python "matter" wheel into the
-    /// pigweed venv that `scripts/activate.sh` already sets up.
+    /// pigweed venv that `scripts/activate.sh` already sets up, plus the
+    /// runtime requirements that the `MatterBaseTest`-style scripts in
+    /// `src/python_testing/` import (zeroconf, ifaddr, mobly, …). Both
+    /// happen in a single `scripts/build_python.sh` call so we stay
+    /// aligned with how CHIP's own CI bootstraps the venv — no
+    /// hand-rolled `pip install` lines that would drift from upstream's
+    /// dependency list.
     ///
     /// Required by `scripts/tests/run_python_test.py`, whose imports
     /// (`matter.testing.metadata`, `matter.testing.tasks`) come from
-    /// the wheel built by `scripts/build_python.sh`.
+    /// the wheel built by `scripts/build_python.sh`, and by the test
+    /// scripts themselves (e.g. CADMIN tests pull in `mdns_discovery`,
+    /// which imports `zeroconf`).
     ///
-    /// Idempotent: if the wheel is already importable in the venv,
-    /// this is a no-op (unless `force_rebuild` is set).
+    /// Idempotent: if both the wheel and the python_testing requirements
+    /// are already importable in the venv, this is a no-op (unless
+    /// `force_rebuild` is set).
     pub fn build_python_wheel(&self, force_rebuild: bool) -> anyhow::Result<()> {
         let chip_dir = self.chip_dir();
 
@@ -188,15 +197,17 @@ impl ChipBuilder {
             );
         }
 
-        // Probe: is the `matter.testing` package already importable?
+        // Probe both the wheel and a representative pytest dep (`zeroconf`).
+        // If either is missing we re-run `build_python.sh`, which is
+        // idempotent against an existing venv when invoked with `-c no`.
         let probe = Command::new(venv_dir.join("bin/python3"))
             .arg("-c")
-            .arg("import matter.testing.metadata, matter.testing.tasks")
+            .arg("import matter.testing.metadata, matter.testing.tasks, zeroconf")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status();
         if !force_rebuild && probe.map(|s| s.success()).unwrap_or(false) {
-            info!("CHIP Python wheel already installed in pigweed venv");
+            info!("CHIP Python wheel and test requirements already installed in pigweed venv");
             return Ok(());
         }
 
@@ -204,10 +215,17 @@ impl ChipBuilder {
 
         // `-i <venv>` installs the wheel into the existing venv; `-c no`
         // keeps the venv (preserves mobly etc.) instead of recreating it.
+        // `--include_pytest_deps yes` pulls in `scripts/tests/requirements.txt`
+        // and `src/python_testing/requirements.txt` (zeroconf, ifaddr, …) —
+        // matches what CHIP CI does so the venv ends up with the same set of
+        // packages the upstream test scripts assume. Note that this requires
+        // `libpcsclite-dev` on the host (already listed in `REQUIRED_PACKAGES`)
+        // because `pyscard` in those requirements builds a native extension
+        // against `<winscard.h>`.
         // `run_in_build_env.sh` sources `activate.sh` first so that
         // `python`, `gn`, `ninja` etc. are on PATH.
         let runner = chip_dir.join("scripts/run_in_build_env.sh");
-        let cmd_line = "./scripts/build_python.sh -i .environment/pigweed-venv -c no -d false";
+        let cmd_line = "./scripts/build_python.sh -i .environment/pigweed-venv -c no -d false --include_pytest_deps yes";
 
         // PW_ACTIVATE_SKIP_CHECKS=1 bypasses the `pw doctor` health check in
         // activate.sh which fails when the `pw` CLI isn't on PATH (e.g. when
@@ -226,7 +244,7 @@ impl ChipBuilder {
             !self.print_cmd_output,
         )?;
 
-        info!("CHIP Python wheel installed successfully");
+        info!("CHIP Python wheel and test requirements installed successfully");
 
         Ok(())
     }

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -139,8 +139,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TC_OPCREDS_3_2",
     "TC_OPCREDS_3_4",
     "TC_OPCREDS_3_5",
-    // "TC_OPCREDS_3_8", // Skipped: requires the Matter 1.4 `VID Verification` feature (`SignVIDVerificationRequest`, `SetVIDVerificationStatement`, the `vvsc` field on `NOCs`, and the `VIDVerificationStatement` field on `Fabrics`). rs-matter currently stubs both VID-Verification commands, so steps 4+ of this test all surface as `Failure`. The "non-fabric-filtered NOCs read" gap that originally blocked step 2 is fixed (`NOCStruct.noc` / `.icac` are no longer treated as fabric-sensitive in `NocHandler::nocs`), but enabling the test requires implementing VID Verification end-to-end (signing TBS with the fabric's NOC key, plus persisted VVSC/VID/VIDVerificationStatement on `Fabric`).
-
+    "TC_OPCREDS_3_8",
     //
     // Python tests — Session/Commissioning (general Matter protocol)
     //
@@ -558,6 +557,17 @@ impl ITests {
             // construction.
             "TC_CADMIN_1_3_4" | "TC_CADMIN_1_5" | "TC_CADMIN_1_9" | "TC_CADMIN_1_11"
             | "TC_CADMIN_1_15" | "TC_CADMIN_1_22" | "TC_CADMIN_1_25" => Some(300),
+            // TC_OPCREDS_3_8 exercises the VID-Verification feature (Matter
+            // 1.4): it sets a 400-byte VVSC and an 85-byte
+            // VIDVerificationStatement on a fabric and then issues
+            // non-fabric-filtered reads of `NOCs` / `Fabrics` covering both
+            // fabrics. With two ~750-byte struct entries plus the 400-byte
+            // VVSC the response cannot fit in a single MTU and rs-matter
+            // falls back to its chunked-read path, which on the debug
+            // profile is dominated by per-error backtrace dumps. Bump the
+            // per-test ceiling so the chunked transfer has time to
+            // complete; the test passes in well under a minute on release.
+            "TC_OPCREDS_3_8" => Some(300),
             _ => None,
         }
     }
@@ -614,6 +624,16 @@ impl ITests {
                  --PICS src/app/tests/suites/certification/ci-pics-values"
             }
             "TC_CGEN_2_4" => " --endpoint 0",
+            // TC_OPCREDS_3_8 reads `NOCs` non-fabric-filtered with two
+            // fabrics, each carrying a max-sized 400-byte VVSC; the
+            // resulting payload is well past one MTU and rs-matter falls
+            // back to chunked reads. On the debug profile every chunk
+            // boundary triggers an `Error::NoSpace` whose backtrace dump
+            // dominates the per-chunk wall-clock. Bumping the test's
+            // `default_timeout` (90 s) past the per_endpoint_runner
+            // wait_for is enough to let the chunked transfers finish; the
+            // test passes in well under 30 s on release.
+            "TC_OPCREDS_3_8" => " --endpoint 0 --timeout 240",
             // CADMIN (Administrator Commissioning) tests target the root
             // endpoint via `@run_if_endpoint_matches(has_cluster(...))`.
             "TC_CADMIN_1_3_4"
@@ -632,7 +652,6 @@ impl ITests {
             | "TC_OPCREDS_3_2"
             | "TC_OPCREDS_3_4"
             | "TC_OPCREDS_3_5"
-            | "TC_OPCREDS_3_8"
             // SC (Secure Channel) tests target the root endpoint.
             | "TC_SC_3_4"
             | "TC_SC_3_6"

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -123,7 +123,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     // "TC_CADMIN_1_28",  // Skipped: requires the CHIP `jfc-server-app` (Joint Fabric Controller); rs-matter does not implement JF.
     "TC_CGEN_2_1",
     "TC_CGEN_2_2",
-    // "TC_CGEN_2_4",  // TODO: `CommissioningComplete` returns an unexpected SDK error part on the negative paths exercised here (no fail-safe armed / wrong fabric). Needs alignment with the spec's expected error category.
+    "TC_CGEN_2_4",
     // "TC_CGEN_2_5",  // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
     // "TC_CGEN_2_6",  // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
     // "TC_CGEN_2_7",  // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
@@ -613,6 +613,7 @@ impl ITests {
                 " --endpoint 0 --int-arg PIXIT.CGEN.FailsafeExpiryLengthSeconds:10 \
                  --PICS src/app/tests/suites/certification/ci-pics-values"
             }
+            "TC_CGEN_2_4" => " --endpoint 0",
             // CADMIN (Administrator Commissioning) tests target the root
             // endpoint via `@run_if_endpoint_matches(has_cluster(...))`.
             "TC_CADMIN_1_3_4"

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -138,7 +138,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TC_OPCREDS_3_1",
     "TC_OPCREDS_3_2",
     "TC_OPCREDS_3_4",
-    // "TC_OPCREDS_3_5", // TODO: `UpdateNOC` returns `kMissingCsr` instead of `kOk` even on the valid happy path — looks like the CSR slot is being cleared too eagerly between the CSR request and the `UpdateNOC` call.
+    "TC_OPCREDS_3_5",
     // "TC_OPCREDS_3_8", // TODO: a second-fabric NOC entry is not visible in the `NOCs` attribute when read non-fabric-filtered — likely a fabric-scoped attribute filter incorrectly applied to a non-fabric-filtered read.
 
     //

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -116,7 +116,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TC_CADMIN_1_9",
     "TC_CADMIN_1_11",
     "TC_CADMIN_1_15",
-    // "TC_CADMIN_1_19",  // TODO: multi-fabric stress test commissions `SupportedFabrics` controllers back-to-back. Fails part-way with `Incorrect state` from the Python pairing controller. Likely needs deeper investigation of CASE setup between rapid commissioning rounds; not blocking other coverage.
+    "TC_CADMIN_1_19",
     "TC_CADMIN_1_22",
     "TC_CADMIN_1_25",
     // "TC_CADMIN_1_27",  // Skipped: requires the CHIP `jfc-server-app` (Joint Fabric Controller); rs-matter does not implement JF.

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -137,7 +137,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     //
     "TC_OPCREDS_3_1",
     "TC_OPCREDS_3_2",
-    // "TC_OPCREDS_3_4", // TODO: `UpdateNOC` returns `FailSafeRequired` / `NocMissingCsr` on the negative paths, but the test expects the spec's specific `NodeOperationalCertStatusEnum` values for each error condition. Needs alignment of error mapping.
+    "TC_OPCREDS_3_4",
     // "TC_OPCREDS_3_5", // TODO: `UpdateNOC` returns `kMissingCsr` instead of `kOk` even on the valid happy path — looks like the CSR slot is being cleared too eagerly between the CSR request and the `UpdateNOC` call.
     // "TC_OPCREDS_3_8", // TODO: a second-fabric NOC entry is not visible in the `NOCs` attribute when read non-fabric-filtered — likely a fabric-scoped attribute filter incorrectly applied to a non-fabric-filtered read.
 

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -139,7 +139,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TC_OPCREDS_3_2",
     "TC_OPCREDS_3_4",
     "TC_OPCREDS_3_5",
-    // "TC_OPCREDS_3_8", // TODO: a second-fabric NOC entry is not visible in the `NOCs` attribute when read non-fabric-filtered — likely a fabric-scoped attribute filter incorrectly applied to a non-fabric-filtered read.
+    // "TC_OPCREDS_3_8", // Skipped: requires the Matter 1.4 `VID Verification` feature (`SignVIDVerificationRequest`, `SetVIDVerificationStatement`, the `vvsc` field on `NOCs`, and the `VIDVerificationStatement` field on `Fabrics`). rs-matter currently stubs both VID-Verification commands, so steps 4+ of this test all surface as `Failure`. The "non-fabric-filtered NOCs read" gap that originally blocked step 2 is fixed (`NOCStruct.noc` / `.icac` are no longer treated as fabric-sensitive in `NocHandler::nocs`), but enabling the test requires implementing VID Verification end-to-end (signing TBS with the fabric's NOC key, plus persisted VVSC/VID/VIDVerificationStatement on `Fabric`).
 
     //
     // Python tests — Session/Commissioning (general Matter protocol)

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -86,9 +86,9 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     //
     // Python tests — Interaction Data Model (general Matter protocol)
     //
-    "TC_IDM_2_2",
     "TC_IDM_1_2",
     "TC_IDM_1_4",
+    "TC_IDM_2_2",
     "TC_IDM_4_2",
     //
     // Python tests — Access Control (system cluster)

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -122,7 +122,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     // "TC_CADMIN_1_27",  // Skipped: requires the CHIP `jfc-server-app` (Joint Fabric Controller); rs-matter does not implement JF.
     // "TC_CADMIN_1_28",  // Skipped: requires the CHIP `jfc-server-app` (Joint Fabric Controller); rs-matter does not implement JF.
     "TC_CGEN_2_1",
-    // "TC_CGEN_2_2",  // TODO: after `AddTrustedRootCertificate` during a failsafe, the read-back of `TrustedRootCertificates` still reports the original size — the new root isn't surfaced. Likely an attribute-list issue in rs-matter's NOC handler.
+    "TC_CGEN_2_2",
     // "TC_CGEN_2_4",  // TODO: `CommissioningComplete` returns an unexpected SDK error part on the negative paths exercised here (no fail-safe armed / wrong fabric). Needs alignment with the spec's expected error category.
     // "TC_CGEN_2_5",  // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
     // "TC_CGEN_2_6",  // Skipped: requires `CGEN.S.F00` (TermsAndConditions feature); rs-matter does not implement TC.
@@ -587,6 +587,32 @@ impl ITests {
             // ACL events. argparse keeps the last `--endpoint`, so appending
             // here wins.
             "TC_ACL_2_6" | "TC_ACL_2_7" | "TC_ACL_2_8" => " --endpoint 0",
+            // TC_CGEN_2_2 lives on the root endpoint (GeneralCommissioning /
+            // OperationalCredentials clusters) and uses
+            // `PIXIT.CGEN.FailsafeExpiryLengthSeconds` to bound the fail-safe
+            // window for several "arm → mutate → read" sub-flows. With the CI
+            // default of 1s the fail-safe expires mid-way through chunked
+            // reads of the (relatively large) `TrustedRootCertificates`
+            // attribute on a debug build, so the pending root certificate is
+            // dropped before the response finishes serializing. Bump it to a
+            // value that survives chunking on a slow build while keeping the
+            // overall test runtime reasonable.
+            //
+            // The `--PICS` file enables `PICS_SDK_CI_ONLY=1`, which the test
+            // uses to skip the step #38–#44 sub-flow. Those steps reassign
+            // the test's local `maxFailsafe` to `failsafe_expiration_seconds`
+            // and then assert that the *device's* fail-safe times out after
+            // that shortened window — which only holds if the device's
+            // `BasicCommissioningInfo.MaxCumulativeFailsafeSeconds` is set
+            // to the same small value. rs-matter advertises 900s here (see
+            // `CommPolicy::failsafe_max_cml_secs`), so the Cert path's
+            // assumption does not match this device and step #44 would always
+            // see the still-armed pending root cert. CI mode covers the same
+            // attribute / command surface without that assumption.
+            "TC_CGEN_2_2" => {
+                " --endpoint 0 --int-arg PIXIT.CGEN.FailsafeExpiryLengthSeconds:10 \
+                 --PICS src/app/tests/suites/certification/ci-pics-values"
+            }
             // CADMIN (Administrator Commissioning) tests target the root
             // endpoint via `@run_if_endpoint_matches(has_cluster(...))`.
             "TC_CADMIN_1_3_4"

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -135,7 +135,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     //
     // Python tests — Operational Credentials (system cluster)
     //
-    // "TC_OPCREDS_3_1", // TODO: rs-matter accepts an `AddTrustedRootCertificate` payload with a malformed signature (the test expects this to be rejected). NOC handler needs to validate the RCAC's self-signature before accepting it.
+    "TC_OPCREDS_3_1",
     "TC_OPCREDS_3_2",
     // "TC_OPCREDS_3_4", // TODO: `UpdateNOC` returns `FailSafeRequired` / `NocMissingCsr` on the negative paths, but the test expects the spec's specific `NodeOperationalCertStatusEnum` values for each error condition. Needs alignment of error mapping.
     // "TC_OPCREDS_3_5", // TODO: `UpdateNOC` returns `kMissingCsr` instead of `kOk` even on the valid happy path — looks like the CSR slot is being cleared too eagerly between the CSR request and the `UpdateNOC` call.


### PR DESCRIPTION
**Work in progress**

##### TC_CGEN_2_2

- Auto-arm on PASE session establishment (this is a bit controversial!)
- NOC cluster: report the trusted root cert which is in-flight

##### TC_CGEN_2_4

- Fabric-scoped invoke over PASE. 
  - Per Matter Core spec §8.9.4: "if the command in the path is fabric-scoped and there is no accessing fabric, a CommandStatusIB SHALL be generated with the UNSUPPORTED_ACCESS Status Code." check_cmd_access now rejects fabric-scoped commands when accessor.fab_idx == 0 (PASE pre-NOC) with UnsupportedAccess instead of letting them fall through to the cluster handler — which would have returned kInvalidAuthentication (cluster status), not 0x7E (IM global status). This is what the test asserts for stages 3-18 (kArmFailsafe through kSendTrustedRootCert).

- RevokeCommissioning had to clean up state. 
  - The test runs 8 commission/revoke iterations. After iteration 1 the breadcrumb was still > 0, the auto-armed PASE fail-safe was still armed, and the dangling PASE session was still alive. CHIP's [AutoCommissioner](https://github.com/project-chip/connectedhomeip/blob/master/src/controller/AutoCommissioner.cpp#L367-L375) reads breadcrumb > 0 and assumes "this is a resumed commissioning, skip past ArmFailsafe" — which made iteration 2 jump straight to operational lookup and time out. Mirrors CHIP's [AdministratorCommissioningLogic::RevokeCommissioning](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/administrator-commissioning-server/AdministratorCommissioningLogic.cpp#L104-L121): force-expire the fail-safe (rolling back any uncommitted fabric, resetting breadcrumb to 0) and drop unpromoted PASE sessions before closing the window.

- SetRegulatoryConfig validation. 
  - Per spec §11.10.7.2: an unsupported NewRegulatoryConfig value (or one that doesn't match LocationCapability) must return kValueOutsideRange in the response, not a generic IM Failure. The post-loop steps 17-19 of the test deliberately send RegulatoryLocationTypeEnum(3) to verify this. The handler now decodes the request defensively and matches against CommPolicy::location_cap().

##### TC_OPCREDS_3_1

**Multiple** spec-conformance fixes in the OperationalCredentials cluster:

- AddTrustedRootCertificate validates RCAC self-signature
  - add_trusted_root_cert now decodes the payload as a CertRef and calls verify_chain_start().finalise() (self-verify); decode/signature failures map to INVALID_COMMAND per spec §11.18.6.13.

- AddNOC / UpdateNOC cert-chain failures map to kInvalidNOC
  - validate_certs failures get coerced to ErrorCode::NocInvalidNoc instead of bubbling up as IM Failure.

- AddNOC validates caseAdminSubject
  - must be a valid Operational Node ID or NOC CAT (is_node() / is_noc_cat() from acl.rs); rejected with new ErrorCode::NocInvalidAdminSubject → kInvalidAdminSubject.

- AddNOC / UpdateNOC checks NOC pubkey vs. last CSR pubkey
  - derives the public key from the stashed CSR secret key and compares to noc.pubkey(); mismatch → new ErrorCode::NocInvalidPublicKey → kInvalidPublicKey.

- Reject self-signed ICAC
  - cert.rs is_self_signed() helper; validate_certs rejects when commissioner re-uses the RCAC as the ICAC (spec §6.5).

- NodeOperationalCertStatusEnum::map
  - now covers NocFabricConflict → FabricConflict, NocLabelConflict → LabelConflict, NocInvalidNoc → InvalidNOC, NocInvalidPublicKey → InvalidPublicKey, NocInvalidAdminSubject → InvalidAdminSubject, NocMissingCsr → MissingCsr. Removed the blanket ConstraintError → MissingCsr mapping so "second AddNOC in the same fail-safe context" surfaces as IM ConstraintError (spec §11.18.6.6) rather than being swallowed as a NOCResponse cluster status.

- UpdateFabricLabel accepts upgraded-PASE
  - noc.rs no longer requires SessionMode::Case; uses sess.get_local_fabric_idx() so a PASE session whose fab_idx was upgraded by AddNOC (the standard in-commissioning case) works. The IM-layer fabric-scoped check still rejects pre-AddNOC PASE.

- ArmFailSafe(0) actually rolls back
  - gen_comm.rs handle_arm_fail_safe now routes expiryLengthSeconds == 0 through FailSafe::force_expiry so uncommitted fabric/network state is reverted (spec §11.10.7.1), not just state = Idle.

- KeySetRead(id=0) returns IPK info
  - grp_key_mgmt.rs - special-cases ID 0 (IPK lives on the fabric, not the generic key-set list); responds with TrustFirst policy and null epoch keys per spec.
 
##### TC_OPCREDS_3_4

- UpdateNOC required ADD_ROOT_CERT_RECVD in its present flags
  - wrong per Matter Core §11.18.6.7. UpdateNOC re-uses the existing fabric's root cert and AddTrustedRootCertificate having been received in the same fail-safe context is actually a forbidden state. Moved ADD_ROOT_CERT_RECVD from present to absent.

- Fabrics::update was passing the staged failsafe.root_ca to the fabric
  - Would have either overwritten or doubled the bytes. Reworked Fabrics::update to drop the root_ca parameter entirely; Fabric::update now takes Option<&[u8]> and None means "keep existing" (also clear()s before extending, fixing a latent append bug). UpdateNOC re-uses the fabric's own root_ca by spec.

- check_state mis-mapped "wrong CSR type"
  - for op == UPDATE_NOC_RECVD && flags has ADD_CSR_REQ_RECVD (and the symmetric AddNOC case), it returned NocFabricConflict (cluster status FabricConflict). Per spec §11.18.6.6/7, this should be IM CONSTRAINT_ERROR. Removed that special branch — falls through to the generic ConstraintError.

- check_state mis-mapped "missing CSR" for the wrong-type case
  - when some CSR existed but with the opposite isForUpdateNOC, we returned NocMissingCsr (cluster status MissingCsr). Per spec, that's only for the "no CSR at all" case. Now we check intersects(ADD_CSR_REQ_RECVD | UPDATE_CSR_REQ_RECVD) — if any CSR exists but the wrong kind, fall through to IM CONSTRAINT_ERROR.

- CSRRequest(isForUpdateNOC=true) over PASE returned IM Failure 
  - hit the generic GennCommInvalidAuthentication → Failure mapping. Per spec §11.18.6.5, this must be IM INVALID_COMMAND because UpdateNOC can never run over PASE. Added an explicit pre-check in handle_csr_request.

- RevokeCommissioning over PASE killed its own response
  - the handler called state.sessions.remove_pase() which evicted the calling PASE session before the Success response could be sent, so the commissioner saw a 10s timeout. Added an expire_sess_id parameter to remove_pase: that session is marked expired (stops accepting new exchanges, lets the in-flight one finish) instead of removed, mirroring how RemoveFabric handles its own session.

##### TC_OPCREDS_3_5

- no fixes necessary.

##### TC_OPCREDS_3_8

- VID Verification implementation

##### TC_CADMIN_1_19

(Was commented out before)

Two underlying bugs were fixed:

- PASE session leak on CommissioningComplete
  - Spec V1.3 §5.5 / V1.4 §11.10.7.4 mandates terminating PASE on commissioning complete, but rs-matter only closed the commissioning window. With modern controllers (CHIP SDK 1.4+) that send CommissioningComplete over operational CASE rather than PASE, the just-finished PASE session was leaking. After 4 rounds the session table (16 slots) filled up and the next round's PBKDFParamRequest got BUSY. Added Sessions::remove_all_pase() and call it from the handler.

- mDNS broadcast packet overflow with many fabrics
  - A pre-existing TODO ("Apple commissions > 1 fabric we are overflowing"). 5 commissioned services + 1 commissionable + IPv4/IPv6 records exceed one Matter MTU, so Host::broadcast returned BufferTooSmall mid-loop and the entire broadcast aborted. Now: catch the overflow per-service, stop appending, send what fit, log a warning. Controllers still discover via the per-instance solicited-query path (Host::respond returns one service at a time).NOTE: We DO need a proper fix here, as I'm not sure that the mDNS packet remains well-formed on a BufferTooSmall error.
