### PR TITLE
Rearrange mDNS arguments for extra convenience in downstream rs-matter-stack

### DIFF
--- a/examples/src/common/mdns.rs
+++ b/examples/src/common/mdns.rs
@@ -38,17 +38,21 @@ pub async fn run_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(), E
         feature = "resolve",
         not(any(feature = "zeroconf", feature = "astro-dnssd"))
     ))]
-    rs_matter::transport::network::mdns::resolve::ResolveMdnsResponder::new(rs_matter::utils::zbus::Connection::system().await.unwrap())
-        .run(matter)
-        .await?;
+    rs_matter::transport::network::mdns::resolve::ResolveMdnsResponder::new(
+        rs_matter::utils::zbus::Connection::system().await.unwrap(),
+    )
+    .run(matter)
+    .await?;
 
     #[cfg(all(
         feature = "avahi",
         not(any(feature = "resolve", feature = "zeroconf", feature = "astro-dnssd"))
     ))]
-    rs_matter::transport::network::mdns::avahi::AvahiMdnsResponder::new(rs_matter::utils::zbus::Connection::system().await.unwrap())
-        .run(matter)
-        .await?;
+    rs_matter::transport::network::mdns::avahi::AvahiMdnsResponder::new(
+        rs_matter::utils::zbus::Connection::system().await.unwrap(),
+    )
+    .run(matter)
+    .await?;
 
     #[cfg(not(any(
         feature = "avahi",

--- a/examples/src/common/mdns.rs
+++ b/examples/src/common/mdns.rs
@@ -25,29 +25,29 @@ use socket2::{Domain, Protocol, Socket, Type};
 #[allow(unused)]
 pub async fn run_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(), Error> {
     #[cfg(feature = "astro-dnssd")]
-    rs_matter::transport::network::mdns::astro::AstroMdnsResponder::new(matter)
-        .run()
+    rs_matter::transport::network::mdns::astro::AstroMdnsResponder::new()
+        .run(matter)
         .await?;
 
     #[cfg(all(feature = "zeroconf", not(feature = "astro-dnssd")))]
-    rs_matter::transport::network::mdns::zeroconf::ZeroconfMdnsResponder::new(matter)
-        .run()
+    rs_matter::transport::network::mdns::zeroconf::ZeroconfMdnsResponder::new()
+        .run(matter)
         .await?;
 
     #[cfg(all(
         feature = "resolve",
         not(any(feature = "zeroconf", feature = "astro-dnssd"))
     ))]
-    rs_matter::transport::network::mdns::resolve::ResolveMdnsResponder::new(matter)
-        .run(&rs_matter::utils::zbus::Connection::system().await.unwrap())
+    rs_matter::transport::network::mdns::resolve::ResolveMdnsResponder::new(rs_matter::utils::zbus::Connection::system().await.unwrap())
+        .run(matter)
         .await?;
 
     #[cfg(all(
         feature = "avahi",
         not(any(feature = "resolve", feature = "zeroconf", feature = "astro-dnssd"))
     ))]
-    rs_matter::transport::network::mdns::avahi::AvahiMdnsResponder::new(matter)
-        .run(&rs_matter::utils::zbus::Connection::system().await.unwrap())
+    rs_matter::transport::network::mdns::avahi::AvahiMdnsResponder::new(rs_matter::utils::zbus::Connection::system().await.unwrap())
+        .run(matter)
         .await?;
 
     #[cfg(not(any(

--- a/rs-matter/src/transport/network/mdns/astro.rs
+++ b/rs-matter/src/transport/network/mdns/astro.rs
@@ -26,7 +26,6 @@ use std::net::ToSocketAddrs;
 use std::time::Duration;
 
 use crate::error::{Error, ErrorCode};
-use crate::im::{AttrId, ClusterId, EndptId};
 use crate::transport::network::mdns::MatterService;
 use crate::Matter;
 
@@ -37,27 +36,28 @@ use super::{CommissionableFilter, DiscoveredDevice, PushUnique};
 ///
 /// NOTE: For Linux, you need to install the avahi-compat libraries. E.g., on Ubuntu:
 /// `sudo apt install -y libavahi-compat-libdnssd-dev libavahi-compat-libdnssd1`
-pub struct AstroMdnsResponder<'a> {
-    matter: &'a Matter<'a>,
+pub struct AstroMdnsResponder {
     services: HashMap<MatterService, RegisteredDnsService>,
 }
 
-impl<'a> AstroMdnsResponder<'a> {
+impl AstroMdnsResponder {
     /// Create a new `AstroMdnsResponder` for the given `Matter` instance.
-    pub fn new(matter: &'a Matter<'a>) -> Self {
+    pub fn new() -> Self {
         Self {
-            matter,
             services: HashMap::new(),
         }
     }
 
     /// Run the mDNS responder
-    pub async fn run(&mut self) -> Result<(), Error> {
+    ///
+    /// # Arguments
+    /// - `matter`: A reference to the Matter instance to get mDNS services from.
+    pub async fn run(&mut self, matter: &Matter<'_>) -> Result<(), Error> {
         loop {
-            self.matter.wait_mdns().await;
+            matter.wait_mdns().await;
 
             let mut services = HashSet::new();
-            self.matter.mdns_services(|service| {
+            matter.mdns_services(|service| {
                 services.insert(service);
 
                 Ok(())
@@ -65,17 +65,21 @@ impl<'a> AstroMdnsResponder<'a> {
 
             info!("mDNS services changed, updating...");
 
-            self.update_services(&services).await?;
+            self.update_services(matter, &services).await?;
 
             info!("mDNS services updated");
         }
     }
 
-    async fn update_services(&mut self, services: &HashSet<MatterService>) -> Result<(), Error> {
+    async fn update_services(
+        &mut self,
+        matter: &Matter<'_>,
+        services: &HashSet<MatterService>,
+    ) -> Result<(), Error> {
         for service in services {
             if !self.services.contains_key(service) {
                 info!("Registering mDNS service: {:?}", service);
-                let registered = self.register(service)?;
+                let registered = self.register(matter, service)?;
                 self.services.insert(service.clone(), registered);
             }
         }
@@ -97,11 +101,15 @@ impl<'a> AstroMdnsResponder<'a> {
         Ok(())
     }
 
-    fn register(&mut self, service: &MatterService) -> Result<RegisteredDnsService, Error> {
+    fn register(
+        &mut self,
+        matter: &Matter<'_>,
+        service: &MatterService,
+    ) -> Result<RegisteredDnsService, Error> {
         // Scratch buffer for expanding `MatterService` into a `Service` view —
         // the strings (name, subtypes, TXT values) are formatted into this buffer.
         let mut buf = [0u8; 512];
-        let (service, _) = service.service(self.matter.dev_det(), self.matter.port(), &mut buf)?;
+        let (service, _) = service.service(matter.dev_det(), matter.port(), &mut buf)?;
 
         // Materialize subtypes once: we need both `is_empty` and `join`.
         let subtypes: Vec<&str> = service.service_subtypes.clone().collect();

--- a/rs-matter/src/transport/network/mdns/astro.rs
+++ b/rs-matter/src/transport/network/mdns/astro.rs
@@ -41,7 +41,7 @@ pub struct AstroMdnsResponder {
 }
 
 impl AstroMdnsResponder {
-    /// Create a new `AstroMdnsResponder` for the given `Matter` instance.
+    /// Create a new `AstroMdnsResponder`.
     pub fn new() -> Self {
         Self {
             services: HashMap::new(),
@@ -65,13 +65,13 @@ impl AstroMdnsResponder {
 
             info!("mDNS services changed, updating...");
 
-            self.update_services(matter, &services).await?;
+            self.update_services(matter, &services)?;
 
             info!("mDNS services updated");
         }
     }
 
-    async fn update_services(
+    fn update_services(
         &mut self,
         matter: &Matter<'_>,
         services: &HashSet<MatterService>,

--- a/rs-matter/src/transport/network/mdns/avahi.rs
+++ b/rs-matter/src/transport/network/mdns/avahi.rs
@@ -48,35 +48,35 @@ const AVAHI_IF_UNSPEC: i32 = -1;
 const AVAHI_PROTO_UNSPEC: i32 = -1;
 
 /// An mDNS responder for Matter utilizing the Avahi daemon over DBus.
-pub struct AvahiMdnsResponder<'a> {
-    matter: &'a Matter<'a>,
+pub struct AvahiMdnsResponder {
     services: HashMap<MatterService, OwnedObjectPath>,
+    connection: Connection,
 }
 
-impl<'a> AvahiMdnsResponder<'a> {
+impl AvahiMdnsResponder {
     /// Create a new instance of the Avahi mDNS responder.
-    pub fn new(matter: &'a Matter<'a>) -> Self {
+    pub fn new(connection: Connection) -> Self {
         Self {
-            matter,
             services: HashMap::new(),
+            connection,
         }
     }
 
     /// Run the mDNS responder
     ///
     /// # Arguments
-    /// - `connection`: A reference to the DBus system connection to use for communication with Avahi.
-    pub async fn run(&mut self, connection: &Connection) -> Result<(), Error> {
+    /// - `matter`: A reference to the Matter instance to get mDNS services from.
+    pub async fn run(&mut self, matter: &Matter<'_>) -> Result<(), Error> {
         {
-            let avahi = Server2Proxy::new(connection).await?;
+            let avahi = Server2Proxy::new(&self.connection).await?;
             info!("Avahi API version: {}", avahi.get_apiversion().await?);
         }
 
         loop {
-            self.matter.wait_mdns().await;
+            matter.wait_mdns().await;
 
             let mut services = HashSet::new();
-            self.matter.mdns_services(|service| {
+            matter.mdns_services(|service| {
                 services.insert(service);
 
                 Ok(())
@@ -84,7 +84,7 @@ impl<'a> AvahiMdnsResponder<'a> {
 
             info!("mDNS services changed, updating...");
 
-            self.update_services(connection, &services).await?;
+            self.update_services(matter, &services).await?;
 
             info!("mDNS services updated");
         }
@@ -92,13 +92,13 @@ impl<'a> AvahiMdnsResponder<'a> {
 
     async fn update_services(
         &mut self,
-        connection: &Connection,
+        matter: &Matter<'_>,
         services: &HashSet<MatterService>,
     ) -> Result<(), Error> {
         for service in services {
             if !self.services.contains_key(service) {
                 info!("Registering mDNS service: {:?}", service);
-                let path = self.register(connection, service).await?;
+                let path = self.register(matter, service).await?;
                 self.services.insert(service.clone(), path);
             }
         }
@@ -111,7 +111,7 @@ impl<'a> AvahiMdnsResponder<'a> {
 
             if let Some((service, path)) = removed {
                 info!("Deregistering mDNS service: {:?}", service);
-                Self::deregister(connection, path.as_ref()).await?;
+                self.deregister(path.as_ref()).await?;
                 self.services.remove(&service.clone());
             } else {
                 break;
@@ -123,19 +123,19 @@ impl<'a> AvahiMdnsResponder<'a> {
 
     async fn register(
         &mut self,
-        connection: &Connection,
+        matter: &Matter<'_>,
         service: &MatterService,
     ) -> Result<OwnedObjectPath, Error> {
         // Scratch buffer for expanding `MatterService` into a `Service` view —
         // the strings (name, subtypes, TXT values) are formatted into this buffer.
         let mut buf = [0u8; 512];
-        let (service, _) = service.service(self.matter.dev_det(), self.matter.port(), &mut buf)?;
+        let (service, _) = service.service(matter.dev_det(), matter.port(), &mut buf)?;
 
-        let avahi = Server2Proxy::new(connection).await?;
+        let avahi = Server2Proxy::new(&self.connection).await?;
 
         let path = avahi.entry_group_new().await?;
 
-        let group = EntryGroupProxy::builder(connection)
+        let group = EntryGroupProxy::builder(&self.connection)
             .path(path.clone())?
             .build()
             .await?;
@@ -206,8 +206,8 @@ impl<'a> AvahiMdnsResponder<'a> {
         Ok(path)
     }
 
-    async fn deregister(connection: &Connection, path: ObjectPath<'_>) -> Result<(), Error> {
-        let group = EntryGroupProxy::builder(connection)
+    async fn deregister(&self, path: ObjectPath<'_>) -> Result<(), Error> {
+        let group = EntryGroupProxy::builder(&self.connection)
             .path(path)?
             .build()
             .await?;

--- a/rs-matter/src/transport/network/mdns/resolve.rs
+++ b/rs-matter/src/transport/network/mdns/resolve.rs
@@ -64,30 +64,30 @@ const DNS_TYPE_PTR: u16 = 12;
 /// required by the systemd-resolved daemon so as to register mDNS services.
 ///
 /// For testing, easiest is to run the application with `sudo` or as root.
-pub struct ResolveMdnsResponder<'a> {
-    matter: &'a Matter<'a>,
+pub struct ResolveMdnsResponder {
     services: HashMap<MatterService, OwnedObjectPath>,
+    connection: Connection,
 }
 
-impl<'a> ResolveMdnsResponder<'a> {
+impl ResolveMdnsResponder {
     /// Create a new instance of the systemd-resolved mDNS responder.
-    pub fn new(matter: &'a Matter<'a>) -> Self {
+    pub fn new(connection: Connection) -> Self {
         Self {
-            matter,
             services: HashMap::new(),
+            connection,
         }
     }
 
     /// Run the mDNS responder
     ///
     /// # Arguments
-    /// - `connection`: A reference to the DBus system connection to use for communication with Avahi.
-    pub async fn run(&mut self, connection: &Connection) -> Result<(), Error> {
+    /// - `matter`: A reference to the Matter instance to get mDNS services from.
+    pub async fn run(&mut self, matter: &Matter<'_>) -> Result<(), Error> {
         loop {
-            self.matter.wait_mdns().await;
+            matter.wait_mdns().await;
 
             let mut services = HashSet::new();
-            self.matter.mdns_services(|service| {
+            matter.mdns_services(|service| {
                 services.insert(service);
 
                 Ok(())
@@ -95,7 +95,7 @@ impl<'a> ResolveMdnsResponder<'a> {
 
             info!("mDNS services changed, updating...");
 
-            self.update_services(connection, &services).await?;
+            self.update_services(matter, &services).await?;
 
             info!("mDNS services updated");
         }
@@ -103,13 +103,13 @@ impl<'a> ResolveMdnsResponder<'a> {
 
     async fn update_services(
         &mut self,
-        connection: &Connection,
+        matter: &Matter<'_>,
         services: &HashSet<MatterService>,
     ) -> Result<(), Error> {
         for service in services {
             if !self.services.contains_key(service) {
                 info!("Registering mDNS service: {:?}", service);
-                let path = self.register(connection, service).await?;
+                let path = self.register(matter, service).await?;
                 self.services.insert(service.clone(), path);
             }
         }
@@ -122,7 +122,7 @@ impl<'a> ResolveMdnsResponder<'a> {
 
             if let Some((service, path)) = removed {
                 info!("Deregistering mDNS service: {:?}", service);
-                Self::deregister(connection, path.as_ref()).await?;
+                self.deregister(path.as_ref()).await?;
                 self.services.remove(&service.clone());
             } else {
                 break;
@@ -134,15 +134,15 @@ impl<'a> ResolveMdnsResponder<'a> {
 
     async fn register(
         &mut self,
-        connection: &Connection,
+        matter: &Matter<'_>,
         service: &MatterService,
     ) -> Result<OwnedObjectPath, Error> {
         // Scratch buffer for expanding `MatterService` into a `Service` view —
         // the strings (name, subtypes, TXT values) are formatted into this buffer.
         let mut buf = [0u8; 512];
-        let (service, _) = service.service(self.matter.dev_det(), self.matter.port(), &mut buf)?;
+        let (service, _) = service.service(matter.dev_det(), matter.port(), &mut buf)?;
 
-        let resolve = ManagerProxy::new(connection).await?;
+        let resolve = ManagerProxy::new(&self.connection).await?;
 
         let txt = service
             .txt_kvs
@@ -174,8 +174,8 @@ impl<'a> ResolveMdnsResponder<'a> {
         Ok(path)
     }
 
-    async fn deregister(connection: &Connection, path: ObjectPath<'_>) -> Result<(), Error> {
-        let resolve = ManagerProxy::new(connection).await?;
+    async fn deregister(&self, path: ObjectPath<'_>) -> Result<(), Error> {
+        let resolve = ManagerProxy::new(&self.connection).await?;
 
         resolve.unregister_service(&path).await?;
 

--- a/rs-matter/src/transport/network/mdns/zeroconf.rs
+++ b/rs-matter/src/transport/network/mdns/zeroconf.rs
@@ -31,7 +31,6 @@ use zeroconf::txt_record::TTxtRecord;
 use zeroconf::{MdnsBrowser, ServiceDiscovery, ServiceType};
 
 use crate::error::{Error, ErrorCode};
-use crate::im::{AttrId, ClusterId, EndptId};
 use crate::transport::network::mdns::MatterService;
 use crate::Matter;
 
@@ -39,27 +38,28 @@ use super::{CommissionableFilter, DiscoveredDevice, PushUnique};
 
 /// An mDNS responder for Matter utilizing the `zeroconf` crate.
 /// In theory, it should work on all of Linux, MacOS and Windows, however seems to have issues on MacOSX and Windows.
-pub struct ZeroconfMdnsResponder<'a> {
-    matter: &'a Matter<'a>,
+pub struct ZeroconfMdnsResponder {
     services: HashMap<MatterService, MdnsEntry>,
 }
 
-impl<'a> ZeroconfMdnsResponder<'a> {
-    /// Create a new `ZeroconfMdnsResponder` for the given `Matter` instance.
-    pub fn new(matter: &'a Matter<'a>) -> Self {
+impl ZeroconfMdnsResponder {
+    /// Create a new `ZeroconfMdnsResponder`.
+    pub fn new() -> Self {
         Self {
-            matter,
             services: HashMap::new(),
         }
     }
 
-    /// Run the mDNS responder.
-    pub async fn run(&mut self) -> Result<(), Error> {
+    /// Run the mDNS responder
+    ///
+    /// # Arguments
+    /// - `matter`: A reference to the Matter instance to get mDNS services from.
+    pub async fn run(&mut self, matter: &Matter<'_>) -> Result<(), Error> {
         loop {
-            self.matter.wait_mdns().await;
+            matter.wait_mdns().await;
 
             let mut services = HashSet::new();
-            self.matter.mdns_services(|service| {
+            matter.mdns_services(|service| {
                 services.insert(service);
 
                 Ok(())
@@ -67,18 +67,22 @@ impl<'a> ZeroconfMdnsResponder<'a> {
 
             info!("mDNS services changed, updating...");
 
-            self.update_services(&services)?;
+            self.update_services(matter, &services)?;
 
             info!("mDNS services updated");
         }
     }
 
-    fn update_services(&mut self, services: &HashSet<MatterService>) -> Result<(), Error> {
+    fn update_services(
+        &mut self,
+        matter: &Matter<'_>,
+        services: &HashSet<MatterService>,
+    ) -> Result<(), Error> {
         for service in services {
             if !self.services.contains_key(service) {
                 info!("Registering mDNS service: {:?}", service);
 
-                let zeroconf_service = SendableZeroconfMdnsService::new(self.matter, service)?;
+                let zeroconf_service = SendableZeroconfMdnsService::new(matter, service)?;
                 let (sender, receiver) = sync_channel(1);
 
                 // Spawning a thread for each service is not ideal, but unavoidable with the current API of `zeroconf`


### PR DESCRIPTION
Subject says it all.
A minor thing really, but saves quite some wrapping downstream in `rs-matter-atack` by keeping all `run` signatures the same.