### PR TITLE
Fix SAI and SII to be u32 as the spec requires

### DIFF
--- a/rs-matter/src/dm/clusters/basic_info.rs
+++ b/rs-matter/src/dm/clusters/basic_info.rs
@@ -196,13 +196,19 @@ pub struct BasicInfoConfig<'a> {
     /// Session Active Interval in ms
     /// If not specified, defaults to 300
     ///
+    /// Per the Matter Core Spec, the value is a 32-bit unsigned integer and
+    /// SHALL NOT exceed 3,600,000 (1 hour in milliseconds).
+    ///
     /// Not a real attribute, just used to configure the session timeouts
-    pub sai: Option<u16>,
+    pub sai: Option<u32>,
     /// Session Idle Interval in ms
     /// If not specified, defaults to 5000
     ///
+    /// Per the Matter Core Spec, the value is a 32-bit unsigned integer and
+    /// SHALL NOT exceed 3,600,000 (1 hour in milliseconds).
+    ///
     /// Not a real attribute, just used to configure the session timeouts
-    pub sii: Option<u16>,
+    pub sii: Option<u32>,
     /// Whether the device supports TCP transport.
     ///
     /// Not a real attribute; advertised via the `T` TXT record key in mDNS.

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -86,9 +86,9 @@ pub struct Transport {
     /// Notification for when an exchange is dropped.
     exchange_dropped: Notification,
     /// Device SAI (Secure Association Identifier)
-    device_sai: Option<u16>,
+    device_sai: Option<u32>,
     /// Device SII (Secure Identity Identifier)
-    device_sii: Option<u16>,
+    device_sii: Option<u32>,
 }
 
 impl Transport {

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -447,8 +447,8 @@ impl ExchangeState {
         &mut self,
         tx_plain: &PlainHdr,
         tx_proto: &mut ProtoHdr,
-        session_active_interval_ms: Option<u16>,
-        session_idle_interval_ms: Option<u16>,
+        session_active_interval_ms: Option<u32>,
+        session_idle_interval_ms: Option<u32>,
     ) -> Result<(), Error> {
         if matches!(self.role, Role::Initiator(_)) {
             tx_proto.set_initiator();

--- a/rs-matter/src/transport/mrp.rs
+++ b/rs-matter/src/transport/mrp.rs
@@ -21,7 +21,7 @@ use crate::utils::epoch::Epoch;
 use super::{plain_hdr::PlainHdr, proto_hdr::ProtoHdr};
 
 //const MRP_STANDALONE_ACK_TIMEOUT_MS: u64 = 200;   // TODO: Use to pro-actively send ACKs
-const MRP_BASE_RETRY_INTERVAL_MS: u16 = 300;
+const MRP_BASE_RETRY_INTERVAL_MS: u32 = 300;
 const MRP_MAX_TRANSMISSIONS: u16 = 10;
 const MRP_BACKOFF_THRESHOLD: u16 = 1;
 const MRP_BACKOFF_BASE: (u64, u64) = (16, 10); // 1.6
@@ -33,7 +33,7 @@ const MRP_JITTER_RAND_MAX: u8 = u8::MAX;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RetransEntry {
     /// The retransmission delay interval in milliseconds
-    base_delay_interval_ms: u16,
+    base_delay_interval_ms: u32,
     // The msg counter that we are waiting to be acknowledged
     msg_ctr: u32,
     // The retransmission counter
@@ -41,7 +41,7 @@ pub struct RetransEntry {
 }
 
 impl RetransEntry {
-    pub fn new(base_delay_interval_ms: Option<u16>, msg_ctr: u32) -> Self {
+    pub fn new(base_delay_interval_ms: Option<u32>, msg_ctr: u32) -> Self {
         Self {
             base_delay_interval_ms: base_delay_interval_ms.unwrap_or(MRP_BASE_RETRY_INTERVAL_MS),
             msg_ctr,
@@ -154,10 +154,10 @@ impl ReliableMessage {
         &mut self,
         tx_plain: &PlainHdr,
         tx_proto: &mut ProtoHdr,
-        session_active_interval_ms: Option<u16>,
+        session_active_interval_ms: Option<u32>,
         // TODO: Need to make use of it in future,
         // once we detect idle vs active devices
-        _session_idle_interval_ms: Option<u16>,
+        _session_idle_interval_ms: Option<u32>,
     ) -> Result<(), Error> {
         // Check if any acknowledgements are pending for this exchange,
         if let Some(ack) = &mut self.ack {

--- a/rs-matter/src/transport/network/mdns.rs
+++ b/rs-matter/src/transport/network/mdns.rs
@@ -554,16 +554,29 @@ impl MatterService {
                 // `_I<compressed_fabric_id>._sub._matter._tcp.local.` lets a
                 // controller browse for nodes of a given fabric without
                 // already knowing each node's id.
-                let (subtype_i, wb) = write_split!(wb, "_I{:016X}", compressed_fabric_id)?;
+                let (subtype_i, mut wb) = write_split!(wb, "_I{:016X}", compressed_fabric_id)?;
+                let (txt_sai, mut wb) = if let Some(sai) = dev_det.sai {
+                    write_split!(wb, "{}", sai)?
+                } else {
+                    ("", wb)
+                };
+                let (txt_sii, wb) = if let Some(sii) = dev_det.sii {
+                    write_split!(wb, "{}", sii)?
+                } else {
+                    ("", wb)
+                };
 
                 // Per Matter Core Spec Section 4.3.1.14, T is a bitmap:
                 // bit 1 (value 2) = TCP client, bit 2 (value 4) = TCP server
-                let txt_kvs = core::iter::once(if dev_det.tcp_supported {
-                    ("T", "6")
-                } else {
+                let txt_kvs = [
+                    ("SAI", txt_sai),
+                    ("SII", txt_sii),
+                    ("T", if dev_det.tcp_supported { "6" } else { "" }),
                     // Some mDNS responders do not accept empty TXT records
-                    ("dummy", "dummy")
-                });
+                    ("DUMMY", "DUMMY"),
+                ]
+                .into_iter()
+                .filter(|(_, v)| !v.is_empty());
 
                 Ok((
                     Service {
@@ -612,8 +625,16 @@ impl MatterService {
 
                 let (txt_discr, mut wb) = write_split!(wb, "{}", *discriminator)?;
                 let (txt_vid_pid, mut wb) = write_split!(wb, "{}+{}", dev_det.vid, dev_det.pid)?;
-                let (txt_sai, mut wb) = write_split!(wb, "{}", dev_det.sai.unwrap_or(300))?;
-                let (txt_sii, mut wb) = write_split!(wb, "{}", dev_det.sii.unwrap_or(5000))?;
+                let (txt_sai, mut wb) = if let Some(sai) = dev_det.sai {
+                    write_split!(wb, "{}", sai)?
+                } else {
+                    ("", wb)
+                };
+                let (txt_sii, mut wb) = if let Some(sii) = dev_det.sii {
+                    write_split!(wb, "{}", sii)?
+                } else {
+                    ("", wb)
+                };
                 let (txt_dn, mut wb) = write_split!(wb, "{}", dev_det.device_name)?;
                 let (txt_pi, mut wb) = write_split!(wb, "{}", dev_det.pairing_instruction)?;
                 let (txt_ph, mut wb) = write_split!(wb, "{}", dev_det.pairing_hint.bits())?;

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -359,8 +359,8 @@ impl Session {
         &mut self,
         exch_index: Option<usize>,
         tx_header: &mut PacketHdr,
-        session_active_interval_ms: Option<u16>,
-        session_idle_interval_ms: Option<u16>,
+        session_active_interval_ms: Option<u32>,
+        session_idle_interval_ms: Option<u32>,
     ) -> Result<(Address, bool), Error> {
         let ctr = if let Some(exchange_index) = exch_index {
             let exchange = unwrap!(self.exchanges[exchange_index].as_mut());


### PR DESCRIPTION
Additionally, the SAI and SII are advertised for commissioned nodes too. Which is what #406 addressed too.
