### PR TITLE
Reduce the duration of the node metadata lock

### DIFF
--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -468,7 +468,7 @@ fn main() -> ! {
         unwrap!(stack.matter.open_basic_comm_window(
             MAX_COMM_WINDOW_TIMEOUT_SECS,
             crypto,
-            dm.change_notify()
+            &(),
         ));
     }
 

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -41,8 +41,8 @@ use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
-    Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver, EmptyHandler, Endpoint,
-    EpClMatcher, InvokeContext, Node, ReadContext,
+    Async, Cluster, DataModel, DataModelHandler, Dataver, EmptyHandler, Endpoint, EpClMatcher,
+    InvokeContext, Node, ReadContext,
 };
 use rs_matter::error::Error;
 use rs_matter::pairing::qr::QrTextType;
@@ -140,7 +140,7 @@ fn main() -> Result<(), Error> {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
     }
 
     // Combine all async tasks in a single one
@@ -205,7 +205,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     mut rand: impl RngCore + Copy,
     on_off_ep2: &'a on_off::OnOffHandler<'a, OH, LH>,
     on_off_ep3: &'a on_off::OnOffHandler<'a, OH, LH>,
-) -> impl AsyncMetadata + AsyncHandler + 'a {
+) -> impl DataModelHandler + 'a {
     (
         NODE,
         endpoints::with_eth_sys(

--- a/examples/src/bin/camera_tests.rs
+++ b/examples/src/bin/camera_tests.rs
@@ -72,14 +72,14 @@ use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::groups::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::net_comm::SharedNetworks;
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
-use rs_matter::dm::endpoints;
 use rs_matter::dm::events::NoEvents;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
+use rs_matter::dm::{endpoints, DataModel};
 use rs_matter::dm::{
-    ArrayAttributeRead, Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, DeviceType,
-    EmptyHandler, Endpoint, EpClMatcher, InvokeContext, Node, ReadContext, WriteContext,
+    ArrayAttributeRead, Async, DataModelHandler, Dataver, DeviceType, EmptyHandler, Endpoint,
+    EpClMatcher, InvokeContext, Node, ReadContext, WriteContext,
 };
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::FabricIndex;
@@ -602,7 +602,7 @@ fn main() -> Result<(), Error> {
 
     if !matter.is_commissioned() {
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
-        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
     }
 
     #[cfg(not(windows))]
@@ -678,7 +678,7 @@ fn dm_handler<'a>(
     zone_mgmt: &'a ZoneMgmtHandler<StubZoneHooks, ZONE_NZ, ZONE_NV, ZONE_NT>,
     push_av: &'a PushAvStreamHandler<'static, StubPushHooks, PUSH_NC>,
     chime: ChimeHandler,
-) -> impl AsyncMetadata + AsyncHandler + 'a {
+) -> impl DataModelHandler + 'a {
     (
         NODE,
         endpoints::with_eth_sys(

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -63,8 +63,7 @@ use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
-    Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver, EmptyHandler, Endpoint,
-    EpClMatcher, Node,
+    Async, Cluster, DataModel, DataModelHandler, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter::error::Error;
 use rs_matter::pairing::qr::QrTextType;
@@ -308,7 +307,7 @@ fn main() -> Result<(), Error> {
 
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
     }
 
     // Optional `--app-pipe <path>` CLI integration.
@@ -515,7 +514,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     unit_testing_data: &'a RefCell<UnitTestingHandlerData>,
     on_off_1: &'a OnOffHandler<'a, OH, LH>,
     on_off_2: &'a OnOffHandler<'a, OH, LH>,
-) -> impl AsyncMetadata + AsyncHandler + 'a {
+) -> impl DataModelHandler + 'a {
     (
         node,
         endpoints::with_eth_sys(

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -53,8 +53,7 @@ use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::IMBuffer;
 use rs_matter::dm::{
-    Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver, EmptyHandler, Endpoint,
-    EpClMatcher, Node,
+    Async, Cluster, DataModel, DataModelHandler, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::pairing::qr::QrTextType;
@@ -223,7 +222,7 @@ fn run() -> Result<(), Error> {
 
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
     }
 
     // Listen to SIGTERM (or Ctrl-C on Windows, where SIGTERM is not
@@ -272,7 +271,7 @@ fn dm_handler<'a, LH: LevelControlHooks, OH: OnOffHooks>(
     mut rand: impl RngCore + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     level_control: &'a level_control::LevelControlHandler<'a, LH, OH>,
-) -> impl AsyncMetadata + AsyncHandler + 'a {
+) -> impl DataModelHandler + 'a {
     (
         NODE,
         endpoints::with_eth_sys(

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -37,23 +37,20 @@ use rs_matter::crypto::{default_crypto, Crypto};
 //
 // User needs to implement the `ClusterAsyncHandler` trait or the `ClusterHandler` trait
 // so as to handle the requests from the controller.
+use rs_matter::dm::clusters::app::level_control::LevelControlHooks;
+use rs_matter::dm::clusters::app::on_off::{self, test::TestOnOffDeviceLogic, OnOffHooks};
 use rs_matter::dm::clusters::decl::content_launcher::{
     self, ClusterAsyncHandler as _, LaunchContentRequest, LaunchURLRequest,
     LauncherResponseBuilder, SupportedProtocolsBitmap,
 };
-
 use rs_matter::dm::clusters::decl::keypad_input::{
     self, ClusterAsyncHandler as _, SendKeyRequest, SendKeyResponseBuilder,
 };
-
 use rs_matter::dm::clusters::decl::media_playback::{
     self, ActivateAudioTrackRequest, ActivateTextTrackRequest, ClusterAsyncHandler as _,
     FastForwardRequest, PlaybackResponseBuilder, PlaybackStateEnum, RewindRequest, SeekRequest,
     SkipBackwardRequest, SkipForwardRequest, StatusEnum,
 };
-
-use rs_matter::dm::clusters::app::level_control::LevelControlHooks;
-use rs_matter::dm::clusters::app::on_off::{self, test::TestOnOffDeviceLogic, OnOffHooks};
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::net_comm::SharedNetworks;
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
@@ -64,8 +61,8 @@ use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
-    ArrayAttributeRead, Async, AsyncHandler, AsyncMetadata, Cluster, DataModel, Dataver,
-    EmptyHandler, Endpoint, EpClMatcher, InvokeContext, Node, ReadContext,
+    ArrayAttributeRead, Async, Cluster, DataModel, DataModelHandler, Dataver, EmptyHandler,
+    Endpoint, EpClMatcher, InvokeContext, Node, ReadContext,
 };
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::pairing::qr::QrTextType;
@@ -154,7 +151,7 @@ fn main() -> Result<(), Error> {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
     }
 
     // Combine all async tasks in a single one
@@ -187,7 +184,7 @@ const NODE: Node<'static> = Node {
 fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     mut rand: impl RngCore + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
-) -> impl AsyncMetadata + AsyncHandler + 'a {
+) -> impl DataModelHandler + 'a {
     (
         NODE,
         endpoints::with_eth_sys(

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -42,8 +42,7 @@ use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::IMBuffer;
 use rs_matter::dm::{
-    Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
-    Node,
+    Async, DataModel, DataModelHandler, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter::error::Error;
 use rs_matter::pairing::qr::QrTextType;
@@ -179,7 +178,7 @@ fn run() -> Result<(), Error> {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
     }
 
     // Combine all async tasks in a single one
@@ -210,7 +209,7 @@ const NODE: Node<'static> = Node {
 fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     mut rand: impl RngCore + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
-) -> impl AsyncMetadata + AsyncHandler + 'a {
+) -> impl DataModelHandler + 'a {
     (
         NODE,
         endpoints::with_eth_sys(

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -55,8 +55,7 @@ use rs_matter::dm::networks::unix::UnixNetifs;
 use rs_matter::dm::networks::wireless::{NetCtlState, NetCtlWithStatusImpl, WifiNetworks};
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
-    Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
-    Node,
+    Async, DataModel, DataModelHandler, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter::error::Error;
 use rs_matter::pairing::qr::QrTextType;
@@ -197,7 +196,7 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
 
         // BLE commissioning via BlueZ is Linux-only.
         #[cfg(not(target_os = "linux"))]
@@ -277,7 +276,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks, T>(
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     wifi_diag: &'a dyn WifiDiag,
     net_ctl: T,
-) -> impl AsyncMetadata + AsyncHandler + 'a
+) -> impl DataModelHandler + 'a
 where
     T: NetCtl + NetCtlStatus + 'a,
 {

--- a/examples/src/bin/onoff_light_work_stealing.rs
+++ b/examples/src/bin/onoff_light_work_stealing.rs
@@ -189,7 +189,7 @@ fn run() -> Result<(), Error> {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, crypto, dm.change_notify())?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, crypto, &())?;
     }
 
     let executor = async_executor::Executor::new();

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -43,8 +43,7 @@ use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
-    Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
-    Node,
+    Async, DataModel, DataModelHandler, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter::error::Error;
 use rs_matter::pairing::qr::QrTextType;
@@ -152,7 +151,7 @@ fn main() -> Result<(), Error> {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 
-        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
     }
 
     // Combine all async tasks in a single one
@@ -184,7 +183,7 @@ fn dm_handler<'a, LH: LevelControlHooks, OH: OnOffHooks>(
     mut rand: impl RngCore + Copy,
     on_off: &'a OnOffHandler<'a, OH, LH>,
     level_control: &'a LevelControlHandler<'a, LH, OH>,
-) -> impl AsyncMetadata + AsyncHandler + 'a {
+) -> impl DataModelHandler + 'a {
     (
         NODE,
         endpoints::with_eth_sys(

--- a/examples/src/bin/webrtc_camera.rs
+++ b/examples/src/bin/webrtc_camera.rs
@@ -113,9 +113,7 @@ use rs_matter::dm::networks::unix::UnixNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::DeviceType;
 use rs_matter::dm::IMBuffer;
-use rs_matter::dm::{
-    AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
-};
+use rs_matter::dm::{DataModelHandler, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node};
 use rs_matter::error::Error;
 use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
@@ -1346,7 +1344,7 @@ fn main() -> Result<(), Error> {
     if !matter.is_commissioned() {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
-        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
+        matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
     }
 
     let matter_core = select4(&mut transport, &mut mdns, &mut respond, &mut dm_job).coalesce();
@@ -1395,7 +1393,7 @@ fn dm_handler<'a>(
         CAM_AV_SETTINGS_NS,
     >,
     zone_mgmt: &'a ZoneMgmtHandler<DemoZoneHooks, ZONE_NZ, ZONE_NV, ZONE_NT>,
-) -> impl AsyncMetadata + AsyncHandler + 'a {
+) -> impl DataModelHandler + 'a {
     (
         NODE,
         endpoints::with_eth_sys(

--- a/rs-matter-codegen/src/idl.rs
+++ b/rs-matter-codegen/src/idl.rs
@@ -27104,7 +27104,9 @@ pub mod unit_testing {
         ) -> Result<(), rs_matter_crate::error::Error> {
             if let Some(mut writer) = reply.with_dataver(self.0.dataver())? {
                 if ctx.attr().is_system() {
-                    ctx.attr().cluster()?.read(ctx.attr(), writer)
+                    ctx.attr().cluster(ctx.metadata(), |cluster| {
+                        cluster.read(ctx.attr(), writer)
+                    })
                 } else {
                     match AttributeId::try_from(ctx.attr().attr_id)? {
                         AttributeId::Boolean => {

--- a/rs-matter-codegen/src/idl.rs
+++ b/rs-matter-codegen/src/idl.rs
@@ -24811,25 +24811,25 @@ pub mod unit_testing {
             &self,
             ctx: impl rs_matter_crate::dm::ReadContext,
         ) -> Result<bool, rs_matter_crate::error::Error> {
-            Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+            Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
         }
         fn unsupported(
             &self,
             ctx: impl rs_matter_crate::dm::ReadContext,
         ) -> Result<bool, rs_matter_crate::error::Error> {
-            Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+            Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
         }
         fn read_failure_code(
             &self,
             ctx: impl rs_matter_crate::dm::ReadContext,
         ) -> Result<u8, rs_matter_crate::error::Error> {
-            Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+            Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
         }
         fn failure_int_32_u(
             &self,
             ctx: impl rs_matter_crate::dm::ReadContext,
         ) -> Result<u32, rs_matter_crate::error::Error> {
-            Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+            Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
         }
         fn nullable_boolean(
             &self,
@@ -25253,28 +25253,28 @@ pub mod unit_testing {
             ctx: impl rs_matter_crate::dm::WriteContext,
             value: bool,
         ) -> Result<(), rs_matter_crate::error::Error> {
-            Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+            Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
         }
         fn set_unsupported(
             &self,
             ctx: impl rs_matter_crate::dm::WriteContext,
             value: bool,
         ) -> Result<(), rs_matter_crate::error::Error> {
-            Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+            Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
         }
         fn set_read_failure_code(
             &self,
             ctx: impl rs_matter_crate::dm::WriteContext,
             value: u8,
         ) -> Result<(), rs_matter_crate::error::Error> {
-            Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+            Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
         }
         fn set_failure_int_32_u(
             &self,
             ctx: impl rs_matter_crate::dm::WriteContext,
             value: u32,
         ) -> Result<(), rs_matter_crate::error::Error> {
-            Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+            Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
         }
         fn set_nullable_boolean(
             &self,
@@ -25446,7 +25446,7 @@ pub mod unit_testing {
             ctx: impl rs_matter_crate::dm::WriteContext,
             value: u8,
         ) -> Result<(), rs_matter_crate::error::Error> {
-            Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+            Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
         }
         fn set_nullable_global_enum(
             &self,

--- a/rs-matter-codegen/src/idl/handler.rs
+++ b/rs-matter-codegen/src/idl/handler.rs
@@ -445,13 +445,13 @@ fn handler_attribute(
             if asynch {
                 quote!(
                     fn #attr_name<P: #krate::tlv::TLVBuilderParent>(&self, ctx: impl #krate::dm::ReadContext, builder: #attr_type) -> impl core::future::Future<Output = Result<P, #krate::error::Error>> {
-                        core::future::ready(Err(#krate::error::ErrorCode::InvalidAction.into()))
+                        core::future::ready(Err(#krate::error::ErrorCode::AttributeNotFound.into()))
                     }
                 )
             } else {
                 quote!(
                     #pasync fn #attr_name<P: #krate::tlv::TLVBuilderParent>(&self, ctx: impl #krate::dm::ReadContext, builder: #attr_type) -> Result<P, #krate::error::Error> {
-                        Err(#krate::error::ErrorCode::InvalidAction.into())
+                        Err(#krate::error::ErrorCode::AttributeNotFound.into())
                     }
                 )
             }
@@ -478,13 +478,13 @@ fn handler_attribute(
         if asynch {
             quote!(
                 fn #attr_name(&self, ctx: impl #krate::dm::ReadContext) -> impl core::future::Future<Output = Result<#attr_type, #krate::error::Error>> {
-                    core::future::ready(Err(#krate::error::ErrorCode::InvalidAction.into()))
+                    core::future::ready(Err(#krate::error::ErrorCode::AttributeNotFound.into()))
                 }
             )
         } else {
             quote!(
                 #pasync fn #attr_name(&self, ctx: impl #krate::dm::ReadContext) -> Result<#attr_type, #krate::error::Error> {
-                    Err(#krate::error::ErrorCode::InvalidAction.into())
+                    Err(#krate::error::ErrorCode::AttributeNotFound.into())
                 }
             )
         }
@@ -564,13 +564,13 @@ fn handler_attribute_write(
         if asynch {
             quote!(
                 fn #attr_name(&self, ctx: impl #krate::dm::WriteContext, value: #attr_type) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                    core::future::ready(Err(#krate::error::ErrorCode::InvalidAction.into()))
+                    core::future::ready(Err(#krate::error::ErrorCode::AttributeNotFound.into()))
                 }
             )
         } else {
             quote!(
                 #pasync fn #attr_name(&self, ctx: impl #krate::dm::WriteContext, value: #attr_type) -> Result<(), #krate::error::Error> {
-                    Err(#krate::error::ErrorCode::InvalidAction.into())
+                    Err(#krate::error::ErrorCode::AttributeNotFound.into())
                 }
             )
         }
@@ -1319,19 +1319,19 @@ mod tests {
                         &self,
                         ctx: impl rs_matter_crate::dm::ReadContext,
                     ) -> Result<bool, rs_matter_crate::error::Error> {
-                        Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+                        Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
                     }
                     fn on_time(
                         &self,
                         ctx: impl rs_matter_crate::dm::ReadContext,
                     ) -> Result<u16, rs_matter_crate::error::Error> {
-                        Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+                        Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
                     }
                     fn off_wait_time(
                         &self,
                         ctx: impl rs_matter_crate::dm::ReadContext,
                     ) -> Result<u16, rs_matter_crate::error::Error> {
-                        Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+                        Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
                     }
                     fn start_up_on_off(
                         &self,
@@ -1340,28 +1340,28 @@ mod tests {
                         rs_matter_crate::tlv::Nullable<StartUpOnOffEnum>,
                         rs_matter_crate::error::Error,
                     > {
-                        Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+                        Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
                     }
                     fn set_on_time(
                         &self,
                         ctx: impl rs_matter_crate::dm::WriteContext,
                         value: u16,
                     ) -> Result<(), rs_matter_crate::error::Error> {
-                        Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+                        Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
                     }
                     fn set_off_wait_time(
                         &self,
                         ctx: impl rs_matter_crate::dm::WriteContext,
                         value: u16,
                     ) -> Result<(), rs_matter_crate::error::Error> {
-                        Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+                        Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
                     }
                     fn set_start_up_on_off(
                         &self,
                         ctx: impl rs_matter_crate::dm::WriteContext,
                         value: rs_matter_crate::tlv::Nullable<StartUpOnOffEnum>,
                     ) -> Result<(), rs_matter_crate::error::Error> {
-                        Err(rs_matter_crate::error::ErrorCode::InvalidAction.into())
+                        Err(rs_matter_crate::error::ErrorCode::AttributeNotFound.into())
                     }
                     fn handle_off(
                         &self,

--- a/rs-matter-codegen/src/idl/handler.rs
+++ b/rs-matter-codegen/src/idl/handler.rs
@@ -304,7 +304,7 @@ pub fn handler_adaptor(
             ) -> Result<(), #krate::error::Error> {
                 if let Some(mut writer) = reply.with_dataver(self.0.dataver())? {
                     if ctx.attr().is_system() {
-                        ctx.attr().cluster()?.read(ctx.attr(), writer)
+                        ctx.attr().cluster(ctx.metadata(), |cluster| cluster.read(ctx.attr(), writer))
                     } else {
                         #read_stream
                     }
@@ -1534,7 +1534,9 @@ mod tests {
                     ) -> Result<(), rs_matter_crate::error::Error> {
                         if let Some(mut writer) = reply.with_dataver(self.0.dataver())? {
                             if ctx.attr().is_system() {
-                                ctx.attr().cluster()?.read(ctx.attr(), writer)
+                                ctx.attr().cluster(ctx.metadata(), |cluster| {
+                                    cluster.read(ctx.attr(), writer)
+                                })
                             } else {
                                 match AttributeId::try_from(ctx.attr().attr_id)? {
                                     AttributeId::OnOff => {

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -20,7 +20,7 @@ use core::num::NonZeroU8;
 use core::pin::pin;
 use core::time::Duration;
 
-use embassy_futures::select::{select, select3};
+use embassy_futures::select::select3;
 use embassy_time::{Instant, Timer};
 
 use crate::acl::Accessor;
@@ -138,12 +138,6 @@ where
         &self.kv
     }
 
-    /// Return a reference to the `ChangeNotify` instance used by this data model for tracking changes in the data model
-    /// and notifying the subscription processing task about them.
-    pub const fn change_notify(&self) -> &dyn DynAttrChangeNotifier {
-        self.subscriptions
-    }
-
     /// Open the basic commissioning window.
     ///
     /// Equivalent to [`Matter::open_basic_comm_window`] but additionally
@@ -193,16 +187,18 @@ where
         // `AttrChangeNotifier` so the cluster's `Dataver` is bumped
         // too (the `Matter`-level call by itself only routes
         // subscribers and persists).
-        self.kv
-            .access(|kvb, buf| self.matter.bump_configuration_version(kvb, buf, self))
+        self.matter.bump_configuration_version(&self.kv, self)
     }
 
     /// Run the Data Model instance.
     pub async fn run(&self) -> Result<(), Error> {
         let mut timeouts = pin!(self.run_timeout_checks());
         let mut handler = pin!(self.handler.run(self));
+        let mut subs = pin!(self.process_subscriptions(self.matter));
 
-        select(&mut timeouts, &mut handler).coalesce().await
+        select3(&mut timeouts, &mut handler, &mut subs)
+            .coalesce()
+            .await
     }
 
     async fn run_timeout_checks(&self) -> Result<(), Error> {
@@ -211,16 +207,14 @@ where
         loop {
             Timer::after_secs(CHECK_INTERVAL_SECS).await;
 
-            self.timeout_checks()?;
+            self.check_timeouts()?;
         }
     }
 
-    fn timeout_checks(&self) -> Result<(), Error> {
+    fn check_timeouts(&self) -> Result<(), Error> {
         let mut notify_mdns = || self.matter.notify_mdns_changed();
-        let mut notify_change = |endpt_id, clust_id| {
-            self.change_notify()
-                .notify_cluster_changed(endpt_id, clust_id)
-        };
+        let mut notify_change =
+            |endpt_id, clust_id| self.notify_cluster_changed(endpt_id, clust_id);
 
         self.matter.with_state(|state| {
             // Disarm the failsafe on timeout
@@ -272,7 +266,7 @@ where
             None
         };
 
-        self.timeout_checks()?;
+        self.check_timeouts()?;
 
         // TODO: Handle the cases where we receive a timeout request
         // before read and subscribe. This is probably not allowed.
@@ -325,9 +319,6 @@ where
 
         let mut wb = WriteBuf::new(&mut tx);
 
-        let metadata = self.handler.lock().await;
-        let node = metadata.node();
-
         // Honor the `fabricFiltered` flag on the originating Read request.
         // When set, fabric-sensitive events emitted on other fabrics are
         // dropped before they reach the wire (Matter Core spec section 8.5.2).
@@ -335,14 +326,14 @@ where
 
         let mut resp = ReportDataResponder::new(
             &req,
-            &node,
             None,
             HandlerInvoker::new(exchange, self),
             EventReader::new(0, u64::MAX, fabric_filtered),
             self.events,
         );
 
-        resp.respond(&mut wb, true, true, |_, _, _| true).await?;
+        resp.respond(&mut wb, true, true, &self.handler, |_, _, _| true)
+            .await?;
 
         Ok(())
     }
@@ -405,12 +396,9 @@ where
 
             let mut wb = WriteBuf::new(&mut tx);
 
-            let metadata = self.handler.lock().await;
-            let node = metadata.node();
+            let mut resp = WriteResponder::new(&req, HandlerInvoker::new(exchange, self));
 
-            let mut resp = WriteResponder::new(&req, &node, HandlerInvoker::new(exchange, self));
-
-            resp.respond(&mut wb, is_groupcast).await?;
+            resp.respond(&mut wb, &self.handler, is_groupcast).await?;
 
             if req.more_chunks()? {
                 // This write request is just one of the chunks, so we need to wait and process
@@ -482,12 +470,9 @@ where
 
         let mut wb = WriteBuf::new(&mut tx);
 
-        let metadata = self.handler.lock().await;
-        let node = metadata.node();
+        let mut resp = InvokeResponder::new(&req, HandlerInvoker::new(exchange, self));
 
-        let mut resp = InvokeResponder::new(&req, &node, HandlerInvoker::new(exchange, self));
-
-        resp.respond(&mut wb, is_groupcast).await
+        resp.respond(&mut wb, &self.handler, is_groupcast).await
     }
 
     /// Respond to a `SubscribeReq` request by priming the subscription (i.e. doing an initial data report)
@@ -503,7 +488,7 @@ where
 
         let accessor = exchange.accessor()?;
 
-        if let Err(err) = self.validate_subscribe(&req, &accessor).await {
+        if let Err(err) = self.validate_subscribe(&req, &accessor) {
             error!("Invalid subscribe request: {:?}", err);
             return Self::send_status(exchange, err.code().into()).await;
         }
@@ -563,7 +548,7 @@ where
     }
 
     /// Validates the subscription request
-    async fn validate_subscribe(
+    fn validate_subscribe(
         &self,
         req: &SubscribeReq<'_>,
         accessor: &Accessor<'_>,
@@ -572,56 +557,54 @@ where
         // contains existing endpoints, clusters and attributes, and if not
         // we should (a bit surprisingly) return InvalidAction
 
-        let metadata = self.handler.lock().await;
+        self.handler.access(|node| {
+            let mut has_attrs = false;
+            let mut has_events = false;
 
-        let node = metadata.node();
+            if let Some(attr_requests) = req.attr_requests()? {
+                has_attrs = true;
 
-        let mut has_attrs = false;
-        let mut has_events = false;
+                for attr_req in attr_requests {
+                    let path = attr_req?;
 
-        if let Some(attr_requests) = req.attr_requests()? {
-            has_attrs = true;
+                    if path.is_wildcard() {
+                        Self::validate_attr_wildcard_path(&path)?;
 
-            for attr_req in attr_requests {
-                let path = attr_req?;
-
-                if path.is_wildcard() {
-                    Self::validate_attr_wildcard_path(&path)?;
-
-                    if !node.has_accessible_attr(&path, accessor) {
-                        return Err(ErrorCode::InvalidAction.into());
+                        if !node.has_accessible_attr(&path, accessor) {
+                            return Err(ErrorCode::InvalidAction.into());
+                        }
+                    } else {
+                        node.validate_attr_path(&path, false, false, accessor)
+                            .map_err(|_| ErrorCode::InvalidAction)?;
                     }
-                } else {
-                    node.validate_attr_path(&path, false, false, accessor)
-                        .map_err(|_| ErrorCode::InvalidAction)?;
                 }
             }
-        }
 
-        if let Some(event_reqs) = req.event_requests()? {
-            has_events = true;
+            if let Some(event_reqs) = req.event_requests()? {
+                has_events = true;
 
-            for event_req in event_reqs {
-                let path = event_req?;
+                for event_req in event_reqs {
+                    let path = event_req?;
 
-                if !path.is_wildcard() {
-                    node.validate_event_path(&path, accessor)
-                        .map_err(|_| ErrorCode::InvalidAction)?;
+                    if !path.is_wildcard() {
+                        node.validate_event_path(&path, accessor)
+                            .map_err(|_| ErrorCode::InvalidAction)?;
+                    }
                 }
             }
-        }
 
-        if !has_attrs && !has_events {
-            // Empty subscribe requests are not allowed either
-            return Err(ErrorCode::InvalidAction.into());
-        }
+            if !has_attrs && !has_events {
+                // Empty subscribe requests are not allowed either
+                return Err(ErrorCode::InvalidAction.into());
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 
     /// Process all valid subscriptions in an endless loop, checking for changes
     /// and reporting them to the peers.
-    pub async fn process_subscriptions(&self, matter: &Matter<'_>) -> Result<(), Error> {
+    async fn process_subscriptions(&self, matter: &Matter<'_>) -> Result<(), Error> {
         loop {
             // TODO: Un-hardcode these 4 seconds of waiting when the more precise change detection logic is implemented
             let mut timeout = pin!(Timer::after(embassy_time::Duration::from_secs(4)));
@@ -813,9 +796,6 @@ where
             ReportDataReq::SubscribeReport(&sub_req)
         };
 
-        let metadata = self.handler.lock().await;
-        let node = metadata.node();
-
         // Honor the `fabricFiltered` flag on the originating Subscribe request.
         // When set, fabric-sensitive events emitted on other fabrics are
         // dropped before they reach the wire (Matter Core spec section 8.5.2).
@@ -823,7 +803,6 @@ where
 
         let mut resp = ReportDataResponder::new(
             &req,
-            &node,
             Some(rctx.subscription().ids().id),
             HandlerInvoker::new(exchange, self),
             EventReader::new(
@@ -835,9 +814,13 @@ where
         );
 
         let sub_valid = resp
-            .respond(&mut wb, false, rctx.should_send_if_empty(), |e, c, a| {
-                rctx.should_report_attr(e, c, a)
-            })
+            .respond(
+                &mut wb,
+                false,
+                rctx.should_send_if_empty(),
+                &self.handler,
+                |e, c, a| rctx.should_report_attr(e, c, a),
+            )
             .await?;
 
         if !sub_valid {
@@ -996,6 +979,10 @@ where
         &self.networks
     }
 
+    fn metadata(&self) -> impl Metadata + '_ {
+        &self.handler
+    }
+
     fn handler(&self) -> impl AsyncHandler + '_ {
         &self.handler
     }
@@ -1020,7 +1007,7 @@ where
             Some(cluster_id),
         ));
         self.subscriptions
-            .notify_attribute_changed(endpoint_id, cluster_id, attr_id);
+            .notify_attr_changed(endpoint_id, cluster_id, attr_id);
     }
 
     fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
@@ -1029,20 +1016,19 @@ where
             Some(cluster_id),
         ));
         self.subscriptions
-            .notify_cluster_attrs_changed(endpoint_id, cluster_id);
+            .notify_cluster_changed(endpoint_id, cluster_id);
     }
 
     fn notify_endpoint_changed(&self, endpoint_id: EndptId) {
         self.handler
             .bump_dataver(MatchContextInstance::new(Some(endpoint_id), None));
-        self.subscriptions
-            .notify_endpoint_attrs_changed(endpoint_id)
+        self.subscriptions.notify_endpoint_changed(endpoint_id)
     }
 
     fn notify_all_changed(&self) {
         self.handler
             .bump_dataver(MatchContextInstance::new(None, None));
-        self.subscriptions.notify_all_attrs_changed()
+        self.subscriptions.notify_all_changed()
     }
 }
 
@@ -1093,7 +1079,6 @@ pub enum RespondOutcome {
 /// a `Success` response from the peer after each chunk, and then continuing to send the next chunk until all data is sent.
 struct ReportDataResponder<'a, 'b, 'c, const NE: usize, C> {
     req: &'a ReportDataReq<'a>,
-    node: &'a Node<'a>,
     subscription_id: Option<u32>,
     invoker: HandlerInvoker<'b, 'c, C>,
     event_reader: EventReader,
@@ -1111,7 +1096,6 @@ where
     /// Create a new `ReportDataResponder`.
     const fn new(
         req: &'a ReportDataReq<'a>,
-        node: &'a Node<'a>,
         subscription_id: Option<u32>,
         invoker: HandlerInvoker<'b, 'c, C>,
         event_reader: EventReader,
@@ -1119,7 +1103,6 @@ where
     ) -> Self {
         Self {
             req,
-            node,
             subscription_id,
             invoker,
             event_reader,
@@ -1135,25 +1118,30 @@ where
     /// - `suppress_last_resp` - whether to suppress the response from the peer. When multiple Matter messages are
     ///   being sent due to chunking, this is valid for the last chunk only, as the others - by necessity need to have a
     ///   status response by the other peer
-    async fn respond<F>(
+    async fn respond<M, F>(
         &mut self,
         wb: &mut WriteBuf<'_>,
         suppress_last_resp: bool,
         send_if_empty: bool,
+        metadata: M,
         mut filter: F,
     ) -> Result<bool, Error>
     where
+        M: Metadata,
         F: FnMut(EndptId, ClusterId, u32) -> bool,
     {
         let mut empty = true;
 
         self.start_reply(wb)?;
 
-        if !self.report_attributes(wb, &mut empty, &mut filter).await? {
+        if !self
+            .report_attributes(wb, &mut empty, &metadata, &mut filter)
+            .await?
+        {
             return Ok(false);
         }
 
-        if !self.report_events(wb, &mut empty).await? {
+        if !self.report_events(wb, &mut empty, &metadata).await? {
             return Ok(false);
         }
 
@@ -1167,13 +1155,15 @@ where
         }
     }
 
-    async fn report_attributes<F>(
+    async fn report_attributes<M, F>(
         &mut self,
         wb: &mut WriteBuf<'_>,
         empty: &mut bool,
+        metadata: M,
         mut filter: F,
     ) -> Result<bool, Error>
     where
+        M: Metadata,
         F: FnMut(EndptId, ClusterId, u32) -> bool,
     {
         let accessor = self.invoker.exchange().accessor()?;
@@ -1181,7 +1171,7 @@ where
         if self.req.attr_requests()?.is_some() {
             wb.start_array(&TLVTag::Context(ReportDataRespTag::AttributeReports as u8))?;
 
-            for item in self.node.read(self.req, &accessor, &mut filter)? {
+            for item in expand_read(&metadata, self.req, &accessor, &mut filter)? {
                 let item = item?;
 
                 *empty = false;
@@ -1196,13 +1186,7 @@ where
                                 attr.list_index.is_none()
                                     // The whole attribute is requested
                                     // Check if it is an array, and if so, send it as individual items instead
-                                    && self
-                                        .node
-                                        .endpoint(attr.endpoint_id)
-                                        .and_then(|e| e.cluster(attr.cluster_id))
-                                        .and_then(|c| c.attribute(attr.attr_id))
-                                        .map(|a| a.quality.contains(Quality::ARRAY))
-                                        .unwrap_or(false)
+                                    && attr.array
                             });
 
                             if let Some(array_attr) = array_attr {
@@ -1232,11 +1216,15 @@ where
         Ok(true)
     }
 
-    async fn report_events(
+    async fn report_events<M>(
         &mut self,
         wb: &mut WriteBuf<'_>,
         empty: &mut bool,
-    ) -> Result<bool, Error> {
+        metadata: M,
+    ) -> Result<bool, Error>
+    where
+        M: Metadata,
+    {
         let accessor = self.invoker.exchange().accessor()?;
 
         if let Some(event_reqs) = self.req.event_requests()? {
@@ -1248,7 +1236,9 @@ where
                 let path = event_req?;
 
                 if !path.is_wildcard() {
-                    if let Err(status) = self.node.validate_event_path(&path, &accessor) {
+                    if let Err(status) =
+                        metadata.access(|node| node.validate_event_path(&path, &accessor))
+                    {
                         if matches!(status, IMStatusCode::UnsupportedEvent) {
                             // Event does not exist on this endpoint
                             // TODO: Look at TestEventsById.yaml
@@ -1285,28 +1275,30 @@ where
 
             loop {
                 let finished = self.events.fetch(|events| {
-                    for event in events {
-                        let result = self.event_reader.process_read(
-                            event,
-                            &event_reqs,
-                            &event_filters,
-                            self.node,
-                            &accessor,
-                            &mut *wb,
-                        );
+                    metadata.access(|node| {
+                        for event in events {
+                            let result = self.event_reader.process_read(
+                                event,
+                                &event_reqs,
+                                &event_filters,
+                                node,
+                                &accessor,
+                                &mut *wb,
+                            );
 
-                        if let Err(e) = &result {
-                            if e.code() == ErrorCode::NoSpace {
-                                return Ok::<_, Error>(false);
+                            if let Err(e) = &result {
+                                if e.code() == ErrorCode::NoSpace {
+                                    return Ok::<_, Error>(false);
+                                }
+                            }
+
+                            if result? {
+                                *empty = false;
                             }
                         }
 
-                        if result? {
-                            *empty = false;
-                        }
-                    }
-
-                    Ok(true)
+                        Ok(true)
+                    })
                 })?;
 
                 if finished {
@@ -1337,7 +1329,7 @@ where
     /// - `wb` - the buffer to use while sending the items
     async fn send_array_items(
         &mut self,
-        attr: &AttrDetails<'_>,
+        attr: &AttrDetails,
         wb: &mut WriteBuf<'_>,
     ) -> Result<bool, Error> {
         let mut attr = attr.clone();
@@ -1550,7 +1542,6 @@ enum ReportDataChunkState {
 /// for all the chunks of the write request, until the `WriteReq::more_chunks()` returns `false`.
 struct WriteResponder<'a, 'b, 'c, C> {
     req: &'a WriteReq<'a>,
-    node: &'a Node<'a>,
     invoker: HandlerInvoker<'b, 'c, C>,
 }
 
@@ -1559,17 +1550,21 @@ where
     C: HandlerContext,
 {
     /// Create a new `WriteResponder`.
-    const fn new(
-        req: &'a WriteReq<'a>,
-        node: &'a Node<'a>,
-        invoker: HandlerInvoker<'b, 'c, C>,
-    ) -> Self {
-        Self { req, node, invoker }
+    const fn new(req: &'a WriteReq<'a>, invoker: HandlerInvoker<'b, 'c, C>) -> Self {
+        Self { req, invoker }
     }
 
     /// Respond to the write request by processing each write attribute in the request
     /// and sending a response back.
-    async fn respond(&mut self, wb: &mut WriteBuf<'_>, suppress_resp: bool) -> Result<(), Error> {
+    async fn respond<M>(
+        &mut self,
+        wb: &mut WriteBuf<'_>,
+        metadata: M,
+        suppress_resp: bool,
+    ) -> Result<(), Error>
+    where
+        M: Metadata,
+    {
         let accessor = self.invoker.exchange().accessor()?;
 
         wb.reset();
@@ -1577,7 +1572,7 @@ where
         wb.start_struct(&TLVTag::Anonymous)?;
         wb.start_array(&TLVTag::Context(WriteRespTag::WriteResponses as u8))?;
 
-        for item in self.node.write(self.req, &accessor)? {
+        for item in expand_write(metadata, self.req, &accessor)? {
             self.invoker.process_write(&item?, &mut *wb).await?;
         }
 
@@ -1607,7 +1602,6 @@ where
 /// the responder will send 3 Matter messages, each containing a single command response.
 struct InvokeResponder<'a, 'b, 'c, C> {
     req: &'a InvReq<'a>,
-    node: &'a Node<'a>,
     invoker: HandlerInvoker<'b, 'c, C>,
 }
 
@@ -1616,17 +1610,21 @@ where
     C: HandlerContext,
 {
     /// Create a new `InvokeResponder`.
-    const fn new(
-        req: &'a InvReq<'a>,
-        node: &'a Node<'a>,
-        invoker: HandlerInvoker<'b, 'c, C>,
-    ) -> Self {
-        Self { req, node, invoker }
+    const fn new(req: &'a InvReq<'a>, invoker: HandlerInvoker<'b, 'c, C>) -> Self {
+        Self { req, invoker }
     }
 
     /// Respond to the invoke request by processing each command in the request
     /// and sending one or more reponses back.
-    async fn respond(&mut self, wb: &mut WriteBuf<'_>, suppress_resp: bool) -> Result<(), Error> {
+    async fn respond<M>(
+        &mut self,
+        wb: &mut WriteBuf<'_>,
+        metadata: M,
+        suppress_resp: bool,
+    ) -> Result<(), Error>
+    where
+        M: Metadata,
+    {
         wb.reset();
 
         wb.start_struct(&TLVTag::Anonymous)?;
@@ -1645,7 +1643,7 @@ where
 
         let accessor = self.invoker.exchange().accessor()?;
 
-        for item in self.node.invoke(self.req, &accessor)? {
+        for item in expand_invoke(metadata, self.req, &accessor)? {
             self.invoker.process_invoke(&item?, &mut *wb).await?;
         }
 

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -55,7 +55,7 @@ impl AclHandler {
     fn acl<P: TLVBuilderParent>(
         &self,
         fabrics: &Fabrics,
-        attr: &AttrDetails<'_>,
+        attr: &AttrDetails,
         builder: ArrayAttributeRead<
             AccessControlEntryStructArrayBuilder<P>,
             AccessControlEntryStructBuilder<P>,
@@ -369,8 +369,8 @@ mod tests {
         AccessControlEntryStruct, AccessControlEntryStructArrayBuilder, Dataver,
     };
     use crate::dm::{
-        ArrayAttributeRead, ArrayAttributeWrite, AttrDetails, AttrReadReplyInstance, Node,
-        Privilege, ReadReply, ReadReplyInstance, Reply,
+        ArrayAttributeRead, ArrayAttributeWrite, AttrDetails, AttrReadReplyInstance, Privilege,
+        ReadReply, ReadReplyInstance, Reply,
     };
     use crate::fabric::Fabrics;
     use crate::tlv::{get_root_node_struct, TLVElement, TLVTag, TLVWriteParent, ToTLV};
@@ -537,7 +537,6 @@ mod tests {
         // Test 1, all 3 entries are read in the response without fabric filtering
         {
             let attr = AttrDetails {
-                node: &Node { endpoints: &[] },
                 endpoint_id: 0,
                 cluster_id: 0,
                 attr_id: 0,
@@ -547,6 +546,7 @@ mod tests {
                 fab_filter: false,
                 dataver: None,
                 wildcard: false,
+                array: false,
                 cluster_status: Cell::new(0),
             };
 
@@ -565,7 +565,6 @@ mod tests {
         // Test 2, only single entry is read in the response with fabric filtering and fabric idx 1
         {
             let attr = AttrDetails {
-                node: &Node { endpoints: &[] },
                 endpoint_id: 0,
                 cluster_id: 0,
                 attr_id: 0,
@@ -575,6 +574,7 @@ mod tests {
                 fab_filter: true,
                 dataver: None,
                 wildcard: false,
+                array: false,
                 cluster_status: Cell::new(0),
             };
 
@@ -592,7 +592,6 @@ mod tests {
         // Test 3, only single entry is read in the response with fabric filtering and fabric idx 2
         {
             let attr = AttrDetails {
-                node: &Node { endpoints: &[] },
                 endpoint_id: 0,
                 cluster_id: 0,
                 attr_id: 0,
@@ -602,6 +601,7 @@ mod tests {
                 fab_filter: true,
                 dataver: None,
                 wildcard: false,
+                array: false,
                 cluster_status: Cell::new(0),
             };
 
@@ -617,12 +617,7 @@ mod tests {
         }
     }
 
-    fn acl_read(
-        acl: &AclHandler,
-        fabrics: &Fabrics,
-        attr: &AttrDetails<'_>,
-        tw: &mut WriteBuf<'_>,
-    ) {
+    fn acl_read(acl: &AclHandler, fabrics: &Fabrics, attr: &AttrDetails, tw: &mut WriteBuf<'_>) {
         let encoder = ReadReplyInstance::new(attr, &mut *tw);
         let mut writer = unwrap!(unwrap!(encoder.with_dataver(acl.dataver.get())));
         let build_root = TLVWriteParent::new((), writer.writer());

--- a/rs-matter/src/dm/clusters/app/cam_av_settings.rs
+++ b/rs-matter/src/dm/clusters/app/cam_av_settings.rs
@@ -69,6 +69,7 @@
 //! lists.
 
 use core::cell::RefCell;
+use core::future::Future;
 
 use heapless::String as HString;
 
@@ -190,10 +191,7 @@ pub trait CamAvSettingsHooks {
     ///
     /// On `Err` the handler rolls back its internal `MPTZPosition`
     /// snapshot to the prior value.
-    fn mptz_apply(
-        &self,
-        target: &Mptz,
-    ) -> impl core::future::Future<Output = Result<(), CamAvSettingsError>> {
+    fn mptz_apply(&self, target: &Mptz) -> impl Future<Output = Result<(), CamAvSettingsError>> {
         async { Ok(()) }
     }
 
@@ -201,10 +199,7 @@ pub trait CamAvSettingsHooks {
     /// handler has validated `x1<x2`, `y1<y2`. Hardware-specific
     /// per-stream bounds (resolution caps, aspect-ratio constraints)
     /// are the implementation's responsibility.
-    fn dptz_apply(
-        &self,
-        view: &DptzView,
-    ) -> impl core::future::Future<Output = Result<(), CamAvSettingsError>> {
+    fn dptz_apply(&self, view: &DptzView) -> impl Future<Output = Result<(), CamAvSettingsError>> {
         async { Ok(()) }
     }
 
@@ -215,7 +210,7 @@ pub trait CamAvSettingsHooks {
     fn preset_saved(
         &self,
         preset: &MptzPreset,
-    ) -> impl core::future::Future<Output = Result<(), CamAvSettingsError>> {
+    ) -> impl Future<Output = Result<(), CamAvSettingsError>> {
         async { Ok(()) }
     }
 
@@ -223,8 +218,35 @@ pub trait CamAvSettingsHooks {
     fn preset_removed(
         &self,
         preset_id: u8,
-    ) -> impl core::future::Future<Output = Result<(), CamAvSettingsError>> {
+    ) -> impl Future<Output = Result<(), CamAvSettingsError>> {
         async { Ok(()) }
+    }
+}
+
+impl<T> CamAvSettingsHooks for &T
+where
+    T: CamAvSettingsHooks,
+{
+    fn mptz_apply(&self, target: &Mptz) -> impl Future<Output = Result<(), CamAvSettingsError>> {
+        (**self).mptz_apply(target)
+    }
+
+    fn dptz_apply(&self, view: &DptzView) -> impl Future<Output = Result<(), CamAvSettingsError>> {
+        (**self).dptz_apply(view)
+    }
+
+    fn preset_saved(
+        &self,
+        preset: &MptzPreset,
+    ) -> impl Future<Output = Result<(), CamAvSettingsError>> {
+        (**self).preset_saved(preset)
+    }
+
+    fn preset_removed(
+        &self,
+        preset_id: u8,
+    ) -> impl Future<Output = Result<(), CamAvSettingsError>> {
+        (**self).preset_removed(preset_id)
     }
 }
 

--- a/rs-matter/src/dm/clusters/app/cam_av_stream.rs
+++ b/rs-matter/src/dm/clusters/app/cam_av_stream.rs
@@ -1067,7 +1067,7 @@ where
         _request: AudioStreamAllocateRequest<'_>,
         _response: AudioStreamAllocateResponseBuilder<P>,
     ) -> Result<P, Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::CommandNotFound.into())
     }
 
     async fn handle_audio_stream_deallocate(
@@ -1075,7 +1075,7 @@ where
         _ctx: impl InvokeContext,
         _request: AudioStreamDeallocateRequest<'_>,
     ) -> Result<(), Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::CommandNotFound.into())
     }
 
     async fn handle_snapshot_stream_allocate<P: TLVBuilderParent>(
@@ -1084,7 +1084,7 @@ where
         _request: SnapshotStreamAllocateRequest<'_>,
         _response: SnapshotStreamAllocateResponseBuilder<P>,
     ) -> Result<P, Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::CommandNotFound.into())
     }
 
     async fn handle_snapshot_stream_modify(
@@ -1092,7 +1092,7 @@ where
         _ctx: impl InvokeContext,
         _request: SnapshotStreamModifyRequest<'_>,
     ) -> Result<(), Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::CommandNotFound.into())
     }
 
     async fn handle_snapshot_stream_deallocate(
@@ -1100,7 +1100,7 @@ where
         _ctx: impl InvokeContext,
         _request: SnapshotStreamDeallocateRequest<'_>,
     ) -> Result<(), Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::CommandNotFound.into())
     }
 
     async fn handle_capture_snapshot<P: TLVBuilderParent>(
@@ -1109,7 +1109,7 @@ where
         _request: CaptureSnapshotRequest<'_>,
         _response: CaptureSnapshotResponseBuilder<P>,
     ) -> Result<P, Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::CommandNotFound.into())
     }
 }
 

--- a/rs-matter/src/dm/clusters/app/cam_av_stream.rs
+++ b/rs-matter/src/dm/clusters/app/cam_av_stream.rs
@@ -72,6 +72,7 @@
 //!   Each is a follow-up.
 
 use core::cell::{Cell, RefCell};
+use core::future::Future;
 
 use crate::dm::{ArrayAttributeRead, Cluster, Dataver, EndptId, InvokeContext, ReadContext};
 use crate::error::{Error, ErrorCode};
@@ -209,10 +210,7 @@ pub trait CameraAvStreamHooks {
     ///
     /// `stream` carries the just-assigned `video_stream_id` and the
     /// validated parameters. `reference_count` is always 0 here.
-    fn allocate_video(
-        &self,
-        stream: &VideoStream,
-    ) -> impl core::future::Future<Output = Result<(), CamAvError>>;
+    fn allocate_video(&self, stream: &VideoStream) -> impl Future<Output = Result<(), CamAvError>>;
 
     /// Called when a controller requests `VideoStreamModify`.
     ///
@@ -226,14 +224,39 @@ pub trait CameraAvStreamHooks {
         video_stream_id: u16,
         watermark_enabled: Option<bool>,
         osd_enabled: Option<bool>,
-    ) -> impl core::future::Future<Output = Result<(), CamAvError>>;
+    ) -> impl Future<Output = Result<(), CamAvError>>;
 
     /// Called when a controller requests `VideoStreamDeallocate` AND
     /// the handler has confirmed the stream's reference count is zero.
     fn deallocate_video(
         &self,
         video_stream_id: u16,
-    ) -> impl core::future::Future<Output = Result<(), CamAvError>>;
+    ) -> impl Future<Output = Result<(), CamAvError>>;
+}
+
+impl<T> CameraAvStreamHooks for &T
+where
+    T: CameraAvStreamHooks,
+{
+    fn allocate_video(&self, stream: &VideoStream) -> impl Future<Output = Result<(), CamAvError>> {
+        (*self).allocate_video(stream)
+    }
+
+    fn modify_video(
+        &self,
+        video_stream_id: u16,
+        watermark_enabled: Option<bool>,
+        osd_enabled: Option<bool>,
+    ) -> impl Future<Output = Result<(), CamAvError>> {
+        (*self).modify_video(video_stream_id, watermark_enabled, osd_enabled)
+    }
+
+    fn deallocate_video(
+        &self,
+        video_stream_id: u16,
+    ) -> impl Future<Output = Result<(), CamAvError>> {
+        (*self).deallocate_video(video_stream_id)
+    }
 }
 
 /// Maximum number of `StreamUsageEnum` entries the handler will hold for

--- a/rs-matter/src/dm/clusters/app/level_control.rs
+++ b/rs-matter/src/dm/clusters/app/level_control.rs
@@ -1642,12 +1642,12 @@ pub trait LevelControlHooks {
     /// Raw start_up_current_level getter.
     /// This value should persist across reboots.
     fn start_up_current_level(&self) -> Result<Option<u8>, Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::AttributeNotFound.into())
     }
     /// Raw start_up_current_level setter.
     /// This value should persist across reboots.
     fn set_start_up_current_level(&self, _value: Option<u8>) -> Result<(), Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::AttributeNotFound.into())
     }
 
     /// Background task for out-of-band notifications to the handler.

--- a/rs-matter/src/dm/clusters/app/push_av_stream.rs
+++ b/rs-matter/src/dm/clusters/app/push_av_stream.rs
@@ -225,6 +225,53 @@ pub trait PushAvStreamHooks {
     }
 }
 
+impl<T> PushAvStreamHooks for &T
+where
+    T: PushAvStreamHooks,
+{
+    fn on_allocate(
+        &self,
+        connection_id: u16,
+        fabric_index: FabricIndex,
+        request: &AllocatePushTransportRequest<'_>,
+    ) -> impl core::future::Future<Output = Result<(), PushAvError>> {
+        (*self).on_allocate(connection_id, fabric_index, request)
+    }
+
+    fn on_deallocate(
+        &self,
+        connection_id: u16,
+    ) -> impl core::future::Future<Output = Result<(), PushAvError>> {
+        (*self).on_deallocate(connection_id)
+    }
+
+    fn on_modify(
+        &self,
+        connection_id: u16,
+        request: &ModifyPushTransportRequest<'_>,
+    ) -> impl core::future::Future<Output = Result<(), PushAvError>> {
+        (*self).on_modify(connection_id, request)
+    }
+
+    fn on_set_status(
+        &self,
+        connection_id: Option<u16>,
+        status: TransportStatusEnum,
+    ) -> impl core::future::Future<Output = Result<(), PushAvError>> {
+        (*self).on_set_status(connection_id, status)
+    }
+
+    fn on_manually_trigger(
+        &self,
+        connection_id: u16,
+        activation_reason: TriggerActivationReasonEnum,
+        time_control: Option<TransportMotionTriggerTimeControlStruct<'_>>,
+        user_defined: Option<&[u8]>,
+    ) -> impl core::future::Future<Output = Result<(), PushAvError>> {
+        (*self).on_manually_trigger(connection_id, activation_reason, time_control, user_defined)
+    }
+}
+
 struct State<const NC: usize> {
     connections: Vec<PushConnection, NC>,
 }

--- a/rs-matter/src/dm/clusters/app/webrtc_prov.rs
+++ b/rs-matter/src/dm/clusters/app/webrtc_prov.rs
@@ -73,10 +73,8 @@
 //!   [`OutboundWork::End`] (camera-initiated teardown) are driven from
 //!   [`WebRtcProvHandler::run`] via [`WebRtcHooks::next_outbound`].
 
-#[allow(unused_imports)]
-pub use crate::dm::clusters::decl::web_rtc_transport_provider::*;
-
 use core::cell::{Cell, RefCell};
+use core::future::Future;
 
 use crate::dm::clusters::decl::globals::{
     ICECandidateStruct, ICECandidateStructArrayBuilder, StreamUsageEnum, WebRTCEndReasonEnum,
@@ -95,6 +93,9 @@ use crate::with;
 
 use super::super::decl::web_rtc_transport_provider as decl;
 use super::super::decl::web_rtc_transport_requestor as req_decl;
+
+#[allow(unused_imports)]
+pub use crate::dm::clusters::decl::web_rtc_transport_provider::*;
 
 /// Cluster ID of `WebRTCTransportRequestor` (spec 1.5, §1.16), the peer
 /// cluster we invoke for outbound trickle-ICE and session-end pushes.
@@ -351,6 +352,80 @@ pub trait WebRtcHooks {
         _sdp_out: &mut [u8],
     ) -> Result<usize, WebRtcError> {
         Err(WebRtcError::InvalidInState)
+    }
+}
+
+impl<T> WebRtcHooks for &T
+where
+    T: WebRtcHooks,
+{
+    fn on_solicit_offer(
+        &self,
+        session_id: u16,
+        params: &OfferParams,
+    ) -> impl Future<Output = Result<SolicitOutcome, WebRtcError>> {
+        (*self).on_solicit_offer(session_id, params)
+    }
+
+    fn on_offer(
+        &self,
+        session_id: u16,
+        sdp: &str,
+        params: &OfferParams,
+    ) -> impl Future<Output = Result<AnswerOutcome, WebRtcError>> {
+        (*self).on_offer(session_id, sdp, params)
+    }
+
+    fn on_answer(
+        &self,
+        session_id: u16,
+        sdp: &str,
+    ) -> impl Future<Output = Result<(), WebRtcError>> {
+        (*self).on_answer(session_id, sdp)
+    }
+
+    fn on_ice_candidates(
+        &self,
+        session_id: u16,
+        candidates: &TLVArray<'_, ICECandidateStruct<'_>>,
+    ) -> impl Future<Output = Result<(), WebRtcError>> {
+        (*self).on_ice_candidates(session_id, candidates)
+    }
+
+    fn on_end_session(
+        &self,
+        session_id: u16,
+        reason: WebRTCEndReasonEnum,
+    ) -> impl Future<Output = Result<(), WebRtcError>> {
+        (*self).on_end_session(session_id, reason)
+    }
+
+    fn next_outbound(&self) -> impl Future<Output = OutboundWork> {
+        (*self).next_outbound()
+    }
+
+    fn fill_ice_candidates<P: TLVBuilderParent>(
+        &self,
+        session_id: u16,
+        candidates: ICECandidateStructArrayBuilder<P>,
+    ) -> impl Future<Output = Result<P, Error>> {
+        (*self).fill_ice_candidates(session_id, candidates)
+    }
+
+    fn take_answer_sdp(
+        &self,
+        session_id: u16,
+        sdp_out: &mut [u8],
+    ) -> impl Future<Output = Result<usize, WebRtcError>> {
+        (*self).take_answer_sdp(session_id, sdp_out)
+    }
+
+    fn take_offer_sdp(
+        &self,
+        session_id: u16,
+        sdp_out: &mut [u8],
+    ) -> impl Future<Output = Result<usize, WebRtcError>> {
+        (*self).take_offer_sdp(session_id, sdp_out)
     }
 }
 

--- a/rs-matter/src/dm/clusters/app/zone_mgmt.rs
+++ b/rs-matter/src/dm/clusters/app/zone_mgmt.rs
@@ -47,6 +47,7 @@
 //! * `FOCUS_ZONES` — not yet.
 
 use core::cell::{Cell, RefCell};
+use core::future::Future;
 
 use heapless::String as HString;
 
@@ -120,46 +121,57 @@ pub struct Trigger {
 /// need to override the events they actually care about.
 #[allow(unused_variables)]
 pub trait ZoneMgmtHooks<const NV: usize> {
-    fn zone_created(
-        &self,
-        zone: &Zone<NV>,
-    ) -> impl core::future::Future<Output = Result<(), ZoneError>> {
+    fn zone_created(&self, zone: &Zone<NV>) -> impl Future<Output = Result<(), ZoneError>> {
         async { Ok(()) }
     }
 
-    fn zone_updated(
-        &self,
-        zone: &Zone<NV>,
-    ) -> impl core::future::Future<Output = Result<(), ZoneError>> {
+    fn zone_updated(&self, zone: &Zone<NV>) -> impl Future<Output = Result<(), ZoneError>> {
         async { Ok(()) }
     }
 
-    fn zone_removed(
-        &self,
-        zone_id: u16,
-    ) -> impl core::future::Future<Output = Result<(), ZoneError>> {
+    fn zone_removed(&self, zone_id: u16) -> impl Future<Output = Result<(), ZoneError>> {
         async { Ok(()) }
     }
 
-    fn trigger_set(
-        &self,
-        trigger: &Trigger,
-    ) -> impl core::future::Future<Output = Result<(), ZoneError>> {
+    fn trigger_set(&self, trigger: &Trigger) -> impl Future<Output = Result<(), ZoneError>> {
         async { Ok(()) }
     }
 
-    fn trigger_removed(
-        &self,
-        zone_id: u16,
-    ) -> impl core::future::Future<Output = Result<(), ZoneError>> {
+    fn trigger_removed(&self, zone_id: u16) -> impl Future<Output = Result<(), ZoneError>> {
         async { Ok(()) }
     }
 
-    fn set_sensitivity(
-        &self,
-        value: u8,
-    ) -> impl core::future::Future<Output = Result<(), ZoneError>> {
+    fn set_sensitivity(&self, value: u8) -> impl Future<Output = Result<(), ZoneError>> {
         async { Ok(()) }
+    }
+}
+
+impl<const NV: usize, T> ZoneMgmtHooks<NV> for &T
+where
+    T: ZoneMgmtHooks<NV>,
+{
+    fn zone_created(&self, zone: &Zone<NV>) -> impl Future<Output = Result<(), ZoneError>> {
+        (*self).zone_created(zone)
+    }
+
+    fn zone_updated(&self, zone: &Zone<NV>) -> impl Future<Output = Result<(), ZoneError>> {
+        (*self).zone_updated(zone)
+    }
+
+    fn zone_removed(&self, zone_id: u16) -> impl Future<Output = Result<(), ZoneError>> {
+        (*self).zone_removed(zone_id)
+    }
+
+    fn trigger_set(&self, trigger: &Trigger) -> impl Future<Output = Result<(), ZoneError>> {
+        (*self).trigger_set(trigger)
+    }
+
+    fn trigger_removed(&self, zone_id: u16) -> impl Future<Output = Result<(), ZoneError>> {
+        (*self).trigger_removed(zone_id)
+    }
+
+    fn set_sensitivity(&self, value: u8) -> impl Future<Output = Result<(), ZoneError>> {
+        (*self).set_sensitivity(value)
     }
 }
 

--- a/rs-matter/src/dm/clusters/basic_info.rs
+++ b/rs-matter/src/dm/clusters/basic_info.rs
@@ -637,7 +637,7 @@ impl ClusterHandler for BasicInfoHandler {
     }
 
     fn handle_mfg_specific_ping(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::CommandNotFound.into())
     }
 
     fn manufacturing_date<P: TLVBuilderParent>(

--- a/rs-matter/src/dm/clusters/desc.rs
+++ b/rs-matter/src/dm/clusters/desc.rs
@@ -19,7 +19,7 @@
 
 use core::fmt::Debug;
 
-use crate::dm::{ArrayAttributeRead, Cluster, Dataver, Endpoint, EndptId, ReadContext};
+use crate::dm::{ArrayAttributeRead, Cluster, Dataver, Endpoint, EndptId, Metadata, ReadContext};
 use crate::error::{Error, ErrorCode};
 use crate::tlv::{TLVBuilderParent, ToTLVArrayBuilder, ToTLVBuilder};
 use crate::utils::sync::DynBase;
@@ -116,11 +116,19 @@ impl<'a> DescHandler<'a> {
         HandlerAdaptor(self)
     }
 
-    fn endpoint<'b>(ctx: &'b impl ReadContext) -> Result<&'b Endpoint<'b>, Error> {
-        ctx.attr()
-            .node
-            .endpoint(ctx.attr().endpoint_id)
-            .ok_or_else(|| ErrorCode::EndpointNotFound.into())
+    fn with_endpoint<F, R>(ctx: impl ReadContext, f: F) -> Result<R, Error>
+    where
+        F: FnOnce(&Endpoint) -> Result<R, Error>,
+    {
+        let metadata = ctx.metadata();
+
+        metadata.access(|node| {
+            let endpoint = node
+                .endpoint(ctx.attr().endpoint_id)
+                .ok_or_else(|| Error::new(ErrorCode::EndpointNotFound))?;
+
+            f(endpoint)
+        })
     }
 }
 
@@ -140,9 +148,7 @@ impl ClusterHandler for DescHandler<'_> {
         ctx: impl ReadContext,
         builder: ArrayAttributeRead<DeviceTypeStructArrayBuilder<P>, DeviceTypeStructBuilder<P>>,
     ) -> Result<P, Error> {
-        let endpoint = Self::endpoint(&ctx)?;
-
-        match builder {
+        Self::with_endpoint(ctx, |endpoint| match builder {
             ArrayAttributeRead::ReadAll(mut builder) => {
                 for dev_type in endpoint.device_types {
                     builder = builder
@@ -165,7 +171,7 @@ impl ClusterHandler for DescHandler<'_> {
                     .end()
             }
             ArrayAttributeRead::ReadNone(builder) => builder.end(),
-        }
+        })
     }
 
     fn server_list<P: TLVBuilderParent>(
@@ -173,9 +179,7 @@ impl ClusterHandler for DescHandler<'_> {
         ctx: impl ReadContext,
         builder: ArrayAttributeRead<ToTLVArrayBuilder<P, u32>, ToTLVBuilder<P, u32>>,
     ) -> Result<P, Error> {
-        let endpoint = Self::endpoint(&ctx)?;
-
-        match builder {
+        Self::with_endpoint(ctx, |endpoint| match builder {
             ArrayAttributeRead::ReadAll(mut builder) => {
                 for cluster in endpoint.clusters {
                     builder = builder.push(&cluster.id)?;
@@ -191,7 +195,7 @@ impl ClusterHandler for DescHandler<'_> {
                 builder.set(&cluster.id)
             }
             ArrayAttributeRead::ReadNone(builder) => builder.end(),
-        }
+        })
     }
 
     fn client_list<P: TLVBuilderParent>(
@@ -199,14 +203,14 @@ impl ClusterHandler for DescHandler<'_> {
         ctx: impl ReadContext,
         builder: ArrayAttributeRead<ToTLVArrayBuilder<P, u32>, ToTLVBuilder<P, u32>>,
     ) -> Result<P, Error> {
-        let _endpoint = Self::endpoint(&ctx)?;
-
-        // Client clusters not support yet
-        match builder {
-            ArrayAttributeRead::ReadAll(builder) => builder.end(),
-            ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
-            ArrayAttributeRead::ReadNone(builder) => builder.end(),
-        }
+        Self::with_endpoint(ctx, |_| {
+            // Client clusters not support yet
+            match builder {
+                ArrayAttributeRead::ReadAll(builder) => builder.end(),
+                ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
+                ArrayAttributeRead::ReadNone(builder) => builder.end(),
+            }
+        })
     }
 
     fn parts_list<P: TLVBuilderParent>(
@@ -214,30 +218,32 @@ impl ClusterHandler for DescHandler<'_> {
         ctx: impl ReadContext,
         builder: ArrayAttributeRead<ToTLVArrayBuilder<P, u16>, ToTLVBuilder<P, u16>>,
     ) -> Result<P, Error> {
-        let mut ep_ids = ctx
-            .attr()
-            .node
-            .endpoints
-            .iter()
-            .map(|e| e.id)
-            .filter(|e| self.matcher.matches(ctx.attr().endpoint_id, *e));
+        let metadata = ctx.metadata();
 
-        match builder {
-            ArrayAttributeRead::ReadAll(mut builder) => {
-                for id in ep_ids {
-                    builder = builder.push(&id)?;
+        metadata.access(|node| {
+            let mut ep_ids = node
+                .endpoints
+                .iter()
+                .map(|e| e.id)
+                .filter(|e| self.matcher.matches(ctx.attr().endpoint_id, *e));
+
+            match builder {
+                ArrayAttributeRead::ReadAll(mut builder) => {
+                    for id in ep_ids {
+                        builder = builder.push(&id)?;
+                    }
+
+                    builder.end()
                 }
+                ArrayAttributeRead::ReadOne(index, builder) => {
+                    let Some(ep_id) = ep_ids.nth(index as usize) else {
+                        return Err(ErrorCode::ConstraintError.into());
+                    };
 
-                builder.end()
+                    builder.set(&ep_id)
+                }
+                ArrayAttributeRead::ReadNone(builder) => builder.end(),
             }
-            ArrayAttributeRead::ReadOne(index, builder) => {
-                let Some(ep_id) = ep_ids.nth(index as usize) else {
-                    return Err(ErrorCode::ConstraintError.into());
-                };
-
-                builder.set(&ep_id)
-            }
-            ArrayAttributeRead::ReadNone(builder) => builder.end(),
-        }
+        })
     }
 }

--- a/rs-matter/src/dm/clusters/eth_diag.rs
+++ b/rs-matter/src/dm/clusters/eth_diag.rs
@@ -54,6 +54,6 @@ impl ClusterHandler for EthDiagHandler {
     }
 
     fn handle_reset_counts(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::CommandNotFound.into())
     }
 }

--- a/rs-matter/src/dm/clusters/net_comm.rs
+++ b/rs-matter/src/dm/clusters/net_comm.rs
@@ -1532,7 +1532,7 @@ where
         _request: QueryIdentityRequest<'_>,
         _response: QueryIdentityResponseBuilder<P>,
     ) -> impl Future<Output = Result<P, Error>> {
-        ready(Err(ErrorCode::InvalidAction.into()))
+        ready(Err(ErrorCode::CommandNotFound.into()))
     }
 }
 

--- a/rs-matter/src/dm/clusters/thread_diag.rs
+++ b/rs-matter/src/dm/clusters/thread_diag.rs
@@ -687,7 +687,7 @@ impl ClusterHandler for ThreadDiagHandler<'_> {
     }
 
     fn handle_reset_counts(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::CommandNotFound.into())
     }
 }
 

--- a/rs-matter/src/dm/clusters/wifi_diag.rs
+++ b/rs-matter/src/dm/clusters/wifi_diag.rs
@@ -171,7 +171,7 @@ impl ClusterHandler for WifiDiagHandler<'_> {
     }
 
     fn handle_reset_counts(&self, _ctx: impl InvokeContext) -> Result<(), Error> {
-        Err(ErrorCode::InvalidAction.into())
+        Err(ErrorCode::CommandNotFound.into())
     }
 }
 

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -19,9 +19,7 @@ use core::num::NonZeroU8;
 
 use embassy_time::Instant;
 
-use crate::dm::{
-    AttrChangeNotifier, AttrId, ClusterId, EndptId, EventId, EventNumber, IMBuffer, NodeId,
-};
+use crate::dm::{AttrId, ClusterId, EndptId, EventId, EventNumber, IMBuffer, NodeId};
 use crate::fabric::MAX_FABRICS;
 use crate::utils::cell::RefCell;
 use crate::utils::init::{init, Init};
@@ -134,7 +132,7 @@ impl<const N: usize> Subscriptions<N> {
     /// - `endpoint_id`: The endpoint ID of the cluster that had changed.
     /// - `cluster_id`: The cluster ID of the cluster that had changed.
     /// - `attr_id`: The attribute ID of the attribute that changed.
-    pub(crate) fn notify_attribute_changed(
+    pub(crate) fn notify_attr_changed(
         &self,
         endpoint_id: EndptId,
         cluster_id: ClusterId,
@@ -157,7 +155,7 @@ impl<const N: usize> Subscriptions<N> {
     /// Record a cluster-wide change. Every attribute of `(endpoint_id,
     /// cluster_id)` is treated as changed for the purposes of subscription
     /// reporting.
-    pub(crate) fn notify_cluster_attrs_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+    pub(crate) fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
         self.state.lock(|internal| {
             internal
                 .borrow_mut()
@@ -171,7 +169,7 @@ impl<const N: usize> Subscriptions<N> {
     /// Record an endpoint-wide change. Every attribute on every cluster of
     /// `endpoint_id` is treated as changed for the purposes of subscription
     /// reporting.
-    pub(crate) fn notify_endpoint_attrs_changed(&self, endpoint_id: EndptId) {
+    pub(crate) fn notify_endpoint_changed(&self, endpoint_id: EndptId) {
         self.state.lock(|internal| {
             internal
                 .borrow_mut()
@@ -185,7 +183,7 @@ impl<const N: usize> Subscriptions<N> {
     /// Record a fully-global change. Every attribute on every cluster on
     /// every endpoint is treated as changed for the purposes of subscription
     /// reporting. Intended for coarse-grained reset / restart scenarios.
-    pub(crate) fn notify_all_attrs_changed(&self) {
+    pub(crate) fn notify_all_changed(&self) {
         self.state.lock(|internal| {
             internal
                 .borrow_mut()
@@ -413,24 +411,6 @@ impl<const N: usize> Subscriptions<N> {
 impl<const N: usize> Default for Subscriptions<N> {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl<const N: usize> AttrChangeNotifier for Subscriptions<N> {
-    fn notify_attr_changed(&self, endpt: EndptId, clust: ClusterId, attr: AttrId) {
-        Subscriptions::<N>::notify_attribute_changed(self, endpt, clust, attr);
-    }
-
-    fn notify_cluster_changed(&self, endpt: EndptId, clust: ClusterId) {
-        Subscriptions::<N>::notify_cluster_attrs_changed(self, endpt, clust);
-    }
-
-    fn notify_endpoint_changed(&self, endpt: EndptId) {
-        Subscriptions::<N>::notify_endpoint_attrs_changed(self, endpt);
-    }
-
-    fn notify_all_changed(&self) {
-        Subscriptions::<N>::notify_all_attrs_changed(self);
     }
 }
 
@@ -1919,7 +1899,7 @@ mod tests {
 
         let now = Instant::now();
 
-        subs.notify_attribute_changed(1, 2, 3);
+        subs.notify_attr_changed(1, 2, 3);
         {
             let mut rctx = subs
                 .add(
@@ -1946,7 +1926,7 @@ mod tests {
         }
 
         // A new change bumps the watermark and becomes pending.
-        subs.notify_attribute_changed(1, 2, 4);
+        subs.notify_attr_changed(1, 2, 4);
         // `min_int` = 1s has not elapsed at `now`, so the subscription is not
         // yet report-allowed; step past it.
         let later = now + Duration::from_secs(2);
@@ -2063,7 +2043,7 @@ mod tests {
         }
 
         // Record one attribute change — watermark advances to 1.
-        subs.notify_attribute_changed(1, 2, 3);
+        subs.notify_attr_changed(1, 2, 3);
 
         // At the same instant, min_int (1s) has NOT elapsed so the sub is not
         // report-allowed: even though there is a pending change, `report()`
@@ -2287,7 +2267,7 @@ mod tests {
         // Start an incremental report and, while it is "in flight", issue
         // a `remove` that matches the in-flight subscription. Also flip
         // `set_keep` to verify the cancel flag wins over `keep`.
-        subs.notify_attribute_changed(1, 2, 3);
+        subs.notify_attr_changed(1, 2, 3);
         let later = now + Duration::from_secs(2);
         {
             let mut rctx = subs.report(later, 0, &subs_bufs).unwrap();
@@ -2337,7 +2317,7 @@ mod tests {
             rctx.set_keep();
         }
 
-        subs.notify_attribute_changed(1, 2, 3);
+        subs.notify_attr_changed(1, 2, 3);
         let later = now + Duration::from_secs(2);
         {
             let mut rctx = subs.report(later, 0, &subs_bufs).unwrap();
@@ -2379,8 +2359,8 @@ mod tests {
         }
 
         // Record two changes. Watermark becomes 2.
-        subs.notify_attribute_changed(1, 2, 3); // id 1
-        subs.notify_attribute_changed(1, 2, 4); // id 2
+        subs.notify_attr_changed(1, 2, 3); // id 1
+        subs.notify_attr_changed(1, 2, 4); // id 2
 
         // Advance both subs to watermark 2 via two `report` + keep cycles.
         let later = base + Duration::from_secs(2);
@@ -2398,7 +2378,7 @@ mod tests {
         assert!(subs.report(later, 0, &subs_bufs).is_none());
 
         // A brand new change becomes pending again post-purge.
-        subs.notify_attribute_changed(5, 6, 7);
+        subs.notify_attr_changed(5, 6, 7);
         let even_later = later + Duration::from_secs(2);
         {
             let mut rctx = subs.report(even_later, 0, &subs_bufs).unwrap();

--- a/rs-matter/src/dm/types/attribute.rs
+++ b/rs-matter/src/dm/types/attribute.rs
@@ -22,12 +22,13 @@ use core::fmt::{self, Debug};
 use strum::FromRepr;
 
 use crate::attribute_enum;
+use crate::dm::Metadata;
 use crate::error::{Error, ErrorCode};
 use crate::im::{AttrPath, AttrStatus, IMStatusCode};
 use crate::tlv::{AsNullable, FromTLV, Nullable, TLVBuilder, TLVBuilderParent, TLVElement, TLVTag};
 use crate::utils::maybe::Maybe;
 
-use super::{Access, AttrId, Cluster, ClusterId, EndptId, Node, Quality};
+use super::{Access, AttrId, Cluster, ClusterId, EndptId, Quality};
 
 /// A type modeling the attribute meta-data in the Matter data model.
 #[derive(Debug, Clone)]
@@ -246,9 +247,7 @@ impl<T, E> ArrayAttributeWrite<T, E> {
 /// This type is built by the Data Model during the expansion of the attributes in the `Read` and `Write` IM actions
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct AttrDetails<'a> {
-    /// The node meta-data
-    pub node: &'a Node<'a>,
+pub struct AttrDetails {
     /// The concrete (expanded) endpoint ID
     pub endpoint_id: EndptId,
     /// The concrete (expanded) cluster ID
@@ -257,7 +256,7 @@ pub struct AttrDetails<'a> {
     pub attr_id: AttrId,
     /// List index, if any
     pub list_index: Option<Nullable<u16>>,
-    /// Valid only when the operation is attrubute read of
+    /// Valid only when the operation is attribute read of
     /// an individual array item
     /// When `true`, the path written to the output will contain
     /// `null` as a list index. This is necessary when we are returning
@@ -269,8 +268,10 @@ pub struct AttrDetails<'a> {
     pub fab_filter: bool,
     /// Attribute expected data version (when writing)
     pub dataver: Option<u32>,
-    /// Whether the original attribute was a wildcard one
+    /// Whether the original attribute path was a wildcard one
     pub wildcard: bool,
+    /// Whether the attribute is an array
+    pub array: bool,
     /// Cluster-specific status to stamp into the response `StatusIB.clusterStatus`
     /// for this attribute read or write. `0` means "no cluster status" (the
     /// reserved `kSuccess` value in Matter cluster-status enums).
@@ -284,7 +285,7 @@ pub struct AttrDetails<'a> {
     pub cluster_status: Cell<u8>,
 }
 
-impl AttrDetails<'_> {
+impl AttrDetails {
     /// Return `true` if the attribute is a system one (i.e. a global attribute).
     pub const fn is_system(&self) -> bool {
         Attribute::is_system_attr(self.attr_id)
@@ -312,14 +313,25 @@ impl AttrDetails<'_> {
         }
     }
 
-    pub fn cluster(&self) -> Result<&Cluster<'_>, Error> {
-        self.node
-            .endpoint(self.endpoint_id)
-            .and_then(|endpoint| endpoint.cluster(self.cluster_id))
-            .ok_or_else(|| {
-                error!("Cluster not found");
-                ErrorCode::ClusterNotFound.into()
-            })
+    /// Access the cluster associated with this attribute read/write operation.
+    ///
+    /// Utility method used by the codegen cluster handlers.
+    pub fn cluster<M, F, R>(&self, metadata: M, f: F) -> Result<R, Error>
+    where
+        M: Metadata,
+        F: FnOnce(&Cluster) -> Result<R, Error>,
+    {
+        metadata.access(|node| {
+            let cluster = node
+                .endpoint(self.endpoint_id)
+                .and_then(|endpoint| endpoint.cluster(self.cluster_id))
+                .ok_or_else(|| {
+                    error!("Cluster not found");
+                    Error::new(ErrorCode::ClusterNotFound)
+                })?;
+
+            f(cluster)
+        })
     }
 
     /// Stamp a cluster-specific status code onto this attribute access. The

--- a/rs-matter/src/dm/types/command.rs
+++ b/rs-matter/src/dm/types/command.rs
@@ -20,7 +20,7 @@ use core::fmt;
 
 use crate::im::{CmdPath, CmdStatus, IMStatusCode};
 
-use super::{Access, ClusterId, CmdId, EndptId, Node};
+use super::{Access, ClusterId, CmdId, EndptId};
 
 /// A type modeling the command meta-data in the Matter data model.
 #[derive(Debug, Clone)]
@@ -82,9 +82,7 @@ macro_rules! command_enum {
 /// This type is built by the Data Model during the expansion of the commands in the `Invoke` IM action
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct CmdDetails<'a> {
-    /// The node meta-data
-    pub node: &'a Node<'a>,
+pub struct CmdDetails {
     /// The concrete (expanded) endpoint ID
     pub endpoint_id: EndptId,
     /// The concrete (expanded) cluster ID
@@ -106,14 +104,13 @@ pub struct CmdDetails<'a> {
     /// before returning an error. Stored here as a `Cell<u8>` rather than
     /// on `Error` so that `Result<T, Error>` keeps its compact 1-byte error
     /// payload across the codebase.
-    cluster_status: Cell<u8>,
+    pub cluster_status: Cell<u8>,
 }
 
-impl<'a> CmdDetails<'a> {
+impl CmdDetails {
     /// Construct a new `CmdDetails`. Initializes `cluster_status` to `0`
     /// (no cluster-specific status to report).
     pub const fn new(
-        node: &'a Node<'a>,
         endpoint_id: EndptId,
         cluster_id: ClusterId,
         cmd_id: CmdId,
@@ -122,7 +119,6 @@ impl<'a> CmdDetails<'a> {
         command_ref: Option<u16>,
     ) -> Self {
         Self {
-            node,
             endpoint_id,
             cluster_id,
             cmd_id,
@@ -149,7 +145,7 @@ impl<'a> CmdDetails<'a> {
     }
 }
 
-impl CmdDetails<'_> {
+impl CmdDetails {
     /// Return the path with which this command invocation request
     /// should be replied, for the case where the command generates a simple
     /// status message as opposed to a true command reply.

--- a/rs-matter/src/dm/types/dataver.rs
+++ b/rs-matter/src/dm/types/dataver.rs
@@ -21,7 +21,6 @@ use core::num::Wrapping;
 
 use rand_core::RngCore;
 
-use crate::dm::{AttrChangeNotifier, AttrId, ClusterId, EndptId};
 use crate::utils::sync::blocking::Mutex;
 
 pub struct Dataver(Mutex<Cell<Wrapping<u32>>>);
@@ -45,51 +44,6 @@ impl Dataver {
 
             state.get().0
         })
-    }
-
-    /// Bump the cluster data version and notify any subscribers that the
-    /// given attribute has changed.
-    ///
-    /// This is the preferred way to signal an attribute mutation that happens
-    /// outside the normal write/invoke dispatch path (e.g. from a timer, an
-    /// async I/O completion, or a state-machine transition), because it keeps
-    /// the cluster data version and the subscription notification in lockstep.
-    ///
-    /// For mutations that happen *inside* the normal write/invoke dispatch
-    /// path, the generated `HandlerAdaptor` already bumps the data version;
-    /// call [`AttrChangeNotifier::notify_attr_changed`] directly in that case.
-    pub fn changed_and_notify_attr<N>(
-        &self,
-        notifier: N,
-        endpoint_id: EndptId,
-        cluster_id: ClusterId,
-        attr_id: AttrId,
-    ) -> u32
-    where
-        N: AttrChangeNotifier,
-    {
-        let v = self.changed();
-        notifier.notify_attr_changed(endpoint_id, cluster_id, attr_id);
-        v
-    }
-
-    /// Bump the cluster data version and notify any subscribers that every
-    /// attribute on the given cluster may have changed.
-    ///
-    /// Use this when a single operation mutates many attributes of the same
-    /// cluster and enumerating them would be cumbersome or error-prone.
-    pub fn changed_and_notify_cluster<N>(
-        &self,
-        notifier: N,
-        endpoint_id: EndptId,
-        cluster_id: ClusterId,
-    ) -> u32
-    where
-        N: AttrChangeNotifier,
-    {
-        let v = self.changed();
-        notifier.notify_cluster_changed(endpoint_id, cluster_id);
-        v
     }
 }
 

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -1171,7 +1171,23 @@ impl EmptyHandler {
 
 impl Handler for EmptyHandler {
     fn read(&self, _ctx: impl ReadContext, _reply: impl ReadReply) -> Result<(), Error> {
-        Err(ErrorCode::AttributeNotFound.into())
+        // The empty handler sits at the end of every `ChainedHandler`
+        // chain; reaching it means no matcher in the chain claimed
+        // the requested `(endpoint, cluster)`. That can happen either
+        // because the handler genuinely doesn't service the endpoint,
+        // or because the handler shape changed between path expansion
+        // (under the metadata lock) and dispatch (lock released). In
+        // both cases the safest, most informative IM status is
+        // `UnsupportedEndpoint`.
+        Err(ErrorCode::EndpointNotFound.into())
+    }
+
+    fn write(&self, _ctx: impl WriteContext) -> Result<(), Error> {
+        Err(ErrorCode::EndpointNotFound.into())
+    }
+
+    fn invoke(&self, _ctx: impl InvokeContext, _reply: impl InvokeReply) -> Result<(), Error> {
+        Err(ErrorCode::EndpointNotFound.into())
     }
 
     fn bump_dataver(&self, _ctx: impl MatchContext) {
@@ -1618,7 +1634,22 @@ mod asynch {
             _ctx: impl ReadContext,
             _reply: impl ReadReply,
         ) -> impl Future<Output = Result<(), Error>> {
-            core::future::ready(Err(ErrorCode::AttributeNotFound.into()))
+            // See the blocking-`Handler` impl for the rationale on
+            // returning `EndpointNotFound` rather than
+            // `AttributeNotFound` here.
+            core::future::ready(Err(ErrorCode::EndpointNotFound.into()))
+        }
+
+        fn write(&self, _ctx: impl WriteContext) -> impl Future<Output = Result<(), Error>> {
+            core::future::ready(Err(ErrorCode::EndpointNotFound.into()))
+        }
+
+        fn invoke(
+            &self,
+            _ctx: impl InvokeContext,
+            _reply: impl InvokeReply,
+        ) -> impl Future<Output = Result<(), Error>> {
+            core::future::ready(Err(ErrorCode::EndpointNotFound.into()))
         }
 
         fn bump_dataver(&self, _ctx: impl MatchContext) {

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -23,7 +23,7 @@ use embassy_futures::select::select;
 use crate::crypto::Crypto;
 use crate::dm::clusters::net_comm::NetworksAccess;
 use crate::dm::events::EventTLVWrite;
-use crate::dm::{EventId, IMBuffer};
+use crate::dm::{EventId, IMBuffer, Metadata};
 use crate::error::{Error, ErrorCode};
 use crate::im::{EventNumber, EventPriority};
 use crate::persist::KvBlobStoreAccess;
@@ -264,6 +264,9 @@ pub trait HandlerContext: AttrChangeNotifier + EventEmitter {
     /// Return the networks access object.
     fn networks(&self) -> impl NetworksAccess + '_;
 
+    /// Return the metadata of the node that is associated with this handler.
+    fn metadata(&self) -> impl Metadata + '_;
+
     /// Return the global handler that this handler is part of.
     ///
     /// Useful in case a concrete cluster handler (say, the Scenes one) needs to
@@ -295,6 +298,10 @@ where
 
     fn networks(&self) -> impl NetworksAccess + '_ {
         (**self).networks()
+    }
+
+    fn metadata(&self) -> impl Metadata + '_ {
+        (**self).metadata()
     }
 
     fn handler(&self) -> impl AsyncHandler + '_ {
@@ -372,14 +379,14 @@ where
 /// A context type that is passed to the handler when processing an attribute Read operation.
 pub trait ReadContext: OperationContext {
     /// Return the attribute object that is associated with this read operation.
-    fn attr(&self) -> &AttrDetails<'_>;
+    fn attr(&self) -> &AttrDetails;
 }
 
 impl<T> ReadContext for &T
 where
     T: ReadContext,
 {
-    fn attr(&self) -> &AttrDetails<'_> {
+    fn attr(&self) -> &AttrDetails {
         (**self).attr()
     }
 }
@@ -387,7 +394,7 @@ where
 /// A context type that is passed to the handler when processing an attribute Write operation.
 pub trait WriteContext: OperationContext {
     /// Return the attribute object that is associated with this write operation.
-    fn attr(&self) -> &AttrDetails<'_>;
+    fn attr(&self) -> &AttrDetails;
 
     /// Return the attribute data that is associated with this write operation.
     fn data(&self) -> &TLVElement<'_>;
@@ -406,7 +413,7 @@ impl<T> WriteContext for &T
 where
     T: WriteContext,
 {
-    fn attr(&self) -> &AttrDetails<'_> {
+    fn attr(&self) -> &AttrDetails {
         (**self).attr()
     }
 
@@ -421,7 +428,7 @@ where
 
 pub trait InvokeContext: OperationContext {
     /// Return the command object that is associated with this invoke operation.
-    fn cmd(&self) -> &CmdDetails<'_>;
+    fn cmd(&self) -> &CmdDetails;
 
     /// Return the command data that is associated with this invoke operation.
     fn data(&self) -> &TLVElement<'_>;
@@ -431,7 +438,7 @@ impl<T> InvokeContext for &T
 where
     T: InvokeContext,
 {
-    fn cmd(&self) -> &CmdDetails<'_> {
+    fn cmd(&self) -> &CmdDetails {
         (**self).cmd()
     }
 
@@ -444,7 +451,7 @@ where
 pub(crate) struct ReadContextInstance<'a, C> {
     exchange: &'a Exchange<'a>,
     context: C,
-    attr: &'a AttrDetails<'a>,
+    attr: &'a AttrDetails,
 }
 
 impl<'a, C> ReadContextInstance<'a, C>
@@ -453,11 +460,7 @@ where
 {
     /// Construct a new instance.
     #[inline(always)]
-    pub(crate) const fn new(
-        exchange: &'a Exchange<'a>,
-        context: C,
-        attr: &'a AttrDetails<'a>,
-    ) -> Self {
+    pub(crate) const fn new(exchange: &'a Exchange<'a>, context: C, attr: &'a AttrDetails) -> Self {
         Self {
             exchange,
             context,
@@ -484,6 +487,10 @@ where
 
     fn networks(&self) -> impl NetworksAccess + '_ {
         self.context.networks()
+    }
+
+    fn metadata(&self) -> impl Metadata + '_ {
+        self.context.metadata()
     }
 
     fn handler(&self) -> impl AsyncHandler + '_ {
@@ -603,7 +610,7 @@ impl<C> ReadContext for ReadContextInstance<'_, C>
 where
     C: HandlerContext,
 {
-    fn attr(&self) -> &AttrDetails<'_> {
+    fn attr(&self) -> &AttrDetails {
         self.attr
     }
 }
@@ -612,7 +619,7 @@ where
 pub(crate) struct WriteContextInstance<'a, C> {
     exchange: &'a Exchange<'a>,
     context: C,
-    attr: &'a AttrDetails<'a>,
+    attr: &'a AttrDetails,
     data: &'a TLVElement<'a>,
 }
 
@@ -626,7 +633,7 @@ where
     pub(crate) const fn new(
         exchange: &'a Exchange<'a>,
         context: C,
-        attr: &'a AttrDetails<'a>,
+        attr: &'a AttrDetails,
         data: &'a TLVElement<'a>,
     ) -> Self {
         Self {
@@ -656,6 +663,10 @@ where
 
     fn networks(&self) -> impl NetworksAccess + '_ {
         self.context.networks()
+    }
+
+    fn metadata(&self) -> impl Metadata + '_ {
+        self.context.metadata()
     }
 
     fn handler(&self) -> impl AsyncHandler + '_ {
@@ -775,7 +786,7 @@ impl<C> WriteContext for WriteContextInstance<'_, C>
 where
     C: HandlerContext,
 {
-    fn attr(&self) -> &AttrDetails<'_> {
+    fn attr(&self) -> &AttrDetails {
         self.attr
     }
 
@@ -788,7 +799,7 @@ where
 pub(crate) struct InvokeContextInstance<'a, C> {
     exchange: &'a Exchange<'a>,
     context: C,
-    cmd: &'a CmdDetails<'a>,
+    cmd: &'a CmdDetails,
     data: &'a TLVElement<'a>,
 }
 
@@ -802,7 +813,7 @@ where
     pub(crate) const fn new(
         exchange: &'a Exchange<'a>,
         context: C,
-        cmd: &'a CmdDetails<'a>,
+        cmd: &'a CmdDetails,
         data: &'a TLVElement<'a>,
     ) -> Self {
         Self {
@@ -832,6 +843,10 @@ where
 
     fn networks(&self) -> impl NetworksAccess + '_ {
         self.context.networks()
+    }
+
+    fn metadata(&self) -> impl Metadata + '_ {
+        self.context.metadata()
     }
 
     fn handler(&self) -> impl AsyncHandler + '_ {
@@ -951,7 +966,7 @@ impl<C> InvokeContext for InvokeContextInstance<'_, C>
 where
     C: HandlerContext,
 {
-    fn cmd(&self) -> &CmdDetails<'_> {
+    fn cmd(&self) -> &CmdDetails {
         self.cmd
     }
 
@@ -960,8 +975,8 @@ where
     }
 }
 
-pub trait DataModelHandler: super::AsyncMetadata + AsyncHandler {}
-impl<T> DataModelHandler for T where T: super::AsyncMetadata + AsyncHandler {}
+pub trait DataModelHandler: Metadata + AsyncHandler {}
+impl<T> DataModelHandler for T where T: Metadata + AsyncHandler {}
 
 /// A version of the `AsyncHandler` trait that never awaits any operation.
 ///

--- a/rs-matter/src/dm/types/metadata.rs
+++ b/rs-matter/src/dm/types/metadata.rs
@@ -17,86 +17,32 @@
 
 use crate::dm::Node;
 
-pub use asynch::*;
-
 use super::Async;
 
-pub trait MetadataGuard {
-    fn node(&self) -> Node<'_>;
-}
-
-impl<T> MetadataGuard for &T
-where
-    T: MetadataGuard,
-{
-    fn node(&self) -> Node<'_> {
-        (**self).node()
-    }
-}
-
-impl<T> MetadataGuard for &mut T
-where
-    T: MetadataGuard,
-{
-    fn node(&self) -> Node<'_> {
-        (**self).node()
-    }
-}
-
 pub trait Metadata {
-    type MetadataGuard<'a>: MetadataGuard
+    fn access<F, R>(&self, f: F) -> R
     where
-        Self: 'a;
-
-    fn lock(&self) -> Self::MetadataGuard<'_>;
+        F: FnOnce(&Node<'_>) -> R;
 }
 
 impl<T> Metadata for &T
 where
     T: Metadata,
 {
-    type MetadataGuard<'a>
-        = T::MetadataGuard<'a>
+    fn access<F, R>(&self, f: F) -> R
     where
-        Self: 'a;
-
-    fn lock(&self) -> Self::MetadataGuard<'_> {
-        (**self).lock()
-    }
-}
-
-impl<T> Metadata for &mut T
-where
-    T: Metadata,
-{
-    type MetadataGuard<'a>
-        = T::MetadataGuard<'a>
-    where
-        Self: 'a;
-
-    fn lock(&self) -> Self::MetadataGuard<'_> {
-        (**self).lock()
-    }
-}
-
-impl MetadataGuard for Node<'_> {
-    fn node(&self) -> Node<'_> {
-        Node {
-            endpoints: self.endpoints,
-        }
+        F: FnOnce(&Node<'_>) -> R,
+    {
+        (**self).access(f)
     }
 }
 
 impl Metadata for Node<'_> {
-    type MetadataGuard<'g>
-        = Node<'g>
+    fn access<F, R>(&self, f: F) -> R
     where
-        Self: 'g;
-
-    fn lock(&self) -> Self::MetadataGuard<'_> {
-        Node {
-            endpoints: self.endpoints,
-        }
+        F: FnOnce(&Node<'_>) -> R,
+    {
+        f(self)
     }
 }
 
@@ -104,13 +50,11 @@ impl<M, H> Metadata for (M, H)
 where
     M: Metadata,
 {
-    type MetadataGuard<'a>
-        = M::MetadataGuard<'a>
+    fn access<F, R>(&self, f: F) -> R
     where
-        Self: 'a;
-
-    fn lock(&self) -> Self::MetadataGuard<'_> {
-        self.0.lock()
+        F: FnOnce(&Node<'_>) -> R,
+    {
+        self.0.access(f)
     }
 }
 
@@ -118,97 +62,10 @@ impl<T> Metadata for Async<T>
 where
     T: Metadata,
 {
-    type MetadataGuard<'a>
-        = T::MetadataGuard<'a>
+    fn access<F, R>(&self, f: F) -> R
     where
-        Self: 'a;
-
-    fn lock(&self) -> Self::MetadataGuard<'_> {
-        self.0.lock()
-    }
-}
-
-mod asynch {
-    use core::future::Future;
-
-    use crate::dm::{Async, Node};
-
-    use super::{Metadata, MetadataGuard};
-
-    pub trait AsyncMetadata {
-        type MetadataGuard<'a>: MetadataGuard
-        where
-            Self: 'a;
-
-        async fn lock(&self) -> Self::MetadataGuard<'_>;
-    }
-
-    impl<T> AsyncMetadata for &T
-    where
-        T: AsyncMetadata,
+        F: FnOnce(&Node<'_>) -> R,
     {
-        type MetadataGuard<'a>
-            = T::MetadataGuard<'a>
-        where
-            Self: 'a;
-
-        fn lock(&self) -> impl Future<Output = Self::MetadataGuard<'_>> {
-            (**self).lock()
-        }
-    }
-
-    impl<T> AsyncMetadata for &mut T
-    where
-        T: AsyncMetadata,
-    {
-        type MetadataGuard<'a>
-            = T::MetadataGuard<'a>
-        where
-            Self: 'a;
-
-        fn lock(&self) -> impl Future<Output = Self::MetadataGuard<'_>> {
-            (**self).lock()
-        }
-    }
-
-    impl AsyncMetadata for Node<'_> {
-        type MetadataGuard<'g>
-            = Node<'g>
-        where
-            Self: 'g;
-
-        async fn lock(&self) -> Self::MetadataGuard<'_> {
-            Node {
-                endpoints: self.endpoints,
-            }
-        }
-    }
-
-    impl<M, H> AsyncMetadata for (M, H)
-    where
-        M: AsyncMetadata,
-    {
-        type MetadataGuard<'a>
-            = M::MetadataGuard<'a>
-        where
-            Self: 'a;
-
-        fn lock(&self) -> impl Future<Output = Self::MetadataGuard<'_>> {
-            self.0.lock()
-        }
-    }
-
-    impl<T> AsyncMetadata for Async<T>
-    where
-        T: Metadata,
-    {
-        type MetadataGuard<'a>
-            = T::MetadataGuard<'a>
-        where
-            Self: 'a;
-
-        async fn lock(&self) -> Self::MetadataGuard<'_> {
-            self.0.lock()
-        }
+        self.0.access(f)
     }
 }

--- a/rs-matter/src/dm/types/metadata.rs
+++ b/rs-matter/src/dm/types/metadata.rs
@@ -19,7 +19,12 @@ use crate::dm::Node;
 
 use super::Async;
 
+/// A trait for types that can provide access to a `Node` for the purpose of metadata retrieval.
 pub trait Metadata {
+    /// Access the `Node` associated with this metadata provider.
+    ///
+    /// # Arguments
+    /// - `f`: A closure that takes a reference to a `Node` and returns a value of type `R`.
     fn access<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&Node<'_>) -> R;

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -32,10 +32,27 @@ use crate::utils::storage::Vec;
 use super::{AttrDetails, ClusterId, CmdDetails, EndptId};
 
 /// The main Matter metadata type describing a Matter Node.
+///
+/// # Invariants
+///
+/// 1. Endpoints must be in **strictly increasing order** of `Endpoint::id`.
+/// 2. Per-endpoint shape is **stable for the endpoint's lifetime**.
+///    Once an endpoint with a given id has been added to a `Node`, its
+///    `clusters` slice and each cluster's attribute / command / event
+///    lists must not change. Whole endpoints may still be added or
+///    removed at runtime. Mutating a cluster's attribute or server
+///    list is a change to F-quality metadata (Matter Core spec
+///    §7.13.2.2 `AttributeList`, §7.13.2.4 `ServerList`) and must be
+///    accompanied by a `ConfigurationVersion` bump, which in practice
+///    means a restart of the `rs-matter` service and likely - of the
+///    whole process anyway.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Node<'a> {
     /// The endpoints of the (one and only) node in the Interaction & Data Model.
+    ///
+    /// See the [`Node`] type-level docs for the invariants this slice
+    /// must satisfy.
     pub endpoints: &'a [Endpoint<'a>],
 }
 
@@ -229,27 +246,24 @@ impl<'a, const N: usize> DynamicNode<'a, N> {
     }
 
     /// Add an endpoint to the dynamic node.
+    ///
+    /// The endpoint is inserted so that [`Node::endpoints`] stays
+    /// sorted by id (see the [`Node`] invariants).
     pub fn add(&mut self, endpoint: Endpoint<'a>) -> Result<(), Endpoint<'a>> {
-        if !self.endpoints.iter().any(|ep| ep.id == endpoint.id) {
-            self.endpoints.push(endpoint)
-        } else {
-            Err(endpoint)
+        match self.endpoints.iter().position(|ep| ep.id >= endpoint.id) {
+            Some(i) if self.endpoints[i].id == endpoint.id => Err(endpoint),
+            Some(i) => self.endpoints.insert(i, endpoint),
+            None => self.endpoints.push(endpoint),
         }
     }
 
     /// Remove an endpoint from the dynamic node.
+    ///
+    /// Uses an order-preserving `remove` (rather than `swap_remove`)
+    /// to keep [`Node::endpoints`] sorted by id.
     pub fn remove(&mut self, endpoint_id: u16) -> Option<Endpoint<'a>> {
-        let index = self
-            .endpoints
-            .iter()
-            .enumerate()
-            .find_map(|(index, ep)| (ep.id == endpoint_id).then_some(index));
-
-        if let Some(index) = index {
-            Some(self.endpoints.swap_remove(index))
-        } else {
-            None
-        }
+        let index = self.endpoints.iter().position(|ep| ep.id == endpoint_id)?;
+        Some(self.endpoints.remove(index))
     }
 }
 
@@ -549,11 +563,37 @@ struct PathExpander<'a, T, I, F> {
     items: Option<I>,
     /// The current path item being expanded.
     item: Option<T>,
-    /// The current endpoint index if the path is a wildcard one.
-    endpoint_index: u32,
-    /// The current cluster index.
+    /// The id of the endpoint currently anchoring the scan, or `None`
+    /// before the first endpoint has been entered (or right after the
+    /// item changes / the previous endpoint has been exhausted). This
+    /// is the *only* state needed to resume correctly across
+    /// metadata-lock releases:
+    ///
+    /// At the top of every `next_for_path` call we look the id up in
+    /// `Node::endpoints` via `binary_search_by_key`:
+    /// - `Ok(i)` — endpoint is still there (possibly at a different
+    ///   index); use `i` as `endpoint_index` and trust the existing
+    ///   `cluster_index` / `leaf_index` (Node-level invariant: an
+    ///   endpoint's cluster shape is stable for its lifetime).
+    /// - `Err(i)` — endpoint is gone; resume at `endpoint_index = i`
+    ///   (the insertion point — strictly past everything we've already
+    ///   yielded, because endpoints are sorted ascending by id) with
+    ///   `cluster_index` / `leaf_index` zeroed.
+    ///
+    /// `cluster_index` / `leaf_index` are not separately mirrored by
+    /// id: the per-endpoint shape invariant means the array slot we
+    /// were about to read next is still the right one, so positional
+    /// indices suffice once the endpoint is re-anchored.
+    ///
+    /// The endpoint array *index* is not held on `self` at all — it
+    /// is derived fresh at the top of every `next_for_path` call from
+    /// this id (via `binary_search_by_key`), since the array layout
+    /// can shift between calls. Within a single call it lives on the
+    /// stack as the outer-loop counter.
+    endpoint_id: Option<EndptId>,
+    /// The current cluster index within the anchored endpoint.
     cluster_index: u16,
-    /// The current leaf index.
+    /// The current leaf index within the anchored cluster.
     leaf_index: u16,
     /// Filter the expanded item or not
     filter: F,
@@ -597,7 +637,7 @@ where
             timed,
             items: paths,
             item: None,
-            endpoint_index: 0,
+            endpoint_id: None,
             cluster_index: 0,
             leaf_index: 0,
             filter,
@@ -620,7 +660,9 @@ where
                     Ok(item) => self.item = Some(item),
                 }
 
-                self.endpoint_index = 0;
+                // Each new item starts expansion from scratch; the
+                // endpoint-id resume anchor is per-item.
+                self.endpoint_id = None;
                 self.cluster_index = 0;
                 self.leaf_index = 0;
             }
@@ -686,8 +728,19 @@ where
             }
         }
 
-        while (self.endpoint_index as usize) < node.endpoints.len() {
-            let endpoint = &node.endpoints[self.endpoint_index as usize];
+        // Re-anchor the scan against the *current* Node before
+        // resuming. If the Node hasn't changed since the previous
+        // call this is an O(log N) check; otherwise we recover by
+        // looking up the endpoint id we were last anchored at.
+        // See the `endpoint_id` field doc-comment for semantics.
+        let mut endpoint_index = self.resume_endpoint_index(node);
+
+        while endpoint_index < node.endpoints.len() {
+            let endpoint = &node.endpoints[endpoint_index];
+            // Remember the id of the endpoint we're entering so the
+            // next `next_for_path` call can re-anchor against it even
+            // if the underlying `Node` has been swapped in between.
+            self.endpoint_id = Some(endpoint.id);
 
             if (path.endpoint.is_none() || path.endpoint == Some(endpoint.id))
                 && self.accessor.is_endpoint_accessible(endpoint.id)
@@ -718,12 +771,8 @@ where
                             if path.leaf.is_none() || path.leaf == Some(leaf_id as _) {
                                 // Leaf found, filter and check its access rights
 
+                                #[allow(clippy::if_same_then_else)]
                                 let check = if (self.filter)(endpoint.id, cluster.id, leaf_id) {
-                                    // Cache hit: this concrete triple was just
-                                    // authorized within the same expansion run.
-                                    // Skip the access re-check — see the
-                                    // `last_authorized` field doc on
-                                    // `PathExpander` for the rationale.
                                     if self.last_authorized
                                         == Some((endpoint.id, cluster.id, leaf_id))
                                     {
@@ -774,7 +823,10 @@ where
                                 match check {
                                     Ok(true) => {
                                         // Because on the next call we should start from the next leaf or if leaves
-                                        // are over, from the next cluster and so on
+                                        // are over, from the next cluster and so on. `endpoint_id` is
+                                        // already set to `endpoint.id` at the top of the outer loop,
+                                        // which is how the next call re-anchors to this endpoint even
+                                        // if the underlying Node has been mutated in between.
                                         self.leaf_index += 1;
 
                                         // Cache this concrete triple as the
@@ -840,13 +892,64 @@ where
                 self.cluster_index = 0;
             }
 
-            self.endpoint_index += 1;
+            endpoint_index += 1;
         }
 
         if !path.is_wildcard() {
             Err(IMStatusCode::UnsupportedEndpoint)
         } else {
             Ok(None)
+        }
+    }
+
+    /// Compute the starting `endpoint_index` for the outer loop in
+    /// `next_for_path` by re-anchoring against the *current* `node`
+    /// using the `endpoint_id` we last entered. Called once at the
+    /// top of every `next_for_path` so the scan resumes correctly
+    /// even if the underlying `Node` has been swapped or mutated
+    /// since the last `next` call.
+    ///
+    /// Relies on the [`Node`]-level invariants:
+    /// - **`endpoints` sorted ascending by id, no duplicates** —
+    ///   enables `binary_search_by_key` and means the insertion point
+    ///   on a miss is strictly past everything we've already yielded.
+    /// - **Per-endpoint shape is stable for the endpoint's lifetime**
+    ///   — means `cluster_index` and `leaf_index` are still valid
+    ///   positional cursors whenever the endpoint is found again.
+    ///
+    /// Returns `0` when `endpoint_id` is `None` (we haven't entered
+    /// any endpoint yet for the current item; the cluster / leaf
+    /// cursors are already at `0/0`).
+    fn resume_endpoint_index(&mut self, node: &Node<'_>) -> usize {
+        let Some(ep_id) = self.endpoint_id else {
+            return 0;
+        };
+
+        debug_assert!(
+            node.endpoints.windows(2).all(|w| w[0].id < w[1].id),
+            "Node::endpoints must be sorted ascending by id and contain no duplicates",
+        );
+
+        match node.endpoints.binary_search_by_key(&ep_id, |e| e.id) {
+            // Same endpoint, possibly at a different slot. The
+            // per-endpoint shape invariant means `cluster_index` and
+            // `leaf_index` still point at the array slot we were
+            // going to read next, so leave them alone.
+            Ok(i) => i,
+            Err(i) => {
+                // Endpoint is gone. The insertion point `i` is the
+                // index of the first remaining endpoint whose id is
+                // strictly greater than ours — i.e. one we have not
+                // yielded yet (would have come after the lost
+                // endpoint in the previous-Node iteration order).
+                // Reset the cluster / leaf cursors and clear the
+                // anchor so the outer loop reads the new endpoint
+                // fresh.
+                self.cluster_index = 0;
+                self.leaf_index = 0;
+                self.endpoint_id = None;
+                i
+            }
         }
     }
 }
@@ -1332,5 +1435,337 @@ mod test {
             |_ep, _cl, leaf| leaf != 1,
             &[Ok(Ok(GenericPath::new(Some(0), Some(1), Some(2))))],
         );
+    }
+
+    // -----------------------------------------------------------------
+    // Recovery from concurrent Node mutations between `next()` calls.
+    //
+    // The `Metadata` lock is now acquired afresh per `next()` call (see
+    // `PathExpanderIterator`), so the application is free to swap in a
+    // different `Node` between iterations. `PathExpander` is expected
+    // to recover by ID — these tests pin down the behaviour:
+    // - stable Node                                  → unchanged output
+    // - endpoint added/removed between iterations    → graceful advance
+    // - cluster added/removed                        → graceful advance
+    // - attribute added/removed                      → graceful advance
+    // - whole Node swapped                           → best-effort
+    // -----------------------------------------------------------------
+
+    use core::cell::Cell;
+
+    use crate::dm::Metadata;
+
+    /// A `Metadata` impl whose backing `Node` can be hot-swapped between
+    /// `access` calls — the test simulator for concurrent application
+    /// mutations.
+    struct SwappableMetadata {
+        current: Cell<&'static Node<'static>>,
+    }
+
+    impl SwappableMetadata {
+        fn new(node: &'static Node<'static>) -> Self {
+            Self {
+                current: Cell::new(node),
+            }
+        }
+
+        fn swap(&self, new_node: &'static Node<'static>) {
+            self.current.set(new_node);
+        }
+    }
+
+    impl Metadata for SwappableMetadata {
+        fn access<F, R>(&self, f: F) -> R
+        where
+            F: FnOnce(&Node<'_>) -> R,
+        {
+            f(self.current.get())
+        }
+    }
+
+    /// Run the expander interactively, invoking `after_yield(i, &metadata)`
+    /// after each `next()` result so the test can swap the Node in
+    /// between iterations. Compares the cumulative output to `expected`.
+    fn test_swap(
+        initial: &'static Node<'static>,
+        input: &[GenericPath],
+        mut after_yield: impl FnMut(usize, &SwappableMetadata),
+        expected: &[Result<Result<GenericPath, IMStatusCode>, ErrorCode>],
+    ) {
+        let matter = test_matter();
+        let accessor = Accessor::new(0, AccessorSubjects::new(0), Some(AuthMode::Pase), &matter);
+
+        let metadata = SwappableMetadata::new(initial);
+
+        let mut expander = PathExpanderIterator::new(
+            &metadata,
+            &accessor,
+            false,
+            Some(input.iter().cloned().map(Ok::<_, Error>)),
+            |_, _, _| true,
+        );
+
+        let mut actual: alloc::vec::Vec<_> = alloc::vec::Vec::new();
+        let mut i = 0;
+        while let Some(result) = expander.next() {
+            actual.push(result.map_err(|e| e.code()));
+            after_yield(i, &metadata);
+            i += 1;
+        }
+
+        assert_eq!(actual.as_slice(), expected);
+    }
+
+    // ---- Fixtures used across the recovery tests ------------------------
+
+    /// Sanity check: with no mutations the swap-aware test path matches
+    /// the static-Node test path.
+    #[test]
+    fn recovery_stable_node() {
+        static EP0_C1_A12: [Cluster; 1] = [make_cluster_const(1, &[1, 2])];
+        static NODE: Node = Node::new(&[Endpoint::new(0, &[], &EP0_C1_A12)]);
+
+        test_swap(
+            &NODE,
+            &[GenericPath::new(None, None, None)],
+            |_, _| {}, // no swap
+            &[
+                Ok(Ok(GenericPath::new(Some(0), Some(1), Some(1)))),
+                Ok(Ok(GenericPath::new(Some(0), Some(1), Some(2)))),
+            ],
+        );
+    }
+
+    /// New endpoint inserted *after* the yielded one. We must continue
+    /// from where we left off and then also visit the newcomer.
+    #[test]
+    fn recovery_endpoint_inserted_after_yield() {
+        static EP0_C1_A1: [Cluster; 1] = [make_cluster_const(1, &[1])];
+        static EP7_C1_A1: [Cluster; 1] = [make_cluster_const(1, &[1])];
+
+        static ONE_EP: [Endpoint; 1] = [Endpoint::new(0, &[], &EP0_C1_A1)];
+        static TWO_EPS: [Endpoint; 2] = [
+            Endpoint::new(0, &[], &EP0_C1_A1),
+            Endpoint::new(7, &[], &EP7_C1_A1),
+        ];
+
+        static NODE_BEFORE: Node = Node::new(&ONE_EP);
+        static NODE_AFTER: Node = Node::new(&TWO_EPS);
+
+        test_swap(
+            &NODE_BEFORE,
+            &[GenericPath::new(None, None, None)],
+            |i, m| {
+                // After the first yield, swap in the larger Node.
+                if i == 0 {
+                    m.swap(&NODE_AFTER);
+                }
+            },
+            &[
+                Ok(Ok(GenericPath::new(Some(0), Some(1), Some(1)))),
+                Ok(Ok(GenericPath::new(Some(7), Some(1), Some(1)))),
+            ],
+        );
+    }
+
+    /// Endpoint *removed* between two yields (the one we just yielded
+    /// against): we must still visit the remaining endpoints exactly
+    /// once each.
+    #[test]
+    fn recovery_endpoint_removed_after_yield() {
+        static EP0_C1_A1: [Cluster; 1] = [make_cluster_const(1, &[1])];
+        static EP5_C1_A1: [Cluster; 1] = [make_cluster_const(1, &[1])];
+        static EP7_C1_A1: [Cluster; 1] = [make_cluster_const(1, &[1])];
+
+        static THREE_EPS: [Endpoint; 3] = [
+            Endpoint::new(0, &[], &EP0_C1_A1),
+            Endpoint::new(5, &[], &EP5_C1_A1),
+            Endpoint::new(7, &[], &EP7_C1_A1),
+        ];
+        // After yield #1 we remove endpoint 5 (which was at index 1).
+        // Endpoint 7 shifts to index 1.
+        static TWO_EPS: [Endpoint; 2] = [
+            Endpoint::new(0, &[], &EP0_C1_A1),
+            Endpoint::new(7, &[], &EP7_C1_A1),
+        ];
+
+        static NODE_BEFORE: Node = Node::new(&THREE_EPS);
+        static NODE_AFTER: Node = Node::new(&TWO_EPS);
+
+        test_swap(
+            &NODE_BEFORE,
+            &[GenericPath::new(None, None, None)],
+            |i, m| {
+                // After yielding ep=0, drop ep=5. `binary_search` for
+                // ep_id=0 still finds it at slot 0; we exhaust it,
+                // advance to slot 1 — now ep=7 in the new array — and
+                // yield once from there. ep=5 is never re-visited.
+                if i == 0 {
+                    m.swap(&NODE_AFTER);
+                }
+            },
+            &[
+                Ok(Ok(GenericPath::new(Some(0), Some(1), Some(1)))),
+                Ok(Ok(GenericPath::new(Some(7), Some(1), Some(1)))),
+            ],
+        );
+    }
+
+    /// Cluster removed from the endpoint we're currently iterating
+    /// after we yielded against it. NB: this scenario *violates* the
+    /// [`Node`] per-endpoint-shape-stability invariant — once an
+    /// endpoint with a given id is exposed, its cluster slice must
+    /// not change. The test stays in place as defence-in-depth:
+    /// even under that contract violation the expander must not
+    /// panic or duplicate yields, it just exits gracefully when the
+    /// cluster array turns out shorter than the cursor.
+    #[test]
+    fn recovery_cluster_removed_after_yield() {
+        static C1_A1: [Cluster; 1] = [make_cluster_const(1, &[1])];
+        static C1_C10: [Cluster; 2] = [make_cluster_const(1, &[1]), make_cluster_const(10, &[1])];
+
+        static EP_BEFORE: [Endpoint; 1] = [Endpoint::new(0, &[], &C1_C10)];
+        // After yield #1 we drop cluster 10. Cluster 1 is still there.
+        static EP_AFTER: [Endpoint; 1] = [Endpoint::new(0, &[], &C1_A1)];
+
+        static NODE_BEFORE: Node = Node::new(&EP_BEFORE);
+        static NODE_AFTER: Node = Node::new(&EP_AFTER);
+
+        test_swap(
+            &NODE_BEFORE,
+            &[GenericPath::new(None, None, None)],
+            |i, m| {
+                if i == 0 {
+                    // We just yielded (ep=0, cluster=1, attr=1).
+                    // Now remove cluster 10. The expander should
+                    // notice the cluster array shortened and exit
+                    // gracefully.
+                    m.swap(&NODE_AFTER);
+                }
+            },
+            &[Ok(Ok(GenericPath::new(Some(0), Some(1), Some(1))))],
+        );
+    }
+
+    /// Attribute appended to the cluster after the slot we just
+    /// yielded against. As with `recovery_cluster_removed_after_yield`,
+    /// this scenario *violates* the [`Node`] per-endpoint-shape-stability
+    /// invariant; the test remains as defence-in-depth, documenting that
+    /// the expander deterministically picks up an extended attribute
+    /// list rather than panicking or skipping.
+    #[test]
+    fn recovery_attribute_appended() {
+        static C1_A1: [Cluster; 1] = [make_cluster_const(1, &[1])];
+        static C1_A1_A2: [Cluster; 1] = [make_cluster_const(1, &[1, 2])];
+
+        static EP_BEFORE: [Endpoint; 1] = [Endpoint::new(0, &[], &C1_A1)];
+        static EP_AFTER: [Endpoint; 1] = [Endpoint::new(0, &[], &C1_A1_A2)];
+
+        static NODE_BEFORE: Node = Node::new(&EP_BEFORE);
+        static NODE_AFTER: Node = Node::new(&EP_AFTER);
+
+        test_swap(
+            &NODE_BEFORE,
+            &[GenericPath::new(None, None, None)],
+            |i, m| {
+                if i == 0 {
+                    // Append attribute id=2 to cluster 1 after we
+                    // yielded attribute id=1.
+                    m.swap(&NODE_AFTER);
+                }
+            },
+            &[
+                Ok(Ok(GenericPath::new(Some(0), Some(1), Some(1)))),
+                // The newly-appended attribute is picked up.
+                Ok(Ok(GenericPath::new(Some(0), Some(1), Some(2)))),
+            ],
+        );
+    }
+
+    /// Whole Node replaced after the first yield — best-effort
+    /// continuation. Documents the observable behaviour rather than
+    /// asserting a specific "right" answer; the contract is that the
+    /// expander does not panic and does not infinite-loop.
+    #[test]
+    fn recovery_whole_node_swapped() {
+        static C1_A1: [Cluster; 1] = [make_cluster_const(1, &[1])];
+        static EP0_ORIG: [Endpoint; 1] = [Endpoint::new(0, &[], &C1_A1)];
+        static EP99_NEW: [Endpoint; 1] = [Endpoint::new(99, &[], &C1_A1)];
+
+        static NODE_BEFORE: Node = Node::new(&EP0_ORIG);
+        static NODE_AFTER: Node = Node::new(&EP99_NEW);
+
+        test_swap(
+            &NODE_BEFORE,
+            &[GenericPath::new(None, None, None)],
+            |i, m| {
+                if i == 0 {
+                    m.swap(&NODE_AFTER);
+                }
+            },
+            // After yielding (0, 1, 1) we swap to a Node whose only
+            // endpoint is id=99. `binary_search` for ep_id=0 in [99]
+            // returns `Err(0)` — the insertion point is index 0, so
+            // we resume there onto the new endpoint with the cluster /
+            // leaf cursors reset to 0.
+            &[
+                Ok(Ok(GenericPath::new(Some(0), Some(1), Some(1)))),
+                Ok(Ok(GenericPath::new(Some(99), Some(1), Some(1)))),
+            ],
+        );
+    }
+
+    /// Helper: `const fn` wrapper around `Cluster::new` for use inside
+    /// `static` initializers. Equivalent to the `make_cluster` runtime
+    /// helper but evaluable at compile time, which is what `static`
+    /// arrays require.
+    const fn make_cluster_const(id: ClusterId, attr_ids: &[u32]) -> Cluster<'static> {
+        // Specialised for the attribute layouts we use in recovery
+        // fixtures: [1], [1, 2], [1, 2, 3], [10], [20].
+        static ATTRS_1: [Attribute; 1] = [Attribute::new(1, Access::all(), Quality::all())];
+        static ATTRS_10: [Attribute; 1] = [Attribute::new(10, Access::all(), Quality::all())];
+        static ATTRS_20: [Attribute; 1] = [Attribute::new(20, Access::all(), Quality::all())];
+        static ATTRS_1_2: [Attribute; 2] = [
+            Attribute::new(1, Access::all(), Quality::all()),
+            Attribute::new(2, Access::all(), Quality::all()),
+        ];
+        static ATTRS_1_2_3: [Attribute; 3] = [
+            Attribute::new(1, Access::all(), Quality::all()),
+            Attribute::new(2, Access::all(), Quality::all()),
+            Attribute::new(3, Access::all(), Quality::all()),
+        ];
+
+        let slice: &[Attribute] = if attr_ids.len() == 1 {
+            match attr_ids[0] {
+                1 => &ATTRS_1,
+                10 => &ATTRS_10,
+                20 => &ATTRS_20,
+                _ => panic!("unsupported single-attr fixture"),
+            }
+        } else if attr_ids.len() == 2 {
+            match (attr_ids[0], attr_ids[1]) {
+                (1, 2) => &ATTRS_1_2,
+                _ => panic!("unsupported two-attr fixture"),
+            }
+        } else if attr_ids.len() == 3 {
+            match (attr_ids[0], attr_ids[1], attr_ids[2]) {
+                (1, 2, 3) => &ATTRS_1_2_3,
+                _ => panic!("unsupported three-attr fixture"),
+            }
+        } else {
+            panic!("unsupported attr_ids len");
+        };
+
+        Cluster::new(
+            id,
+            1,
+            0,
+            slice,
+            &[],
+            &[],
+            |_, _, _| true,
+            |_, _, _| true,
+            |_, _, _| true,
+        )
     }
 }

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -19,7 +19,7 @@ use core::cell::Cell;
 use core::fmt;
 
 use crate::acl::Accessor;
-use crate::dm::{Cluster, Endpoint};
+use crate::dm::{Cluster, Endpoint, Metadata, Quality};
 use crate::error::Error;
 use crate::im::{
     AttrData, AttrPath, AttrStatus, CmdData, CmdStatus, DataVersionFilter, EventPath, GenericPath,
@@ -50,90 +50,6 @@ impl<'a> Node<'a> {
         self.endpoints.iter().find(|endpoint| endpoint.id == id)
     }
 
-    /// Expand (potentially wildcard) read requests into concrete attribute details
-    /// using the node metadata.
-    ///
-    /// As part of the expansion, the method will check whether the attributes are
-    /// accessible by the accessor and whether they should be served based on the
-    /// fabric filtering and dataver filtering rules and filter out the inaccessible ones (wildcard reads)
-    /// or report an error status for the non-wildcard ones.
-    pub fn read<'m, F>(
-        &'m self,
-        req: &'m ReportDataReq,
-        accessor: &'m Accessor<'m>,
-        filter: F,
-    ) -> Result<impl Iterator<Item = Result<Result<AttrDetails<'m>, AttrStatus>, Error>> + 'm, Error>
-    where
-        F: FnMut(EndptId, ClusterId, u32) -> bool + 'm,
-    {
-        let dataver_filters = req.dataver_filters()?;
-        let fabric_filtered = req.fabric_filtered()?;
-
-        Ok(PathExpander::new(
-            self,
-            accessor,
-            false,
-            req.attr_requests()?.map(|reqs| {
-                reqs.into_iter().map(move |path_result| {
-                    path_result.map(|path| AttrReadPath {
-                        path,
-                        dataver_filters: dataver_filters.clone(),
-                        fabric_filtered,
-                    })
-                })
-            }),
-            filter,
-        ))
-    }
-
-    /// Expand (potentially wildcard) write requests into concrete attribute details
-    /// using the node metadata.
-    ///
-    /// As part of the expansion, the method will check whether the attributes are
-    /// accessible by the accessor and filter out the inaccessible ones (wildcard writes)
-    /// or report an error status for the non-wildcard ones.
-    #[allow(clippy::type_complexity)]
-    pub fn write<'m>(
-        &'m self,
-        req: &'m WriteReq,
-        accessor: &'m Accessor<'m>,
-    ) -> Result<
-        impl Iterator<Item = Result<Result<(AttrDetails<'m>, TLVElement<'m>), AttrStatus>, Error>> + 'm,
-        Error,
-    > {
-        Ok(PathExpander::new(
-            self,
-            accessor,
-            req.timed_request()?,
-            Some(req.write_requests()?.into_iter()),
-            |_, _, _| true,
-        ))
-    }
-
-    /// Expand (potentially wildcard) invoke requests into concrete command details
-    /// using the node metadata.
-    ///
-    /// As part of the expansion, the method will check whether the commands are
-    /// accessible by the accessor and filter out the inaccessible ones (wildcard invocations)
-    /// or report an error status for the non-wildcard ones.
-    #[allow(clippy::type_complexity)]
-    pub fn invoke<'m>(
-        &'m self,
-        req: &'m InvReq,
-        accessor: &'m Accessor<'m>,
-    ) -> Result<
-        impl Iterator<Item = Result<Result<(CmdDetails<'m>, TLVElement<'m>), CmdStatus>, Error>> + 'm,
-        Error,
-    > {
-        Ok(PathExpander::new(
-            self,
-            accessor,
-            req.timed_request()?,
-            req.inv_requests()?.map(move |reqs| reqs.into_iter()),
-            |_, _, _| true,
-        ))
-    }
-
     pub(crate) fn validate_attr_path(
         &self,
         path: &AttrPath,
@@ -156,6 +72,73 @@ impl<'a> Node<'a> {
         };
 
         cluster.check_attr_access(accessor, timed, gp, endpoint.device_types, write, attr.id)
+    }
+
+    pub(crate) fn validate_event_path(
+        &self,
+        path: &EventPath,
+        accessor: &Accessor<'_>,
+    ) -> Result<(), IMStatusCode> {
+        if let Some(node_id) = path.node {
+            self.validate_node_id(node_id, accessor)?;
+        }
+
+        let gp = path.to_gp();
+
+        let Some((endpoint, cluster, event_id)) = self.validate_cluster_path(&gp)? else {
+            return Ok(());
+        };
+
+        let Some(event) = cluster.event(event_id) else {
+            return Err(IMStatusCode::UnsupportedEvent);
+        };
+
+        cluster.check_event_access(accessor, gp, endpoint.device_types, event.id)
+    }
+
+    fn validate_cluster_path(
+        &self,
+        path: &GenericPath,
+    ) -> Result<Option<(&Endpoint<'_>, &Cluster<'_>, u32)>, IMStatusCode> {
+        let Some(endpoint_id) = path.endpoint else {
+            return Ok(None);
+        };
+
+        let Some(endpoint) = self.endpoint(endpoint_id) else {
+            // Endpoint does not exist
+            return Err(IMStatusCode::UnsupportedEndpoint);
+        };
+
+        let Some(cluster_id) = path.cluster else {
+            return Ok(None);
+        };
+
+        let Some(cluster) = endpoint.cluster(cluster_id) else {
+            // Cluster does not exist on this endpoint
+            return Err(IMStatusCode::UnsupportedCluster);
+        };
+
+        let Some(leaf_id) = path.leaf else {
+            return Ok(None);
+        };
+
+        Ok(Some((endpoint, cluster, leaf_id)))
+    }
+
+    fn validate_node_id(
+        &self,
+        node_id: NodeId,
+        accessor: &Accessor<'_>,
+    ) -> Result<(), IMStatusCode> {
+        let Some(accessor_node_id) = accessor.node_id() else {
+            return Err(IMStatusCode::UnsupportedNode);
+        };
+
+        if node_id != accessor_node_id {
+            return Err(IMStatusCode::UnsupportedNode);
+        }
+
+        Ok(())
     }
 
     /// Return `true` if at least one attribute matching the (potentially wildcard) path
@@ -202,73 +185,6 @@ impl<'a> Node<'a> {
         }
 
         false
-    }
-
-    pub(crate) fn validate_event_path(
-        &self,
-        path: &EventPath,
-        accessor: &Accessor<'_>,
-    ) -> Result<(), IMStatusCode> {
-        if let Some(node_id) = path.node {
-            self.validate_node_id(node_id, accessor)?;
-        }
-
-        let gp = path.to_gp();
-
-        let Some((endpoint, cluster, event_id)) = self.validate_cluster_path(&gp)? else {
-            return Ok(());
-        };
-
-        let Some(event) = cluster.event(event_id) else {
-            return Err(IMStatusCode::UnsupportedEvent);
-        };
-
-        cluster.check_event_access(accessor, gp, endpoint.device_types, event.id)
-    }
-
-    fn validate_node_id(
-        &self,
-        node_id: NodeId,
-        accessor: &Accessor<'_>,
-    ) -> Result<(), IMStatusCode> {
-        let Some(accessor_node_id) = accessor.node_id() else {
-            return Err(IMStatusCode::UnsupportedNode);
-        };
-
-        if node_id != accessor_node_id {
-            return Err(IMStatusCode::UnsupportedNode);
-        }
-
-        Ok(())
-    }
-
-    fn validate_cluster_path(
-        &self,
-        path: &GenericPath,
-    ) -> Result<Option<(&Endpoint<'_>, &Cluster<'_>, u32)>, IMStatusCode> {
-        let Some(endpoint_id) = path.endpoint else {
-            return Ok(None);
-        };
-
-        let Some(endpoint) = self.endpoint(endpoint_id) else {
-            // Endpoint does not exist
-            return Err(IMStatusCode::UnsupportedEndpoint);
-        };
-
-        let Some(cluster_id) = path.cluster else {
-            return Ok(None);
-        };
-
-        let Some(cluster) = endpoint.cluster(cluster_id) else {
-            // Cluster does not exist on this endpoint
-            return Err(IMStatusCode::UnsupportedCluster);
-        };
-
-        let Some(leaf_id) = path.leaf else {
-            return Ok(None);
-        };
-
-        Ok(Some((endpoint, cluster, leaf_id)))
     }
 }
 
@@ -349,6 +265,97 @@ impl<'a, const N: usize> Default for DynamicNode<'a, N> {
     }
 }
 
+/// Expand (potentially wildcard) read requests into concrete attribute details
+/// using the node metadata.
+///
+/// As part of the expansion, the method will check whether the attributes are
+/// accessible by the accessor and whether they should be served based on the
+/// fabric filtering and dataver filtering rules and filter out the inaccessible ones (wildcard reads)
+/// or report an error status for the non-wildcard ones.
+pub fn expand_read<'m, M, F>(
+    metadata: M,
+    req: &'m ReportDataReq,
+    accessor: &'m Accessor<'m>,
+    filter: F,
+) -> Result<impl Iterator<Item = Result<Result<AttrDetails, AttrStatus>, Error>> + 'm, Error>
+where
+    M: Metadata + 'm,
+    F: FnMut(EndptId, ClusterId, u32) -> bool + 'm,
+{
+    let dataver_filters = req.dataver_filters()?;
+    let fabric_filtered = req.fabric_filtered()?;
+
+    Ok(PathExpanderIterator::new(
+        metadata,
+        accessor,
+        false,
+        req.attr_requests()?.map(|reqs| {
+            reqs.into_iter().map(move |path_result| {
+                path_result.map(|path| AttrReadPath {
+                    path,
+                    dataver_filters: dataver_filters.clone(),
+                    fabric_filtered,
+                })
+            })
+        }),
+        filter,
+    ))
+}
+
+/// Expand (potentially wildcard) write requests into concrete attribute details
+/// using the node metadata.
+///
+/// As part of the expansion, the method will check whether the attributes are
+/// accessible by the accessor and filter out the inaccessible ones (wildcard writes)
+/// or report an error status for the non-wildcard ones.
+#[allow(clippy::type_complexity)]
+pub fn expand_write<'m, M>(
+    metadata: M,
+    req: &'m WriteReq,
+    accessor: &'m Accessor<'m>,
+) -> Result<
+    impl Iterator<Item = Result<Result<(AttrDetails, TLVElement<'m>), AttrStatus>, Error>> + 'm,
+    Error,
+>
+where
+    M: Metadata + 'm,
+{
+    Ok(PathExpanderIterator::new(
+        metadata,
+        accessor,
+        req.timed_request()?,
+        Some(req.write_requests()?.into_iter()),
+        |_, _, _| true,
+    ))
+}
+
+/// Expand (potentially wildcard) invoke requests into concrete command details
+/// using the node metadata.
+///
+/// As part of the expansion, the method will check whether the commands are
+/// accessible by the accessor and filter out the inaccessible ones (wildcard invocations)
+/// or report an error status for the non-wildcard ones.
+#[allow(clippy::type_complexity)]
+pub fn expand_invoke<'m, M>(
+    metadata: M,
+    req: &'m InvReq,
+    accessor: &'m Accessor<'m>,
+) -> Result<
+    impl Iterator<Item = Result<Result<(CmdDetails, TLVElement<'m>), CmdStatus>, Error>> + 'm,
+    Error,
+>
+where
+    M: Metadata + 'm,
+{
+    Ok(PathExpanderIterator::new(
+        metadata,
+        accessor,
+        req.timed_request()?,
+        req.inv_requests()?.map(move |reqs| reqs.into_iter()),
+        |_, _, _| true,
+    ))
+}
+
 /// A helper type for `AttrPath` that enriches it with the request-scope information
 /// of whether the attributes served as part of that request should be fabric filtered
 /// as well as with information which attributes should only be served if their
@@ -393,11 +400,11 @@ trait PathExpansionItem<'a> {
     /// as the original ones might be wildcarded.
     fn expand(
         &self,
-        node: &'a Node<'a>,
-        accessor: &'a Accessor<'a>,
+        accessor: &Accessor<'_>,
         endpoint_id: EndptId,
         cluster_id: ClusterId,
         leaf_id: u32,
+        array: bool,
     ) -> Result<Self::Expanded<'a>, Error>;
 
     /// Convert the item into an error status if the expansion failed.
@@ -408,7 +415,7 @@ trait PathExpansionItem<'a> {
 impl<'a> PathExpansionItem<'a> for AttrReadPath<'a> {
     const OPERATION: Operation = Operation::Read;
 
-    type Expanded<'n> = AttrDetails<'n>;
+    type Expanded<'n> = AttrDetails;
     type Status = AttrStatus;
 
     fn path(&self) -> GenericPath {
@@ -417,14 +424,13 @@ impl<'a> PathExpansionItem<'a> for AttrReadPath<'a> {
 
     fn expand(
         &self,
-        node: &'a Node<'a>,
-        accessor: &'a Accessor<'a>,
+        accessor: &Accessor<'_>,
         endpoint_id: EndptId,
         cluster_id: ClusterId,
         leaf_id: u32,
+        array: bool,
     ) -> Result<Self::Expanded<'a>, Error> {
         Ok(AttrDetails {
-            node,
             endpoint_id,
             cluster_id,
             attr_id: leaf_id as _,
@@ -434,6 +440,7 @@ impl<'a> PathExpansionItem<'a> for AttrReadPath<'a> {
             fab_idx: accessor.fab_idx,
             fab_filter: self.fabric_filtered,
             dataver: dataver(self.dataver_filters.as_ref(), endpoint_id, cluster_id)?,
+            array,
             cluster_status: Cell::new(0),
         })
     }
@@ -447,7 +454,7 @@ impl<'a> PathExpansionItem<'a> for AttrReadPath<'a> {
 impl<'a> PathExpansionItem<'a> for AttrData<'a> {
     const OPERATION: Operation = Operation::Write;
 
-    type Expanded<'n> = (AttrDetails<'n>, TLVElement<'n>);
+    type Expanded<'n> = (AttrDetails, TLVElement<'n>);
     type Status = AttrStatus;
 
     fn path(&self) -> GenericPath {
@@ -456,15 +463,14 @@ impl<'a> PathExpansionItem<'a> for AttrData<'a> {
 
     fn expand(
         &self,
-        node: &'a Node<'a>,
-        accessor: &'a Accessor<'a>,
+        accessor: &Accessor<'_>,
         endpoint_id: EndptId,
         cluster_id: ClusterId,
         leaf_id: u32,
+        array: bool,
     ) -> Result<Self::Expanded<'a>, Error> {
         let expanded = (
             AttrDetails {
-                node,
                 endpoint_id,
                 cluster_id,
                 attr_id: leaf_id as _,
@@ -476,6 +482,7 @@ impl<'a> PathExpansionItem<'a> for AttrData<'a> {
                 // are assumed to be always fabric-filtered
                 fab_filter: true,
                 dataver: self.data_ver,
+                array,
                 cluster_status: Cell::new(0),
             },
             self.data.clone(),
@@ -493,7 +500,7 @@ impl<'a> PathExpansionItem<'a> for AttrData<'a> {
 impl<'a> PathExpansionItem<'a> for CmdData<'a> {
     const OPERATION: Operation = Operation::Invoke;
 
-    type Expanded<'n> = (CmdDetails<'n>, TLVElement<'n>);
+    type Expanded<'n> = (CmdDetails, TLVElement<'n>);
     type Status = CmdStatus;
 
     fn path(&self) -> GenericPath {
@@ -502,15 +509,14 @@ impl<'a> PathExpansionItem<'a> for CmdData<'a> {
 
     fn expand(
         &self,
-        node: &'a Node<'a>,
-        accessor: &'a Accessor<'a>,
+        accessor: &Accessor<'_>,
         endpoint_id: EndptId,
         cluster_id: ClusterId,
         leaf_id: u32,
+        _array: bool,
     ) -> Result<Self::Expanded<'a>, Error> {
         let expanded = (
             CmdDetails::new(
-                node,
                 endpoint_id,
                 cluster_id,
                 leaf_id,
@@ -534,12 +540,7 @@ impl<'a> PathExpansionItem<'a> for CmdData<'a> {
 /// While the iterator can be (and used to be) implemented by using monadic combinators,
 /// this implementation is done in a more imperative way to avoid the overhead of monadic
 /// combinators in terms of memory size.
-struct PathExpander<'a, T, I, F>
-where
-    I: Iterator<Item = Result<T, Error>>,
-{
-    /// The metatdata node to expand the paths on.
-    node: &'a Node<'a>,
+struct PathExpander<'a, T, I, F> {
     /// The accessor to check the access rights.
     accessor: &'a Accessor<'a>,
     /// Where the paths are part of a timed interaction
@@ -589,16 +590,9 @@ where
     T: PathExpansionItem<'a>,
     F: FnMut(EndptId, ClusterId, u32) -> bool,
 {
-    /// Create a new path expander with the given node, accessor, and paths.
-    pub const fn new(
-        node: &'a Node<'a>,
-        accessor: &'a Accessor<'a>,
-        timed: bool,
-        paths: Option<I>,
-        filter: F,
-    ) -> Self {
+    /// Create a new path expander with the given accessor and paths.
+    pub const fn new(accessor: &'a Accessor<'a>, timed: bool, paths: Option<I>, filter: F) -> Self {
         Self {
-            node,
             accessor,
             timed,
             items: paths,
@@ -611,6 +605,60 @@ where
         }
     }
 
+    #[allow(clippy::type_complexity)]
+    fn next(
+        &mut self,
+        node: &Node<'_>,
+    ) -> Option<Result<Result<T::Expanded<'a>, T::Status>, Error>> {
+        loop {
+            // Fetch an item to expand if not already there
+            if self.item.is_none() {
+                let item = self.items.as_mut().and_then(|items| items.next())?;
+
+                match item {
+                    Err(err) => break Some(Err(err)),
+                    Ok(item) => self.item = Some(item),
+                }
+
+                self.endpoint_index = 0;
+                self.cluster_index = 0;
+                self.leaf_index = 0;
+            }
+
+            // From here on, we do have a valid `self.item` to expand
+
+            // Step on the first/next expanded path of the item
+            match self.next_for_path(node) {
+                Ok(Some((endpoint_id, cluster_id, leaf_id, array))) => {
+                    // Next expansion of the path
+
+                    let expanded = unwrap!(self.item.as_ref()).expand(
+                        self.accessor,
+                        endpoint_id,
+                        cluster_id,
+                        leaf_id,
+                        array,
+                    );
+
+                    if !unwrap!(self.item.as_ref()).path().is_wildcard() {
+                        // Non-wildcard path, remove the current item
+                        self.item = None;
+                    }
+
+                    break Some(expanded.map(Ok));
+                }
+                Ok(None) => {
+                    // This path is exhausted, time to move to the next one
+                    self.item = None;
+                }
+                Err(status) => {
+                    // Report an error status and remove the current item
+                    break Some(Ok(Err(unwrap!(self.item.take()).into_status(status))));
+                }
+            }
+        }
+    }
+
     /// Move to the next (endpoint, cluster, leaf) triple that matches the path
     /// of the current item.
     ///
@@ -618,13 +666,17 @@ where
     /// whether the endpoint, the cluster, or the leaf is not matching.
     ///
     /// This method should only be called when `self.item` is `Some` or else it will panic.
-    fn next_for_path(&mut self) -> Result<Option<(EndptId, ClusterId, u32)>, IMStatusCode> {
+    fn next_for_path(
+        &mut self,
+        node: &Node<'_>,
+    ) -> Result<Option<(EndptId, ClusterId, u32, bool)>, IMStatusCode> {
         let path = unwrap!(self.item.as_ref().map(PathExpansionItem::path));
 
         let command = matches!(T::OPERATION, Operation::Invoke);
+        let attr_read = matches!(T::OPERATION, Operation::Read);
 
         // Do some basic checks on wildcards, as not all wildcards are supported for each type of operation
-        if !matches!(T::OPERATION, Operation::Read) {
+        if !attr_read {
             if path.cluster.is_none() {
                 return Err(IMStatusCode::UnsupportedCluster);
             }
@@ -634,8 +686,8 @@ where
             }
         }
 
-        while (self.endpoint_index as usize) < self.node.endpoints.len() {
-            let endpoint = &self.node.endpoints[self.endpoint_index as usize];
+        while (self.endpoint_index as usize) < node.endpoints.len() {
+            let endpoint = &node.endpoints[self.endpoint_index as usize];
 
             if (path.endpoint.is_none() || path.endpoint == Some(endpoint.id))
                 && self.accessor.is_endpoint_accessible(endpoint.id)
@@ -676,7 +728,7 @@ where
                                         == Some((endpoint.id, cluster.id, leaf_id))
                                     {
                                         Ok(true)
-                                    } else if matches!(T::OPERATION, Operation::Invoke) {
+                                    } else if command {
                                         cluster
                                             .check_cmd_access(
                                                 self.accessor,
@@ -707,7 +759,7 @@ where
                                                     Some(leaf_id),
                                                 ),
                                                 endpoint.device_types,
-                                                matches!(T::OPERATION, Operation::Write),
+                                                !attr_read,
                                                 unwrap!(cluster
                                                     .attributes()
                                                     .map(|attr| attr.id)
@@ -735,7 +787,13 @@ where
                                         self.last_authorized =
                                             Some((endpoint.id, cluster.id, leaf_id));
 
-                                        return Ok(Some((endpoint.id, cluster.id, leaf_id)));
+                                        let array = !command
+                                            && cluster
+                                                .attribute(leaf_id)
+                                                .map(|attr| attr.quality.contains(Quality::ARRAY))
+                                                .unwrap_or(false);
+
+                                        return Ok(Some((endpoint.id, cluster.id, leaf_id, array)));
                                     }
                                     Ok(false) => {
                                         // Filtered out. For a non-wildcard path the
@@ -793,8 +851,36 @@ where
     }
 }
 
-impl<'a, T, I, F> Iterator for PathExpander<'a, T, I, F>
+struct PathExpanderIterator<'a, M, T, I, F> {
+    metadata: M,
+    expander: PathExpander<'a, T, I, F>,
+}
+
+impl<'a, M, T, I, F> PathExpanderIterator<'a, M, T, I, F>
 where
+    M: Metadata,
+    I: Iterator<Item = Result<T, Error>>,
+    T: PathExpansionItem<'a>,
+    F: FnMut(EndptId, ClusterId, u32) -> bool,
+{
+    /// Create a new path expander iterator with the given metadata, accessor and paths.
+    pub const fn new(
+        metadata: M,
+        accessor: &'a Accessor<'a>,
+        timed: bool,
+        paths: Option<I>,
+        filter: F,
+    ) -> Self {
+        Self {
+            metadata,
+            expander: PathExpander::new(accessor, timed, paths, filter),
+        }
+    }
+}
+
+impl<'a, M, T, I, F> Iterator for PathExpanderIterator<'a, M, T, I, F>
+where
+    M: Metadata,
     I: Iterator<Item = Result<T, Error>>,
     T: PathExpansionItem<'a>,
     F: FnMut(EndptId, ClusterId, u32) -> bool,
@@ -802,53 +888,10 @@ where
     type Item = Result<Result<T::Expanded<'a>, T::Status>, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            // Fetch an item to expand if not already there
-            if self.item.is_none() {
-                let item = self.items.as_mut().and_then(|items| items.next())?;
+        let metadata = &self.metadata;
+        let expander = &mut self.expander;
 
-                match item {
-                    Err(err) => break Some(Err(err)),
-                    Ok(item) => self.item = Some(item),
-                }
-
-                self.endpoint_index = 0;
-                self.cluster_index = 0;
-                self.leaf_index = 0;
-            }
-
-            // From here on, we do have a valid `self.item` to expand
-
-            // Step on the first/next expanded path of the item
-            match self.next_for_path() {
-                Ok(Some((endpoint_id, cluster_id, leaf_id))) => {
-                    // Next expansion of the path
-
-                    let expanded = unwrap!(self.item.as_ref()).expand(
-                        self.node,
-                        self.accessor,
-                        endpoint_id,
-                        cluster_id,
-                        leaf_id,
-                    );
-
-                    if !unwrap!(self.item.as_ref()).path().is_wildcard() {
-                        // Non-wildcard path, remove the current item
-                        self.item = None;
-                    }
-
-                    break Some(expanded.map(Ok));
-                }
-                Ok(None) => {
-                    // This path is exhausted, time to move to the next one
-                    self.item = None;
-                }
-                Err(status) => {
-                    // Report an error status and remove the current item
-                    break Some(Ok(Err(unwrap!(self.item.take()).into_status(status))));
-                }
-            }
-        }
+        metadata.access(|node| expander.next(node))
     }
 }
 
@@ -883,7 +926,7 @@ mod test {
     use crate::im::IMStatusCode;
     use crate::test::test_matter;
 
-    use super::{Node, Operation, PathExpander, PathExpansionItem};
+    use super::{Node, Operation, PathExpanderIterator, PathExpansionItem};
 
     // For tests
     impl<'a> PathExpansionItem<'a> for GenericPath {
@@ -898,11 +941,11 @@ mod test {
 
         fn expand(
             &self,
-            _node: &'a Node<'a>,
-            _accessor: &'a Accessor<'a>,
+            _accessor: &Accessor<'_>,
             endpoint_id: EndptId,
             cluster_id: ClusterId,
             leaf_id: u32,
+            _array: bool,
         ) -> Result<Self::Expanded<'a>, Error> {
             Ok(GenericPath::new(
                 Some(endpoint_id),
@@ -936,7 +979,7 @@ mod test {
         let matter = test_matter();
         let accessor = Accessor::new(0, AccessorSubjects::new(0), Some(AuthMode::Pase), &matter);
 
-        let expander = PathExpander::new(
+        let expander = PathExpanderIterator::new(
             node,
             &accessor,
             false,

--- a/rs-matter/src/dm/types/reply.rs
+++ b/rs-matter/src/dm/types/reply.rs
@@ -86,7 +86,7 @@ where
 
     pub async fn process_read<T: TLVWrite + Send>(
         &mut self,
-        item: &Result<AttrDetails<'_>, AttrStatus>,
+        item: &Result<AttrDetails, AttrStatus>,
         mut tw: T,
     ) -> Result<(), Error> {
         let tail = tw.get_tail();
@@ -103,7 +103,7 @@ where
 
     async fn do_process_read<T: TLVWrite + Send>(
         &mut self,
-        item: &Result<AttrDetails<'_>, AttrStatus>,
+        item: &Result<AttrDetails, AttrStatus>,
         mut tw: T,
     ) -> Result<(), Error> {
         let result = match item {
@@ -139,7 +139,7 @@ where
 
     pub async fn read<T: TLVWrite + Send>(
         &mut self,
-        attr: &AttrDetails<'_>,
+        attr: &AttrDetails,
         tw: T,
     ) -> Result<(), Error> {
         self.context
@@ -153,7 +153,7 @@ where
 
     pub async fn process_write<T: TLVWrite>(
         &mut self,
-        item: &Result<(AttrDetails<'_>, TLVElement<'_>), AttrStatus>,
+        item: &Result<(AttrDetails, TLVElement<'_>), AttrStatus>,
         mut tw: T,
     ) -> Result<(), Error> {
         let tail = tw.get_tail();
@@ -170,7 +170,7 @@ where
 
     async fn do_process_write<T: TLVWrite>(
         &mut self,
-        item: &Result<(AttrDetails<'_>, TLVElement<'_>), AttrStatus>,
+        item: &Result<(AttrDetails, TLVElement<'_>), AttrStatus>,
         mut tw: T,
     ) -> Result<(), Error> {
         let result = match item {
@@ -216,11 +216,7 @@ where
         }
     }
 
-    pub async fn write(
-        &mut self,
-        attr: &AttrDetails<'_>,
-        data: &TLVElement<'_>,
-    ) -> Result<(), Error> {
+    pub async fn write(&mut self, attr: &AttrDetails, data: &TLVElement<'_>) -> Result<(), Error> {
         self.context
             .handler()
             .write(WriteContextInstance::new(
@@ -234,7 +230,7 @@ where
 
     pub async fn process_invoke<T: TLVWrite + Send>(
         &mut self,
-        item: &Result<(CmdDetails<'_>, TLVElement<'_>), CmdStatus>,
+        item: &Result<(CmdDetails, TLVElement<'_>), CmdStatus>,
         mut tw: T,
     ) -> Result<(), Error> {
         let tail = tw.get_tail();
@@ -251,7 +247,7 @@ where
 
     async fn do_process_invoke<T: TLVWrite + Send>(
         &mut self,
-        item: &Result<(CmdDetails<'_>, TLVElement<'_>), CmdStatus>,
+        item: &Result<(CmdDetails, TLVElement<'_>), CmdStatus>,
         mut tw: T,
     ) -> Result<(), Error> {
         let result = match item {
@@ -293,7 +289,7 @@ where
 
     pub async fn invoke<T: TLVWrite + Send>(
         &mut self,
-        cmd: &CmdDetails<'_>,
+        cmd: &CmdDetails,
         data: &TLVElement<'_>,
         tw: T,
     ) -> Result<(), Error> {

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -32,8 +32,11 @@
 use core::future::Future;
 
 use crate::crypto::Crypto;
+use crate::dm::clusters::basic_info::AttributeId;
+use crate::dm::clusters::basic_info::FULL_CLUSTER as BASIC_INFO_CLUSTER;
 use crate::dm::clusters::basic_info::{BasicInfoConfig, BasicInfoSettings};
 use crate::dm::clusters::dev_att::DeviceAttestation;
+use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::dm::AttrChangeNotifier;
 use crate::error::{Error, ErrorCode};
 use crate::fabric::Fabrics;
@@ -43,6 +46,9 @@ use crate::pairing::qr::{
 };
 use crate::pairing::DiscoveryCapabilities;
 use crate::persist::KvBlobStore;
+use crate::persist::KvBlobStoreAccess;
+use crate::persist::Persist;
+use crate::persist::BASIC_INFO_KEY;
 use crate::sc::pase::spake2p::{Spake2pVerifierPassword, SPAKE2P_VERIFIER_SALT_ZEROED};
 use crate::sc::pase::Pase;
 use crate::transport::network::mdns::MatterService;
@@ -498,45 +504,30 @@ impl<'a> Matter<'a> {
     /// [`AttrChangeNotifier`] impl.
     ///
     /// Returns the new `ConfigurationVersion` value.
-    pub fn bump_configuration_version<S: KvBlobStore>(
+    pub fn bump_configuration_version<S: KvBlobStoreAccess>(
         &self,
-        mut kv: S,
-        buf: &mut [u8],
+        kv: S,
         notify: &dyn AttrChangeNotifier,
     ) -> Result<u32, Error> {
-        use crate::dm::clusters::basic_info::AttributeId;
-        use crate::dm::clusters::basic_info::FULL_CLUSTER as BASIC_INFO_CLUSTER;
-        use crate::dm::endpoints::ROOT_ENDPOINT_ID;
-        use crate::persist::BASIC_INFO_KEY;
-        use crate::tlv::{TLVTag, ToTLV};
-        use crate::utils::storage::WriteBuf;
+        let mut persist = Persist::new(kv);
 
-        let new_v = self.with_state(|state| {
-            Ok::<_, Error>(state.basic_info_settings.bump_configuration_version())
+        let new_version = self.with_state(|state| {
+            let new_version = state.basic_info_settings.bump_configuration_version();
+
+            persist.store_tlv(BASIC_INFO_KEY, &state.basic_info_settings)?;
+
+            notify.notify_attr_changed(
+                ROOT_ENDPOINT_ID,
+                BASIC_INFO_CLUSTER.id,
+                AttributeId::ConfigurationVersion as _,
+            );
+
+            Ok::<_, Error>(new_version)
         })?;
 
-        // Serialise the (mutated) `BasicInfoSettings` blob into the
-        // caller's scratch buffer, then hand the encoded prefix to the
-        // KV store. Same on-disk key (`BASIC_INFO_KEY`) NodeLabel and
-        // friends use, so a future `Matter::load_persist` reads the
-        // bumped value back.
-        let len = self.with_state(|state| {
-            let mut wb = WriteBuf::new(buf);
-            state
-                .basic_info_settings
-                .to_tlv(&TLVTag::Anonymous, &mut wb)?;
-            Ok::<_, Error>(wb.get_tail())
-        })?;
-        let (data, scratch) = buf.split_at_mut(len);
-        kv.store(BASIC_INFO_KEY, data, scratch)?;
+        persist.run()?;
 
-        notify.notify_attr_changed(
-            ROOT_ENDPOINT_ID,
-            BASIC_INFO_CLUSTER.id,
-            AttributeId::ConfigurationVersion as crate::dm::AttrId,
-        );
-
-        Ok(new_v)
+        Ok(new_version)
     }
 
     /// Create a new transport runner instance

--- a/rs-matter/src/respond.rs
+++ b/rs-matter/src/respond.rs
@@ -19,7 +19,7 @@ use core::fmt::Display;
 use core::future::Future;
 use core::pin::pin;
 
-use embassy_futures::select::{select3, select_slice};
+use embassy_futures::select::{select, select_slice};
 
 use crate::crypto::Crypto;
 use crate::dm::clusters::net_comm;
@@ -262,7 +262,7 @@ where
             ChainedExchangeHandler::new(
                 PROTO_ID_INTERACTION_MODEL,
                 data_model,
-                SecureChannel::new(data_model.crypto(), data_model.change_notify()),
+                SecureChannel::new(data_model.crypto(), data_model),
             ),
             data_model.matter(),
             0,
@@ -326,9 +326,8 @@ where
     pub async fn run<const A: usize, const O: usize>(&self) -> Result<(), Error> {
         let mut actual = pin!(self.responder.run::<A>());
         let mut busy = pin!(self.busy_responder.run::<O>());
-        let mut sub = pin!(self.process_subscriptions());
 
-        select3(&mut actual, &mut busy, &mut sub).coalesce().await
+        select(&mut actual, &mut busy).coalesce().await
     }
 
     /// Get a reference to the main responder.
@@ -351,18 +350,5 @@ where
         &self,
     ) -> &Responder<'a, ChainedExchangeHandler<BusyInteractionModel, BusySecureChannel>> {
         &self.busy_responder
-    }
-
-    /// Process subscriptions.
-    ///
-    /// Useful when the user would like to call `process_subscriptions` manually rather than using the `run` method.
-    pub async fn process_subscriptions(&self) -> Result<(), Error> {
-        let mut process = pin!(self
-            .responder
-            .handler()
-            .handler
-            .process_subscriptions(self.responder.matter));
-
-        (&mut process).await
     }
 }

--- a/rs-matter/tests/commissioning.rs
+++ b/rs-matter/tests/commissioning.rs
@@ -56,14 +56,12 @@ use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::net_comm::DummyNetworkAccess;
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
-use rs_matter::dm::endpoints;
 use rs_matter::dm::events::NoEvents;
 use rs_matter::dm::networks::unix::UnixNetifs;
 use rs_matter::dm::subscriptions::Subscriptions;
-use rs_matter::dm::IMBuffer;
 use rs_matter::dm::{
-    Async, AsyncHandler, AsyncMetadata, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher,
-    Node,
+    endpoints, Async, DataModel, DataModelHandler, Dataver, EmptyHandler, Endpoint, EpClMatcher,
+    IMBuffer, Node,
 };
 use rs_matter::error::Error;
 use rs_matter::im::client::ImClient;
@@ -137,7 +135,7 @@ const NODE: Node<'static> = Node {
 fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     mut rand: impl RngCore + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
-) -> impl AsyncMetadata + AsyncHandler + 'a {
+) -> impl DataModelHandler + 'a {
     (
         NODE,
         endpoints::with_eth_sys(

--- a/rs-matter/tests/common/e2e.rs
+++ b/rs-matter/tests/common/e2e.rs
@@ -19,6 +19,7 @@ use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use core::num::NonZeroU8;
 
 use embassy_futures::select::select4;
+
 use embassy_sync::zerocopy_channel::{Channel, Receiver, Sender};
 
 use rs_matter::acl::{AclEntry, AuthMode};
@@ -27,8 +28,7 @@ use rs_matter::dm::clusters::net_comm::DummyNetworkAccess;
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::events::Events;
 use rs_matter::dm::subscriptions::Subscriptions;
-use rs_matter::dm::{AsyncHandler, AsyncMetadata, Privilege};
-use rs_matter::dm::{DataModel, IMBuffer};
+use rs_matter::dm::{DataModel, DataModelHandler, IMBuffer, Privilege};
 use rs_matter::error::Error;
 use rs_matter::persist::DummyKvBlobStoreAccess;
 use rs_matter::respond::Responder;
@@ -167,7 +167,7 @@ impl<C: Crypto> E2eRunner<C> {
     /// drive the tests (i.e. it does not have any server clusters and such).
     pub async fn run<H>(&self, handler: H) -> Result<(), Error>
     where
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
     {
         self.init()?;
 
@@ -209,7 +209,7 @@ impl<C: Crypto> E2eRunner<C> {
                 NoNetwork,
             ),
             responder.run::<4>(),
-            dm.process_subscriptions(&self.matter),
+            dm.run(),
         )
         .coalesce()
         .await

--- a/rs-matter/tests/common/e2e/im/attributes.rs
+++ b/rs-matter/tests/common/e2e/im/attributes.rs
@@ -16,7 +16,7 @@
  */
 
 use rs_matter::crypto::Crypto;
-use rs_matter::dm::{AsyncHandler, AsyncMetadata};
+use rs_matter::dm::DataModelHandler;
 use rs_matter::error::Error;
 use rs_matter::im::GenericPath;
 use rs_matter::im::{AttrPath, AttrStatus};
@@ -246,7 +246,7 @@ impl<C: Crypto> E2eRunner<C> {
         input: &'a [AttrPath],
         expected: &'a [TestAttrResp<'a>],
     ) where
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
     {
         self.test_one(handler, TLVTest::read_attrs(input, expected))
     }
@@ -258,7 +258,7 @@ impl<C: Crypto> E2eRunner<C> {
         input: &'a [TestAttrData<'a>],
         expected: &'a [AttrStatus],
     ) where
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
     {
         self.test_one(handler, TLVTest::write_attrs(input, expected))
     }

--- a/rs-matter/tests/common/e2e/im/commands.rs
+++ b/rs-matter/tests/common/e2e/im/commands.rs
@@ -16,7 +16,7 @@
  */
 
 use rs_matter::crypto::Crypto;
-use rs_matter::dm::{AsyncHandler, AsyncMetadata};
+use rs_matter::dm::DataModelHandler;
 use rs_matter::error::Error;
 use rs_matter::im::{CmdPath, CmdStatus};
 use rs_matter::tlv::{TLVTag, TLVWrite};
@@ -161,7 +161,7 @@ impl<C: Crypto> E2eRunner<C> {
         input: &'a [TestCmdData<'a>],
         expected: &'a [TestCmdResp<'a>],
     ) where
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
     {
         self.test_one(handler, TLVTest::inv_cmds(input, expected))
     }

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -25,9 +25,8 @@ use rs_matter::dm::clusters::desc::{self, ClusterHandler as _, DescHandler};
 use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ROOT_NODE};
 use rs_matter::dm::endpoints::{with_eth_sys, EthSysHandler, ROOT_ENDPOINT_ID};
 use rs_matter::dm::{
-    Async, AsyncHandler, AsyncMetadata, ChainedHandler, Dataver, EmptyHandler, Endpoint,
-    EpClMatcher, InvokeContext, InvokeReply, MatchContext, Node, ReadContext, ReadReply,
-    WriteContext,
+    Async, AsyncHandler, ChainedHandler, Dataver, EmptyHandler, Endpoint, EpClMatcher,
+    InvokeContext, InvokeReply, MatchContext, Metadata, Node, ReadContext, ReadReply, WriteContext,
 };
 use rs_matter::error::Error;
 use rs_matter::{clusters, handler_chain_type};
@@ -129,14 +128,12 @@ impl<'a, OH: OnOffHooks, LH: LevelControlHooks> AsyncHandler for E2eTestHandler<
     }
 }
 
-impl<'a, OH: OnOffHooks, LH: LevelControlHooks> AsyncMetadata for E2eTestHandler<'a, OH, LH> {
-    type MetadataGuard<'g>
-        = Node<'g>
+impl<'a, OH: OnOffHooks, LH: LevelControlHooks> Metadata for E2eTestHandler<'a, OH, LH> {
+    fn access<F, R>(&self, f: F) -> R
     where
-        Self: 'g;
-
-    async fn lock(&self) -> Self::MetadataGuard<'_> {
-        Self::NODE
+        F: FnOnce(&Node<'_>) -> R,
+    {
+        f(&Self::NODE)
     }
 }
 

--- a/rs-matter/tests/common/e2e/test.rs
+++ b/rs-matter/tests/common/e2e/test.rs
@@ -23,7 +23,7 @@ use embassy_futures::select::select;
 use embassy_time::{Duration, Timer};
 
 use rs_matter::crypto::Crypto;
-use rs_matter::dm::{AsyncHandler, AsyncMetadata};
+use rs_matter::dm::DataModelHandler;
 use rs_matter::error::Error;
 use rs_matter::transport::exchange::{Exchange, MessageMeta};
 use rs_matter::utils::select::Coalesce;
@@ -91,7 +91,7 @@ impl<C: Crypto> E2eRunner<C> {
     /// until the test completes or fails.
     pub fn test_one<H, T>(&self, handler: H, test: T)
     where
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         T: E2eTest,
     {
         self.test_all(handler, core::iter::once(test))
@@ -101,7 +101,7 @@ impl<C: Crypto> E2eRunner<C> {
     /// until all tests complete or the first one fails.
     pub fn test_all<H, I, T>(&self, handler: H, tests: I)
     where
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         I: IntoIterator<Item = T>,
         T: E2eTest,
     {


### PR DESCRIPTION
Hmm, seems Gemini actually 100% groked the idea of this pull request (see below):
"
This pull request refactors the Metadata and AsyncMetadata traits into a single synchronous Metadata trait using an access method with a closure. This change removes the need for asynchronous locking when accessing node metadata, simplifying the data model handling across the codebase.
"

Yes, that's exactly the case.
As to why this is a net win: because it simplifies downstream work when the meta-data is dynamic (typically, for bridges where endpoints typically come and go).

Before this change, with the async-lock on the meta-data, it was just not possible to modify the meta-data while there was an on-going read/write/invoke or subscription reporting.

Given that the philosophy of matter seems to be "eventual consistency" and "the controller will eventually figure it out" - so that the device (= us) can have an easier life and be lighter on resources, I think this the right call.