### PR TITLE
User label handler

### DIFF
--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -54,6 +54,7 @@ use rs_matter::dm::clusters::noc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::unit_testing::{
     ClusterHandler as _, UnitTestingHandler, UnitTestingHandlerData,
 };
+use rs_matter::dm::clusters::user_label::{self, UserLabelHandler};
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ROOT_NODE};
 use rs_matter::dm::endpoints::{self, ROOT_ENDPOINT_ID};
@@ -392,12 +393,19 @@ const BASIC_INFO: BasicInfoConfig<'static> = BasicInfoConfig {
 /// the Groups EpClMatcher in `with_sys()` were dropped to keep
 /// device-type-pure compositions the *default* — having Groups on
 /// EP0 here is a deliberate per-fixture exception.
+///
+/// `UserLabel` (cluster ID 0x0041) is also wired onto EP0 even though
+/// it isn't part of the Root Node device type — the
+/// `TestUserLabelClusterConstraints` YAML test targets `endpoint: 0`
+/// and exercises the `LabelList` length-constraint behaviour. Same
+/// rationale as Groups: Matter Core §7.16.4 permits extras, our
+/// device-type-conformance test is already on the skip list.
 const NODE: Node<'static> = Node {
     endpoints: &[
         Endpoint {
             id: ROOT_ENDPOINT_ID,
             device_types: devices!(DEV_TYPE_ROOT_NODE),
-            clusters: clusters!(eth; groups::GroupsHandler::CLUSTER),
+            clusters: clusters!(eth; groups::GroupsHandler::CLUSTER, user_label::CLUSTER),
         },
         Endpoint {
             id: 1,
@@ -456,8 +464,9 @@ const NODE_BINFO_CV_EXPOSED: Node<'static> = Node {
             // Manually expanded `clusters!(eth;)` with `BasicInfoHandler::CLUSTER`
             // replaced by `BASIC_INFO_CLUSTER_CV_EXPOSED`. Keep this in sync
             // with `clusters!(eth;)` in `rs-matter/src/dm/types/cluster.rs`.
-            // `GroupsHandler::CLUSTER` is included for the same
-            // `TestGroupMessaging` reason documented on `NODE`.
+            // `GroupsHandler::CLUSTER` and `user_label::CLUSTER` are
+            // included for the same `TestGroupMessaging` /
+            // `TestUserLabelClusterConstraints` reasons documented on `NODE`.
             clusters: clusters!(
                 desc::DescHandler::CLUSTER,
                 acl::AclHandler::CLUSTER,
@@ -468,6 +477,7 @@ const NODE_BINFO_CV_EXPOSED: Node<'static> = Node {
                 noc::NocHandler::CLUSTER,
                 grp_key_mgmt::GrpKeyMgmtHandler::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
+                user_label::CLUSTER,
                 net_comm::NetworkType::Ethernet.cluster(),
                 eth_diag::EthDiagHandler::CLUSTER,
             ),
@@ -532,6 +542,15 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                         Some(groups::GroupsHandler::CLUSTER.id),
                     ),
                     Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+                )
+                // UserLabel handler at the root endpoint. Wired here for
+                // the same per-fixture-exception reason as Groups above:
+                // `TestUserLabelClusterConstraints` writes / reads the
+                // cluster at `endpoint: 0`. The handler uses bounded
+                // in-memory storage with `N = 4` (default).
+                .chain(
+                    EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(user_label::CLUSTER.id)),
+                    Async(UserLabelHandler::<4>::new(Dataver::new_rand(&mut rand)).adapt()),
                 )
                 // Clusters for Endpoint 1
                 .chain(

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -57,12 +57,6 @@ pub mod subscriptions;
 
 mod types;
 
-/// The Maximum number of expanded writer request per transaction
-///
-/// The write requests are first wildcard-expanded, and these many number of
-/// write requests per-transaction will be supported.
-const MAX_WRITE_ATTRS_IN_ONE_TRANS: usize = 15;
-
 pub type IMBuffer = crate::utils::storage::Vec<u8, MAX_EXCHANGE_RX_BUF_SIZE>;
 
 /// An `ExchangeHandler` implementation capable of handling responder exchanges for the Interaction Model protocol.
@@ -1583,20 +1577,7 @@ where
         wb.start_struct(&TLVTag::Anonymous)?;
         wb.start_array(&TLVTag::Context(WriteRespTag::WriteResponses as u8))?;
 
-        // The spec expects that a single write request like DeleteList + AddItem
-        // should cause all ACLs of that fabric to be deleted and the new one to be added (Case 1).
-        //
-        // This is in conflict with the immediate-effect expectation of ACL: an ACL
-        // write should instantaneously update the ACL so that immediate next WriteAttribute
-        // *in the same WriteRequest* should see that effect (Case 2).
-        //
-        // As with the C++ SDK, here we do all the ACLs checks first, before any write begins.
-        // Thus we support the Case1 by doing this. It does come at the cost of maintaining an
-        // additional list of expanded write requests as we start processing those.
-        let write_attrs: heapless::Vec<_, MAX_WRITE_ATTRS_IN_ONE_TRANS> =
-            self.node.write(self.req, &accessor)?.collect();
-
-        for item in write_attrs {
+        for item in self.node.write(self.req, &accessor)? {
             self.invoker.process_write(&item?, &mut *wb).await?;
         }
 

--- a/rs-matter/src/dm/clusters.rs
+++ b/rs-matter/src/dm/clusters.rs
@@ -37,6 +37,7 @@ pub mod net_comm;
 pub mod noc;
 pub mod thread_diag;
 pub mod unit_testing;
+pub mod user_label;
 pub mod wifi_diag;
 
 /// Generated cluster declarations from Matter IDL (via build.rs).

--- a/rs-matter/src/dm/clusters/user_label.rs
+++ b/rs-matter/src/dm/clusters/user_label.rs
@@ -1,0 +1,247 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! UserLabel cluster handler (Matter Application Cluster spec §9.7).
+//!
+//! The UserLabel cluster lets a commissioner persist a free-form list of
+//! `(label, value)` string pairs on an endpoint — typical use is the
+//! commissioner letting the user tag a device with metadata such as
+//! `"room"` → `"living room"` or `"orientation"` → `"east"`. The list is
+//! per-endpoint and *not* fabric-scoped: every fabric that has access
+//! sees the same list (subject to the usual ACL rules — `LabelList` reads
+//! at view-privilege, writes at manage-privilege).
+//!
+//! [`UserLabelHandler`] ships with bounded in-memory storage. Persistence
+//! across reboots — which the spec requires (§9.7.5) — is not yet wired:
+//! applications that need the labels to survive restart need to subscribe
+//! to writes via `Matter::subscribe_changes` and store the values in
+//! their own KV blob, or extend this handler with an explicit storage
+//! hook trait. The CI test
+//! [`TestUserLabelClusterConstraints`](`https://github.com/project-chip/connectedhomeip/blob/master/src/app/tests/suites/TestUserLabelClusterConstraints.yaml`)
+//! exercises only the in-session length-constraint behaviour and passes
+//! against this implementation; the `TestUserLabelCluster` YAML — which
+//! includes a Reboot-and-read-back step — does not yet pass and remains
+//! commented out in `xtask/src/itest.rs`.
+
+use core::cell::RefCell;
+
+use crate::dm::{
+    ArrayAttributeRead, ArrayAttributeWrite, Cluster, Dataver, ReadContext, WriteContext,
+};
+use crate::error::{Error, ErrorCode};
+use crate::tlv::{TLVArray, TLVBuilderParent};
+use crate::utils::sync::blocking::Mutex;
+use crate::with;
+
+pub use crate::dm::clusters::decl::globals::{
+    LabelStruct, LabelStructArrayBuilder, LabelStructBuilder,
+};
+pub use crate::dm::clusters::decl::user_label::*;
+
+/// Cluster metadata exposed by [`UserLabelHandler`] regardless of the
+/// `N` capacity parameter.
+///
+/// Equivalent to `<UserLabelHandler<N> as ClusterHandler>::CLUSTER` for
+/// any `N`, exposed here as a free constant so callers don't have to
+/// spell out the generic parameter when they just want the cluster ID
+/// for an `EpClMatcher` or a `clusters!(...)` literal.
+pub const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
+
+/// Maximum length of a single `label` string, in characters.
+/// Per Matter Application Cluster spec §9.6.4 (`LabelStruct`): 16 chars.
+pub const MAX_LABEL_LEN: usize = 16;
+
+/// Maximum length of a single `value` string, in characters.
+/// Per Matter Application Cluster spec §9.6.4 (`LabelStruct`): 16 chars.
+pub const MAX_VALUE_LEN: usize = 16;
+
+/// One entry in a `LabelList`.
+type LabelEntry = (
+    heapless::String<MAX_LABEL_LEN>,
+    heapless::String<MAX_VALUE_LEN>,
+);
+
+/// The handler for the UserLabel Matter cluster.
+///
+/// Per-endpoint instance: each endpoint that advertises the UserLabel
+/// cluster must own a separate `UserLabelHandler` so the per-endpoint
+/// `LabelList` stays segregated.
+///
+/// `N` (default 4) sets the maximum number of entries the list can hold;
+/// writes that exceed it are rejected with `ErrorCode::ResourceExhausted`,
+/// which the framework maps to the IM `ResourceExhausted` status. This
+/// matches the `TestUserLabelClusterConstraints` test's expectation of
+/// rejecting an oversized list.
+///
+/// Concurrency: the entry list is wrapped in a blocking [`Mutex`] +
+/// `RefCell` so the handler is sound under a future work-stealing executor
+/// configuration of rs-matter. Lock holds are bounded — the lock is
+/// *never* held across `.await` points (this is a sync `ClusterHandler`
+/// in the first place, so there are no `.await`s).
+///
+/// Dataver is bumped automatically by the framework after each write/invoke
+/// and on every `notify_attr_changed`; this handler never calls
+/// `dataver_changed()` directly.
+pub struct UserLabelHandler<const N: usize = 4> {
+    dataver: Dataver,
+    entries: Mutex<RefCell<heapless::Vec<LabelEntry, N>>>,
+}
+
+impl<const N: usize> UserLabelHandler<N> {
+    /// Creates a new `UserLabelHandler` with an empty `LabelList`.
+    pub const fn new(dataver: Dataver) -> Self {
+        Self {
+            dataver,
+            entries: Mutex::new(RefCell::new(heapless::Vec::new())),
+        }
+    }
+
+    /// Adapt the handler instance to the generic `rs-matter` `Handler` trait.
+    pub const fn adapt(self) -> HandlerAdaptor<Self> {
+        HandlerAdaptor(self)
+    }
+
+    /// Validate a single `LabelStruct` against the spec length limits.
+    /// Returns `ConstraintError` when the entry violates the limits —
+    /// `TestUserLabelClusterConstraints` writes oversized entries and
+    /// expects this exact failure mode.
+    fn validate_entry<'a>(entry: &'a LabelStruct<'a>) -> Result<(&'a str, &'a str), Error> {
+        let label = entry.label()?;
+        let value = entry.value()?;
+        if label.len() > MAX_LABEL_LEN || value.len() > MAX_VALUE_LEN {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+        Ok((label, value))
+    }
+
+    /// Push a `(label, value)` pair into a `Vec`. Returns
+    /// `ResourceExhausted` when the bounded vec is full.
+    fn push_into(
+        list: &mut heapless::Vec<LabelEntry, N>,
+        label: &str,
+        value: &str,
+    ) -> Result<(), Error> {
+        let mut entry = (
+            heapless::String::<MAX_LABEL_LEN>::new(),
+            heapless::String::<MAX_VALUE_LEN>::new(),
+        );
+        // `push_str` on `heapless::String` returns `Err(())` on overflow.
+        // We've already validated lengths above, so this can only fail if
+        // the bounds change without `validate_entry` being updated.
+        entry
+            .0
+            .push_str(label)
+            .map_err(|_| ErrorCode::ConstraintError)?;
+        entry
+            .1
+            .push_str(value)
+            .map_err(|_| ErrorCode::ConstraintError)?;
+        list.push(entry).map_err(|_| ErrorCode::ResourceExhausted)?;
+        Ok(())
+    }
+}
+
+impl<const N: usize> ClusterHandler for UserLabelHandler<N> {
+    const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
+
+    fn dataver(&self) -> u32 {
+        self.dataver.get()
+    }
+
+    fn dataver_changed(&self) {
+        self.dataver.changed();
+    }
+
+    fn label_list<P: TLVBuilderParent>(
+        &self,
+        _ctx: impl ReadContext,
+        builder: ArrayAttributeRead<LabelStructArrayBuilder<P>, LabelStructBuilder<P>>,
+    ) -> Result<P, Error> {
+        self.entries.lock(|cell| {
+            let entries = cell.borrow();
+            match builder {
+                ArrayAttributeRead::ReadAll(mut array) => {
+                    for (label, value) in entries.iter() {
+                        array = array
+                            .push()?
+                            .label(label.as_str())?
+                            .value(value.as_str())?
+                            .end()?;
+                    }
+                    array.end()
+                }
+                ArrayAttributeRead::ReadOne(index, item) => {
+                    let Some((label, value)) = entries.get(index as usize) else {
+                        return Err(ErrorCode::ConstraintError.into());
+                    };
+                    item.label(label.as_str())?.value(value.as_str())?.end()
+                }
+                ArrayAttributeRead::ReadNone(array) => array.end(),
+            }
+        })
+    }
+
+    fn set_label_list(
+        &self,
+        _ctx: impl WriteContext,
+        value: ArrayAttributeWrite<TLVArray<'_, LabelStruct<'_>>, LabelStruct<'_>>,
+    ) -> Result<(), Error> {
+        match value {
+            ArrayAttributeWrite::Replace(list) => {
+                // Two-pass: validate every entry first so we never end up
+                // with a partially-applied list on a malformed input. If
+                // validation passes we know `push_into` will succeed for
+                // every entry up to the capacity bound. Mirrors
+                // `acl::AclHandler::set_acl`'s validate-then-commit shape.
+                let mut count = 0usize;
+                for entry in &list {
+                    let entry = entry?;
+                    Self::validate_entry(&entry)?;
+                    count += 1;
+                    if count > N {
+                        return Err(ErrorCode::ResourceExhausted.into());
+                    }
+                }
+
+                self.entries.lock(|cell| {
+                    let mut entries = cell.borrow_mut();
+                    entries.clear();
+                    for entry in &list {
+                        // unwrap-equivalent is safe: we validated each
+                        // entry above and the count is within capacity.
+                        let entry = entry?;
+                        let (label, value) = Self::validate_entry(&entry)?;
+                        Self::push_into(&mut entries, label, value)?;
+                    }
+                    Ok(())
+                })
+            }
+            ArrayAttributeWrite::Add(entry) => {
+                let (label, value) = Self::validate_entry(&entry)?;
+                self.entries
+                    .lock(|cell| Self::push_into(&mut cell.borrow_mut(), label, value))
+            }
+            // The Matter Core spec (V1.4.2 §10.6.4.3.1) does not yet
+            // support per-element list update / remove writes — the
+            // framework already converts these to `InvalidAction` before
+            // the value reaches us, but match exhaustively to be safe.
+            ArrayAttributeWrite::Update(_, _) | ArrayAttributeWrite::Remove(_) => {
+                Err(ErrorCode::InvalidAction.into())
+            }
+        }
+    }
+}

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -556,6 +556,31 @@ where
     leaf_index: u16,
     /// Filter the expanded item or not
     filter: F,
+    /// Last concrete `(endpoint_id, cluster_id, leaf_id)` triple whose
+    /// access check succeeded during this expansion run. When the next
+    /// expanded leaf matches this triple, the access check is bypassed.
+    ///
+    /// This is the mechanism that resolves the "DeleteAll + Add×N on the
+    /// ACL cluster within one WriteRequest" tension (Matter Core spec
+    /// §10.6.4): chip-tool serializes a list-replace as `DeleteAll`
+    /// followed by N per-element `Add`s, all targeting the **same**
+    /// concrete attribute path. The first op authorizes against the
+    /// fabric's current ACL; subsequent same-path ops cache-hit and
+    /// bypass the re-check — so an admin's permission isn't accidentally
+    /// revoked midway through replacing their own ACL with a new entry.
+    /// Mirrors `mLastSuccessfullyWrittenPath` in CHIP's `WriteHandler`.
+    ///
+    /// Soundness: the required privilege for a given concrete path is
+    /// constant (cluster-metadata-defined), and the accessor / session
+    /// doesn't change within an expansion, so re-using a prior
+    /// authorization for the same path is safe. The cache is **not**
+    /// reset when advancing to a new item from `items` — that's
+    /// deliberate: `DeleteAll + Add×N` arrives as N+1 separate
+    /// `AttrData` items in the same WriteRequest, and they all need
+    /// to share one access decision for the operation to be atomic.
+    /// A different concrete `(endpoint, cluster, leaf)` triple simply
+    /// misses the cache and re-runs the check.
+    last_authorized: Option<(EndptId, ClusterId, u32)>,
 }
 
 impl<'a, T, I, F> PathExpander<'a, T, I, F>
@@ -582,6 +607,7 @@ where
             cluster_index: 0,
             leaf_index: 0,
             filter,
+            last_authorized: None,
         }
     }
 
@@ -641,42 +667,54 @@ where
                                 // Leaf found, filter and check its access rights
 
                                 let check = if (self.filter)(endpoint.id, cluster.id, leaf_id) {
-                                    if matches!(T::OPERATION, Operation::Invoke) {
-                                        cluster.check_cmd_access(
-                                            self.accessor,
-                                            self.timed,
-                                            GenericPath::new(
-                                                Some(endpoint.id),
-                                                Some(cluster.id),
-                                                Some(leaf_id),
-                                            ),
-                                            endpoint.device_types,
-                                            unwrap!(cluster
-                                                .commands()
-                                                .map(|cmd| cmd.id)
-                                                .nth(self.leaf_index as usize)),
-                                        )
+                                    // Cache hit: this concrete triple was just
+                                    // authorized within the same expansion run.
+                                    // Skip the access re-check — see the
+                                    // `last_authorized` field doc on
+                                    // `PathExpander` for the rationale.
+                                    if self.last_authorized
+                                        == Some((endpoint.id, cluster.id, leaf_id))
+                                    {
+                                        Ok(true)
+                                    } else if matches!(T::OPERATION, Operation::Invoke) {
+                                        cluster
+                                            .check_cmd_access(
+                                                self.accessor,
+                                                self.timed,
+                                                GenericPath::new(
+                                                    Some(endpoint.id),
+                                                    Some(cluster.id),
+                                                    Some(leaf_id),
+                                                ),
+                                                endpoint.device_types,
+                                                unwrap!(cluster
+                                                    .commands()
+                                                    .map(|cmd| cmd.id)
+                                                    .nth(self.leaf_index as usize)),
+                                            )
+                                            .map(|_| true)
                                     } else {
                                         // TODO: Need to also check that the code is not trying to access an element of an array
                                         // when the attribute is not an array
 
-                                        cluster.check_attr_access(
-                                            self.accessor,
-                                            self.timed,
-                                            GenericPath::new(
-                                                Some(endpoint.id),
-                                                Some(cluster.id),
-                                                Some(leaf_id),
-                                            ),
-                                            endpoint.device_types,
-                                            matches!(T::OPERATION, Operation::Write),
-                                            unwrap!(cluster
-                                                .attributes()
-                                                .map(|attr| attr.id)
-                                                .nth(self.leaf_index as usize)),
-                                        )
+                                        cluster
+                                            .check_attr_access(
+                                                self.accessor,
+                                                self.timed,
+                                                GenericPath::new(
+                                                    Some(endpoint.id),
+                                                    Some(cluster.id),
+                                                    Some(leaf_id),
+                                                ),
+                                                endpoint.device_types,
+                                                matches!(T::OPERATION, Operation::Write),
+                                                unwrap!(cluster
+                                                    .attributes()
+                                                    .map(|attr| attr.id)
+                                                    .nth(self.leaf_index as usize)),
+                                            )
+                                            .map(|_| true)
                                     }
-                                    .map(|_| true)
                                 } else {
                                     Ok(false)
                                 };
@@ -686,6 +724,16 @@ where
                                         // Because on the next call we should start from the next leaf or if leaves
                                         // are over, from the next cluster and so on
                                         self.leaf_index += 1;
+
+                                        // Cache this concrete triple as the
+                                        // last-authorized one. The next
+                                        // expansion that lands on the same
+                                        // (endpoint, cluster, leaf) — typical
+                                        // for chip-tool's list-write
+                                        // `DeleteAll + Add×N` encoding — will
+                                        // bypass the access re-check above.
+                                        self.last_authorized =
+                                            Some((endpoint.id, cluster.id, leaf_id));
 
                                         return Ok(Some((endpoint.id, cluster.id, leaf_id)));
                                     }

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -80,8 +80,16 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TestSubscribe_AdministratorCommissioning",
     "TestSubscribe_OnOff",
     // "TestSystemCommands", // TODO: Error attempting to start secondary device
-    // "TestUserLabelCluster", // TODO: User Label cluster not yet implemented
-    // "TestUserLabelClusterConstraints", // TODO: User Label cluster not yet implemented
+    // "TestUserLabelCluster", // Skipped: the test issues a SystemCommands `Reboot`
+    //                          // and reads the LabelList back to verify persistence.
+    //                          // The reboot step shares the limitation that gates
+    //                          // `TestSystemCommands` (we don't yet survive
+    //                          // chip-tool-driven restarts), and the
+    //                          // `UserLabelHandler` we ship today stores entries
+    //                          // in-memory only — persistence is a separate
+    //                          // workstream. The pre-reboot steps (write / read /
+    //                          // clear) would all pass against the current handler.
+    "TestUserLabelClusterConstraints",
     // "TestTimeSynchronization", // Skipped: TimeSynchronization cluster not implemented by rs-matter (optional, Matter spec §11.16).
     // "TestIcdManagementCluster", // Skipped: ICD Management cluster not implemented (rs-matter doesn't ship Intermittently Connected Device support).
     "TestUnitTestingClusterMei",


### PR DESCRIPTION
This unlocks one more test.

**Important addition** 
- I have finally removed the on-stack accumulation of attribute write paths and replaced it with a smarter algorithm within PathExpander itself 
- It addresses more intelligently the "`DeleteAll+Add1+Add2+...+AddN` series of attribute write requests does not quite work for an ACL attribute" issue

AI checked that in the C++ SDK they use the same algorithm (cache the ACL check for the previously-expanded attribute path and apply it for the current one _if the current one happens to be the same attribute path_) so I hope we are fine.

We can't really afford ourselves to cache `AttrDetails` anymore as they are quite big, our cache would remain upper-bounded and worst of all: we get stack overflows anyway the moment I try to increase the MAX_WRITE_PATHS parameter so that the Python integration test does not fail.