### PR TITLE
Implement persistence for the User-Label cluster handler; Fixed-Label cluster handler

### DIFF
--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -54,7 +54,7 @@ use rs_matter::dm::clusters::noc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::unit_testing::{
     ClusterHandler as _, UnitTestingHandler, UnitTestingHandlerData,
 };
-use rs_matter::dm::clusters::user_label::{self, UserLabelHandler};
+use rs_matter::dm::clusters::user_label::{self, UserLabelHandler, UserLabels};
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ROOT_NODE};
 use rs_matter::dm::endpoints::{self, ROOT_ENDPOINT_ID};
@@ -94,6 +94,9 @@ static EVENTS: StaticCell<Events> = StaticCell::new();
 static KV_BUF: StaticCell<[u8; 4096]> = StaticCell::new();
 static UNIT_TESTING_DATA: StaticCell<RefCell<UnitTestingHandlerData>> = StaticCell::new();
 static GEN_DIAG: StaticCell<TestEventTriggerDiag> = StaticCell::new();
+// UserLabel registry — host endpoints and labels-per-endpoint counts
+// match `dm_handler`'s `UserLabelHandler<'_, E, N>` parameterisation.
+static USER_LABELS: StaticCell<UserLabels<1, 4>> = StaticCell::new();
 
 fn main() -> Result<(), Error> {
     // Enable detailed backtraces for debugging test failures
@@ -176,6 +179,19 @@ fn main() -> Result<(), Error> {
         TestOnOffDeviceLogic::new(false),
     );
 
+    // Shared UserLabel registry. We only host the UserLabel cluster on
+    // the root endpoint here, so `E = 1` is enough (raise it if more
+    // endpoints later acquire the cluster). Loaded from
+    // KV *before* the data model accepts commissioner traffic so the
+    // post-reboot `Verify User Label List after reboot` step of the
+    // `TestUserLabelCluster` YAML test sees the labels the previous
+    // boot wrote.
+    let user_labels = USER_LABELS.uninit().init_with(UserLabels::init());
+    futures_lite::future::block_on(user_labels.load_persist(&mut kv, kv_buf))?;
+
+    let user_label_handler =
+        UserLabelHandler::new(Dataver::new_rand(&mut rand), ROOT_ENDPOINT_ID, user_labels);
+
     // Our unit testing cluster data
     let unit_testing_data = UNIT_TESTING_DATA
         .uninit()
@@ -220,6 +236,7 @@ fn main() -> Result<(), Error> {
             unit_testing_data,
             &on_off_handler_1,
             &on_off_handler_2,
+            &user_label_handler,
         ),
         SharedKvBlobStore::new(kv, kv_buf),
         SharedNetworks::new(EthNetwork::new_default()),
@@ -514,6 +531,7 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     unit_testing_data: &'a RefCell<UnitTestingHandlerData>,
     on_off_1: &'a OnOffHandler<'a, OH, LH>,
     on_off_2: &'a OnOffHandler<'a, OH, LH>,
+    user_label_handler: &'a UserLabelHandler<'a, 1, 4>,
 ) -> impl DataModelHandler + 'a {
     (
         node,
@@ -544,12 +562,16 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                 )
                 // UserLabel handler at the root endpoint. Wired here for
                 // the same per-fixture-exception reason as Groups above:
-                // `TestUserLabelClusterConstraints` writes / reads the
-                // cluster at `endpoint: 0`. The handler uses bounded
-                // in-memory storage with `N = 4` (default).
+                // `TestUserLabelClusterConstraints` and the persistence-
+                // focused `TestUserLabelCluster` write / read the cluster
+                // at `endpoint: 0`. The handler is owned by `main` so we
+                // can call `load_persist` *before* the data model is
+                // exposed; we hand it in by reference here and wrap it
+                // with `user_label::HandlerAdaptor` (rather than the
+                // owning-`.adapt()`) so the chain doesn't take ownership.
                 .chain(
                     EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(user_label::CLUSTER.id)),
-                    Async(UserLabelHandler::<4>::new(Dataver::new_rand(&mut rand)).adapt()),
+                    Async(user_label::HandlerAdaptor(user_label_handler)),
                 )
                 // Clusters for Endpoint 1
                 .chain(

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -44,6 +44,7 @@ use rs_matter::dm::clusters::basic_info::{
 };
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::eth_diag::{self, ClusterHandler as _};
+use rs_matter::dm::clusters::fixed_label::{self, FixedLabelEntry, FixedLabelHandler};
 use rs_matter::dm::clusters::gen_comm::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::gen_diag::{self, ClusterHandler as _, GenDiag};
 use rs_matter::dm::clusters::groups::{self, ClusterHandler as _};
@@ -416,6 +417,21 @@ const BASIC_INFO: BasicInfoConfig<'static> = BasicInfoConfig {
 /// and exercises the `LabelList` length-constraint behaviour. Same
 /// rationale as Groups: Matter Core §7.16.4 permits extras, our
 /// device-type-conformance test is already on the skip list.
+/// Static fixed-label data exposed by EP1's `FixedLabel` cluster.
+/// `TC_FLABEL_2_1` step 2 asserts every entry's `label`/`value` is a
+/// string ≤ 16 bytes (Matter Application Cluster spec §9.6.4); both
+/// pairs below satisfy that constraint.
+const FIXED_LABELS_EP1: &[FixedLabelEntry<'static>] = &[
+    FixedLabelEntry {
+        label: "room",
+        value: "test",
+    },
+    FixedLabelEntry {
+        label: "orientation",
+        value: "north",
+    },
+];
+
 const NODE: Node<'static> = Node {
     endpoints: &[
         Endpoint {
@@ -426,10 +442,16 @@ const NODE: Node<'static> = Node {
         Endpoint {
             id: 1,
             device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
+            // `FixedLabel` (cluster ID 0x0040) is wired on EP1 because
+            // `TC_FLABEL_2_1` runs with `--endpoint 1` and skips cleanly
+            // via `has_attribute(FixedLabel.LabelList)` when the cluster
+            // is absent; adding it here turns the skip into an actual
+            // content + read-only-write check.
             clusters: clusters!(
                 desc::DescHandler::CLUSTER,
                 identify::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
+                fixed_label::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER,
                 UnitTestingHandler::CLUSTER
             ),
@@ -501,10 +523,16 @@ const NODE_BINFO_CV_EXPOSED: Node<'static> = Node {
         Endpoint {
             id: 1,
             device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
+            // `FixedLabel` (cluster ID 0x0040) is wired on EP1 because
+            // `TC_FLABEL_2_1` runs with `--endpoint 1` and skips cleanly
+            // via `has_attribute(FixedLabel.LabelList)` when the cluster
+            // is absent; adding it here turns the skip into an actual
+            // content + read-only-write check.
             clusters: clusters!(
                 desc::DescHandler::CLUSTER,
                 identify::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
+                fixed_label::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER,
                 UnitTestingHandler::CLUSTER
             ),
@@ -585,6 +613,13 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                 .chain(
                     EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
                     Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+                )
+                .chain(
+                    EpClMatcher::new(Some(1), Some(fixed_label::CLUSTER.id)),
+                    Async(
+                        FixedLabelHandler::new(Dataver::new_rand(&mut rand), FIXED_LABELS_EP1)
+                            .adapt(),
+                    ),
                 )
                 .chain(
                     EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),

--- a/rs-matter/src/dm/clusters.rs
+++ b/rs-matter/src/dm/clusters.rs
@@ -28,6 +28,7 @@ pub mod basic_info;
 pub mod desc;
 pub mod dev_att;
 pub mod eth_diag;
+pub mod fixed_label;
 pub mod gen_comm;
 pub mod gen_diag;
 pub mod groups;

--- a/rs-matter/src/dm/clusters/fixed_label.rs
+++ b/rs-matter/src/dm/clusters/fixed_label.rs
@@ -1,0 +1,141 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! FixedLabel cluster handler (Matter Application Cluster spec §9.8).
+//!
+//! Per-endpoint **read-only** list of `(label, value)` string pairs
+//! that the manufacturer bakes into the device firmware — typical use
+//! is exposing immutable tags such as `"serial"` → `"abc123"` or
+//! `"hwrev"` → `"B"`. Compare with [`super::user_label`], the
+//! writable counterpart used by commissioners.
+//!
+//! The list is **fixed** in the F-quality sense (Matter Core spec
+//! §7.13.2): it never changes for the lifetime of the device firmware,
+//! so we don't need a persistence layer, a mutex, or any per-entry
+//! storage. [`FixedLabelHandler`] just borrows a static slice of
+//! [`FixedLabelEntry`] from the application and iterates it on read.
+//! Writes are rejected by the framework before they reach the handler
+//! because the cluster metadata declares `LabelList` as read-only
+//! (`Access::READ`), which the IM dispatch maps to `UnsupportedWrite`
+//! — exactly the behaviour `TC_FLABEL_2_1` step 3 expects.
+//!
+//! Application wiring:
+//!
+//! ```ignore
+//! const LABELS: &[FixedLabelEntry] = &[
+//!     FixedLabelEntry { label: "room", value: "kitchen" },
+//!     FixedLabelEntry { label: "hwrev", value: "B" },
+//! ];
+//!
+//! let handler = FixedLabelHandler::new(Dataver::new_rand(rand), LABELS);
+//! ```
+
+use crate::dm::{ArrayAttributeRead, Cluster, Dataver, ReadContext};
+use crate::error::{Error, ErrorCode};
+use crate::tlv::TLVBuilderParent;
+use crate::with;
+
+pub use crate::dm::clusters::decl::fixed_label::*;
+pub use crate::dm::clusters::decl::globals::{
+    LabelStruct, LabelStructArrayBuilder, LabelStructBuilder,
+};
+
+/// Cluster metadata exposed by [`FixedLabelHandler`].
+///
+/// Exposed as a free constant so callers can spell out
+/// `EpClMatcher::new(Some(ep), Some(fixed_label::CLUSTER.id))` without
+/// reaching for the lifetime-parameterised handler type.
+pub const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
+
+/// One entry in a `LabelList`.
+///
+/// Per Matter Application Cluster spec §9.6.4 (`LabelStruct`), each
+/// field is at most 16 characters. We don't enforce this here — the
+/// application is responsible for supplying spec-compliant data, and
+/// `TC_FLABEL_2_1` step 2 sanity-checks the lengths on the read path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FixedLabelEntry<'a> {
+    pub label: &'a str,
+    pub value: &'a str,
+}
+
+/// The handler for the FixedLabel Matter cluster.
+///
+/// Per-endpoint instance: each endpoint that advertises FixedLabel
+/// must own its own handler so the per-cluster-instance `Dataver`
+/// stays granular (Matter Core spec §7.13.2.1). The entries slice is
+/// borrowed — typically a `&'static [FixedLabelEntry<'static>]` —
+/// because the list is part of the device's firmware identity and
+/// doesn't change at runtime.
+pub struct FixedLabelHandler<'a> {
+    dataver: Dataver,
+    entries: &'a [FixedLabelEntry<'a>],
+}
+
+impl<'a> FixedLabelHandler<'a> {
+    /// Construct a handler exposing `entries` as the cluster's
+    /// `LabelList` attribute.
+    pub const fn new(dataver: Dataver, entries: &'a [FixedLabelEntry<'a>]) -> Self {
+        Self { dataver, entries }
+    }
+
+    /// Adapt the handler instance to the generic `rs-matter` `Handler` trait.
+    pub const fn adapt(self) -> HandlerAdaptor<Self> {
+        HandlerAdaptor(self)
+    }
+}
+
+impl ClusterHandler for FixedLabelHandler<'_> {
+    const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
+
+    fn dataver(&self) -> u32 {
+        self.dataver.get()
+    }
+
+    fn dataver_changed(&self) {
+        self.dataver.changed();
+    }
+
+    fn label_list<P: TLVBuilderParent>(
+        &self,
+        _ctx: impl ReadContext,
+        builder: ArrayAttributeRead<LabelStructArrayBuilder<P>, LabelStructBuilder<P>>,
+    ) -> Result<P, Error> {
+        match builder {
+            ArrayAttributeRead::ReadAll(mut array) => {
+                for entry in self.entries {
+                    array = array
+                        .push()?
+                        .label(entry.label)?
+                        .value(entry.value)?
+                        .end()?;
+                }
+                array.end()
+            }
+            ArrayAttributeRead::ReadOne(index, item) => {
+                let Some(entry) = self.entries.get(index as usize) else {
+                    // List-element index out of bounds — IM convention
+                    // is `ConstraintError`; mirrors `UserLabelHandler`'s
+                    // out-of-range behaviour.
+                    return Err(ErrorCode::ConstraintError.into());
+                };
+                item.label(entry.label)?.value(entry.value)?.end()
+            }
+            ArrayAttributeRead::ReadNone(array) => array.end(),
+        }
+    }
+}

--- a/rs-matter/src/dm/clusters/identify.rs
+++ b/rs-matter/src/dm/clusters/identify.rs
@@ -100,21 +100,13 @@ pub enum IdentifyAction {
 pub trait IdentifyHooks {
     /// Return the kind of identification mechanism this endpoint provides.
     /// Reported as the `IdentifyType` attribute (per App Cluster spec
-    /// §1.2.5.2). The default is [`IdentifyTypeEnum::None`] which means
-    /// "no physical mechanism."
-    fn identify_type(&self) -> IdentifyTypeEnum {
-        IdentifyTypeEnum::None
-    }
+    /// §1.2.5.2).
+    fn identify_type(&self) -> IdentifyTypeEnum;
 
     /// Drive the application's identify hardware in response to a state
-    /// transition. The default implementation is a no-op — useful for
-    /// headless test fixtures.
-    fn identify(&self, action: IdentifyAction) {
-        let _ = action;
-    }
+    /// transition.
+    fn identify(&self, action: IdentifyAction);
 }
-
-impl IdentifyHooks for () {}
 
 impl<T> IdentifyHooks for &T
 where
@@ -126,6 +118,16 @@ where
 
     fn identify(&self, action: IdentifyAction) {
         (*self).identify(action)
+    }
+}
+
+impl IdentifyHooks for () {
+    fn identify_type(&self) -> IdentifyTypeEnum {
+        IdentifyTypeEnum::None
+    }
+
+    fn identify(&self, action: IdentifyAction) {
+        let _ = action;
     }
 }
 

--- a/rs-matter/src/dm/clusters/user_label.rs
+++ b/rs-matter/src/dm/clusters/user_label.rs
@@ -25,25 +25,35 @@
 //! sees the same list (subject to the usual ACL rules — `LabelList` reads
 //! at view-privilege, writes at manage-privilege).
 //!
-//! [`UserLabelHandler`] ships with bounded in-memory storage. Persistence
-//! across reboots — which the spec requires (§9.7.5) — is not yet wired:
-//! applications that need the labels to survive restart need to subscribe
-//! to writes via `Matter::subscribe_changes` and store the values in
-//! their own KV blob, or extend this handler with an explicit storage
-//! hook trait. The CI test
-//! [`TestUserLabelClusterConstraints`](`https://github.com/project-chip/connectedhomeip/blob/master/src/app/tests/suites/TestUserLabelClusterConstraints.yaml`)
-//! exercises only the in-session length-constraint behaviour and passes
-//! against this implementation; the `TestUserLabelCluster` YAML — which
-//! includes a Reboot-and-read-back step — does not yet pass and remains
-//! commented out in `xtask/src/itest.rs`.
-
-use core::cell::RefCell;
+//! Spec §9.7.5 requires the `LabelList` to persist across reboots.
+//! Persistence is implemented by [`UserLabels`], a registry that holds
+//! every endpoint's `LabelList` and serialises the lot under a single
+//! KV key ([`USER_LABELS_KEY`]) on every mutation. Each endpoint that
+//! advertises the UserLabel cluster gets its own [`UserLabelHandler`]
+//! facade (so the per-cluster-instance `Dataver` stays granular per
+//! Matter Core spec §7.13.2.1), and all facades share one `UserLabels`
+//! by reference.
+//!
+//! Application wiring:
+//!
+//! ```ignore
+//! // One registry, sized for up to `E` endpoints, each holding up to `N` labels.
+//! let labels = UserLabels::<2, 4>::new();
+//! labels.load_persist(&mut kv, kv_buf).await?;
+//!
+//! let ep0_handler = UserLabelHandler::new(Dataver::new_rand(rand), 0, &labels);
+//! let ep1_handler = UserLabelHandler::new(Dataver::new_rand(rand), 1, &labels);
+//! ```
 
 use crate::dm::{
-    ArrayAttributeRead, ArrayAttributeWrite, Cluster, Dataver, ReadContext, WriteContext,
+    ArrayAttributeRead, ArrayAttributeWrite, Cluster, Dataver, EndptId, ReadContext, WriteContext,
 };
 use crate::error::{Error, ErrorCode};
-use crate::tlv::{TLVArray, TLVBuilderParent};
+use crate::persist::{KvBlobStore, Persist};
+use crate::tlv::{FromTLV, TLVArray, TLVBuilderParent, TLVElement, TLVTag, TLVWrite, ToTLV, TLV};
+use crate::utils::cell::RefCell;
+use crate::utils::init::{init, Init};
+use crate::utils::storage::Vec;
 use crate::utils::sync::blocking::Mutex;
 use crate::with;
 
@@ -51,14 +61,14 @@ pub use crate::dm::clusters::decl::globals::{
     LabelStruct, LabelStructArrayBuilder, LabelStructBuilder,
 };
 pub use crate::dm::clusters::decl::user_label::*;
+pub use crate::persist::USER_LABELS_KEY;
 
 /// Cluster metadata exposed by [`UserLabelHandler`] regardless of the
-/// `N` capacity parameter.
+/// const-generic parameters.
 ///
-/// Equivalent to `<UserLabelHandler<N> as ClusterHandler>::CLUSTER` for
-/// any `N`, exposed here as a free constant so callers don't have to
-/// spell out the generic parameter when they just want the cluster ID
-/// for an `EpClMatcher` or a `clusters!(...)` literal.
+/// Exposed as a free constant so callers don't have to spell out the
+/// generic parameters of [`UserLabelHandler`] when they just want the
+/// cluster ID for an `EpClMatcher` or a `clusters!(...)` literal.
 pub const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
 
 /// Maximum length of a single `label` string, in characters.
@@ -70,49 +80,248 @@ pub const MAX_LABEL_LEN: usize = 16;
 pub const MAX_VALUE_LEN: usize = 16;
 
 /// One entry in a `LabelList`.
-type LabelEntry = (
-    heapless::String<MAX_LABEL_LEN>,
-    heapless::String<MAX_VALUE_LEN>,
-);
-
-/// The handler for the UserLabel Matter cluster.
 ///
-/// Per-endpoint instance: each endpoint that advertises the UserLabel
-/// cluster must own a separate `UserLabelHandler` so the per-endpoint
-/// `LabelList` stays segregated.
-///
-/// `N` (default 4) sets the maximum number of entries the list can hold;
-/// writes that exceed it are rejected with `ErrorCode::ResourceExhausted`,
-/// which the framework maps to the IM `ResourceExhausted` status. This
-/// matches the `TestUserLabelClusterConstraints` test's expectation of
-/// rejecting an oversized list.
-///
-/// Concurrency: the entry list is wrapped in a blocking [`Mutex`] +
-/// `RefCell` so the handler is sound under a future work-stealing executor
-/// configuration of rs-matter. Lock holds are bounded — the lock is
-/// *never* held across `.await` points (this is a sync `ClusterHandler`
-/// in the first place, so there are no `.await`s).
-///
-/// Dataver is bumped automatically by the framework after each write/invoke
-/// and on every `notify_attr_changed`; this handler never calls
-/// `dataver_changed()` directly.
-pub struct UserLabelHandler<const N: usize = 4> {
-    dataver: Dataver,
-    entries: Mutex<RefCell<heapless::Vec<LabelEntry, N>>>,
+/// Named struct (rather than a tuple) so the `derive(FromTLV, ToTLV)`
+/// pair gives us a stable persisted shape for free — the on-disk
+/// representation matches the Matter spec's `LabelStruct` field layout
+/// (`label` at tag 0, `value` at tag 1).
+#[derive(Debug, Clone, PartialEq, Eq, FromTLV, ToTLV)]
+pub struct LabelEntry {
+    pub label: heapless::String<MAX_LABEL_LEN>,
+    pub value: heapless::String<MAX_VALUE_LEN>,
 }
 
-impl<const N: usize> UserLabelHandler<N> {
-    /// Creates a new `UserLabelHandler` with an empty `LabelList`.
-    pub const fn new(dataver: Dataver) -> Self {
+/// One slot in the persisted [`UserLabels`] blob: the `LabelList` for a
+/// specific endpoint. The TLV impls are hand-rolled (rather than
+/// `#[derive(FromTLV, ToTLV)]`) because the derive macro doesn't yet
+/// support const-generic structs. Wire format is a struct with two
+/// context-tagged fields:
+/// - `0`: `endpoint_id` (`u16`)
+/// - `1`: `entries` (TLV array of `LabelEntry`)
+///
+/// No spec dictates this layout; it just needs to be internally
+/// consistent between [`Self::to_tlv`] and [`Self::from_tlv`].
+#[derive(Debug, Clone)]
+struct EndpointLabels<const N: usize> {
+    endpoint_id: EndptId,
+    entries: Vec<LabelEntry, N>,
+}
+
+impl<const N: usize> ToTLV for EndpointLabels<N> {
+    fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, mut tw: W) -> Result<(), Error> {
+        tw.start_struct(tag)?;
+        self.endpoint_id.to_tlv(&TLVTag::Context(0), &mut tw)?;
+        self.entries.to_tlv(&TLVTag::Context(1), &mut tw)?;
+        tw.end_container()
+    }
+
+    fn tlv_iter(&self, _tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
+        // Not used by `Persist::store_tlv` — that goes through
+        // `to_tlv` above. Returning an empty iterator keeps the trait
+        // bound satisfied without dragging in extra machinery.
+        core::iter::empty()
+    }
+}
+
+impl<'a, const N: usize> FromTLV<'a> for EndpointLabels<N> {
+    fn from_tlv(element: &TLVElement<'a>) -> Result<Self, Error> {
+        let s = element.structure()?;
+        Ok(Self {
+            endpoint_id: EndptId::from_tlv(&s.ctx(0)?)?,
+            entries: Vec::<LabelEntry, N>::from_tlv(&s.ctx(1)?)?,
+        })
+    }
+}
+
+/// Shared registry of every endpoint's UserLabel `LabelList`.
+///
+/// Persisted as a single TLV blob under [`USER_LABELS_KEY`] — every
+/// successful write to any [`UserLabelHandler`] re-serialises the whole
+/// registry and stores it. Read paths take the lock briefly to copy
+/// labels into the TLV builder.
+///
+/// Const generics:
+/// - `E` — max number of endpoints that may have a `LabelList`. Bound
+///   on the in-memory `Vec` of per-endpoint slots.
+/// - `N` — max number of `LabelEntry` rows per endpoint. Bound on each
+///   slot's inner `Vec`. Defaults to 4.
+///
+/// Lock holds are bounded — the `Mutex<RefCell<_>>` is never held
+/// across an `.await`, so the registry is sound under a work-stealing
+/// executor.
+pub struct UserLabels<const E: usize, const N: usize = 4> {
+    state: Mutex<RefCell<Vec<EndpointLabels<N>, E>>>,
+}
+
+impl<const E: usize, const N: usize> UserLabels<E, N> {
+    /// Create an empty registry. Call [`Self::load_persist`] at
+    /// application startup to populate it from KV.
+    ///
+    /// Prefer [`Self::init`] for non-trivial `E` * `N` so the
+    /// registry's storage can be initialised in-place (typically in a
+    /// `StaticCell`) instead of being constructed on the stack and
+    /// moved. The two paths produce structurally identical instances.
+    pub const fn new() -> Self {
         Self {
-            dataver,
-            entries: Mutex::new(RefCell::new(heapless::Vec::new())),
+            state: Mutex::new(RefCell::new(Vec::new())),
         }
     }
 
-    /// Adapt the handler instance to the generic `rs-matter` `Handler` trait.
-    pub const fn adapt(self) -> HandlerAdaptor<Self> {
-        HandlerAdaptor(self)
+    /// Return an in-place initialiser for an empty registry. Use this
+    /// when `E` * `N` * `size_of::<LabelEntry>` is large enough that
+    /// stack-constructing a [`Self::new`] instance and moving it into
+    /// long-lived storage would overflow the stack or bloat
+    /// `.rodata`. Typical usage:
+    ///
+    /// ```ignore
+    /// static USER_LABELS: StaticCell<UserLabels<8, 4>> = StaticCell::new();
+    /// let user_labels = USER_LABELS.uninit().init_with(UserLabels::init());
+    /// ```
+    pub fn init() -> impl Init<Self> {
+        init!(Self {
+            state <- Mutex::init(RefCell::init(Vec::init())),
+        })
+    }
+
+    /// Re-hydrate the registry from `store` under [`USER_LABELS_KEY`].
+    /// Call once at application startup, before exposing the data
+    /// model to commissioners, so subsequent reads see the labels
+    /// written before the last reboot.
+    ///
+    /// Missing key (first boot, or persistence cleared) is not an
+    /// error — the registry simply stays empty.
+    pub async fn load_persist<S: KvBlobStore>(
+        &self,
+        mut store: S,
+        buf: &mut [u8],
+    ) -> Result<(), Error> {
+        self.state.lock(|cell| cell.borrow_mut().clear());
+
+        let Some(data) = store.load(USER_LABELS_KEY, buf)? else {
+            return Ok(());
+        };
+
+        let loaded = Vec::<EndpointLabels<N>, E>::from_tlv(&TLVElement::new(data))?;
+
+        self.state.lock(|cell| {
+            let mut state = cell.borrow_mut();
+            state.clear();
+            for slot in loaded {
+                state.push(slot).map_err(|_| ErrorCode::ResourceExhausted)?;
+            }
+            Ok::<_, Error>(())
+        })?;
+
+        info!("Loaded UserLabel entries for all endpoints from storage");
+
+        Ok(())
+    }
+
+    /// Serialise the current registry to `ctx.kv()` under
+    /// [`USER_LABELS_KEY`]. Called from every mutating handler path
+    /// after the in-memory change is committed.
+    fn store_persist<C: WriteContext>(&self, ctx: &C) -> Result<(), Error> {
+        let mut persist = Persist::new(ctx.kv());
+
+        self.state.lock(|cell| {
+            let state = cell.borrow();
+            persist.store_tlv(USER_LABELS_KEY, &*state)
+        })?;
+
+        persist.run()
+    }
+
+    /// Run a closure with read-only access to the `LabelList` for
+    /// `endpoint_id`. The closure receives an empty slice if the
+    /// endpoint has no entries (or isn't registered yet).
+    fn with_entries<R>(
+        &self,
+        endpoint_id: EndptId,
+        f: impl FnOnce(&[LabelEntry]) -> Result<R, Error>,
+    ) -> Result<R, Error> {
+        self.state.lock(|cell| {
+            let state = cell.borrow();
+            match state.iter().find(|slot| slot.endpoint_id == endpoint_id) {
+                Some(slot) => f(slot.entries.as_slice()),
+                None => f(&[]),
+            }
+        })
+    }
+
+    /// Replace this endpoint's entire `LabelList` with the entries
+    /// produced by the provided iterator. The new list is validated
+    /// up front (each entry against the spec length limits) before
+    /// any in-memory state changes; on success the whole registry is
+    /// re-persisted.
+    fn replace_entries<'a, C: WriteContext>(
+        &self,
+        ctx: &C,
+        endpoint_id: EndptId,
+        list: &TLVArray<'a, LabelStruct<'a>>,
+    ) -> Result<(), Error> {
+        // Two-pass validation: count + spec checks first, so a
+        // malformed input never partially mutates the registry.
+        let mut count = 0usize;
+        for entry in list {
+            let entry = entry?;
+            Self::validate_entry(&entry)?;
+            count += 1;
+            if count > N {
+                return Err(ErrorCode::ResourceExhausted.into());
+            }
+        }
+
+        self.state.lock(|cell| {
+            let mut state = cell.borrow_mut();
+            let slot = Self::slot_mut(&mut state, endpoint_id)?;
+            slot.entries.clear();
+            for entry in list {
+                let entry = entry?;
+                let (label, value) = Self::validate_entry(&entry)?;
+                Self::push_into(&mut slot.entries, label, value)?;
+            }
+            Ok::<_, Error>(())
+        })?;
+
+        self.store_persist(ctx)
+    }
+
+    /// Append one entry to this endpoint's `LabelList`. Validates the
+    /// spec length limits, then persists.
+    fn add_entry<'a, C: WriteContext>(
+        &self,
+        ctx: &C,
+        endpoint_id: EndptId,
+        entry: &LabelStruct<'a>,
+    ) -> Result<(), Error> {
+        let (label, value) = Self::validate_entry(entry)?;
+
+        self.state.lock(|cell| {
+            let mut state = cell.borrow_mut();
+            let slot = Self::slot_mut(&mut state, endpoint_id)?;
+            Self::push_into(&mut slot.entries, label, value)
+        })?;
+
+        self.store_persist(ctx)
+    }
+
+    /// Return a mutable reference to the slot for `endpoint_id`,
+    /// inserting an empty slot if necessary.
+    fn slot_mut(
+        state: &mut Vec<EndpointLabels<N>, E>,
+        endpoint_id: EndptId,
+    ) -> Result<&mut EndpointLabels<N>, Error> {
+        if let Some(idx) = state.iter().position(|s| s.endpoint_id == endpoint_id) {
+            return Ok(&mut state[idx]);
+        }
+        state
+            .push(EndpointLabels {
+                endpoint_id,
+                entries: Vec::new(),
+            })
+            .map_err(|_| ErrorCode::ResourceExhausted)?;
+        // `push` succeeded → the new slot is the last element.
+        Ok(state.last_mut().expect("just pushed"))
     }
 
     /// Validate a single `LabelStruct` against the spec length limits.
@@ -128,26 +337,19 @@ impl<const N: usize> UserLabelHandler<N> {
         Ok((label, value))
     }
 
-    /// Push a `(label, value)` pair into a `Vec`. Returns
-    /// `ResourceExhausted` when the bounded vec is full.
-    fn push_into(
-        list: &mut heapless::Vec<LabelEntry, N>,
-        label: &str,
-        value: &str,
-    ) -> Result<(), Error> {
-        let mut entry = (
-            heapless::String::<MAX_LABEL_LEN>::new(),
-            heapless::String::<MAX_VALUE_LEN>::new(),
-        );
-        // `push_str` on `heapless::String` returns `Err(())` on overflow.
-        // We've already validated lengths above, so this can only fail if
-        // the bounds change without `validate_entry` being updated.
+    /// Push a `(label, value)` pair into a bounded vec. Returns
+    /// `ResourceExhausted` when the vec is full.
+    fn push_into(list: &mut Vec<LabelEntry, N>, label: &str, value: &str) -> Result<(), Error> {
+        let mut entry = LabelEntry {
+            label: heapless::String::new(),
+            value: heapless::String::new(),
+        };
         entry
-            .0
+            .label
             .push_str(label)
             .map_err(|_| ErrorCode::ConstraintError)?;
         entry
-            .1
+            .value
             .push_str(value)
             .map_err(|_| ErrorCode::ConstraintError)?;
         list.push(entry).map_err(|_| ErrorCode::ResourceExhausted)?;
@@ -155,7 +357,41 @@ impl<const N: usize> UserLabelHandler<N> {
     }
 }
 
-impl<const N: usize> ClusterHandler for UserLabelHandler<N> {
+impl<const E: usize, const N: usize> Default for UserLabels<E, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Per-`(endpoint, UserLabel)`-instance handler facade. Owns the
+/// cluster's `Dataver` and is bound to one `endpoint_id`; the actual
+/// state lives in the shared [`UserLabels`] registry the facade points
+/// at. Multiple facades may reference the same registry — that's how
+/// a multi-endpoint device shares one persisted blob.
+pub struct UserLabelHandler<'a, const E: usize, const N: usize = 4> {
+    dataver: Dataver,
+    endpoint_id: EndptId,
+    labels: &'a UserLabels<E, N>,
+}
+
+impl<'a, const E: usize, const N: usize> UserLabelHandler<'a, E, N> {
+    /// Construct a facade for `(endpoint_id, UserLabel)` backed by the
+    /// shared `labels` registry.
+    pub const fn new(dataver: Dataver, endpoint_id: EndptId, labels: &'a UserLabels<E, N>) -> Self {
+        Self {
+            dataver,
+            endpoint_id,
+            labels,
+        }
+    }
+
+    /// Adapt the handler instance to the generic `rs-matter` `Handler` trait.
+    pub const fn adapt(self) -> HandlerAdaptor<Self> {
+        HandlerAdaptor(self)
+    }
+}
+
+impl<const E: usize, const N: usize> ClusterHandler for UserLabelHandler<'_, E, N> {
     const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
 
     fn dataver(&self) -> u32 {
@@ -171,69 +407,41 @@ impl<const N: usize> ClusterHandler for UserLabelHandler<N> {
         _ctx: impl ReadContext,
         builder: ArrayAttributeRead<LabelStructArrayBuilder<P>, LabelStructBuilder<P>>,
     ) -> Result<P, Error> {
-        self.entries.lock(|cell| {
-            let entries = cell.borrow();
-            match builder {
+        self.labels
+            .with_entries(self.endpoint_id, |entries| match builder {
                 ArrayAttributeRead::ReadAll(mut array) => {
-                    for (label, value) in entries.iter() {
+                    for entry in entries {
                         array = array
                             .push()?
-                            .label(label.as_str())?
-                            .value(value.as_str())?
+                            .label(entry.label.as_str())?
+                            .value(entry.value.as_str())?
                             .end()?;
                     }
                     array.end()
                 }
                 ArrayAttributeRead::ReadOne(index, item) => {
-                    let Some((label, value)) = entries.get(index as usize) else {
+                    let Some(entry) = entries.get(index as usize) else {
                         return Err(ErrorCode::ConstraintError.into());
                     };
-                    item.label(label.as_str())?.value(value.as_str())?.end()
+                    item.label(entry.label.as_str())?
+                        .value(entry.value.as_str())?
+                        .end()
                 }
                 ArrayAttributeRead::ReadNone(array) => array.end(),
-            }
-        })
+            })
     }
 
     fn set_label_list(
         &self,
-        _ctx: impl WriteContext,
+        ctx: impl WriteContext,
         value: ArrayAttributeWrite<TLVArray<'_, LabelStruct<'_>>, LabelStruct<'_>>,
     ) -> Result<(), Error> {
         match value {
             ArrayAttributeWrite::Replace(list) => {
-                // Two-pass: validate every entry first so we never end up
-                // with a partially-applied list on a malformed input. If
-                // validation passes we know `push_into` will succeed for
-                // every entry up to the capacity bound. Mirrors
-                // `acl::AclHandler::set_acl`'s validate-then-commit shape.
-                let mut count = 0usize;
-                for entry in &list {
-                    let entry = entry?;
-                    Self::validate_entry(&entry)?;
-                    count += 1;
-                    if count > N {
-                        return Err(ErrorCode::ResourceExhausted.into());
-                    }
-                }
-
-                self.entries.lock(|cell| {
-                    let mut entries = cell.borrow_mut();
-                    entries.clear();
-                    for entry in &list {
-                        // unwrap-equivalent is safe: we validated each
-                        // entry above and the count is within capacity.
-                        let entry = entry?;
-                        let (label, value) = Self::validate_entry(&entry)?;
-                        Self::push_into(&mut entries, label, value)?;
-                    }
-                    Ok(())
-                })
+                self.labels.replace_entries(&ctx, self.endpoint_id, &list)
             }
             ArrayAttributeWrite::Add(entry) => {
-                let (label, value) = Self::validate_entry(&entry)?;
-                self.entries
-                    .lock(|cell| Self::push_into(&mut cell.borrow_mut(), label, value))
+                self.labels.add_entry(&ctx, self.endpoint_id, &entry)
             }
             // The Matter Core spec (V1.4.2 §10.6.4.3.1) does not yet
             // support per-element list update / remove writes — the

--- a/rs-matter/src/dm/clusters/user_label.rs
+++ b/rs-matter/src/dm/clusters/user_label.rs
@@ -195,22 +195,17 @@ impl<const E: usize, const N: usize> UserLabels<E, N> {
         mut store: S,
         buf: &mut [u8],
     ) -> Result<(), Error> {
-        self.state.lock(|cell| cell.borrow_mut().clear());
-
         let Some(data) = store.load(USER_LABELS_KEY, buf)? else {
+            // No prior persistence — reset to empty so re-calling
+            // `load_persist` after a `remove` of the key behaves
+            // deterministically.
+            self.state.lock(|cell| cell.borrow_mut().clear());
             return Ok(());
         };
 
         let loaded = Vec::<EndpointLabels<N>, E>::from_tlv(&TLVElement::new(data))?;
 
-        self.state.lock(|cell| {
-            let mut state = cell.borrow_mut();
-            state.clear();
-            for slot in loaded {
-                state.push(slot).map_err(|_| ErrorCode::ResourceExhausted)?;
-            }
-            Ok::<_, Error>(())
-        })?;
+        self.state.lock(|cell| *cell.borrow_mut() = loaded);
 
         info!("Loaded UserLabel entries for all endpoints from storage");
 
@@ -340,19 +335,10 @@ impl<const E: usize, const N: usize> UserLabels<E, N> {
     /// Push a `(label, value)` pair into a bounded vec. Returns
     /// `ResourceExhausted` when the vec is full.
     fn push_into(list: &mut Vec<LabelEntry, N>, label: &str, value: &str) -> Result<(), Error> {
-        let mut entry = LabelEntry {
-            label: heapless::String::new(),
-            value: heapless::String::new(),
-        };
-        entry
-            .label
-            .push_str(label)
-            .map_err(|_| ErrorCode::ConstraintError)?;
-        entry
-            .value
-            .push_str(value)
-            .map_err(|_| ErrorCode::ConstraintError)?;
-        list.push(entry).map_err(|_| ErrorCode::ResourceExhausted)?;
+        let label = heapless::String::try_from(label).map_err(|_| ErrorCode::ConstraintError)?;
+        let value = heapless::String::try_from(value).map_err(|_| ErrorCode::ConstraintError)?;
+        list.push(LabelEntry { label, value })
+            .map_err(|_| ErrorCode::ResourceExhausted)?;
         Ok(())
     }
 }

--- a/rs-matter/src/persist.rs
+++ b/rs-matter/src/persist.rs
@@ -41,7 +41,11 @@ pub const BASIC_INFO_KEY: u16 = FABRIC_KEYS_START + 256;
 pub const EVENT_EPOCH_KEY: u16 = BASIC_INFO_KEY + 1;
 
 /// The key used for storing the wireless networks state.
-pub const NETWORKS_KEY: u16 = BASIC_INFO_KEY + 2;
+pub const NETWORKS_KEY: u16 = EVENT_EPOCH_KEY + 1;
+
+/// The key used for storing all UserLabel `LabelList` data across every
+/// endpoint that hosts the UserLabel cluster.
+pub const USER_LABELS_KEY: u16 = NETWORKS_KEY + 1;
 
 /// A trait representing a key-value BLOB storage.
 ///

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -80,15 +80,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TestSubscribe_AdministratorCommissioning",
     "TestSubscribe_OnOff",
     // "TestSystemCommands", // TODO: Error attempting to start secondary device
-    // "TestUserLabelCluster", // Skipped: the test issues a SystemCommands `Reboot`
-    //                          // and reads the LabelList back to verify persistence.
-    //                          // The reboot step shares the limitation that gates
-    //                          // `TestSystemCommands` (we don't yet survive
-    //                          // chip-tool-driven restarts), and the
-    //                          // `UserLabelHandler` we ship today stores entries
-    //                          // in-memory only — persistence is a separate
-    //                          // workstream. The pre-reboot steps (write / read /
-    //                          // clear) would all pass against the current handler.
+    "TestUserLabelCluster",
     "TestUserLabelClusterConstraints",
     // "TestTimeSynchronization", // Skipped: TimeSynchronization cluster not implemented by rs-matter (optional, Matter spec §11.16).
     // "TestIcdManagementCluster", // Skipped: ICD Management cluster not implemented (rs-matter doesn't ship Intermittently Connected Device support).

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -308,7 +308,10 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     //
     // Python tests — Fixed Label (optional system cluster)
     //
-    "TC_FLABEL_2_1", // FixedLabel not implemented (optional, Matter spec §9.8); `@run_if_endpoint_matches(has_attribute(FixedLabel.LabelList))` skips cleanly via `no_fail_on_skipped.py`.
+    "TC_FLABEL_2_1", // FixedLabel wired on EP1 of `chip_tool_tests` with two static
+    //                  spec-conformant entries (see `FIXED_LABELS_EP1`). The test reads
+    //                  the list, attempts a write (expected `UnsupportedWrite` since
+    //                  `LabelList` is read-only), and re-reads to confirm stability.
     //
     // Python tests — Bridged Device Basic Information (optional, bridges)
     //
@@ -968,7 +971,6 @@ impl ITests {
                 | "TC_TIMESYNC_2_1"  // has_cluster(TimeSynchronization) and has_attribute(TimeSource)
                 | "TC_DGSW_2_1"      // has_cluster(SoftwareDiagnostics)
                 | "TC_DGSW_2_2"      // has_cluster(SoftwareDiagnostics)
-                | "TC_FLABEL_2_1"    // has_attribute(FixedLabel.LabelList)
                 | "TC_LCFG_2_1"      // has_cluster(LocalizationConfiguration)
                 | "TC_LTIME_3_1"     // has_cluster(TimeFormatLocalization)
                 | "TC_LUNIT_3_1"     // has_cluster(UnitLocalization) and has_attribute(TemperatureUnit)


### PR DESCRIPTION
The User-Label cluster handler was introduced with an earlier commit, but it was missing an out of the box persistence, and without it the handler is kind of useless given that it is basically all about persisting those labels.

Additionally, I've now pushed an implementation of the Fixed-Label cluster handler which is even simpler, in that its labels are typically hard-coded in the firmware and thus do not even need persistence.

The two handlers allow us to enable two more tests.