### PR TITLE
Support for client clusters

### DIFF
--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -633,14 +633,14 @@ fn report_total_size(total_size: usize) {
 const NODE: Node<'static> = Node {
     endpoints: &[
         root_endpoint!(wifi),
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
-            clusters: clusters!(
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 on_off::test::TestOnOffDeviceLogic::CLUSTER
             ),
-        },
+        ),
     ],
 };
 

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -162,41 +162,41 @@ const NODE: Node<'static> = Node {
         // Optionally, the aggregator can declare and implement the `Actions` cluster
         // (see below in the handler the meaning of this cluster).
         // In any case, this endpoint must be of the Aggregator device type.
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_AGGREGATOR),
-            clusters: clusters!(desc::DescHandler::CLUSTER),
-        },
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_AGGREGATOR),
+            clusters!(desc::DescHandler::CLUSTER),
+        ),
         // This is the first bridged device. It could have any ID as long as it is not 0 or 1.
         //
         // The Matter Bridge needs to declare as many endpoints as there are bridged devices.
         // If the bridged devices can vary over time, rather than using a static `Node`
         // definition, one could use an `(Async)MetaData` implementation that returns a node
         // which references the endpoints off from a `Vec` or a `heapless::Vec`.
-        Endpoint {
-            id: 2,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_BRIDGED_NODE),
-            clusters: clusters!(
+        Endpoint::new(
+            2,
+            devices!(DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_BRIDGED_NODE),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 BridgedHandler::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER
             ),
-        },
+        ),
         // This is the second bridged device.
         //
         // It could have a completely different device type, yet here - for simplicity - we
         // just declare another lamp.
-        Endpoint {
-            id: 3,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_BRIDGED_NODE),
-            clusters: clusters!(
+        Endpoint::new(
+            3,
+            devices!(DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_BRIDGED_NODE),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 BridgedHandler::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER
             ),
-        },
+        ),
     ],
 };
 

--- a/examples/src/bin/camera_tests.rs
+++ b/examples/src/bin/camera_tests.rs
@@ -645,10 +645,10 @@ const BASIC_INFO: BasicInfoConfig<'static> = BasicInfoConfig {
 const NODE: Node<'static> = Node {
     endpoints: &[
         root_endpoint!(eth),
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_MATTER_CAMERA),
-            clusters: clusters!(
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_MATTER_CAMERA),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 CamAv::CLUSTER_VIDEO_AUDIO,
@@ -658,7 +658,7 @@ const NODE: Node<'static> = Node {
                 WebRtc::CLUSTER,
                 chime_decl::FULL_CLUSTER
             ),
-        },
+        ),
     ],
 };
 

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -42,6 +42,7 @@ use rs_matter::dm::clusters::basic_info::{
     AttributeId as BasicInfoAttributeId, BasicInfoConfig, ColorEnum, PairingHintFlags,
     ProductAppearance, ProductFinishEnum, FULL_CLUSTER as BASIC_INFO_FULL_CLUSTER,
 };
+use rs_matter::dm::clusters::binding::{self, BindingHandler, Bindings};
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::eth_diag::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::fixed_label::{self, FixedLabelEntry, FixedLabelHandler};
@@ -98,6 +99,11 @@ static GEN_DIAG: StaticCell<TestEventTriggerDiag> = StaticCell::new();
 // UserLabel registry — host endpoints and labels-per-endpoint counts
 // match `dm_handler`'s `UserLabelHandler<'_, E, N>` parameterisation.
 static USER_LABELS: StaticCell<UserLabels<1, 4>> = StaticCell::new();
+// Binding registry. Capacity 16 — `TestBinding` writes a 17-entry
+// table and expects `RESOURCE_EXHAUSTED`, so this bound is what makes
+// that step pass. Two fabrics × ~8 entries per fabric is comfortably
+// above what the YAML's per-fabric scenarios actually exercise.
+static BINDINGS: StaticCell<Bindings<16>> = StaticCell::new();
 
 fn main() -> Result<(), Error> {
     // Enable detailed backtraces for debugging test failures
@@ -193,6 +199,16 @@ fn main() -> Result<(), Error> {
     let user_label_handler =
         UserLabelHandler::new(Dataver::new_rand(&mut rand), ROOT_ENDPOINT_ID, user_labels);
 
+    // Binding registry — same `StaticCell` + in-place-init pattern as
+    // UserLabels. Loaded from KV before the data model accepts traffic
+    // so bindings written pre-reboot survive (spec §9.6.6.1, N quality).
+    let bindings = BINDINGS.uninit().init_with(Bindings::init());
+    futures_lite::future::block_on(bindings.load_persist(&mut kv, kv_buf))?;
+
+    let binding_handler_ep0 =
+        BindingHandler::new(Dataver::new_rand(&mut rand), ROOT_ENDPOINT_ID, bindings);
+    let binding_handler_ep1 = BindingHandler::new(Dataver::new_rand(&mut rand), 1, bindings);
+
     // Our unit testing cluster data
     let unit_testing_data = UNIT_TESTING_DATA
         .uninit()
@@ -238,6 +254,8 @@ fn main() -> Result<(), Error> {
             &on_off_handler_1,
             &on_off_handler_2,
             &user_label_handler,
+            &binding_handler_ep0,
+            &binding_handler_ep1,
         ),
         SharedKvBlobStore::new(kv, kv_buf),
         SharedNetworks::new(EthNetwork::new_default()),
@@ -434,38 +452,59 @@ const FIXED_LABELS_EP1: &[FixedLabelEntry<'static>] = &[
 
 const NODE: Node<'static> = Node {
     endpoints: &[
-        Endpoint {
-            id: ROOT_ENDPOINT_ID,
-            device_types: devices!(DEV_TYPE_ROOT_NODE),
-            clusters: clusters!(eth; groups::GroupsHandler::CLUSTER, user_label::CLUSTER),
-        },
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
-            // `FixedLabel` (cluster ID 0x0040) is wired on EP1 because
-            // `TC_FLABEL_2_1` runs with `--endpoint 1` and skips cleanly
-            // via `has_attribute(FixedLabel.LabelList)` when the cluster
-            // is absent; adding it here turns the skip into an actual
-            // content + read-only-write check.
-            clusters: clusters!(
+        // `Binding` (cluster ID 0x001E) is wired on EP0 too because
+        // `TestBinding` exercises writes against both endpoints
+        // (see step "Write binding table (endpoint 0)" in the
+        // YAML) and asserts per-endpoint isolation. Pairing
+        // Binding-server with a client cluster declaration in
+        // `client_clusters` is the rs-matter way to advertise
+        // "this endpoint will initiate `OnOff` interactions" via
+        // `Descriptor::ClientList`.
+        Endpoint::new_with_clients(
+            ROOT_ENDPOINT_ID,
+            devices!(DEV_TYPE_ROOT_NODE),
+            clusters!(
+                eth;
+                groups::GroupsHandler::CLUSTER,
+                user_label::CLUSTER,
+                binding::CLUSTER
+            ),
+            &[on_off::FULL_CLUSTER.id],
+        ),
+        // `FixedLabel` (cluster ID 0x0040) is wired on EP1 because
+        // `TC_FLABEL_2_1` runs with `--endpoint 1` and skips cleanly
+        // via `has_attribute(FixedLabel.LabelList)` when the cluster
+        // is absent; adding it here turns the skip into an actual
+        // content + read-only-write check.
+        //
+        // `Binding` is wired on EP1 to satisfy `TestBinding`, which
+        // writes/reads its primary table here. Paired with a
+        // client-cluster declaration so `Descriptor::ClientList`
+        // truthfully advertises the intent to control OnOff bulbs.
+        Endpoint::new_with_clients(
+            1,
+            devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 identify::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 fixed_label::CLUSTER,
+                binding::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER,
                 UnitTestingHandler::CLUSTER
             ),
-        },
-        Endpoint {
-            id: 2,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
-            clusters: clusters!(
+            &[on_off::FULL_CLUSTER.id],
+        ),
+        Endpoint::new(
+            2,
+            devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 identify::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER
             ),
-        },
+        ),
     ],
 };
 
@@ -496,16 +535,16 @@ const BASIC_INFO_CLUSTER_CV_EXPOSED: Cluster<'static> = BASIC_INFO_FULL_CLUSTER
 /// `connectedhomeip@faf4d09ad1`) keep using the default `NODE`.
 const NODE_BINFO_CV_EXPOSED: Node<'static> = Node {
     endpoints: &[
-        Endpoint {
-            id: ROOT_ENDPOINT_ID,
-            device_types: devices!(DEV_TYPE_ROOT_NODE),
-            // Manually expanded `clusters!(eth;)` with `BasicInfoHandler::CLUSTER`
-            // replaced by `BASIC_INFO_CLUSTER_CV_EXPOSED`. Keep this in sync
-            // with `clusters!(eth;)` in `rs-matter/src/dm/types/cluster.rs`.
-            // `GroupsHandler::CLUSTER` and `user_label::CLUSTER` are
-            // included for the same `TestGroupMessaging` /
-            // `TestUserLabelClusterConstraints` reasons documented on `NODE`.
-            clusters: clusters!(
+        // Manually expanded `clusters!(eth;)` with `BasicInfoHandler::CLUSTER`
+        // replaced by `BASIC_INFO_CLUSTER_CV_EXPOSED`. Keep this in sync
+        // with `clusters!(eth;)` in `rs-matter/src/dm/types/cluster.rs`.
+        // `GroupsHandler::CLUSTER` and `user_label::CLUSTER` are
+        // included for the same `TestGroupMessaging` /
+        // `TestUserLabelClusterConstraints` reasons documented on `NODE`.
+        Endpoint::new_with_clients(
+            ROOT_ENDPOINT_ID,
+            devices!(DEV_TYPE_ROOT_NODE),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 acl::AclHandler::CLUSTER,
                 BASIC_INFO_CLUSTER_CV_EXPOSED,
@@ -516,42 +555,55 @@ const NODE_BINFO_CV_EXPOSED: Node<'static> = Node {
                 grp_key_mgmt::GrpKeyMgmtHandler::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 user_label::CLUSTER,
+                binding::CLUSTER,
                 net_comm::NetworkType::Ethernet.cluster(),
                 eth_diag::EthDiagHandler::CLUSTER,
             ),
-        },
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
-            // `FixedLabel` (cluster ID 0x0040) is wired on EP1 because
-            // `TC_FLABEL_2_1` runs with `--endpoint 1` and skips cleanly
-            // via `has_attribute(FixedLabel.LabelList)` when the cluster
-            // is absent; adding it here turns the skip into an actual
-            // content + read-only-write check.
-            clusters: clusters!(
+            &[on_off::FULL_CLUSTER.id],
+        ),
+        // `FixedLabel` (cluster ID 0x0040) is wired on EP1 because
+        // `TC_FLABEL_2_1` runs with `--endpoint 1` and skips cleanly
+        // via `has_attribute(FixedLabel.LabelList)` when the cluster
+        // is absent; adding it here turns the skip into an actual
+        // content + read-only-write check.
+        //
+        // `Binding` is wired on EP1 to satisfy `TestBinding`, which
+        // writes/reads its primary table here. Paired with a
+        // client-cluster declaration so `Descriptor::ClientList`
+        // truthfully advertises the intent to control OnOff bulbs.
+        Endpoint::new_with_clients(
+            1,
+            devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 identify::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 fixed_label::CLUSTER,
+                binding::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER,
                 UnitTestingHandler::CLUSTER
             ),
-        },
-        Endpoint {
-            id: 2,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
-            clusters: clusters!(
+            &[on_off::FULL_CLUSTER.id],
+        ),
+        Endpoint::new(
+            2,
+            devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 identify::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER
             ),
-        },
+        ),
     ],
 };
 
 /// The Data Model handler + meta-data for our Matter device.
 /// The handler is the root endpoint 0 handler plus the on-off and unit testing handlers.
+// The test-fixture function is intentionally a wide top-level
+// composition root — every additional cluster handler we wire grows
+// the parameter list. Suppressing here is cleaner than abstracting.
+#[allow(clippy::too_many_arguments)]
 fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     node: &'static Node<'static>,
     gen_diag: &'a dyn GenDiag,
@@ -560,6 +612,8 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     on_off_1: &'a OnOffHandler<'a, OH, LH>,
     on_off_2: &'a OnOffHandler<'a, OH, LH>,
     user_label_handler: &'a UserLabelHandler<'a, 1, 4>,
+    binding_handler_ep0: &'a BindingHandler<'a, 16>,
+    binding_handler_ep1: &'a BindingHandler<'a, 16>,
 ) -> impl DataModelHandler + 'a {
     (
         node,
@@ -601,6 +655,14 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                     EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(user_label::CLUSTER.id)),
                     Async(user_label::HandlerAdaptor(user_label_handler)),
                 )
+                // Binding handler at the root endpoint — owned by main
+                // (so `load_persist` can run before commissioner
+                // traffic), borrowed by reference into the chain.
+                // `TestBinding` exercises writes against EP0.
+                .chain(
+                    EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(binding::CLUSTER.id)),
+                    Async(binding::HandlerAdaptor(binding_handler_ep0)),
+                )
                 // Clusters for Endpoint 1
                 .chain(
                     EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
@@ -620,6 +682,13 @@ fn dm_handler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                         FixedLabelHandler::new(Dataver::new_rand(&mut rand), FIXED_LABELS_EP1)
                             .adapt(),
                     ),
+                )
+                // Binding handler at EP1 — same registry as EP0,
+                // separate facade so the per-cluster-instance Dataver
+                // stays granular per Matter Core §7.13.2.1.
+                .chain(
+                    EpClMatcher::new(Some(1), Some(binding::CLUSTER.id)),
+                    Async(binding::HandlerAdaptor(binding_handler_ep1)),
                 )
                 .chain(
                     EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),

--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -18,6 +18,8 @@
 //! A dedicated Matter device for ConnectedHomeIP YAML integration tests.
 //! Implements On/Off and Unit Testing clusters over Ethernet.
 
+#![recursion_limit = "256"]
+
 use core::pin::pin;
 
 use std::net::UdpSocket;

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -252,16 +252,16 @@ fn run() -> Result<(), Error> {
 const NODE: Node<'static> = Node {
     endpoints: &[
         root_endpoint!(eth),
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_DIMMABLE_LIGHT),
-            clusters: clusters!(
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_DIMMABLE_LIGHT),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 OnOffDeviceLogic::CLUSTER,
                 LevelControlDeviceLogic::CLUSTER,
             ),
-        },
+        ),
     ],
 };
 

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -165,17 +165,17 @@ fn main() -> Result<(), Error> {
 const NODE: Node<'static> = Node {
     endpoints: &[
         root_endpoint!(eth),
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_CASTING_VIDEO_PLAYER),
-            clusters: clusters!(
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_CASTING_VIDEO_PLAYER),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 MediaHandler::CLUSTER,
                 ContentHandler::CLUSTER,
                 KeypadInputHandler::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER
             ),
-        },
+        ),
     ],
 };
 

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -192,15 +192,15 @@ fn run() -> Result<(), Error> {
 const NODE: Node<'static> = Node {
     endpoints: &[
         root_endpoint!(eth),
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
-            clusters: clusters!(
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER
             ),
-        },
+        ),
     ],
 };
 

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -257,15 +257,15 @@ fn run<N: NetCtl + WifiDiag>(connection: &Connection, net_ctl: N) -> Result<(), 
 const NODE: Node<'static> = Node {
     endpoints: &[
         root_endpoint!(wifi),
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
-            clusters: clusters!(
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 on_off::test::TestOnOffDeviceLogic::CLUSTER
             ),
-        },
+        ),
     ],
 };
 

--- a/examples/src/bin/onoff_light_work_stealing.rs
+++ b/examples/src/bin/onoff_light_work_stealing.rs
@@ -242,11 +242,11 @@ fn run() -> Result<(), Error> {
 const NODE: Node<'static> = Node {
     endpoints: &[
         root_endpoint!(eth),
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
-            clusters: clusters!(desc::DescHandler::CLUSTER, TestOnOffDeviceLogic::CLUSTER),
-        },
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters!(desc::DescHandler::CLUSTER, TestOnOffDeviceLogic::CLUSTER),
+        ),
     ],
 };
 

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -165,15 +165,15 @@ fn main() -> Result<(), Error> {
 const NODE: Node<'static> = Node {
     endpoints: &[
         root_endpoint!(eth),
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_SMART_SPEAKER),
-            clusters: clusters!(
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_SMART_SPEAKER),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 TestOnOffDeviceLogic::CLUSTER,
                 TestLevelControlDeviceLogic::CLUSTER
             ),
-        },
+        ),
     ],
 };
 

--- a/examples/src/bin/webrtc_camera.rs
+++ b/examples/src/bin/webrtc_camera.rs
@@ -1368,10 +1368,10 @@ const BASIC_INFO: BasicInfoConfig<'static> = BasicInfoConfig {
 const NODE: Node<'static> = Node {
     endpoints: &[
         root_endpoint!(eth),
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_MATTER_CAMERA),
-            clusters: clusters!(
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_MATTER_CAMERA),
+            clusters!(
                 desc::DescHandler::CLUSTER,
                 groups::GroupsHandler::CLUSTER,
                 CameraAvStreamHandler::<Str0mCamHooks, CAM_AV_NV>::CLUSTER,
@@ -1379,7 +1379,7 @@ const NODE: Node<'static> = Node {
                 ZoneMgmtHandler::<DemoZoneHooks, ZONE_NZ, ZONE_NV, ZONE_NT>::CLUSTER,
                 WebRtc::CLUSTER
             ),
-        },
+        ),
     ],
 };
 

--- a/rs-matter/src/dm/clusters.rs
+++ b/rs-matter/src/dm/clusters.rs
@@ -25,6 +25,7 @@ pub mod acl;
 pub mod adm_comm;
 pub mod app;
 pub mod basic_info;
+pub mod binding;
 pub mod desc;
 pub mod dev_att;
 pub mod eth_diag;

--- a/rs-matter/src/dm/clusters/binding.rs
+++ b/rs-matter/src/dm/clusters/binding.rs
@@ -1,0 +1,396 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Binding cluster handler (Matter Core spec §9.6).
+//!
+//! Per-endpoint, fabric-scoped, **persistent** list of `TargetStruct`
+//! entries each describing a unicast `(node, endpoint, cluster?)` or
+//! a groupcast `(group, cluster?)` destination. The Binding cluster
+//! is the *device-side address book* a client cluster reads when it
+//! wants to send a command somewhere: a wall switch with `OnOff` in
+//! its client list, for instance, reads its Binding list to find the
+//! bulb(s) it's been paired with.
+//!
+//! See the spec's [`9.6` summary][spec], or the in-tree write-up in
+//! `super::user_label` for the analogous (per-endpoint, persistent,
+//! shared-registry) shape.
+//!
+//! # Persistence
+//!
+//! Spec §9.6.6.1 marks the `Binding` attribute with the `N` quality
+//! bit (Non-Volatile, Matter Core §7.13.2) — values **SHALL** survive
+//! reboots. We re-serialise the whole registry under [`BINDINGS_KEY`]
+//! after every successful write, and re-hydrate on startup via
+//! [`Bindings::load_persist`].
+//!
+//! # Fabric scoping
+//!
+//! `TargetStruct` carries an implicit `FabricIndex` field (id 254)
+//! that the IM dispatch auto-injects from the writing accessor. On
+//! reads, `attr.fab_filter` + `attr.fab_idx` constrain results to the
+//! reading fabric. We store `fab_idx` alongside each entry and apply
+//! the same filter manually on read paths.
+//!
+//! # Validation
+//!
+//! Per spec §9.6.5.1:
+//! - `Group` and `Endpoint` are mutually exclusive (one of the two
+//!   identifies the target).
+//! - `Node` is required when `Endpoint` is present.
+//! - `Cluster` is optional.
+//!
+//! We reject malformed entries with `ConstraintError`.
+
+use core::num::NonZeroU8;
+
+use crate::dm::{
+    ArrayAttributeRead, ArrayAttributeWrite, Cluster, ClusterId, Dataver, EndptId, ReadContext,
+    WriteContext,
+};
+use crate::error::{Error, ErrorCode};
+use crate::persist::{KvBlobStore, Persist};
+use crate::tlv::{FromTLV, TLVArray, TLVBuilderParent, TLVElement, ToTLV};
+use crate::utils::cell::RefCell;
+use crate::utils::init::{init, Init};
+use crate::utils::storage::Vec;
+use crate::utils::sync::blocking::Mutex;
+use crate::with;
+
+pub use crate::dm::clusters::decl::binding::*;
+pub use crate::persist::BINDINGS_KEY;
+
+/// Cluster metadata exposed by [`BindingHandler`].
+///
+/// Exposed as a free constant so callers can spell out
+/// `EpClMatcher::new(Some(ep), Some(binding::CLUSTER.id))` without
+/// reaching for the lifetime-parameterised handler type.
+pub const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
+
+/// One stored binding entry.
+///
+/// Wire layout follows the standard `derive(FromTLV, ToTLV)` shape —
+/// a TLV struct with positional context-tagged fields (0 = first
+/// declared field, 1 = second, …). `Option<T>` fields are
+/// omit-if-`None`. The encoding is decoupled from the wire-level
+/// `TargetStruct` (which puts `FabricIndex` at ctx 254): we own the
+/// persisted layout and only need it to be self-consistent.
+#[derive(Debug, Clone, FromTLV, ToTLV)]
+struct StoredBinding {
+    endpoint_id: EndptId,
+    fab_idx: NonZeroU8,
+    node: Option<u64>,
+    group: Option<u16>,
+    endpoint: Option<EndptId>,
+    cluster: Option<ClusterId>,
+}
+
+/// Shared registry of Binding entries across every endpoint and
+/// fabric. Persisted as a single TLV blob under [`BINDINGS_KEY`].
+///
+/// `N` bounds the total number of entries the device can hold. Per
+/// Matter Core spec §9.6.1, device-type definitions may prescribe a
+/// minimum-per-fabric; the spec also says the total must be
+/// `min_per_fabric × supported_fabrics` — pick `N` accordingly.
+pub struct Bindings<const N: usize> {
+    state: Mutex<RefCell<Vec<StoredBinding, N>>>,
+}
+
+impl<const N: usize> Bindings<N> {
+    /// Create an empty registry. Prefer [`Self::init`] for non-trivial
+    /// `N` so the storage is initialised in BSS.
+    pub const fn new() -> Self {
+        Self {
+            state: Mutex::new(RefCell::new(Vec::new())),
+        }
+    }
+
+    /// Return an in-place initialiser for an empty registry.
+    pub fn init() -> impl Init<Self> {
+        init!(Self {
+            state <- Mutex::init(RefCell::init(Vec::init())),
+        })
+    }
+
+    /// Re-hydrate the registry from `store` under [`BINDINGS_KEY`].
+    /// Call once at startup, before exposing the data model.
+    pub async fn load_persist<S: KvBlobStore>(
+        &self,
+        mut store: S,
+        buf: &mut [u8],
+    ) -> Result<(), Error> {
+        let Some(data) = store.load(BINDINGS_KEY, buf)? else {
+            self.state.lock(|cell| cell.borrow_mut().clear());
+            return Ok(());
+        };
+
+        let loaded = Vec::<StoredBinding, N>::from_tlv(&TLVElement::new(data))?;
+        self.state.lock(|cell| *cell.borrow_mut() = loaded);
+
+        info!("Loaded Binding entries for all endpoints from storage");
+        Ok(())
+    }
+
+    /// Serialise the registry to `ctx.kv()` under [`BINDINGS_KEY`].
+    fn store_persist<C: WriteContext>(&self, ctx: &C) -> Result<(), Error> {
+        let mut persist = Persist::new(ctx.kv());
+
+        self.state.lock(|cell| {
+            let state = cell.borrow();
+            persist.store_tlv(BINDINGS_KEY, &*state)
+        })?;
+
+        persist.run()
+    }
+
+    /// Validate a `TargetStruct` against spec §9.6.5.1 and return a
+    /// fully-built `StoredBinding`. `endpoint_id` and `fab_idx` come
+    /// from the dispatch context (they are not on the wire entry for
+    /// this attribute write — the framework auto-injects fab_idx).
+    fn parse_target(
+        endpoint_id: EndptId,
+        fab_idx: NonZeroU8,
+        t: &TargetStruct<'_>,
+    ) -> Result<StoredBinding, Error> {
+        let node = t.node()?;
+        let group = t.group()?;
+        let endpoint = t.endpoint()?;
+        let cluster = t.cluster()?;
+
+        // Spec §9.6.5.1:
+        // - Group and Endpoint MUST NOT both be present.
+        // - Node SHALL be present when Endpoint is present.
+        // - At least one of (Node+Endpoint) or Group must identify a target.
+        if group.is_some() && endpoint.is_some() {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+        if endpoint.is_some() && node.is_none() {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+        if group.is_none() && node.is_none() && endpoint.is_none() {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+
+        Ok(StoredBinding {
+            endpoint_id,
+            fab_idx,
+            node,
+            group,
+            endpoint,
+            cluster,
+        })
+    }
+
+    /// Replace every entry on `(endpoint_id, fab_idx)` with the
+    /// supplied list. Other endpoints / fabrics are untouched.
+    fn replace_entries<'a, C: WriteContext>(
+        &self,
+        ctx: &C,
+        endpoint_id: EndptId,
+        fab_idx: NonZeroU8,
+        list: &TLVArray<'a, TargetStruct<'a>>,
+    ) -> Result<(), Error> {
+        // Two-pass validation: parse every supplied target *before*
+        // mutating state so a malformed input never partially clears
+        // the existing entries on this fabric.
+        let mut parsed: Vec<StoredBinding, N> = Vec::new();
+        for t in list {
+            let t = t?;
+            let sb = Self::parse_target(endpoint_id, fab_idx, &t)?;
+            parsed.push(sb).map_err(|_| ErrorCode::ResourceExhausted)?;
+        }
+
+        self.state.lock(|cell| {
+            let mut state = cell.borrow_mut();
+            // Drop every existing entry on this (endpoint, fabric).
+            // Iterate-by-index because `retain` doesn't compose with
+            // our bounded Vec API the same way.
+            let mut i = 0;
+            while i < state.len() {
+                let e = &state[i];
+                if e.endpoint_id == endpoint_id && e.fab_idx == fab_idx {
+                    state.remove(i);
+                } else {
+                    i += 1;
+                }
+            }
+            // Now bulk-insert the validated list. Capacity-exhausted
+            // here means the *combined* fabric counts exceeded `N`.
+            for sb in parsed {
+                state.push(sb).map_err(|_| ErrorCode::ResourceExhausted)?;
+            }
+            Ok::<_, Error>(())
+        })?;
+
+        self.store_persist(ctx)
+    }
+
+    /// Append one entry for `(endpoint_id, fab_idx)`.
+    fn add_entry<'a, C: WriteContext>(
+        &self,
+        ctx: &C,
+        endpoint_id: EndptId,
+        fab_idx: NonZeroU8,
+        entry: &TargetStruct<'a>,
+    ) -> Result<(), Error> {
+        let sb = Self::parse_target(endpoint_id, fab_idx, entry)?;
+
+        self.state.lock(|cell| {
+            cell.borrow_mut()
+                .push(sb)
+                .map_err(|_| -> Error { ErrorCode::ResourceExhausted.into() })?;
+            Ok::<_, Error>(())
+        })?;
+
+        self.store_persist(ctx)
+    }
+
+    /// Render every entry on `endpoint_id` matching the read filter
+    /// into the provided builder. `fab_filter = Some(idx)` constrains
+    /// the output to one fabric; `None` returns every fabric's
+    /// entries (used when the reading accessor opted out of fabric
+    /// filtering via `attr.fab_filter == false`).
+    fn render<P: TLVBuilderParent>(
+        &self,
+        endpoint_id: EndptId,
+        fab_filter: Option<NonZeroU8>,
+        builder: ArrayAttributeRead<TargetStructArrayBuilder<P>, TargetStructBuilder<P>>,
+    ) -> Result<P, Error> {
+        self.state.lock(|cell| {
+            let state = cell.borrow();
+            let mut iter = state
+                .iter()
+                .filter(|e| e.endpoint_id == endpoint_id)
+                .filter(|e| fab_filter.is_none_or(|f| e.fab_idx == f));
+
+            match builder {
+                ArrayAttributeRead::ReadAll(mut array) => {
+                    for e in iter {
+                        let item = array.push()?;
+                        let item = item.node(e.node)?;
+                        let item = item.group(e.group)?;
+                        let item = item.endpoint(e.endpoint)?;
+                        let item = item.cluster(e.cluster)?;
+                        array = item.fabric_index(Some(e.fab_idx.get()))?.end()?;
+                    }
+                    array.end()
+                }
+                ArrayAttributeRead::ReadOne(index, item) => {
+                    let Some(e) = iter.nth(index as usize) else {
+                        return Err(ErrorCode::ConstraintError.into());
+                    };
+                    let item = item.node(e.node)?;
+                    let item = item.group(e.group)?;
+                    let item = item.endpoint(e.endpoint)?;
+                    let item = item.cluster(e.cluster)?;
+                    item.fabric_index(Some(e.fab_idx.get()))?.end()
+                }
+                ArrayAttributeRead::ReadNone(array) => array.end(),
+            }
+        })
+    }
+}
+
+impl<const N: usize> Default for Bindings<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Per-`(endpoint, Binding)`-instance handler facade. Holds only a
+/// `Dataver`, the endpoint id it serves, and a borrow of the shared
+/// [`Bindings`] registry. All persisted state lives in the registry.
+pub struct BindingHandler<'a, const N: usize> {
+    dataver: Dataver,
+    endpoint_id: EndptId,
+    bindings: &'a Bindings<N>,
+}
+
+impl<'a, const N: usize> BindingHandler<'a, N> {
+    /// Construct a facade for `(endpoint_id, Binding)` backed by the
+    /// shared `bindings` registry.
+    pub const fn new(dataver: Dataver, endpoint_id: EndptId, bindings: &'a Bindings<N>) -> Self {
+        Self {
+            dataver,
+            endpoint_id,
+            bindings,
+        }
+    }
+
+    /// Adapt the handler instance to the generic `rs-matter` `Handler` trait.
+    pub const fn adapt(self) -> HandlerAdaptor<Self> {
+        HandlerAdaptor(self)
+    }
+}
+
+impl<const N: usize> ClusterHandler for BindingHandler<'_, N> {
+    const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
+
+    fn dataver(&self) -> u32 {
+        self.dataver.get()
+    }
+
+    fn dataver_changed(&self) {
+        self.dataver.changed();
+    }
+
+    fn binding<P: TLVBuilderParent>(
+        &self,
+        ctx: impl ReadContext,
+        builder: ArrayAttributeRead<TargetStructArrayBuilder<P>, TargetStructBuilder<P>>,
+    ) -> Result<P, Error> {
+        let attr = ctx.attr();
+        // Translate the framework's `(fab_filter: bool, fab_idx: u8)` pair
+        // into `Option<NonZeroU8>`. A reader that opted into fabric
+        // filtering but presents an unaccredited fab_idx of 0 gets the
+        // empty list — that's how the spec describes the "no accessing
+        // fabric" state for fabric-scoped attrs.
+        let fab_filter = if attr.fab_filter {
+            Some(NonZeroU8::new(attr.fab_idx).ok_or(ErrorCode::UnsupportedAccess)?)
+        } else {
+            None
+        };
+        self.bindings.render(self.endpoint_id, fab_filter, builder)
+    }
+
+    fn set_binding(
+        &self,
+        ctx: impl WriteContext,
+        value: ArrayAttributeWrite<TLVArray<'_, TargetStruct<'_>>, TargetStruct<'_>>,
+    ) -> Result<(), Error> {
+        // Fabric-scoped writes require a valid accessor fabric — the
+        // `NonZeroU8::new` conversion is the type-system encoding of
+        // that requirement.
+        let fab_idx = NonZeroU8::new(ctx.attr().fab_idx).ok_or(ErrorCode::UnsupportedAccess)?;
+
+        match value {
+            ArrayAttributeWrite::Replace(list) => {
+                self.bindings
+                    .replace_entries(&ctx, self.endpoint_id, fab_idx, &list)
+            }
+            ArrayAttributeWrite::Add(entry) => {
+                self.bindings
+                    .add_entry(&ctx, self.endpoint_id, fab_idx, &entry)
+            }
+            // Per-element list update / remove on fabric-scoped attrs:
+            // the framework converts these to InvalidAction before
+            // reaching us, but match exhaustively to be safe.
+            ArrayAttributeWrite::Update(_, _) | ArrayAttributeWrite::Remove(_) => {
+                Err(ErrorCode::InvalidAction.into())
+            }
+        }
+    }
+}

--- a/rs-matter/src/dm/clusters/binding.rs
+++ b/rs-matter/src/dm/clusters/binding.rs
@@ -170,17 +170,20 @@ impl<const N: usize> Bindings<N> {
         let endpoint = t.endpoint()?;
         let cluster = t.cluster()?;
 
-        // Spec §9.6.5.1:
-        // - Group and Endpoint MUST NOT both be present.
-        // - Node SHALL be present when Endpoint is present.
-        // - At least one of (Node+Endpoint) or Group must identify a target.
+        // Spec §9.6.5.1 — the conformance columns say Group is
+        // `!Endpoint` and Endpoint is `!Group`, so **exactly one** of
+        // them must identify the target. Node's conformance is
+        // `Endpoint`, i.e. Node is mandatory whenever Endpoint is
+        // present (it names the remote node for the unicast target).
         if group.is_some() && endpoint.is_some() {
             return Err(ErrorCode::ConstraintError.into());
         }
-        if endpoint.is_some() && node.is_none() {
+        if group.is_none() && endpoint.is_none() {
+            // Rejects both "all fields missing" and "only Node
+            // present" (no destination at all).
             return Err(ErrorCode::ConstraintError.into());
         }
-        if group.is_none() && node.is_none() && endpoint.is_none() {
+        if endpoint.is_some() && node.is_none() {
             return Err(ErrorCode::ConstraintError.into());
         }
 
@@ -215,18 +218,9 @@ impl<const N: usize> Bindings<N> {
 
         self.state.lock(|cell| {
             let mut state = cell.borrow_mut();
-            // Drop every existing entry on this (endpoint, fabric).
-            // Iterate-by-index because `retain` doesn't compose with
-            // our bounded Vec API the same way.
-            let mut i = 0;
-            while i < state.len() {
-                let e = &state[i];
-                if e.endpoint_id == endpoint_id && e.fab_idx == fab_idx {
-                    state.remove(i);
-                } else {
-                    i += 1;
-                }
-            }
+            // Drop every existing entry on this (endpoint, fabric)
+            // in O(N) — one pass, in-place shift.
+            state.retain(|e| !(e.endpoint_id == endpoint_id && e.fab_idx == fab_idx));
             // Now bulk-insert the validated list. Capacity-exhausted
             // here means the *combined* fabric counts exceeded `N`.
             for sb in parsed {

--- a/rs-matter/src/dm/clusters/desc.rs
+++ b/rs-matter/src/dm/clusters/desc.rs
@@ -203,13 +203,20 @@ impl ClusterHandler for DescHandler<'_> {
         ctx: impl ReadContext,
         builder: ArrayAttributeRead<ToTLVArrayBuilder<P, u32>, ToTLVBuilder<P, u32>>,
     ) -> Result<P, Error> {
-        Self::with_endpoint(ctx, |_| {
-            // Client clusters not support yet
-            match builder {
-                ArrayAttributeRead::ReadAll(builder) => builder.end(),
-                ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
-                ArrayAttributeRead::ReadNone(builder) => builder.end(),
+        Self::with_endpoint(ctx, |endpoint| match builder {
+            ArrayAttributeRead::ReadAll(mut builder) => {
+                for client_id in endpoint.client_clusters {
+                    builder = builder.push(client_id)?;
+                }
+                builder.end()
             }
+            ArrayAttributeRead::ReadOne(index, builder) => {
+                let Some(client_id) = endpoint.client_clusters.get(index as usize) else {
+                    return Err(ErrorCode::ConstraintError.into());
+                };
+                builder.set(client_id)
+            }
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
         })
     }
 

--- a/rs-matter/src/dm/endpoints.rs
+++ b/rs-matter/src/dm/endpoints.rs
@@ -58,6 +58,7 @@ macro_rules! root_endpoint {
             id: $crate::dm::endpoints::ROOT_ENDPOINT_ID,
             device_types: $crate::devices!($crate::dm::devices::DEV_TYPE_ROOT_NODE),
             clusters: $crate::clusters!($t;),
+            client_clusters: &[],
         }
     }
 }

--- a/rs-matter/src/dm/types/endpoint.rs
+++ b/rs-matter/src/dm/types/endpoint.rs
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2022-2025 Project CHIP Authors
+ *    Copyright (c) 2022-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,12 +27,29 @@ pub struct Endpoint<'a> {
     pub id: EndptId,
     /// The list of device types associated with this endpoint.
     pub device_types: &'a [DeviceType],
-    /// The list of clusters associated with this endpoint.
+    /// The list of *server* clusters present on this endpoint. These
+    /// are advertised via `Descriptor::ServerList` and dispatched by
+    /// the `Handler` chain on inbound IM messages.
     pub clusters: &'a [Cluster<'a>],
+    /// The list of *client* cluster IDs present on this endpoint —
+    /// i.e. clusters this endpoint **initiates** interactions for,
+    /// rather than serves. Advertised verbatim via
+    /// `Descriptor::ClientList` so commissioners know which Binding
+    /// targets are meaningful for this endpoint. Empty by default;
+    /// only meaningful on endpoints whose device type prescribes
+    /// client clusters (e.g. `OnOffLightSwitch = 0x0103` lists
+    /// `OnOff` as a mandatory client). No `Cluster<'a>` value is
+    /// needed because a client cluster has no attribute/command
+    /// surface of its own — see Matter Core spec §9.5.4 for the
+    /// `Descriptor::ClientList` semantics.
+    pub client_clusters: &'a [ClusterId],
 }
 
 impl<'a> Endpoint<'a> {
-    /// Create a new `Endpoint` instance.
+    /// Create a new `Endpoint` instance with no client clusters.
+    ///
+    /// Use [`Self::new_with_clients`] when this endpoint should
+    /// advertise client clusters via `Descriptor::ClientList`.
     pub const fn new(
         id: EndptId,
         device_types: &'a [DeviceType],
@@ -42,6 +59,23 @@ impl<'a> Endpoint<'a> {
             id,
             device_types,
             clusters,
+            client_clusters: &[],
+        }
+    }
+
+    /// Create a new `Endpoint` instance that advertises the given
+    /// client cluster IDs in addition to its server clusters.
+    pub const fn new_with_clients(
+        id: EndptId,
+        device_types: &'a [DeviceType],
+        clusters: &'a [Cluster<'a>],
+        client_clusters: &'a [ClusterId],
+    ) -> Self {
+        Self {
+            id,
+            device_types,
+            clusters,
+            client_clusters,
         }
     }
 

--- a/rs-matter/src/persist.rs
+++ b/rs-matter/src/persist.rs
@@ -47,6 +47,10 @@ pub const NETWORKS_KEY: u16 = EVENT_EPOCH_KEY + 1;
 /// endpoint that hosts the UserLabel cluster.
 pub const USER_LABELS_KEY: u16 = NETWORKS_KEY + 1;
 
+/// The key used for storing all Binding entries across every
+/// endpoint+fabric pair that hosts the Binding cluster.
+pub const BINDINGS_KEY: u16 = USER_LABELS_KEY + 1;
+
 /// A trait representing a key-value BLOB storage.
 ///
 /// NOTE: For now, the trait is deliberately modeled as non-async, so that it can be used from

--- a/rs-matter/tests/commissioning.rs
+++ b/rs-matter/tests/commissioning.rs
@@ -124,11 +124,11 @@ static TCP_CTRL_MATTER: StaticCell<Matter> = StaticCell::new();
 const NODE: Node<'static> = Node {
     endpoints: &[
         root_endpoint!(eth),
-        Endpoint {
-            id: 1,
-            device_types: devices!(DEV_TYPE_ON_OFF_LIGHT),
-            clusters: clusters!(desc::DescHandler::CLUSTER, TestOnOffDeviceLogic::CLUSTER),
-        },
+        Endpoint::new(
+            1,
+            devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters!(desc::DescHandler::CLUSTER, TestOnOffDeviceLogic::CLUSTER),
+        ),
     ],
 };
 

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -48,20 +48,20 @@ pub struct E2eTestHandler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
 impl<'a, OH: OnOffHooks, LH: LevelControlHooks> E2eTestHandler<'a, OH, LH> {
     pub const NODE: Node<'static> = Node {
         endpoints: &[
-            Endpoint {
-                id: 0,
-                clusters: clusters!(eth; echo_cluster::CLUSTER),
-                device_types: &[DEV_TYPE_ROOT_NODE],
-            },
-            Endpoint {
-                id: 1,
-                clusters: clusters!(
+            Endpoint::new(
+                0,
+                &[DEV_TYPE_ROOT_NODE],
+                clusters!(eth; echo_cluster::CLUSTER),
+            ),
+            Endpoint::new(
+                1,
+                &[DEV_TYPE_ON_OFF_LIGHT],
+                clusters!(
                     DescHandler::CLUSTER,
                     OnOffHandler::<'_, TestOnOffDeviceLogic, NoLevelControl>::CLUSTER,
                     echo_cluster::CLUSTER,
                 ),
-                device_types: &[DEV_TYPE_ON_OFF_LIGHT],
-            },
+            ),
         ],
     };
 

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -47,7 +47,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TestArmFailSafe",
     "TestAttributesById",
     "TestBasicInformation",
-    // "TestBinding", // TODO: Binding cluster not yet implemented
+    "TestBinding",
     "TestCASERecovery",
     "TestCluster",
     "TestClusterComplexTypes",


### PR DESCRIPTION
**Adding this was quite simple**. Just two things needed:
- `Endpoint` meta-data extended so that the user can enumerate in there the client clusters the endpoint supports; `DescHandler` - in turn - now reports those via the `ClientsList` attribute
- Bindings server cluster with persistence. This is basically the place where the controller would "inject" what server clusters our device endpoints should call; i.e. if our device is an on-off wall switch, the bindings is where we'll find all the lamps we need to turn on/off when the user physically presses our wall switch button

As a result of that, we can finally enable the Bindings cluster unit test as well.

The large change surface is misleading - we simply had to touch all examples that used to construct `Endpoint` instances directly (and thus broke when the `client_clusters` member was introduced to `Endpoint`) to use `Endpoint::new` instead.