### PR TITLE
Switch from absolute to relative path in in clusters_generated.rs

### DIFF
--- a/rs-matter-codegen/src/lib.rs
+++ b/rs-matter-codegen/src/lib.rs
@@ -87,16 +87,17 @@ pub fn generate(rs_matter_crate: &str, dest_dir: &Path) {
     root.push_str(&globals_formatted);
     root.push('\n');
 
-    for (module_name, file_path) in &cluster_files {
+    for (module_name, _file_path) in &cluster_files {
         root.push_str(&format!(
             "/// Generated cluster module\n\
              #[allow(async_fn_in_trait)]\n\
              #[allow(unknown_lints)]\n\
              #[allow(clippy::uninlined_format_args)]\n\
              #[allow(unexpected_cfgs)]\n\
-             #[path = r\"{}\"]\n\
-             pub mod {};\n\n",
-            file_path, module_name
+             pub mod {} {{\n\
+                 include!(concat!(env!(\"OUT_DIR\"), \"/clusters_generated/{}.rs\"));\n\
+             }}\n\n",
+            module_name, module_name
         ));
     }
 


### PR DESCRIPTION
Switch from absolute `#[path]` to inline `mod { include!() }` in clusters_generated.rs.

Currently, rs-matter-codegen writes the per-cluster `mod` declarations as

    #[path = r"<absolute path to OUT_DIR>/clusters_generated/<cluster>.rs"]
    pub mod <cluster>;

The absolute path is captured at build-script execution time. Plain Cargo
builds work because Cargo runs the build script and rustc in the same
target directory, so the captured path is still valid when rustc compiles
the consuming crate.

Bazel runs each action in its own sandbox: the build script writes
clusters_generated.rs with absolute paths under
`.../sandbox/processwrapper-sandbox/<N>/execroot/...`, then the runtime
sandbox is torn down. When rustc later compiles rs-matter in sandbox
<M> != <N>, the captured paths no longer exist and rustc fails with
`couldn't read .../_bs.out_dir/clusters_generated/<cluster>.rs`.

This change switches to `pub mod <cluster> { include!(concat!(env!("OUT_DIR"), ...)); }`.
`env!("OUT_DIR")` is resolved by rustc at compile time of the consumer,
so it always points at the consumer's view of `_bs.out_dir/` and the
per-cluster files are read from the tree artifact regardless of which
sandbox produced them. The change is transparent to Cargo (OUT_DIR is
stable there too).