### PR TITLE
im: client builders auto-inject interactionModelRevision

### DIFF
--- a/rs-matter/src/im/attr/read_builder.rs
+++ b/rs-matter/src/im/attr/read_builder.rs
@@ -63,10 +63,11 @@
 
 use core::marker::PhantomData;
 
-use crate::dm::{AttrId, ClusterId, EndptId};
+use crate::dm::{AttrId, ClusterId, EndptId, GlobalElements};
 use crate::error::Error;
 use crate::im::{
     AttrPath, AttrPathTag, DataVersionFilter, EventFilter, EventPath, NodeId, ReadReqTag,
+    IM_REVISION,
 };
 use crate::tlv::{TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite, ToTLV};
 
@@ -83,6 +84,9 @@ use crate::tlv::{TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite, ToTLV};
 /// - `4`: past `FabricFiltered` (mandatory; no implicit-skip path
 ///   from state 0/1/2/3 to here)
 /// - `5`: past `DataVersionFilters`
+/// - `6`: past `InteractionModelRevision` (auto-injected at default
+///   value [`IM_REVISION`] by `end()` if the optional setter wasn't
+///   called)
 pub struct ReadReqBuilder<P, const F: usize = 0> {
     p: P,
 }
@@ -311,7 +315,50 @@ where
     }
 }
 
+impl<P> ReadReqBuilder<P, 4>
+where
+    P: TLVBuilderParent,
+{
+    /// Write `InteractionModelRevision`, implicitly skipping
+    /// `DataVersionFilters`. This is a typestate skip-shim mirroring
+    /// the pattern PR #447 established for `SuppressResponse` /
+    /// `TimedRequest` on `InvReqBuilder`: callers who don't populate
+    /// the optional preceding field can advance straight to setting
+    /// (or auto-injecting) `InteractionModelRevision` without an
+    /// explicit no-op transition.
+    pub fn interaction_model_revision(self, value: u8) -> Result<ReadReqBuilder<P, 6>, Error> {
+        ReadReqBuilder::<P, 5> { p: self.p }.interaction_model_revision(value)
+    }
+}
+
 impl<P> ReadReqBuilder<P, 5>
+where
+    P: TLVBuilderParent,
+{
+    /// Write the mandatory-on-the-wire `InteractionModelRevision`
+    /// field (Matter Core §8.1.1, p. 545: value is `13` since Matter
+    /// 1.3, unchanged in 1.4 and 1.5). Optional at the API level —
+    /// omit and `end()` injects [`IM_REVISION`] automatically. Set
+    /// explicitly only when speaking a non-default revision is
+    /// required (e.g. interop testing against a peer pinned to an
+    /// older revision).
+    pub fn interaction_model_revision(mut self, value: u8) -> Result<ReadReqBuilder<P, 6>, Error> {
+        self.p.writer().u8(
+            &TLVTag::Context(GlobalElements::InteractionModelRevision as u8),
+            value,
+        )?;
+        Ok(ReadReqBuilder { p: self.p })
+    }
+
+    /// Close the message struct, auto-injecting
+    /// `InteractionModelRevision` at its default value
+    /// [`IM_REVISION`]. Returns the parent.
+    pub fn end(self) -> Result<P, Error> {
+        self.interaction_model_revision(IM_REVISION)?.end()
+    }
+}
+
+impl<P> ReadReqBuilder<P, 6>
 where
     P: TLVBuilderParent,
 {

--- a/rs-matter/src/im/attr/subscribe_builder.rs
+++ b/rs-matter/src/im/attr/subscribe_builder.rs
@@ -69,9 +69,11 @@
 //! }).await
 //! ```
 
+use crate::dm::GlobalElements;
 use crate::error::Error;
 use crate::im::{
     AttrPath, AttrPathArrayBuilder, DataVersionFilter, EventFilter, EventPath, SubscribeReqTag,
+    IM_REVISION,
 };
 use crate::tlv::{TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite, ToTLV};
 
@@ -91,6 +93,9 @@ use crate::tlv::{TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite, ToTLV};
 /// - `7`: past `FabricFiltered` (mandatory; no implicit-skip from
 ///   states 3-6 to `end()` — caller must invoke `fabric_filtered`)
 /// - `8`: past `DataVersionFilters`
+/// - `9`: past `InteractionModelRevision` (auto-injected at default
+///   value [`IM_REVISION`] by `end()` if the optional setter wasn't
+///   called)
 pub struct SubscribeReqBuilder<P, const F: usize = 0> {
     p: P,
 }
@@ -379,7 +384,50 @@ where
     }
 }
 
+impl<P> SubscribeReqBuilder<P, 7>
+where
+    P: TLVBuilderParent,
+{
+    /// Write `InteractionModelRevision`, implicitly skipping
+    /// `DataVersionFilters`. This is a typestate skip-shim mirroring
+    /// the pattern PR #447 established for `SuppressResponse` /
+    /// `TimedRequest` on `InvReqBuilder`: callers who don't populate
+    /// the optional preceding field can advance straight to setting
+    /// (or auto-injecting) `InteractionModelRevision` without an
+    /// explicit no-op transition.
+    pub fn interaction_model_revision(self, value: u8) -> Result<SubscribeReqBuilder<P, 9>, Error> {
+        SubscribeReqBuilder::<P, 8> { p: self.p }.interaction_model_revision(value)
+    }
+}
+
 impl<P> SubscribeReqBuilder<P, 8>
+where
+    P: TLVBuilderParent,
+{
+    /// Write the mandatory-on-the-wire `InteractionModelRevision`
+    /// field (Matter Core §8.1.1, p. 545: value is `13` since Matter
+    /// 1.3, unchanged in 1.4 and 1.5). Optional at the API level —
+    /// omit and `end()` injects [`IM_REVISION`] automatically.
+    pub fn interaction_model_revision(
+        mut self,
+        value: u8,
+    ) -> Result<SubscribeReqBuilder<P, 9>, Error> {
+        self.p.writer().u8(
+            &TLVTag::Context(GlobalElements::InteractionModelRevision as u8),
+            value,
+        )?;
+        Ok(SubscribeReqBuilder { p: self.p })
+    }
+
+    /// Close the message struct, auto-injecting
+    /// `InteractionModelRevision` at its default value
+    /// [`IM_REVISION`]. Returns the parent.
+    pub fn end(self) -> Result<P, Error> {
+        self.interaction_model_revision(IM_REVISION)?.end()
+    }
+}
+
+impl<P> SubscribeReqBuilder<P, 9>
 where
     P: TLVBuilderParent,
 {

--- a/rs-matter/src/im/attr/write_builder.rs
+++ b/rs-matter/src/im/attr/write_builder.rs
@@ -101,9 +101,9 @@
 
 use core::marker::PhantomData;
 
-use crate::dm::{AttrId, ClusterId, EndptId};
+use crate::dm::{AttrId, ClusterId, EndptId, GlobalElements};
 use crate::error::Error;
-use crate::im::{AttrDataTag, AttrPathTag, WriteReqTag};
+use crate::im::{AttrDataTag, AttrPathTag, WriteReqTag, IM_REVISION};
 use crate::tlv::{TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite};
 
 /// Streaming builder for a `WriteRequestMessage`. Type-state-tagged
@@ -118,6 +118,9 @@ use crate::tlv::{TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite};
 /// - `2`: past `TimedRequest`
 /// - `3`: past `WriteRequests` array (closed)
 /// - `4`: past `MoreChunkedMessages`
+/// - `5`: past `InteractionModelRevision` (auto-injected at default
+///   value [`IM_REVISION`] by `end()` if the optional setter wasn't
+///   called)
 ///
 /// In practice almost every call is `WriteReqBuilder::new(p)?
 /// .write_requests()? … .end()?` — `SuppressResponse` and
@@ -267,7 +270,47 @@ where
     }
 }
 
+impl<P> WriteReqBuilder<P, 3>
+where
+    P: TLVBuilderParent,
+{
+    /// Write `InteractionModelRevision`, implicitly skipping
+    /// `MoreChunkedMessages`. This is a typestate skip-shim mirroring
+    /// the pattern PR #447 established for `SuppressResponse` /
+    /// `TimedRequest` on `InvReqBuilder`: callers who don't populate
+    /// the optional preceding field can advance straight to setting
+    /// (or auto-injecting) `InteractionModelRevision` without an
+    /// explicit no-op transition.
+    pub fn interaction_model_revision(self, value: u8) -> Result<WriteReqBuilder<P, 5>, Error> {
+        WriteReqBuilder::<P, 4> { p: self.p }.interaction_model_revision(value)
+    }
+}
+
 impl<P> WriteReqBuilder<P, 4>
+where
+    P: TLVBuilderParent,
+{
+    /// Write the mandatory-on-the-wire `InteractionModelRevision`
+    /// field (Matter Core §8.1.1, p. 545: value is `13` since Matter
+    /// 1.3, unchanged in 1.4 and 1.5). Optional at the API level —
+    /// omit and `end()` injects [`IM_REVISION`] automatically.
+    pub fn interaction_model_revision(mut self, value: u8) -> Result<WriteReqBuilder<P, 5>, Error> {
+        self.p.writer().u8(
+            &TLVTag::Context(GlobalElements::InteractionModelRevision as u8),
+            value,
+        )?;
+        Ok(WriteReqBuilder { p: self.p })
+    }
+
+    /// Close the message struct, auto-injecting
+    /// `InteractionModelRevision` at its default value
+    /// [`IM_REVISION`]. Returns the parent.
+    pub fn end(self) -> Result<P, Error> {
+        self.interaction_model_revision(IM_REVISION)?.end()
+    }
+}
+
+impl<P> WriteReqBuilder<P, 5>
 where
     P: TLVBuilderParent,
 {

--- a/rs-matter/src/im/invoke_builder.rs
+++ b/rs-matter/src/im/invoke_builder.rs
@@ -83,9 +83,9 @@
 
 use core::marker::PhantomData;
 
-use crate::dm::{ClusterId, CmdId, EndptId};
+use crate::dm::{ClusterId, CmdId, EndptId, GlobalElements};
 use crate::error::Error;
-use crate::im::{CmdDataTag, CmdPathTag, InvReqTag};
+use crate::im::{CmdDataTag, CmdPathTag, InvReqTag, IM_REVISION};
 use crate::tlv::{TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite, ToTLV};
 
 /// Streaming builder for an `InvokeRequestMessage`. Type-state-tagged
@@ -106,6 +106,9 @@ use crate::tlv::{TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite, ToTLV};
 /// - `1`: past `SuppressResponse`
 /// - `2`: past `TimedRequest`
 /// - `3`: past `InvokeRequests` array
+/// - `4`: past `InteractionModelRevision` (auto-injected at default
+///   value [`IM_REVISION`] by `end()` if the optional setter wasn't
+///   called)
 pub struct InvReqBuilder<P, const F: usize = 0> {
     p: P,
 }
@@ -238,6 +241,30 @@ where
 }
 
 impl<P> InvReqBuilder<P, 3>
+where
+    P: TLVBuilderParent,
+{
+    /// Write the mandatory-on-the-wire `InteractionModelRevision`
+    /// field (Matter Core §8.1.1, p. 545: value is `13` since Matter
+    /// 1.3, unchanged in 1.4 and 1.5). Optional at the API level —
+    /// omit and `end()` injects [`IM_REVISION`] automatically.
+    pub fn interaction_model_revision(mut self, value: u8) -> Result<InvReqBuilder<P, 4>, Error> {
+        self.p.writer().u8(
+            &TLVTag::Context(GlobalElements::InteractionModelRevision as u8),
+            value,
+        )?;
+        Ok(InvReqBuilder { p: self.p })
+    }
+
+    /// Close the message struct, auto-injecting
+    /// `InteractionModelRevision` at its default value
+    /// [`IM_REVISION`]. Returns the parent.
+    pub fn end(self) -> Result<P, Error> {
+        self.interaction_model_revision(IM_REVISION)?.end()
+    }
+}
+
+impl<P> InvReqBuilder<P, 4>
 where
     P: TLVBuilderParent,
 {

--- a/rs-matter/tests/im_revision.rs
+++ b/rs-matter/tests/im_revision.rs
@@ -1,0 +1,311 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Regression tests for the mandatory `interactionModelRevision` field
+//! (TLV context tag `0xFF`) in IM messages.
+//!
+//! Matter Core spec §8.1.1 (p. 545, doc 23-27349-009) requires every
+//! Interaction Model message to carry an `InteractionModelRevision`
+//! field at the top level. The encoded value has been `13` since
+//! Matter 1.3 and is unchanged in 1.4 and 1.5. matter.js rejects
+//! messages that omit it; the C++ SDK is tolerant in practice, which
+//! is what masked the bug prior to PR #446.
+//!
+//! These tests pin down two invariants in pure-byte form:
+//!
+//! 1. **Client request builders** auto-inject the field at the
+//!    default value when the caller doesn't call
+//!    `interaction_model_revision()` explicitly, and honor an
+//!    explicit override when the caller does.
+//! 2. **Server response encoders** for `StatusResp` and
+//!    `SubscribeResp` emit the field at the default value.
+//!
+//! All assertions are byte-level (`needle` search on the encoded
+//! slice). TLV encoding of "context tag `0xFF`, type unsigned-int-8,
+//! value `V`" is exactly the three bytes `[0x24, 0xff, V]`.
+
+use rs_matter::im::{
+    IMStatusCode, InvReqBuilder, ReadReqBuilder, StatusResp, SubscribeReqBuilder, SubscribeResp,
+    WriteReqBuilder, IM_REVISION,
+};
+use rs_matter::tlv::{TLVTag, TLVWriteParent, ToTLV};
+use rs_matter::utils::storage::WriteBuf;
+
+/// Three-byte TLV encoding of `<context-tag 0xFF, u8 V>`.
+fn im_rev_bytes(v: u8) -> [u8; 3] {
+    [0x24, 0xff, v]
+}
+
+/// `true` if `needle` appears anywhere in `haystack`.
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+// =====================================================================
+// Client-side: ReadReqBuilder
+// =====================================================================
+
+#[test]
+fn read_req_auto_injects_im_revision() {
+    let mut buf = [0u8; 256];
+    let mut wb = WriteBuf::new(&mut buf);
+    {
+        let parent = TLVWriteParent::new((), &mut wb);
+        ReadReqBuilder::new(parent, &TLVTag::Anonymous)
+            .unwrap()
+            .fabric_filtered(false)
+            .unwrap()
+            .end()
+            .unwrap();
+    }
+    let bytes = wb.as_slice();
+    assert!(
+        contains(bytes, &im_rev_bytes(IM_REVISION)),
+        "ReadRequest missing auto-injected IM revision; bytes={:02x?}",
+        bytes
+    );
+}
+
+#[test]
+fn read_req_explicit_override_wins() {
+    let mut buf = [0u8; 256];
+    let mut wb = WriteBuf::new(&mut buf);
+    {
+        let parent = TLVWriteParent::new((), &mut wb);
+        ReadReqBuilder::new(parent, &TLVTag::Anonymous)
+            .unwrap()
+            .fabric_filtered(false)
+            .unwrap()
+            .interaction_model_revision(14)
+            .unwrap()
+            .end()
+            .unwrap();
+    }
+    let bytes = wb.as_slice();
+    assert!(
+        contains(bytes, &im_rev_bytes(14)),
+        "explicit IM revision 14 not present; bytes={:02x?}",
+        bytes
+    );
+    assert!(
+        !contains(bytes, &im_rev_bytes(IM_REVISION)),
+        "default IM revision should not have been written; bytes={:02x?}",
+        bytes
+    );
+}
+
+// =====================================================================
+// Client-side: WriteReqBuilder
+// =====================================================================
+
+#[test]
+fn write_req_auto_injects_im_revision() {
+    let mut buf = [0u8; 256];
+    let mut wb = WriteBuf::new(&mut buf);
+    {
+        let parent = TLVWriteParent::new((), &mut wb);
+        WriteReqBuilder::new(parent, &TLVTag::Anonymous)
+            .unwrap()
+            .write_requests()
+            .unwrap()
+            .end()
+            .unwrap()
+            .end()
+            .unwrap();
+    }
+    let bytes = wb.as_slice();
+    assert!(
+        contains(bytes, &im_rev_bytes(IM_REVISION)),
+        "WriteRequest missing auto-injected IM revision; bytes={:02x?}",
+        bytes
+    );
+}
+
+#[test]
+fn write_req_explicit_override_wins() {
+    let mut buf = [0u8; 256];
+    let mut wb = WriteBuf::new(&mut buf);
+    {
+        let parent = TLVWriteParent::new((), &mut wb);
+        WriteReqBuilder::new(parent, &TLVTag::Anonymous)
+            .unwrap()
+            .write_requests()
+            .unwrap()
+            .end()
+            .unwrap()
+            .interaction_model_revision(14)
+            .unwrap()
+            .end()
+            .unwrap();
+    }
+    let bytes = wb.as_slice();
+    assert!(contains(bytes, &im_rev_bytes(14)));
+    assert!(!contains(bytes, &im_rev_bytes(IM_REVISION)));
+}
+
+// =====================================================================
+// Client-side: SubscribeReqBuilder
+// =====================================================================
+
+#[test]
+fn subscribe_req_auto_injects_im_revision() {
+    let mut buf = [0u8; 256];
+    let mut wb = WriteBuf::new(&mut buf);
+    {
+        let parent = TLVWriteParent::new((), &mut wb);
+        SubscribeReqBuilder::new(parent, &TLVTag::Anonymous)
+            .unwrap()
+            .keep_subs(true)
+            .unwrap()
+            .min_int_floor(0)
+            .unwrap()
+            .max_int_ceil(60)
+            .unwrap()
+            .fabric_filtered(true)
+            .unwrap()
+            .end()
+            .unwrap();
+    }
+    let bytes = wb.as_slice();
+    assert!(
+        contains(bytes, &im_rev_bytes(IM_REVISION)),
+        "SubscribeRequest missing auto-injected IM revision; bytes={:02x?}",
+        bytes
+    );
+}
+
+#[test]
+fn subscribe_req_explicit_override_wins() {
+    let mut buf = [0u8; 256];
+    let mut wb = WriteBuf::new(&mut buf);
+    {
+        let parent = TLVWriteParent::new((), &mut wb);
+        SubscribeReqBuilder::new(parent, &TLVTag::Anonymous)
+            .unwrap()
+            .keep_subs(true)
+            .unwrap()
+            .min_int_floor(0)
+            .unwrap()
+            .max_int_ceil(60)
+            .unwrap()
+            .fabric_filtered(true)
+            .unwrap()
+            .interaction_model_revision(14)
+            .unwrap()
+            .end()
+            .unwrap();
+    }
+    let bytes = wb.as_slice();
+    assert!(contains(bytes, &im_rev_bytes(14)));
+    assert!(!contains(bytes, &im_rev_bytes(IM_REVISION)));
+}
+
+// =====================================================================
+// Client-side: InvReqBuilder
+// =====================================================================
+
+#[test]
+fn invoke_req_auto_injects_im_revision() {
+    let mut buf = [0u8; 256];
+    let mut wb = WriteBuf::new(&mut buf);
+    {
+        let parent = TLVWriteParent::new((), &mut wb);
+        InvReqBuilder::new(parent, &TLVTag::Anonymous)
+            .unwrap()
+            .invoke_requests()
+            .unwrap()
+            .end()
+            .unwrap()
+            .end()
+            .unwrap();
+    }
+    let bytes = wb.as_slice();
+    assert!(
+        contains(bytes, &im_rev_bytes(IM_REVISION)),
+        "InvokeRequest missing auto-injected IM revision; bytes={:02x?}",
+        bytes
+    );
+}
+
+#[test]
+fn invoke_req_explicit_override_wins() {
+    let mut buf = [0u8; 256];
+    let mut wb = WriteBuf::new(&mut buf);
+    {
+        let parent = TLVWriteParent::new((), &mut wb);
+        InvReqBuilder::new(parent, &TLVTag::Anonymous)
+            .unwrap()
+            .invoke_requests()
+            .unwrap()
+            .end()
+            .unwrap()
+            .interaction_model_revision(14)
+            .unwrap()
+            .end()
+            .unwrap();
+    }
+    let bytes = wb.as_slice();
+    assert!(contains(bytes, &im_rev_bytes(14)));
+    assert!(!contains(bytes, &im_rev_bytes(IM_REVISION)));
+}
+
+// =====================================================================
+// Server-side response structs (PR #446 regression cover)
+// =====================================================================
+//
+// `WriteResp`, `InvokeResp`, and `ReportDataResp` carry a `TLVArray`
+// over borrowed wire bytes and aren't ergonomically constructed
+// in-place — they're produced by the on-the-fly emitters in `dm.rs`,
+// which are exercised end-to-end by the existing e2e suite. The two
+// response types below are the cases that *can* be unit-tested
+// directly without going through the data-model engine, and together
+// they pin down the same `ToTLV` invariant.
+
+#[test]
+fn status_resp_default_carries_im_revision() {
+    let mut buf = [0u8; 64];
+    let mut wb = WriteBuf::new(&mut buf);
+    let resp = StatusResp {
+        status: IMStatusCode::Success,
+        ..Default::default()
+    };
+    resp.to_tlv(&TLVTag::Anonymous, &mut wb).unwrap();
+    let bytes = wb.as_slice();
+    assert!(
+        contains(bytes, &im_rev_bytes(IM_REVISION)),
+        "StatusResp encoding missing IM revision; bytes={:02x?}",
+        bytes
+    );
+}
+
+#[test]
+fn subscribe_resp_carries_im_revision() {
+    let mut buf = [0u8; 64];
+    let mut wb = WriteBuf::new(&mut buf);
+    SubscribeResp::write(
+        &mut wb,
+        /* subscription_id */ 0x1234_5678,
+        /* max_int */ 60,
+    )
+    .unwrap();
+    let bytes = wb.as_slice();
+    assert!(
+        contains(bytes, &im_rev_bytes(IM_REVISION)),
+        "SubscribeResp encoding missing IM revision; bytes={:02x?}",
+        bytes
+    );
+}


### PR DESCRIPTION
Follow-up to #446 implementing the client-side fix per @ivmarkov's
review comment on that PR (typestate-but-optional, defaults injected
if the user doesn't call the setter).

## Summary

Each of the four typestate request builders introduced in #447 —
`ReadReqBuilder`, `WriteReqBuilder`, `SubscribeReqBuilder`,
`InvReqBuilder` — gains an optional `interaction_model_revision(u8)`
transition. If the caller never invokes it, `end()` auto-injects
`IM_REVISION` (= 13) before closing the message struct. This matches
the "optional setter, default-injected if skipped" pattern that #447
already established for `SuppressResponse` and `TimedRequest` on
`InvReqBuilder`.

The user-visible bug (matter.js rejecting IM responses during Home
Assistant commissioning) was fixed on the server side by #446;
requests sent through these builders are now spec-compliant by
default too.

Spec: Matter Core §8.1.1 (p. 545 in the Matter 1.5 Core Specification,
doc `23-27349-009`) — `InteractionModelRevision` value `13` since
Matter 1.3, unchanged in 1.4 and 1.5.

## API

Common case is unchanged — `.end()` does the right thing:

```rust
ReadReqBuilder::new(parent, &TLVTag::Anonymous)?
    .fabric_filtered(false)?
    .end()?;   // emits <0xFF, u8, 13> just before end_container
```

Explicit override is available for interop testing against a peer
pinned to an older revision:

```rust
ReadReqBuilder::new(parent, &TLVTag::Anonymous)?
    .fabric_filtered(false)?
    .interaction_model_revision(11)?
    .end()?;
```

## Tests

New `rs-matter/tests/im_revision.rs` carries ten byte-level regression
tests:

- Auto-injection of `<context-tag 0xFF, u8 13>` in each of the four
  request builders when `interaction_model_revision()` is not called.
- Explicit override: caller-supplied value wins and the default is
  not also emitted.
- Server-side coverage for #446 on the two response types that can
  be unit-tested without spinning up the data-model engine:
  `StatusResp` (via `Default`) and `SubscribeResp` (via `::write`).
  The other three response types (`WriteResp`, `InvokeResp`,
  `ReportDataResp`) carry borrowed `TLVArray`s produced by the
  on-the-fly emitters in `dm.rs` and are exercised end-to-end by
  the existing e2e suite.

## Test plan

- [x] `cargo test -p rs-matter --tests` — all suites green including
      the new `im_revision` integration test and the pre-existing
      `im::client_*` tests
- [x] `cargo clippy -p rs-matter --all-targets` — clean
- [x] `cargo fmt --all` — clean
