### PR TITLE
tlv: tolerate arbitrary context-tag order on decode by default

### DIFF
--- a/rs-matter-macros/src/tlv.rs
+++ b/rs-matter-macros/src/tlv.rs
@@ -28,7 +28,19 @@ struct TlvArgs {
     rs_matter_crate: String,
     start: u8,
     datatype: String,
-    unordered: bool,
+    /// If `true`, the derived `FromTLV` implementation assumes incoming
+    /// context tags appear in strictly increasing order (`scan_ctx`,
+    /// linear scan, O(n)). If `false` (the default), it tolerates
+    /// arbitrary tag order (`find_ctx`, quadratic in the number of
+    /// fields). The default is tolerant because Matter Core spec
+    /// §10.6.1 ("Tag Rules") only *recommends* in-order emission ("to
+    /// reduce receiver side complexity in having to deal with arbitrary
+    /// order tags") and does not require receivers to reject out-of-
+    /// order tags; matching the C++ SDK's "accept any order, emit
+    /// in-order" status quo avoids silent interop failures against
+    /// senders that don't strictly order their tags (see e.g.
+    /// matter-js/matter.js#3747).
+    assume_ordered: bool,
     lifetime: syn::Lifetime,
     lifetime_explicit: bool,
 }
@@ -39,7 +51,7 @@ impl Default for TlvArgs {
             start: 0,
             rs_matter_crate: "".to_string(),
             datatype: "struct".to_string(),
-            unordered: false,
+            assume_ordered: false,
             lifetime: Lifetime::new("'_", Span::call_site()),
             lifetime_explicit: false,
         }
@@ -59,9 +71,9 @@ impl TlvArgs {
             self.lifetime_explicit = true;
         } else if meta.path.is_ident("datatype") {
             self.datatype = meta.value()?.parse::<LitStr>()?.value();
-        } else if meta.path.is_ident("unordered") {
+        } else if meta.path.is_ident("assume_ordered") {
             assert!(meta.input.is_empty());
-            self.unordered = true;
+            self.assume_ordered = true;
         } else {
             return Err(meta.error(format!("unsupported attribute: {:?}", meta.path)));
         }
@@ -602,7 +614,14 @@ fn gen_fromtlv_for_struct_named(
     }
 
     let krate = Ident::new(&tlvargs.rs_matter_crate, Span::call_site());
-    let seq_method = format_ident!("{}_ctx", if tlvargs.unordered { "find" } else { "scan" });
+    let seq_method = format_ident!(
+        "{}_ctx",
+        if tlvargs.assume_ordered {
+            "scan"
+        } else {
+            "find"
+        }
+    );
 
     quote! {
         impl #impl_generics #krate::tlv::FromTLV<#lifetime> for #struct_name #generics {
@@ -836,7 +855,7 @@ fn normalize_fromtlv_type(ty: &syn::Type) -> TokenStream {
 /// structure, sequentially, will get Context tags starting from 0
 /// Some configurations are possible through the 'tlvargs' attributes.
 /// For example:
-///  #[tlvargs(lifetime = "'a", start = 1, datatype = "list", unordered)]
+///  #[tlvargs(lifetime = "'a", start = 1, datatype = "list", assume_ordered)]
 ///
 /// start: This can be used to override the default tag from which the
 ///        decoding starts (Default: 0)
@@ -846,8 +865,14 @@ fn normalize_fromtlv_type(ty: &syn::Type) -> TokenStream {
 /// lifetime: If the structure has a lifetime annotation, use this variable
 ///        to indicate that. The 'impl' will then use that lifetime
 ///        indicator.
-/// unordered: By default, the decoder expects that the tags are in
-///        sequentially increasing order. Set this if that is not the case.
+/// assume_ordered: By default, the decoder tolerates incoming context
+///        tags appearing in arbitrary order (matches the C++ SDK and
+///        is safe per Matter Core spec §10.6.1). Set this to switch
+///        to a linear scan that assumes strictly increasing tag order
+///        — faster (O(n) vs O(n²) populate), but rejects valid wire
+///        bytes that happen not to be in spec-recommended order, so
+///        use only for structs whose senders are guaranteed in-order
+///        (e.g. internally generated, never received over the wire).
 ///
 /// Additionally, structure members can use the tagval attribute to
 /// define a specific tag to be used
@@ -895,7 +920,7 @@ mod tests {
         );
 
         let ast: DeriveInput = syn::parse2(quote!(
-            #[tlvargs(unordered)]
+            #[tlvargs(assume_ordered)]
             enum Unused {}
         ))
         .unwrap();
@@ -903,7 +928,7 @@ mod tests {
             parse_tlvargs(&ast, "crate".to_string()),
             TlvArgs {
                 rs_matter_crate: "crate".to_string(),
-                unordered: true,
+                assume_ordered: true,
                 ..Default::default()
             }
         );
@@ -1009,11 +1034,11 @@ mod tests {
                         let mut seq = element.r#struct()?;
 
                         Ok(Self {
-                            field1: u8::from_tlv(&seq.scan_ctx(0u8)?)?,
-                            field2: u32::from_tlv(&seq.scan_ctx(1u8)?)?,
-                            field_opt: Option::from_tlv(&seq.scan_ctx(2u8)?)?,
+                            field1: u8::from_tlv(&seq.find_ctx(0u8)?)?,
+                            field2: u32::from_tlv(&seq.find_ctx(1u8)?)?,
+                            field_opt: Option::from_tlv(&seq.find_ctx(2u8)?)?,
                             field_null: rs_matter_maybe_renamed::tlv::Nullable::from_tlv(
-                                &seq.scan_ctx(3u8)?,
+                                &seq.find_ctx(3u8)?,
                             )?,
                         })
                     }
@@ -1029,10 +1054,10 @@ mod tests {
                             let mut seq = element.r#struct()?;
 
                             let init = rs_matter_maybe_renamed::utils::init::try_init!(Self {
-                                field1 <- u8::init_from_tlv(seq.scan_ctx(0u8)?),
-                                field2 <- u32::init_from_tlv(seq.scan_ctx(1u8)?),
-                                field_opt <- Option::init_from_tlv(seq.scan_ctx(2u8)?),
-                                field_null <- rs_matter_maybe_renamed::tlv::Nullable::init_from_tlv(seq.scan_ctx(3u8)?),
+                                field1 <- u8::init_from_tlv(seq.find_ctx(0u8)?),
+                                field2 <- u32::init_from_tlv(seq.find_ctx(1u8)?),
+                                field_opt <- Option::init_from_tlv(seq.find_ctx(2u8)?),
+                                field_null <- rs_matter_maybe_renamed::tlv::Nullable::init_from_tlv(seq.find_ctx(3u8)?),
                             }? rs_matter_maybe_renamed::error::Error);
 
                             Ok(init)

--- a/rs-matter/src/cert.rs
+++ b/rs-matter/src/cert.rs
@@ -134,7 +134,7 @@ impl BasicConstraints {
 
 #[derive(Debug, Clone, FromTLV, ToTLV, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[tlvargs(start = 1, lifetime = "'a", datatype = "naked", unordered)]
+#[tlvargs(start = 1, lifetime = "'a", datatype = "naked")]
 enum Extension<'a> {
     BasicConstraints(BasicConstraints),
     KeyUsage(u16),

--- a/rs-matter/tests/tlv_encoding.rs
+++ b/rs-matter/tests/tlv_encoding.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Project CHIP Authors
+ * Copyright (c) 2024-2026 Project CHIP Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ mod tlv_encoding_tests {
     use bitflags::bitflags;
     use rs_matter::bitflags_tlv;
     use rs_matter::error::Error;
+    use rs_matter::im::CmdPath;
     use rs_matter::tlv::{FromTLV, TLVElement, TLVTag, ToTLV};
     use rs_matter::utils::storage::WriteBuf;
 
@@ -138,5 +139,78 @@ mod tlv_encoding_tests {
         let b = asserted_ok!(decode_from_tlv(&encoded), "Decode from tlv");
 
         assert_eq!(a, b);
+    }
+
+    /// Regression test for the `CmdPath` decoder dropping the optional
+    /// `endpointId` (context tag 0) when a peer writes the IB members in
+    /// any order other than 0, 1, 2.
+    ///
+    /// Matter Core spec §10.6.1 ("Tag Rules", 1.5 / 1.5.1) requires
+    /// context tags to be emitted in the order defined by the IB, so
+    /// encoders that re-order are non-conformant. matter.js (and hence
+    /// matterjs-server / Home Assistant Matter in beta mode) violates
+    /// this rule for `CommandPathIB`: it writes `clusterId (tag 1),
+    /// commandId (tag 2), endpointId (tag 0)`. See
+    /// matter-js/matter.js#3747 for the upstream-side discussion. A
+    /// `scan_ctx`-based linear decoder (the previous rs-matter default,
+    /// now opt-in via `#[tlvargs(assume_ordered)]`) would pass tag 0
+    /// before checking it and silently report `endpoint = None`, which
+    /// then triggers wildcard endpoint expansion on the receiver. The
+    /// new `find_ctx`-based decoder (the current default) tolerates any
+    /// member order, matching the C++ SDK's status quo.
+    #[test]
+    fn cmd_path_decodes_with_out_of_order_tags() {
+        // CommandPathIB list, members in matter.js order:
+        //   0x37 0x00              // List, context tag 0 (commandPath field)
+        //     0x24 0x01 0x06       // U8 ctx-tag 1: clusterId = 0x06 (OnOff)
+        //     0x24 0x02 0x01       // U8 ctx-tag 2: commandId = 0x01 (On)
+        //     0x24 0x00 0x01       // U8 ctx-tag 0: endpointId = 0x01
+        //   0x18                   // End of List
+        //
+        // Decode as a bare list, anchored at the List opener.
+        let bytes: [u8; 12] = [
+            0x37, 0x00, 0x24, 0x01, 0x06, 0x24, 0x02, 0x01, 0x24, 0x00, 0x01, 0x18,
+        ];
+
+        let element = TLVElement::new(&bytes);
+        let decoded = asserted_ok!(CmdPath::from_tlv(&element), "Decoding CmdPath from TLV");
+
+        assert_eq!(decoded.endpoint, Some(1), "endpointId (tag 0) must decode");
+        assert_eq!(decoded.cluster, Some(6), "clusterId (tag 1) must decode");
+        assert_eq!(decoded.cmd, Some(1), "commandId (tag 2) must decode");
+    }
+
+    /// Sibling of the test above for another non-conformant ordering
+    /// (tags 0, 2, 1 — `endpoint, command, cluster`). Spec-compliant
+    /// encoders emit 0, 1, 2; this exercises the unordered scan from a
+    /// different direction so a future "optimization" that re-introduces
+    /// ordered scanning fails here too.
+    #[test]
+    fn cmd_path_decodes_with_tag_1_after_tag_2() {
+        let bytes: [u8; 12] = [
+            0x37, 0x00, 0x24, 0x00, 0x01, 0x24, 0x02, 0x01, 0x24, 0x01, 0x06, 0x18,
+        ];
+
+        let element = TLVElement::new(&bytes);
+        let decoded = asserted_ok!(CmdPath::from_tlv(&element), "Decoding CmdPath from TLV");
+
+        assert_eq!(decoded.endpoint, Some(1));
+        assert_eq!(decoded.cluster, Some(6));
+        assert_eq!(decoded.cmd, Some(1));
+    }
+
+    /// Wildcard endpoint (tag 0 omitted) must still decode cleanly as
+    /// `endpoint = None`. This is the legitimate use of the option per spec.
+    #[test]
+    fn cmd_path_wildcard_endpoint_still_decodes() {
+        // List with only cluster and command members.
+        let bytes: [u8; 9] = [0x37, 0x00, 0x24, 0x01, 0x06, 0x24, 0x02, 0x01, 0x18];
+
+        let element = TLVElement::new(&bytes);
+        let decoded = asserted_ok!(CmdPath::from_tlv(&element), "Decoding CmdPath from TLV");
+
+        assert_eq!(decoded.endpoint, None);
+        assert_eq!(decoded.cluster, Some(6));
+        assert_eq!(decoded.cmd, Some(1));
     }
 }


### PR DESCRIPTION
Closes #450.

## Summary

Renames `TlvArgs::unordered` → `TlvArgs::assume_ordered` and flips the default: derived `FromTLV` now uses `find_ctx` (tolerant of any context-tag order) instead of `scan_ctx` (linear scan, requires strictly increasing tags). Linear-scan remains available via `#[tlvargs(assume_ordered)]`.

Implements the design @ivmarkov outlined in #450 ("rename `unordered` to `assume_ordered` and have the new name/field be `false` by default").

## Motivation

Matter Core §10.6.1 ("Tag Rules") requires senders to emit in IB-defined order but permits receivers either to scan ascending or accept any order. The CHIP SDK accepts any order, so spec-non-conformant senders go undetected; rs-matter's previous default silently dropped any field whose tag arrived out of position.

The originating bug was matter.js emitting `CommandPathIB` as `1, 2, 0` — `endpointId = 0` was read as absent and the invoke fanned out to every endpoint exposing the named cluster (matter-js/matter.js#3747).

## Tradeoff

Decode becomes O(n²) in the number of struct fields rather than O(n). For typical Matter IBs that's single-digit fields, and "thin" struct usage means the cost is rarely paid on the hot path. Memory unchanged. Per @ivmarkov in #450: *"very cheap to do the switch."*

## Call-site sweep

The only site explicitly opted into the old default was `rs-matter/src/cert.rs::Extension`, which used `#[tlvargs(..., unordered)]` — keyword now redundant, dropped.

I audited every other `FromTLV` derive (23 files) for opt-back-in candidates. None warrant it:

- **Wire types** (IM IBs, SC handshake, cluster attributes/commands, certificates, network credentials) — must tolerate any order; this is the originating reason for the flip.
- **Locally-persisted types** (`fabric.rs`, `acl.rs`, `group_keys.rs`) — could opt in safely since the bytes are written by our own `ToTLV` and loaded on boot, but most are also reused as wire shapes for the corresponding clusters (`AclEntry` ↔ AccessControl, `Fabric` ↔ NOC reads), so opting in would risk silent decode failures the moment a wire-path caller is added. Not worth the foot-gun for boot-time microseconds.
- **Trait/test infrastructure** — inherits default, no behavior change.

Easy to revisit per-struct later if profiling flags a hot decode.

## Tests

`rs-matter/tests/tlv_encoding.rs` gains three regression tests on `CmdPath`:

- `cmd_path_decodes_with_out_of_order_tags` — the matter.js `1, 2, 0` order.
- `cmd_path_decodes_with_tag_1_after_tag_2` — a different non-conformant order (0, 2, 1).
- `cmd_path_wildcard_endpoint_still_decodes` — legitimate omission of tag 0 still produces `endpoint = None`.

`cargo test -p rs-matter --tests`, `cargo test -p rs-matter-macros`, and `cargo clippy -p rs-matter --all-targets` all clean.

## Compatibility

Renaming `unordered` → `assume_ordered` is a source-breaking change for external macro consumers; inside this repo only `cert.rs` was affected. Acceptable given the crate's pre-1.0 status, but let me know if you'd prefer keeping `unordered` as a deprecated alias for a release.