### PR TITLE
level_control: bump TestLevelControlDeviceLogic cluster revision to 6

### DIFF
--- a/rs-matter/src/dm/clusters/app/level_control.rs
+++ b/rs-matter/src/dm/clusters/app/level_control.rs
@@ -1775,7 +1775,7 @@ pub mod test {
         const MAX_LEVEL: u8 = 254;
         const FASTEST_RATE: u8 = 50;
         const CLUSTER: Cluster<'static> = FULL_CLUSTER
-            .with_revision(5)
+            .with_revision(6)
             .with_features(Feature::ON_OFF.bits())
             .with_attrs(with!(
                 required;
@@ -1825,5 +1825,31 @@ pub mod test {
                 .lock(|state| state.borrow_mut().start_up_current_level = value);
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test::TestLevelControlDeviceLogic;
+    use super::{AttributeDefaults, LevelControlHandler};
+    use crate::dm::clusters::app::on_off::test::TestOnOffDeviceLogic;
+    use crate::dm::clusters::app::on_off::OnOffHandler;
+    use crate::dm::Dataver;
+
+    /// Catches drift between `TestLevelControlDeviceLogic::CLUSTER` and
+    /// `LevelControlHandler::validate()`.
+    #[test]
+    fn test_logic_passes_handler_validate() {
+        let level_logic = TestLevelControlDeviceLogic::new();
+        let on_off_logic = TestOnOffDeviceLogic::new(false);
+        let level = LevelControlHandler::new(
+            Dataver::new(1),
+            1,
+            &level_logic,
+            AttributeDefaults::default(),
+        );
+        let on_off = OnOffHandler::new(Dataver::new(2), 1, &on_off_logic);
+        on_off.init(Some(&level));
+        level.init(Some(&on_off));
     }
 }


### PR DESCRIPTION
## Summary

`LevelControlHandler::validate()` panics unless `H::CLUSTER.revision == 6`, and the Matter 1.5.1 IDL declares LevelControl at revision 6. The in-tree `TestLevelControlDeviceLogic` still declared revision 5, so any caller that exercises `init()` panics at startup with:

```
LevelControl validation: incorrect version number: expected 6 got 5
```

`examples/src/bin/speaker.rs` L99–115 hits this — it constructs the handler with `new(...) + .init(...)`. The sibling `TestOnOffDeviceLogic` already tracks revision 6, so this just brings LevelControl in line.

## Changes

- `rs-matter/src/dm/clusters/app/level_control.rs:1778` — `with_revision(5)` → `with_revision(6)`.
- Same file — adds a regression test that constructs the LevelControl + OnOff handler pair the same way `speaker.rs` does, so future drift between `TestLevelControlDeviceLogic::CLUSTER` and what `LevelControlHandler::validate()` requires is caught at CI time rather than at first runtime use.

## References

- `rs-matter/src/dm/clusters/app/level_control.rs` L290–296 — validator (`if H::CLUSTER.revision != 6 { panic!(...) }`).
- `rs-matter-codegen/src/idl/parser/controller-clusters-V1.5.1.0.matter` L557–558 — IDL says revision 6.

## Test plan

- [x] `cargo test --package rs-matter --lib dm::clusters::app::level_control::tests::` — passes.
- [x] Reverted the revision to 5 to confirm the new test fails with the original panic; restored.