### PR TITLE
fix(cert): NotBefore=0 collides with CHIP no-expiry sentinel

### DIFF
--- a/rs-matter/src/cert/builder.rs
+++ b/rs-matter/src/cert/builder.rs
@@ -263,20 +263,23 @@ impl<'a> CertBuilderCore<'a> {
         subject_key_id: &KeyId,
         authority_key_id: &KeyId,
     ) -> Result<(), Error> {
-        // 1. Basic Constraints
+        // 1. Basic Constraints — per Matter Spec §6.5.11.1:
+        //   RCAC: cA = TRUE,  pathLenConstraint SHALL NOT be present
+        //   ICAC: cA = TRUE,  pathLenConstraint = 0
+        //   NOC:  cA = FALSE, pathLenConstraint SHALL NOT be present
         tw.start_struct(&TLVTag::Context(1))?;
         match cert_type {
             CertType::Rcac => {
-                tw.bool(&TLVTag::Context(1), true)?; // is_ca = true
-                tw.u8(&TLVTag::Context(2), 1)?; // path_len = 1
+                tw.bool(&TLVTag::Context(1), true)?;
+                // No path_len for RCAC (was incorrectly set to 1 prior;
+                // CHIP would accept it but it's a spec violation).
             }
             CertType::Icac => {
-                tw.bool(&TLVTag::Context(1), true)?; // is_ca = true
+                tw.bool(&TLVTag::Context(1), true)?;
                 tw.u8(&TLVTag::Context(2), 0)?; // path_len = 0
             }
             CertType::Noc => {
-                tw.bool(&TLVTag::Context(1), false)?; // is_ca = false
-                                                      // No path_len for end entity
+                tw.bool(&TLVTag::Context(1), false)?;
             }
         }
         tw.end_container()?;
@@ -657,6 +660,48 @@ mod tests {
 
         assert!(len > 100);
         assert!(len < MAX_CERT_TLV_LEN);
+    }
+
+    /// Round-trip: build an RCAC, then re-parse and self-verify the
+    /// signature using rs-matter's own `CertVerifier`. If this passes,
+    /// the TLV→ASN.1→hash→verify pipeline is internally consistent.
+    /// If it fails, our signing flow is broken regardless of whether
+    /// CHIP can parse it.
+    #[test]
+    fn test_rcac_self_verify() {
+        let crypto = test_only_crypto();
+        let rcac_secret_key = unwrap!(crypto.generate_secret_key());
+        let rcac_pubkey = rcac_secret_key.pub_key().unwrap();
+
+        let subject = SubjectDN {
+            node_id: None,
+            fabric_id: Some(0x0000_0000_0000_0001),
+            cat_ids: &[],
+            ca_id: Some(0x1122_3344_5566_7788),
+        };
+        let validity = Validity {
+            not_before: 0,
+            not_after: 0,
+        };
+        let mut cert_buf = [0u8; MAX_CERT_TLV_AND_ASN1_LEN];
+        let mut builder = RcacBuilder::new(&mut cert_buf);
+        let len = unwrap!(builder.build(
+            &crypto,
+            subject,
+            validity,
+            &rcac_pubkey,
+            &rcac_secret_key,
+            &[0x01],
+        ));
+
+        // Re-parse the just-built RCAC and self-verify.
+        let cert = CertRef::new(crate::tlv::TLVElement::new(&cert_buf[..len]));
+        let mut scratch = [0u8; MAX_CERT_TLV_AND_ASN1_LEN];
+        let res = cert.verify_chain_start(&crypto).finalise(&mut scratch);
+        assert!(
+            res.is_ok(),
+            "RCAC built by RcacBuilder failed self-verification: {res:?}"
+        );
     }
 
     /// Test building an ICAC signed by RCAC

--- a/rs-matter/src/commissioner/noc_generator.rs
+++ b/rs-matter/src/commissioner/noc_generator.rs
@@ -123,9 +123,22 @@ impl NocGenerator {
             ca_id: Some(rcac_id),
         };
 
+        // NotBefore MUST NOT be 0 (Matter epoch start, 2000-01-01).
+        // CHIP's ChipEpochToASN1Time treats epoch=0 as the "no
+        // well-defined expiration date" sentinel and re-emits it as
+        // GeneralizedTime "99991231235959Z" regardless of which field
+        // it appears in (see CHIPCert.cpp:1076-1106 and the
+        // explanatory comment about CHIP epoch 0 NotBefore producing
+        // an invalid TBS signature on round-trip).
+        //
+        // We sign over UTCTime "000101000000Z" (Matter epoch); CHIP
+        // would reconstruct GeneralizedTime "99991231235959Z" and the
+        // hash would mismatch.  Using 1 second past the Matter epoch
+        // avoids the sentinel collision while keeping the cert
+        // effectively unbounded on the lower end.
         let validity = crate::cert::builder::Validity {
-            not_before: 0, // epoch start
-            not_after: 0,  // no expiry
+            not_before: 1, // 2000-01-01 00:00:01 — past CHIP's epoch=0 sentinel
+            not_after: 0,  // no expiry (NotAfter sentinel is legitimate)
         };
 
         let cert_len = RcacBuilder::new(&mut cert_buf).build(
@@ -234,9 +247,22 @@ impl NocGenerator {
             ca_id: Some(icac_id),
         };
 
+        // NotBefore MUST NOT be 0 (Matter epoch start, 2000-01-01).
+        // CHIP's ChipEpochToASN1Time treats epoch=0 as the "no
+        // well-defined expiration date" sentinel and re-emits it as
+        // GeneralizedTime "99991231235959Z" regardless of which field
+        // it appears in (see CHIPCert.cpp:1076-1106 and the
+        // explanatory comment about CHIP epoch 0 NotBefore producing
+        // an invalid TBS signature on round-trip).
+        //
+        // We sign over UTCTime "000101000000Z" (Matter epoch); CHIP
+        // would reconstruct GeneralizedTime "99991231235959Z" and the
+        // hash would mismatch.  Using 1 second past the Matter epoch
+        // avoids the sentinel collision while keeping the cert
+        // effectively unbounded on the lower end.
         let validity = crate::cert::builder::Validity {
-            not_before: 0, // epoch start
-            not_after: 0,  // no expiry
+            not_before: 1, // 2000-01-01 00:00:01 — past CHIP's epoch=0 sentinel
+            not_after: 0,  // no expiry (NotAfter sentinel is legitimate)
         };
 
         let issuer = crate::cert::builder::IssuerDN {
@@ -330,9 +356,22 @@ impl NocGenerator {
             ca_id: None,
         };
 
+        // NotBefore MUST NOT be 0 (Matter epoch start, 2000-01-01).
+        // CHIP's ChipEpochToASN1Time treats epoch=0 as the "no
+        // well-defined expiration date" sentinel and re-emits it as
+        // GeneralizedTime "99991231235959Z" regardless of which field
+        // it appears in (see CHIPCert.cpp:1076-1106 and the
+        // explanatory comment about CHIP epoch 0 NotBefore producing
+        // an invalid TBS signature on round-trip).
+        //
+        // We sign over UTCTime "000101000000Z" (Matter epoch); CHIP
+        // would reconstruct GeneralizedTime "99991231235959Z" and the
+        // hash would mismatch.  Using 1 second past the Matter epoch
+        // avoids the sentinel collision while keeping the cert
+        // effectively unbounded on the lower end.
         let validity = crate::cert::builder::Validity {
-            not_before: 0, // epoch start
-            not_after: 0,  // no expiry
+            not_before: 1, // 2000-01-01 00:00:01 — past CHIP's epoch=0 sentinel
+            not_after: 0,  // no expiry (NotAfter sentinel is legitimate)
         };
 
         let cert_len = NocBuilder::new(&mut cert_buf).build(


### PR DESCRIPTION
## Summary
Matter operational certificates produced by `NocGenerator` with `NotBefore = 0` (Matter epoch start, 2000-01-01 UTC) are rejected by the CHIP reference SDK on `AddTrustedRootCertificate` with `Invalid signature` (CHIP Error 0x14). The CHIP source ([CHIPCert.cpp:1076-1106](https://github.com/project-chip/connectedhomeip/blob/master/src/credentials/CHIPCert.cpp#L1076)) explicitly warns that `epochTime == 0` is used as the X.509 no-well-defined-expiration sentinel and is **always** re-emitted as `GeneralizedTime "99991231235959Z"` — regardless of whether it lands in `NotBefore` or `NotAfter`. On round-trip, CHIP reconstructs a different TBS DER than what rs-matter signed; the SHA-256 mismatches; ECDSA-verify fails.

rs-matter's own self-verify passes because the conversion is symmetric within rs-matter. The failure only surfaces on interop with the CHIP SDK — which is exactly the production case.

## Fix
1. **`NocGenerator`**: shift `NotBefore` from 0 → 1 (2000-01-01 00:00:01) in the three places that build RCAC, ICAC and NOC. Cert remains effectively unbounded on the lower end, but clears CHIP's sentinel collision.
2. **`cert::builder` BasicConstraints**: drop `pathLenConstraint` from RCAC output. Matter Spec §6.5.11.1.2 mandates *"pathLenConstraint SHALL NOT be present"* for a Root CA cert; rs-matter was emitting `INTEGER 1`. Both ends carried the field through TLV→ASN.1, so signatures still verified, but strict validators (and the spec) reject it.

## New regression test
`test_rcac_self_verify` builds an RCAC via `RcacBuilder` and re-parses it via `CertRef::verify_chain_start().finalise()`. Confirms the TLV→ASN.1→hash→verify pipeline is internally consistent. None of the existing builder tests verified signature — they only checked length bounds.

## Test plan
- [x] `cargo test -p rs-matter --lib cert::builder::tests --features=os` — all 16 tests pass, including the new self-verify.
- [x] End-to-end commissioning against `chip-tool`'s `all-clusters-app` (built from project-chip/connectedhomeip): PASE → ArmFailSafe → CSRRequest → **AddTrustedRootCertificate** → **AddNOC** → CommissioningComplete. Responder log: `OpCreds: successfully created fabric index 0x1 via AddNOC`.