### PR TITLE
fix(tests): commissioning + mdns helper compile against current API

### DIFF
--- a/rs-matter/tests/commissioning.rs
+++ b/rs-matter/tests/commissioning.rs
@@ -338,18 +338,18 @@ async fn discover_and_resolve_device(timeout_ms: u32, use_tcp: bool) -> Result<A
 
 #[cfg(feature = "astro-dnssd")]
 async fn discover_device<const A: usize>(
-    discriminator: u16,
+    filter: &CommissionableFilter,
     timeout_ms: u32,
 ) -> Result<DiscoveredDevice<A>, Error> {
     use rs_matter::transport::network::mdns::astro;
 
+    let filter_owned = filter.clone();
     let (tx, rx) = async_channel::bounded(1);
     std::thread::spawn(move || {
-        let filter = CommissionableFilter {
-            discriminator: Some(discriminator),
-            ..Default::default()
-        };
-        let _ = tx.send_blocking(astro::discover_commissionable::<A>(&filter, timeout_ms));
+        let _ = tx.send_blocking(astro::discover_commissionable::<A>(
+            &filter_owned,
+            timeout_ms,
+        ));
     });
 
     let devices = rx
@@ -358,7 +358,10 @@ async fn discover_device<const A: usize>(
         .map_err(|_| Error::from(rs_matter::error::ErrorCode::Failure))??;
 
     devices.into_iter().next().ok_or_else(|| {
-        warn!("No devices found matching discriminator {discriminator}");
+        warn!(
+            "No devices found matching discriminator {:?}",
+            filter.discriminator
+        );
         rs_matter::error::ErrorCode::NotFound.into()
     })
 }

--- a/rs-matter/tests/common/mdns.rs
+++ b/rs-matter/tests/common/mdns.rs
@@ -32,8 +32,8 @@ use rs_matter::{crypto::Crypto, error::Error};
 #[allow(unused)]
 pub async fn run_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(), Error> {
     #[cfg(feature = "astro-dnssd")]
-    rs_matter::transport::network::mdns::astro::AstroMdnsResponder::new(matter)
-        .run()
+    rs_matter::transport::network::mdns::astro::AstroMdnsResponder::new()
+        .run(matter)
         .await?;
 
     #[cfg(all(feature = "zeroconf", not(feature = "astro-dnssd")))]


### PR DESCRIPTION
## Summary
The `commissioning` integration test currently fails to build on `main` when the `astro-dnssd` feature is selected — three compile errors from API drift between the test helpers and the library.

Repro (verified on `main`):
```
cargo test -p rs-matter --test commissioning \
  --no-default-features \
  --features 'std,rustcrypto,log,astro-dnssd' --no-run
```
```
error[E0061]: this method takes 1 argument but 0 were supplied
  (AstroMdnsResponder::run)
error[E0308]: mismatched types
  expected `u16`, found `&CommissionableFilter`
```

## Fix
1. **`rs-matter/tests/common/mdns.rs`** — `AstroMdnsResponder` moved from `::new(matter).run()` to `::new().run(matter)`. The test helper still used the old shape.
2. **`rs-matter/tests/commissioning.rs`** — the `discover_device` helper kept a `u16 discriminator` parameter for the `astro-dnssd` build while the caller now passes `&CommissionableFilter` (matching the zbus/zeroconf build). Also: the `astro-dnssd` branch was internally re-constructing a filter from only the discriminator, silently dropping any other filter fields the caller specified.

Unified `discover_device(filter: &CommissionableFilter, timeout_ms: u32)` across both feature variants — caller now passes the full filter through to `astro::discover_commissionable`.

## Test plan
- [x] `cargo test -p rs-matter --test commissioning --no-default-features --features 'std,rustcrypto,log,astro-dnssd' --no-run` — builds clean after the patch (failed cleanly on `main` before).