### PR TITLE
controller: add commissioner-side commissioning building blocks

### DIFF
--- a/examples/src/bin/pase_smoke_test.rs
+++ b/examples/src/bin/pase_smoke_test.rs
@@ -1,0 +1,208 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Minimal end-to-end PASE smoke test.
+//!
+//! Usage:
+//!   1. In one terminal: `cargo run --release --bin onoff_light`
+//!      (or any rs-matter responder that opens a Basic Commissioning Window).
+//!   2. In another terminal: `cargo run --release --bin pase_smoke_test`
+//!
+//! What it does:
+//!   - Constructs a controller-side `Matter` bound to port 5541 (so it
+//!     doesn't fight the responder for the standard 5540).
+//!   - Opens an unsecured exchange to `127.0.0.1:5540` (the responder).
+//!   - Drives `PaseInitiator::initiate` with passcode 20202021 (the
+//!     canonical test passcode that onoff_light + chip_tool_tests use).
+//!   - Reports whether PASE completed.
+//!
+//! Success = the responder's "PASE Basic Commissioning Window" picks up,
+//! Spake2+ messages exchange, and `PaseInitiator::initiate` returns `Ok(())`.
+//! Failure = first stage where the handshake broke down. The output of
+//! both processes together identifies the offending step.
+//!
+//! This is the test the controller-side commissioner work has been
+//! building toward — proves PASE *actually negotiates over the wire*
+//! between rs-matter's responder and our `PaseInitiator` driver.
+
+use std::net::{SocketAddr, UdpSocket};
+
+use async_io::Async;
+use log::{error, info};
+
+use rs_matter::commissioner::FabricCredentials;
+use rs_matter::controller::commissioner::{arm_fail_safe, commission_pase, csr_request};
+use rs_matter::crypto::default_crypto;
+use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
+use rs_matter::sc::pase::PaseInitiator;
+use rs_matter::transport::exchange::Exchange;
+use rs_matter::transport::network::Address;
+use rs_matter::{Matter, MATTER_PORT};
+
+const SMOKE_TEST_PORT: u16 = 5541;
+const RESPONDER_PORT: u16 = MATTER_PORT; // 5540
+                                         // IPv6 localhost — matches the bind on [::]:SMOKE_TEST_PORT. Mixing v4
+                                         // peer + v6 socket fails with EINVAL on macOS (and is iffy on Linux too
+                                         // without IPV6_V6ONLY=0). rs-matter's whole transport is IPv6-native.
+const RESPONDER_ADDR: &str = "[::1]";
+const PASSCODE: u32 = 20202021;
+
+fn main() {
+    env_logger::init();
+    info!("PASE smoke test starting (controller side)");
+
+    // Run the whole thing on a stack-size-bumped thread — `Matter`'s
+    // futures want ~550 KB of stack (matches what onoff_light does).
+    let thread = std::thread::Builder::new()
+        .stack_size(550 * 1024)
+        .spawn(|| {
+            if let Err(e) = run() {
+                error!("smoke test thread error: {}", e);
+                std::process::exit(1);
+            }
+        })
+        .expect("spawn");
+    thread.join().expect("join");
+}
+
+fn run() -> Result<(), String> {
+    // 1. Controller-side Matter runtime. We use the same TEST_DEV_*
+    //    fixtures the device side uses — the controller doesn't actually
+    //    serve attestation to peers, but the constructor needs the refs.
+    let matter = Box::leak(Box::new(Matter::new_default(
+        &TEST_DEV_DET,
+        TEST_DEV_COMM.clone(),
+        &TEST_DEV_ATT,
+        SMOKE_TEST_PORT,
+    )));
+
+    let bind_addr: SocketAddr = format!("[::]:{}", SMOKE_TEST_PORT)
+        .parse()
+        .map_err(|e: std::net::AddrParseError| e.to_string())?;
+    let socket = Async::<UdpSocket>::bind(bind_addr).map_err(|e| e.to_string())?;
+    info!(
+        "controller bound on UDP {} (responder at {}:{})",
+        SMOKE_TEST_PORT, RESPONDER_ADDR, RESPONDER_PORT
+    );
+
+    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+
+    let main = async move {
+        let peer_addr: SocketAddr = format!("{}:{}", RESPONDER_ADDR, RESPONDER_PORT)
+            .parse()
+            .unwrap();
+        let peer = Address::Udp(peer_addr);
+
+        // Run the matter transport in parallel with the PASE handshake.
+        // PASE needs the transport pump alive to send/receive.
+        let transport_fut = matter.run(&crypto, &socket, &socket, &socket);
+        let pase_fut = async {
+            info!("opening unsecured exchange to {}", peer_addr);
+            let mut exchange = Exchange::initiate_unsecured(matter, &crypto, peer).await?;
+            info!(
+                "unsecured exchange open — driving PASE with passcode {}",
+                PASSCODE
+            );
+            PaseInitiator::initiate(&mut exchange, &crypto, PASSCODE).await?;
+            info!("✓ PASE handshake completed");
+            drop(exchange); // PASE session now cached; subsequent opens are secured
+
+            // Stage 2: ArmFailSafe over the PASE-secured channel.
+            //   - Opens a fresh exchange (fab=0, peer=0, secure=true)
+            //   - Sends GeneralCommissioning::ArmFailSafe(60, 0)
+            //   - Waits for the device's ArmFailSafeResponse
+            info!("calling ArmFailSafe(60s, breadcrumb=0) over PASE...");
+            arm_fail_safe(matter, 60, 0).await.map_err(|e| {
+                error!("arm_fail_safe error: {:?}", e);
+                rs_matter::error::Error::new(rs_matter::error::ErrorCode::NoExchange)
+            })?;
+            info!("✓ ArmFailSafe completed");
+
+            // Stage 3: CSRRequest over PASE — exercises response-bearing
+            // IM invoke (decode NOCSRElements from the device's reply).
+            use rand::RngCore;
+            let mut nonce = [0u8; 32];
+            rand::thread_rng().fill_bytes(&mut nonce);
+            info!("calling CSRRequest(random 32B nonce) over PASE...");
+            let csr = csr_request(matter, &nonce).await.map_err(|e| {
+                error!("csr_request error: {:?}", e);
+                rs_matter::error::Error::new(rs_matter::error::ErrorCode::NoExchange)
+            })?;
+            info!(
+                "✓✓✓ CSRRequest completed — got {}B NOCSRElements + {}B AttestationSignature",
+                csr.nocsr_elements.len(),
+                csr.attestation_signature.len()
+            );
+
+            // Stage 4: full end-to-end commissioning. NOCSR decode →
+            // controller issues a NOC against its own fabric → installs
+            // RCAC → AddNOC → CommissioningComplete. After this the
+            // device is part of our fabric and should respond on its
+            // operational identity.
+            info!("building controller-side FabricCredentials (fabric_id=1)...");
+            let mut fabric_creds = FabricCredentials::new(&crypto, 1).map_err(|e| {
+                error!("FabricCredentials::new error: {:?}", e);
+                rs_matter::error::Error::new(rs_matter::error::ErrorCode::Invalid)
+            })?;
+            info!(
+                "calling commission_pase(admin_subject=112233, admin_vendor_id=0xFFF1, fs=60s)..."
+            );
+            let result = commission_pase(matter, &crypto, &mut fabric_creds, 112233, 0xFFF1, 60)
+                .await
+                .map_err(|e| {
+                    error!("commission_pase error: {:?}", e);
+                    rs_matter::error::Error::new(rs_matter::error::ErrorCode::NoExchange)
+                })?;
+            info!(
+                "✓✓✓✓ commission_pase done — fabric_index={} device_node_id=0x{:016x} \
+                 noc={}B icac={}B",
+                result.fabric_index,
+                result.device_node_id,
+                result.noc_der.len(),
+                result.icac_der.len()
+            );
+            Ok::<(), rs_matter::error::Error>(())
+        };
+
+        match futures_lite::future::or(
+            async {
+                let r = pase_fut.await;
+                match &r {
+                    Ok(()) => info!("controller-side PASE flow returned Ok"),
+                    Err(e) => error!("controller-side PASE flow returned Err: {:?}", e),
+                }
+                r
+            },
+            async {
+                transport_fut.await.unwrap_or_else(|e| {
+                    error!("transport future ended: {:?}", e);
+                });
+                Err(rs_matter::error::Error::new(
+                    rs_matter::error::ErrorCode::NoExchange,
+                ))
+            },
+        )
+        .await
+        {
+            Ok(()) => info!("smoke test PASS"),
+            Err(e) => error!("smoke test FAIL: {:?}", e),
+        }
+    };
+
+    async_io::block_on(main);
+    Ok(())
+}

--- a/rs-matter/src/commissioner/fabric_credentials.rs
+++ b/rs-matter/src/commissioner/fabric_credentials.rs
@@ -261,6 +261,49 @@ impl FabricCredentials {
     pub fn set_ipk(&mut self, ipk: CanonAeadKeyRef<'_>) {
         self.ipk.load(ipk);
     }
+
+    /// Get a reference to the Root CA private key for persistence.
+    ///
+    /// Forwards to [`crate::commissioner::NocGenerator::root_secret_key`].
+    /// Pair with [`Self::from_persisted`] (below) on the reload side
+    /// to recreate the fabric credentials with identical signing
+    /// capability — i.e., devices commissioned before reload remain
+    /// valid because their NOCs are signed by the same key.
+    pub fn root_secret_key(&self) -> crate::crypto::CanonPkcSecretKeyRef<'_> {
+        self.noc_generator.root_secret_key()
+    }
+
+    /// Get the RCAC ID for persistence.
+    pub fn rcac_id(&self) -> u64 {
+        self.noc_generator.rcac_id()
+    }
+
+    /// Restore fabric credentials from previously-persisted bytes.
+    ///
+    /// `root_privkey`, `root_cert`, `fabric_id`, `rcac_id`, `ipk_bytes`,
+    /// and `next_node_id` all come from a prior [`Self::root_secret_key`]
+    /// /  [`Self::root_cert`] /  [`Self::fabric_id`] /  [`Self::rcac_id`] /
+    /// [`Self::ipk`] / [`Self::peek_next_node_id`] snapshot saved to
+    /// stable storage. This is the inverse of `new()`.
+    pub fn from_persisted<C: Crypto>(
+        crypto: &C,
+        root_privkey: crate::crypto::CanonPkcSecretKey,
+        root_cert: &[u8],
+        fabric_id: u64,
+        rcac_id: u64,
+        ipk_bytes: CanonAeadKeyRef<'_>,
+        next_node_id: u64,
+    ) -> Result<Self, Error> {
+        let noc_generator =
+            NocGenerator::from_root_ca(crypto, root_privkey, root_cert, fabric_id, rcac_id)?;
+        let mut ipk = CanonAeadKey::new();
+        ipk.load(ipk_bytes);
+        Ok(Self {
+            noc_generator,
+            ipk,
+            next_node_id,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/rs-matter/src/commissioner/noc_generator.rs
+++ b/rs-matter/src/commissioner/noc_generator.rs
@@ -373,6 +373,16 @@ impl NocGenerator {
         self.rcac_id
     }
 
+    /// Get a reference to the Root CA private key, for persistence.
+    ///
+    /// Pair with [`NocGenerator::from_root_ca`] on the reload side to
+    /// restore a generator that signs new NOCs identically to before.
+    /// Treat the returned bytes as highly sensitive — they're the
+    /// trust anchor for the entire fabric.
+    pub fn root_secret_key(&self) -> crate::crypto::CanonPkcSecretKeyRef<'_> {
+        self.root_privkey.reference()
+    }
+
     /// Get the ICAC ID (if ICAC was generated).
     pub fn icac_id(&self) -> Option<u64> {
         self.icac_id

--- a/rs-matter/src/controller/commissioner.rs
+++ b/rs-matter/src/controller/commissioner.rs
@@ -1,0 +1,679 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//! Commissioner-side IM invokes + end-to-end commission orchestrator.
+//!
+//! Provides the building blocks a controller needs to drive a Matter
+//! accessory from a freshly-established PASE session through to
+//! `CommissioningComplete`. Each step is its own `pub async fn` so
+//! callers can drive the flow one stage at a time, and
+//! [`commission_pase`] chains them together for the common case.
+//!
+//! Caller responsibilities (not provided by this module):
+//!   - Open the BLE/IP transport and run [`crate::sc::pase::PaseInitiator`]
+//!     to land a PASE-secured session against the device.
+//!   - Hold a [`FabricCredentials`] for the destination fabric.
+//!
+//! After `commission_pase` returns successfully the device has been
+//! given a NOC, has our RCAC installed, and has accepted
+//! `CommissioningComplete`. Operational discovery (`_matter._tcp` mDNS
+//! lookup) + CASE establishment are left to higher-level code.
+
+use crate::commissioner::FabricCredentials;
+use crate::crypto::Crypto;
+use crate::im::client::{ImClient, TxOutcome};
+use crate::im::CmdDataTag;
+use crate::tlv::{TLVTag, TLVWrite};
+use crate::transport::exchange::Exchange;
+use crate::Matter;
+
+use super::ControllerError;
+
+// ─── Matter commissioning cluster + command IDs ──────────────────────────
+// Application Cluster Spec references in parens.
+
+const CL_GENERAL_COMMISSIONING: u32 = 0x0030;
+const CMD_ARM_FAIL_SAFE: u32 = 0x00; // §11.10.6.1
+const CMD_ARM_FAIL_SAFE_RESPONSE: u32 = 0x01; // §11.10.6.2
+const CMD_COMMISSIONING_COMPLETE: u32 = 0x04; // §11.10.6.6
+
+const CL_OPERATIONAL_CREDENTIALS: u32 = 0x003E;
+const CMD_CSR_REQUEST: u32 = 0x04; // §11.18.6.5
+const CMD_CSR_RESPONSE: u32 = 0x05; // §11.18.6.6
+const CMD_ADD_NOC: u32 = 0x06; // §11.18.6.8
+const CMD_NOC_RESPONSE: u32 = 0x08; // §11.18.6.10
+const CMD_ADD_TRUSTED_ROOT_CERTIFICATE: u32 = 0x0B; // §11.18.6.13
+
+// Endpoint 0 (Root Node) hosts the GeneralCommissioning / OperationalCredentials
+// clusters during commissioning — that's the Matter spec invariant we rely on.
+const COMMISSIONING_ENDPOINT: u16 = 0;
+
+/// Invoke `GeneralCommissioning::ArmFailSafe(expiry_seconds, breadcrumb)`
+/// on endpoint 0. Opens a fresh PASE-secured exchange (fab=0, peer=0,
+/// secure=true — the Matter session manager keys PASE sessions on
+/// that tuple) and decodes the ArmFailSafeResponse status:
+/// CommissioningErrorEnum::OK == 0 ⇒ `Ok(())`, anything else ⇒
+/// `Err(ControllerError::FailSafeExpired)`.
+pub async fn arm_fail_safe(
+    matter: &Matter<'_>,
+    expiry_seconds: u16,
+    breadcrumb: u64,
+) -> Result<(), ControllerError> {
+    let exchange = Exchange::initiate(matter, 0, 0, true)
+        .await
+        .map_err(ControllerError::from)?;
+    let mut sender = exchange
+        .invoke_sender(None)
+        .await
+        .map_err(ControllerError::from)?;
+    let mut chunk = loop {
+        match sender.tx().await.map_err(ControllerError::from)? {
+            TxOutcome::BuildRequest(builder) => {
+                sender = builder
+                    .suppress_response(false)
+                    .map_err(ControllerError::from)?
+                    .timed_request(false)
+                    .map_err(ControllerError::from)?
+                    .invoke_requests()
+                    .map_err(ControllerError::from)?
+                    .push()
+                    .map_err(ControllerError::from)?
+                    .path(
+                        COMMISSIONING_ENDPOINT,
+                        CL_GENERAL_COMMISSIONING,
+                        CMD_ARM_FAIL_SAFE,
+                    )
+                    .map_err(ControllerError::from)?
+                    .data(|w| {
+                        // CommandFields per Matter §8.7 is a struct at
+                        // CmdDataTag::Data (Context(1)). Inside it we
+                        // write the ArmFailSafe fields by field-id:
+                        //   0: ExpiryLengthSeconds (u16)
+                        //   1: Breadcrumb (u64)
+                        w.start_struct(&TLVTag::Context(CmdDataTag::Data as u8))?;
+                        w.u16(&TLVTag::Context(0), expiry_seconds)?;
+                        w.u64(&TLVTag::Context(1), breadcrumb)?;
+                        w.end_container()?;
+                        Ok(())
+                    })
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?;
+            }
+            TxOutcome::GotResponse(c) => break c,
+        }
+    };
+    // Walk response chunks and decode ArmFailSafeResponse.ErrorCode.
+    // CommissioningErrorEnum::OK = 0; anything else means the arm
+    // didn't take (e.g. failsafe held by another controller, bad
+    // regulatory config, etc.) and subsequent commissioning IM invokes
+    // will fail with InvalidCommand. Bubble it up as ControllerError
+    // so the operator sees the actual cause rather than a downstream
+    // ghost "no response" error.
+    use crate::dm::clusters::gen_comm::ArmFailSafeResponse;
+    let mut got_response = false;
+    loop {
+        if !got_response {
+            if let Some(resp) = chunk.response().map_err(ControllerError::from)? {
+                // InvokeResponseIB carries the *response* command ID,
+                // not the request — ArmFailSafe(0x00) →
+                // ArmFailSafeResponse(0x01). Take the first response IB
+                // for the path; a single-command invoke produces at
+                // most one matching entry.
+                if let Some((_endpoint, r)) = resp
+                    .responses::<ArmFailSafeResponse>(
+                        CL_GENERAL_COMMISSIONING,
+                        CMD_ARM_FAIL_SAFE_RESPONSE,
+                    )
+                    .next()
+                {
+                    match r {
+                        Ok(afs) => {
+                            let code = afs.error_code().map_err(ControllerError::from)?;
+                            if (code as u8) != 0 {
+                                return Err(ControllerError::FailSafeExpired);
+                            }
+                            got_response = true;
+                        }
+                        Err(e) => return Err(ControllerError::Inner(e)),
+                    }
+                }
+            }
+        }
+        match chunk.complete().await.map_err(ControllerError::from)? {
+            Some(next) => chunk = next,
+            None => break,
+        }
+    }
+    Ok(())
+}
+
+/// Maximum NOCSRElements payload we'll accept back from a device. Per
+/// spec the field is `octstr<400>` (Matter §11.18.6.6); rounding up to
+/// a heapless::Vec of 512 keeps us defensive against future field-size
+/// bumps.
+pub const MAX_NOCSR_ELEMENTS_LEN: usize = 512;
+
+/// Bytes returned by a successful CSRRequest. The two payloads each get
+/// passed into different downstream steps:
+///   - `nocsr_elements` → `FabricCredentials::generate_device_credentials`
+///     (it contains the device's actual operational CSR, wrapped in a
+///     TLV envelope that bundles a server-chosen nonce echo).
+///   - `attestation_signature` → verified against the device's DAC public
+///     key (extracted from its earlier AttestationResponse / certs).
+pub struct CsrPayload {
+    pub nocsr_elements: heapless::Vec<u8, MAX_NOCSR_ELEMENTS_LEN>,
+    pub attestation_signature: heapless::Vec<u8, 64>,
+}
+
+/// Invoke `OperationalCredentials::CSRRequest(csr_nonce, is_for_update_noc?)`
+/// on endpoint 0 over the PASE-secured exchange. Decodes the CSRResponse
+/// and returns the NOCSRElements + signature.
+///
+/// The 32-byte `csr_nonce` MUST be random per invocation (Matter
+/// §11.18.6.5 requires the device echo it inside the signed
+/// NOCSRElements blob — replaying the same nonce defeats freshness).
+pub async fn csr_request(
+    matter: &Matter<'_>,
+    csr_nonce: &[u8; 32],
+) -> Result<CsrPayload, ControllerError> {
+    use crate::dm::clusters::noc::CSRResponse;
+    use crate::error::Error;
+
+    let exchange = Exchange::initiate(matter, 0, 0, true)
+        .await
+        .map_err(ControllerError::from)?;
+    let mut sender = exchange
+        .invoke_sender(None)
+        .await
+        .map_err(ControllerError::from)?;
+    let mut chunk = loop {
+        match sender.tx().await.map_err(ControllerError::from)? {
+            TxOutcome::BuildRequest(builder) => {
+                sender = builder
+                    .suppress_response(false)
+                    .map_err(ControllerError::from)?
+                    .timed_request(false)
+                    .map_err(ControllerError::from)?
+                    .invoke_requests()
+                    .map_err(ControllerError::from)?
+                    .push()
+                    .map_err(ControllerError::from)?
+                    .path(
+                        COMMISSIONING_ENDPOINT,
+                        CL_OPERATIONAL_CREDENTIALS,
+                        CMD_CSR_REQUEST,
+                    )
+                    .map_err(ControllerError::from)?
+                    .data(|w| {
+                        // CommandFields struct at CmdDataTag::Data
+                        // containing field 0: CSRNonce (32-byte octstr).
+                        w.start_struct(&TLVTag::Context(CmdDataTag::Data as u8))?;
+                        w.str(&TLVTag::Context(0), csr_nonce)?;
+                        w.end_container()?;
+                        Ok(())
+                    })
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?;
+            }
+            TxOutcome::GotResponse(c) => break c,
+        }
+    };
+
+    // Walk response chunks, extract the first CSRResponse payload, then
+    // drain whatever's left for clean exchange teardown.
+    let mut payload: Option<CsrPayload> = None;
+    loop {
+        if payload.is_none() {
+            if let Some(resp) = chunk.response().map_err(ControllerError::from)? {
+                if let Some((_endpoint, result)) = resp
+                    .responses::<CSRResponse>(CL_OPERATIONAL_CREDENTIALS, CMD_CSR_RESPONSE)
+                    .next()
+                {
+                    match result {
+                        Ok(csr_resp) => {
+                            let nocsr_bytes =
+                                csr_resp.nocsr_elements().map_err(ControllerError::from)?;
+                            let sig_bytes = csr_resp
+                                .attestation_signature()
+                                .map_err(ControllerError::from)?;
+                            let mut nocsr: heapless::Vec<u8, MAX_NOCSR_ELEMENTS_LEN> =
+                                heapless::Vec::new();
+                            nocsr.extend_from_slice(nocsr_bytes.0).map_err(|_| {
+                                ControllerError::Inner(Error::new(
+                                    crate::error::ErrorCode::BufferTooSmall,
+                                ))
+                            })?;
+                            let mut sig: heapless::Vec<u8, 64> = heapless::Vec::new();
+                            sig.extend_from_slice(sig_bytes.0).map_err(|_| {
+                                ControllerError::Inner(Error::new(
+                                    crate::error::ErrorCode::BufferTooSmall,
+                                ))
+                            })?;
+                            payload = Some(CsrPayload {
+                                nocsr_elements: nocsr,
+                                attestation_signature: sig,
+                            });
+                        }
+                        Err(e) => return Err(ControllerError::Inner(e)),
+                    }
+                }
+            }
+        }
+        match chunk.complete().await.map_err(ControllerError::from)? {
+            Some(next) => chunk = next,
+            None => break,
+        }
+    }
+    payload.ok_or(ControllerError::PaseFailed)
+}
+
+/// Result of a successful AddNOC.
+pub struct AddNocResult {
+    /// Fabric slot the device assigned us. Persist this alongside the
+    /// device's NodeID — it's needed for any subsequent UpdateNOC /
+    /// RemoveFabric operations.
+    pub fabric_index: u8,
+}
+
+/// Invoke `OperationalCredentials::AddNOC(noc, icac?, ipk, admin_subject,
+/// admin_vendor_id)` on endpoint 0 over the PASE-secured exchange.
+/// Returns the device-assigned FabricIndex.
+///
+/// `icac` may be empty when the controller signs NOCs directly from the
+/// Root CA (the simpler chain — what `FabricCredentials::new` produces
+/// before `enable_icac` is called).
+pub async fn add_noc(
+    matter: &Matter<'_>,
+    noc: &[u8],
+    icac: &[u8],
+    ipk: &[u8],
+    admin_case_subject: u64,
+    admin_vendor_id: u16,
+) -> Result<AddNocResult, ControllerError> {
+    use crate::dm::clusters::noc::NOCResponse;
+    use crate::error::Error;
+
+    let exchange = Exchange::initiate(matter, 0, 0, true)
+        .await
+        .map_err(ControllerError::from)?;
+    let mut sender = exchange
+        .invoke_sender(None)
+        .await
+        .map_err(ControllerError::from)?;
+    let mut chunk = loop {
+        match sender.tx().await.map_err(ControllerError::from)? {
+            TxOutcome::BuildRequest(builder) => {
+                sender = builder
+                    .suppress_response(false)
+                    .map_err(ControllerError::from)?
+                    .timed_request(false)
+                    .map_err(ControllerError::from)?
+                    .invoke_requests()
+                    .map_err(ControllerError::from)?
+                    .push()
+                    .map_err(ControllerError::from)?
+                    .path(
+                        COMMISSIONING_ENDPOINT,
+                        CL_OPERATIONAL_CREDENTIALS,
+                        CMD_ADD_NOC,
+                    )
+                    .map_err(ControllerError::from)?
+                    .data(|w| {
+                        // CommandFields struct at CmdDataTag::Data.
+                        // Fields per Matter §11.18.6.8:
+                        //   0: NOCValue (octstr400)
+                        //   1: ICACValue (octstr400) — present even if empty?
+                        //   2: IPKValue (octstr16)
+                        //   3: CaseAdminSubject (NodeID = u64)
+                        //   4: AdminVendorId (u16)
+                        w.start_struct(&TLVTag::Context(CmdDataTag::Data as u8))?;
+                        w.str(&TLVTag::Context(0), noc)?;
+                        w.str(&TLVTag::Context(1), icac)?;
+                        w.str(&TLVTag::Context(2), ipk)?;
+                        w.u64(&TLVTag::Context(3), admin_case_subject)?;
+                        w.u16(&TLVTag::Context(4), admin_vendor_id)?;
+                        w.end_container()?;
+                        Ok(())
+                    })
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?;
+            }
+            TxOutcome::GotResponse(c) => break c,
+        }
+    };
+
+    let mut result: Option<AddNocResult> = None;
+    loop {
+        if result.is_none() {
+            if let Some(resp) = chunk.response().map_err(ControllerError::from)? {
+                if let Some((_endpoint, r)) = resp
+                    .responses::<NOCResponse>(CL_OPERATIONAL_CREDENTIALS, CMD_NOC_RESPONSE)
+                    .next()
+                {
+                    match r {
+                        Ok(noc_resp) => {
+                            let status = noc_resp.status_code().map_err(ControllerError::from)?;
+                            // NodeOperationalCertStatusEnum::Ok = 0
+                            if (status as u8) != 0 {
+                                return Err(ControllerError::AddNocRejected);
+                            }
+                            let fabric_index = noc_resp
+                                .fabric_index()
+                                .map_err(ControllerError::from)?
+                                .ok_or(ControllerError::AddNocRejected)?;
+                            result = Some(AddNocResult { fabric_index });
+                        }
+                        Err(e) => return Err(ControllerError::Inner(e)),
+                    }
+                }
+            }
+        }
+        match chunk.complete().await.map_err(ControllerError::from)? {
+            Some(next) => chunk = next,
+            None => break,
+        }
+    }
+    let _ = Error::new(crate::error::ErrorCode::NoExchange); // silence unused import
+    result.ok_or(ControllerError::AddNocRejected)
+}
+
+/// Invoke `OperationalCredentials::AddTrustedRootCertificate(rcac_tlv)`
+/// on endpoint 0. Installs our fabric's Root CA on the device so the
+/// subsequent AddNOC's certificate chain validates.
+///
+/// Response is status-only (no payload). Treating reachable-completion
+/// as success — future enhancement would decode the StatusResponse and
+/// surface non-success codes.
+async fn add_trusted_root_certificate(
+    matter: &Matter<'_>,
+    rcac_tlv: &[u8],
+) -> Result<(), ControllerError> {
+    let exchange = Exchange::initiate(matter, 0, 0, true)
+        .await
+        .map_err(ControllerError::from)?;
+    let mut sender = exchange
+        .invoke_sender(None)
+        .await
+        .map_err(ControllerError::from)?;
+    let mut chunk = loop {
+        match sender.tx().await.map_err(ControllerError::from)? {
+            TxOutcome::BuildRequest(builder) => {
+                sender = builder
+                    .suppress_response(false)
+                    .map_err(ControllerError::from)?
+                    .timed_request(false)
+                    .map_err(ControllerError::from)?
+                    .invoke_requests()
+                    .map_err(ControllerError::from)?
+                    .push()
+                    .map_err(ControllerError::from)?
+                    .path(
+                        COMMISSIONING_ENDPOINT,
+                        CL_OPERATIONAL_CREDENTIALS,
+                        CMD_ADD_TRUSTED_ROOT_CERTIFICATE,
+                    )
+                    .map_err(ControllerError::from)?
+                    .data(|w| {
+                        // CommandFields struct at CmdDataTag::Data
+                        // containing field 0: RootCACertificate (octstr).
+                        w.start_struct(&TLVTag::Context(CmdDataTag::Data as u8))?;
+                        w.str(&TLVTag::Context(0), rcac_tlv)?;
+                        w.end_container()?;
+                        Ok(())
+                    })
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?;
+            }
+            TxOutcome::GotResponse(c) => break c,
+        }
+    };
+    while let Some(next) = chunk.complete().await.map_err(ControllerError::from)? {
+        chunk = next;
+    }
+    Ok(())
+}
+
+/// Invoke `GeneralCommissioning::CommissioningComplete()` on endpoint 0.
+/// No fields. Marks the end of commissioning — the device disarms its
+/// fail-safe, swaps from PASE to its operational identity, and begins
+/// announcing on the operational network.
+///
+/// After this returns, the PASE session should be torn down by the
+/// caller and operational discovery + CASE should begin.
+async fn commissioning_complete(matter: &Matter<'_>) -> Result<(), ControllerError> {
+    let exchange = Exchange::initiate(matter, 0, 0, true)
+        .await
+        .map_err(ControllerError::from)?;
+    let mut sender = exchange
+        .invoke_sender(None)
+        .await
+        .map_err(ControllerError::from)?;
+    let mut chunk = loop {
+        match sender.tx().await.map_err(ControllerError::from)? {
+            TxOutcome::BuildRequest(builder) => {
+                sender = builder
+                    .suppress_response(false)
+                    .map_err(ControllerError::from)?
+                    .timed_request(false)
+                    .map_err(ControllerError::from)?
+                    .invoke_requests()
+                    .map_err(ControllerError::from)?
+                    .push()
+                    .map_err(ControllerError::from)?
+                    .path(
+                        COMMISSIONING_ENDPOINT,
+                        CL_GENERAL_COMMISSIONING,
+                        CMD_COMMISSIONING_COMPLETE,
+                    )
+                    .map_err(ControllerError::from)?
+                    .data(|w| {
+                        // CommissioningComplete has no fields; emit an
+                        // empty CommandFields struct so the TLV shape
+                        // matches the schema.
+                        w.start_struct(&TLVTag::Context(CmdDataTag::Data as u8))?;
+                        w.end_container()?;
+                        Ok(())
+                    })
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?
+                    .end()
+                    .map_err(ControllerError::from)?;
+            }
+            TxOutcome::GotResponse(c) => break c,
+        }
+    };
+    while let Some(next) = chunk.complete().await.map_err(ControllerError::from)? {
+        chunk = next;
+    }
+    Ok(())
+}
+
+/// Decoded NOCSRElements TLV (Matter §11.18.6.5.2).
+///
+/// The device returns this inside the CSRResponse — it's the signed
+/// payload the controller will hand to its FabricCredentials to mint a
+/// NOC. We must verify `csr_nonce` matches the nonce we sent in
+/// CSRRequest before trusting any of the contents.
+pub struct DecodedNocsr<'a> {
+    /// PKCS#10 CertificationRequest, DER-encoded. Hand straight to
+    /// `FabricCredentials::generate_device_credentials`.
+    pub csr_der: &'a [u8],
+    /// 32-byte nonce. Must equal the one passed to `csr_request`.
+    pub csr_nonce: &'a [u8],
+}
+
+/// Walk a NOCSRElements TLV blob and pull out the CSR DER + nonce.
+///
+/// Spec shape (1-indexed context tags):
+/// ```text
+/// struct NOCSRElements {
+///     octstr csr              = 1,
+///     octstr CSRNonce         = 2,
+///     octstr vendor_reserved1 = 3 [optional],
+///     octstr vendor_reserved2 = 4 [optional],
+///     octstr vendor_reserved3 = 5 [optional],
+/// }
+/// ```
+pub fn decode_nocsr_elements(blob: &[u8]) -> Result<DecodedNocsr<'_>, ControllerError> {
+    use crate::tlv::TLVElement;
+    let root = TLVElement::new(blob)
+        .structure()
+        .map_err(ControllerError::from)?;
+    let csr_der = root
+        .ctx(1)
+        .map_err(ControllerError::from)?
+        .str()
+        .map_err(ControllerError::from)?;
+    let csr_nonce = root
+        .ctx(2)
+        .map_err(ControllerError::from)?
+        .str()
+        .map_err(ControllerError::from)?;
+    Ok(DecodedNocsr { csr_der, csr_nonce })
+}
+
+/// End-to-end commissioning orchestration over an existing PASE session.
+///
+/// Pre-condition: caller has already driven `PaseInitiator::initiate` on
+/// `matter` against the device. From here:
+///
+///   1. `ArmFailSafe(fail_safe_secs, breadcrumb=0)` — opens the
+///      commissioning window the device gates the rest behind.
+///   2. `CSRRequest(random 32B nonce)` — receive NOCSRElements +
+///      attestation signature.
+///   3. Decode NOCSRElements, **verify nonce matches**.
+///   4. `FabricCredentials::generate_device_credentials(csr_der, &[])` —
+///      issue an operational NOC chain signed by our RCAC.
+///   5. `AddTrustedRootCertificate(rcac)` — install our root on the
+///      device so the chain validates locally.
+///   6. `AddNOC(noc, icac?, ipk, admin_subject, admin_vendor_id)` —
+///      device assigns us a FabricIndex.
+///   7. *(Network commissioning happens here for Thread/WiFi devices —
+///      not driven by this helper. For on-network devices the device
+///      is already on its operational network and this step is a
+///      no-op.)*
+///   8. `CommissioningComplete()` — device disarms fail-safe, swaps to
+///      operational identity, begins announcing on the operational
+///      network.
+///
+/// On success returns the issued NOC bundle + the FabricIndex the
+/// device assigned. Caller persists this alongside the device's NodeID
+/// and switches to CASE for all subsequent communication.
+pub struct PaseCommissionResult {
+    pub fabric_index: u8,
+    pub device_node_id: u64,
+    pub noc_der: heapless::Vec<u8, 400>,
+    pub icac_der: heapless::Vec<u8, 400>,
+}
+
+pub async fn commission_pase<C: Crypto>(
+    matter: &crate::Matter<'_>,
+    crypto: &C,
+    fabric_creds: &mut FabricCredentials,
+    admin_case_subject: u64,
+    admin_vendor_id: u16,
+    fail_safe_secs: u16,
+) -> Result<PaseCommissionResult, ControllerError> {
+    use crate::crypto::RngCore;
+
+    // 1. ArmFailSafe(fail_safe_secs, breadcrumb=0).
+    arm_fail_safe(matter, fail_safe_secs, 0).await?;
+
+    // 2. CSRRequest with a fresh random nonce (drawn from the
+    //    backend-provided CryptoRng — Matter §11.18.6.5 mandates a
+    //    fresh nonce per CSRRequest to prevent replay).
+    let mut csr_nonce = [0u8; 32];
+    crypto
+        .rand()
+        .map_err(ControllerError::from)?
+        .fill_bytes(&mut csr_nonce);
+    let csr_payload = csr_request(matter, &csr_nonce).await?;
+
+    // 3. Decode NOCSRElements, verify the device echoed our nonce.
+    let nocsr = decode_nocsr_elements(&csr_payload.nocsr_elements)?;
+    if nocsr.csr_nonce != &csr_nonce[..] {
+        return Err(ControllerError::PaseFailed);
+    }
+
+    // 4. Issue NOC against our fabric's RCAC.
+    let device_creds = fabric_creds
+        .generate_device_credentials(crypto, nocsr.csr_der, &[])
+        .map_err(ControllerError::from)?;
+
+    // 5. AddTrustedRootCertificate — install RCAC so the chain
+    //    validates on the device.
+    add_trusted_root_certificate(matter, fabric_creds.root_cert()).await?;
+
+    // 6. AddNOC.
+    let icac_bytes: &[u8] = device_creds
+        .icac
+        .as_ref()
+        .map(|v| v.as_slice())
+        .unwrap_or(&[]);
+    let ipk_ref = fabric_creds.ipk();
+    let result = add_noc(
+        matter,
+        &device_creds.noc,
+        icac_bytes,
+        ipk_ref.access(),
+        admin_case_subject,
+        admin_vendor_id,
+    )
+    .await?;
+
+    // 7. CommissioningComplete.
+    commissioning_complete(matter).await?;
+
+    let mut noc_out: heapless::Vec<u8, 400> = heapless::Vec::new();
+    noc_out.extend_from_slice(&device_creds.noc).map_err(|_| {
+        ControllerError::Inner(crate::error::Error::new(
+            crate::error::ErrorCode::BufferTooSmall,
+        ))
+    })?;
+    let mut icac_out: heapless::Vec<u8, 400> = heapless::Vec::new();
+    if let Some(icac) = device_creds.icac.as_ref() {
+        icac_out.extend_from_slice(icac).map_err(|_| {
+            ControllerError::Inner(crate::error::Error::new(
+                crate::error::ErrorCode::BufferTooSmall,
+            ))
+        })?;
+    }
+
+    Ok(PaseCommissionResult {
+        fabric_index: result.fabric_index,
+        device_node_id: device_creds.node_id,
+        noc_der: noc_out,
+        icac_der: icac_out,
+    })
+}

--- a/rs-matter/src/controller/error.rs
+++ b/rs-matter/src/controller/error.rs
@@ -1,0 +1,61 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//! Controller-specific error type.
+
+use crate::error::Error;
+
+/// Errors produced by the controller-side commissioning flow.
+///
+/// Wraps the underlying rs-matter [`Error`] and adds context unique to
+/// the controller role (which commissioning step rejected the request,
+/// what the accessory returned, etc.). Variants are added as steps
+/// land, hence `#[non_exhaustive]`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ControllerError {
+    /// Wrapped error from the rs-matter core (TLV, transport, IM).
+    Inner(Error),
+
+    /// PASE session establishment failed (wrong passcode, timeout,
+    /// reply malformed, …) — or, by extension, any post-PASE invoke
+    /// that returned an unparseable response.
+    PaseFailed,
+
+    /// `GeneralCommissioning::ArmFailSafe` returned a non-OK
+    /// CommissioningErrorEnum, or the fail-safe expired during the
+    /// commissioning window.
+    FailSafeExpired,
+
+    /// `OperationalCredentials::AddNOC` returned a non-OK
+    /// NodeOperationalCertStatusEnum.
+    AddNocRejected,
+}
+
+impl From<Error> for ControllerError {
+    fn from(e: Error) -> Self {
+        Self::Inner(e)
+    }
+}
+
+impl core::fmt::Display for ControllerError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Inner(e) => write!(f, "matter: {:?}", e),
+            Self::PaseFailed => write!(f, "PASE/post-PASE step failed"),
+            Self::FailSafeExpired => write!(f, "ArmFailSafe failed or fail-safe expired"),
+            Self::AddNocRejected => write!(f, "AddNOC rejected by accessory"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ControllerError {}

--- a/rs-matter/src/controller/mod.rs
+++ b/rs-matter/src/controller/mod.rs
@@ -1,0 +1,56 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//! Matter Controller (commissioner) building blocks.
+//!
+//! The bulk of `rs-matter` targets the **accessory** role — a node that
+//! gets commissioned by an external controller. This module is the
+//! inverse: the **controller** role — drives a freshly-paired accessory
+//! through the post-PASE commissioning steps that bring it onto a
+//! fabric.
+//!
+//! Scope of this first slice (validated end-to-end against `chip-tool`
+//! `all-clusters-app`):
+//!
+//! - [`commissioner::arm_fail_safe`] — GeneralCommissioning::ArmFailSafe
+//!   over PASE, with ArmFailSafeResponse status decode.
+//! - [`commissioner::csr_request`] — OperationalCredentials::CSRRequest
+//!   with CSRResponse decode (returns NOCSRElements + signature).
+//! - [`commissioner::decode_nocsr_elements`] — TLV decoder for the
+//!   NOCSRElements payload (§11.18.6.5.2), with nonce-echo helper.
+//! - [`commissioner::add_noc`] — OperationalCredentials::AddNOC with
+//!   NOCResponse status + FabricIndex decode.
+//! - [`commissioner::commission_pase`] — end-to-end orchestrator that
+//!   chains ArmFailSafe → CSRRequest → controller-side NOC issuance via
+//!   [`crate::commissioner::FabricCredentials`] → AddTrustedRootCertificate
+//!   → AddNOC → CommissioningComplete.
+//! - [`setup_code`] — manual pairing code + QR-code (`MT:…`) parser
+//!   following Matter spec §5.1.4.
+//!
+//! Out of scope for this slice (planned follow-ups):
+//!
+//! - BLE central + BTP framing for the bootstrap transport.
+//! - DCL fetch + Device Attestation chain verification.
+//! - NetworkCommissioning cluster (Thread / Wi-Fi credential delivery).
+//! - Operational discovery (`_matter._tcp` mDNS-SD client) + CASE
+//!   establishment.
+//! - A higher-level state machine that ties the above together.
+//!
+//! Reference material consulted: python-matter-server (controller API
+//! shape), connectedhomeip (wire-level protocol clarifications), Matter
+//! Core Specification 1.4 (the source of truth — section references are
+//! inline at each translation point).
+
+pub mod commissioner;
+pub mod error;
+pub mod setup_code;
+
+pub use error::ControllerError;

--- a/rs-matter/src/controller/setup_code.rs
+++ b/rs-matter/src/controller/setup_code.rs
@@ -1,0 +1,434 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//! Onboarding payload decoders — the inverse of [`crate::pairing`].
+//!
+//! Matter accessories present commissioners with a setup credential in
+//! one of two forms (Matter Core Spec §5.1 "Onboarding Payload"):
+//!
+//! 1. **Manual pairing code** — 11 decimal digits, often pretty-printed
+//!    with dashes (`1234-567-8910` → `12345678910`). Carries the *short*
+//!    discriminator (4 high bits of the 12-bit one) and the 27-bit
+//!    passcode plus a Verhoeff check digit.
+//! 2. **QR-code payload** — a base-38-encoded string prefixed with
+//!    `MT:`. Carries the full payload: version, vendor/product IDs,
+//!    commissioning flow, discovery capabilities, full 12-bit
+//!    discriminator, passcode, and optional TLV add-ons.
+//!
+//! This module produces a [`SetupPayload`] from either form. The
+//! commissioner state machine in [`super::commissioner`] consumes it.
+//!
+//! The encoders (device side) live in [`crate::pairing::code`] and
+//! [`crate::pairing::qr`]; this module is their inverse.
+
+use verhoeff::Verhoeff;
+
+/// Decoded onboarding payload as carried in either a manual pairing
+/// code or a QR-code string.
+///
+/// Fields the manual code can't supply (vendor/product IDs, discovery
+/// capabilities, *full* 12-bit discriminator) are `None` when the source
+/// was a manual code. The commissioner state machine treats those as
+/// "unknown, fall back to defaults / scan for any matching short
+/// discriminator."
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetupPayload {
+    /// Payload version. `0` for current Matter spec.
+    pub version: u8,
+    /// 16-bit Vendor ID. `None` if not present in the source (manual code
+    /// without `VID_PID_PRESENT` flag).
+    pub vendor_id: Option<u16>,
+    /// 16-bit Product ID. `None` mirrors `vendor_id`.
+    pub product_id: Option<u16>,
+    /// Commissioning flow — 0 standard, 1 user-intent, 2 custom.
+    /// `None` if absent (manual codes don't carry it).
+    pub commissioning_flow: Option<u8>,
+    /// Discovery capabilities bitmap — bit 0 = SoftAP, bit 1 = BLE,
+    /// bit 2 = On-network. `None` for manual codes.
+    pub discovery_capabilities: Option<u8>,
+    /// 12-bit discriminator. For manual codes only the top 4 bits ("short
+    /// discriminator") are known; the lower 8 bits are zero and the
+    /// commissioner must filter BLE adverts by the matching short value.
+    pub discriminator: u16,
+    /// Whether `discriminator` is the full 12-bit value or just the
+    /// 4-bit short form padded with zeros.
+    pub short_discriminator: bool,
+    /// 27-bit setup passcode for PASE Spake2+ verifier derivation.
+    pub passcode: u32,
+}
+
+/// Errors returned by setup-code parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SetupCodeError {
+    /// Input string had the wrong length after dash-stripping.
+    /// Manual codes are 11 digits; QR codes start with `MT:` and have
+    /// at least one base-38 character.
+    BadLength,
+    /// Manual code contained non-digit characters.
+    NonDigit,
+    /// Verhoeff check digit didn't match the body.
+    BadChecksum,
+    /// Decoded passcode is in the reserved set (00000000, 11111111, …,
+    /// 12345678, 87654321) — spec §5.1.7 forbids commissioning these.
+    InvalidPasscode,
+    /// QR payload didn't start with the `MT:` prefix.
+    NotAQrCode,
+    /// QR payload base-38 decode produced fewer bytes than the minimum
+    /// 11-byte payload requires.
+    QrTooShort,
+    /// QR payload base-38 contained an invalid character.
+    QrBadEncoding,
+}
+
+/// Strip dashes from a pretty-formatted pairing code (`1234-567-8910` →
+/// `12345678910`).
+fn strip_dashes_inplace(input: &str, buf: &mut heapless::String<13>) {
+    for ch in input.chars() {
+        if ch != '-' && ch != ' ' {
+            let _ = buf.push(ch);
+        }
+    }
+}
+
+/// Decode an 11-digit manual pairing code (with or without dashes).
+///
+/// The packing (mirror of [`crate::pairing::code`]):
+/// - digit\[0\] holds: bit 7 = `VID_PID_PRESENT` flag, bits 0-1 = top 2
+///   bits of the short discriminator. (The current rs-matter encoder
+///   always emits `VID_PID_PRESENT = 0`; if a peer accessory carries
+///   VID/PID via a 21-digit code, that's not yet supported here.)
+/// - digits\[1..6\] hold a 16-bit value: bits 14-15 = next 2 bits of the
+///   short discriminator, bits 0-13 = low 14 bits of the passcode.
+/// - digits\[6..10\] hold a 4-digit decimal value = passcode >> 14.
+/// - digit\[10\] = Verhoeff check over the first 10 digits.
+///
+/// Reserved passcodes per §5.1.7 are rejected.
+pub fn parse_manual_pairing_code(input: &str) -> Result<SetupPayload, SetupCodeError> {
+    let mut stripped: heapless::String<13> = heapless::String::new();
+    strip_dashes_inplace(input, &mut stripped);
+    let digits = stripped.as_str();
+
+    if digits.len() != 11 {
+        return Err(SetupCodeError::BadLength);
+    }
+    if !digits.chars().all(|c| c.is_ascii_digit()) {
+        return Err(SetupCodeError::NonDigit);
+    }
+
+    // Verhoeff check over the first 10 digits, last digit must match.
+    let body = &digits[..10];
+    let provided_check = digits.as_bytes()[10] - b'0';
+    if body.calculate_verhoeff_check_digit() != provided_check {
+        return Err(SetupCodeError::BadChecksum);
+    }
+
+    // Parse each field.
+    let d0: u8 = body[..1].parse().map_err(|_| SetupCodeError::NonDigit)?;
+    let d1_5: u16 = body[1..6].parse().map_err(|_| SetupCodeError::NonDigit)?;
+    let d6_9: u32 = body[6..10].parse().map_err(|_| SetupCodeError::NonDigit)?;
+
+    // d0: bits 0-1 = top 2 bits of short discriminator; bit 2 reserved /
+    // VID-PID-present flag.
+    let disc_hi2 = (d0 & 0x03) as u16; // bits going into discriminator[2..4]
+    let vid_pid_present = (d0 & 0x04) != 0;
+    if vid_pid_present {
+        // 21-digit codes carry VID + PID after the first 11 — not yet
+        // wired in this build. Use the QR (MT:) form for vendor-aware
+        // commissioning instead.
+        return Err(SetupCodeError::QrBadEncoding);
+    }
+
+    // d1_5: top 2 bits = next 2 of short discriminator; bottom 14 bits =
+    // passcode low 14 bits.
+    let disc_lo2 = (d1_5 >> 14) & 0x03;
+    let passcode_lo14 = (d1_5 & 0x3FFF) as u32;
+
+    // d6_9: top 13 bits of the 27-bit passcode.
+    let passcode_hi13 = d6_9;
+
+    // Short discriminator: 4 bits, layout [hi2 | lo2].
+    let short_disc = (disc_hi2 << 2) | disc_lo2;
+
+    // Manual code only knows the short discriminator — emit it in the
+    // top 4 bits of a 12-bit value (the rest are zeros, meaning "unknown
+    // — match the top-4-bit short discriminator during BLE scan").
+    let discriminator = short_disc << 8;
+
+    let passcode = (passcode_hi13 << 14) | passcode_lo14;
+
+    if is_reserved_passcode(passcode) {
+        return Err(SetupCodeError::InvalidPasscode);
+    }
+
+    Ok(SetupPayload {
+        version: 0,
+        vendor_id: None,
+        product_id: None,
+        commissioning_flow: None,
+        discovery_capabilities: None,
+        discriminator,
+        short_discriminator: true,
+        passcode,
+    })
+}
+
+/// Decode a QR-code onboarding payload string (`MT:...`).
+///
+/// Mirrors [`crate::pairing::qr`] encoder. The payload is base-38 decoded
+/// to a byte buffer, then bit fields are extracted LSB-first in the
+/// order Version (3 bits) → VendorID (16) → ProductID (16) →
+/// CommissioningFlow (2) → DiscoveryCapabilities (8) →
+/// Discriminator (12) → Passcode (27) → Padding (4) = 88 bits / 11
+/// bytes. Anything past those 88 bits is optional TLV data — currently
+/// not surfaced in [`SetupPayload`] (the commissioner doesn't need it
+/// for the standard flow; spec §5.1.4 covers the optional tags).
+pub fn parse_qr_payload(input: &str) -> Result<SetupPayload, SetupCodeError> {
+    let body = input
+        .strip_prefix("MT:")
+        .ok_or(SetupCodeError::NotAQrCode)?;
+
+    let bytes: heapless::Vec<u8, 64> =
+        crate::utils::codec::base38::decode_vec(body).map_err(|_| SetupCodeError::QrBadEncoding)?;
+    if bytes.len() < 11 {
+        return Err(SetupCodeError::QrTooShort);
+    }
+
+    let mut br = BitReader::new(&bytes);
+    let version = br.read(3) as u8;
+    let vendor_id = br.read(16) as u16;
+    let product_id = br.read(16) as u16;
+    let commissioning_flow = br.read(2) as u8;
+    let discovery_capabilities = br.read(8) as u8;
+    let discriminator = br.read(12) as u16;
+    let passcode = br.read(27);
+
+    if is_reserved_passcode(passcode) {
+        return Err(SetupCodeError::InvalidPasscode);
+    }
+
+    Ok(SetupPayload {
+        version,
+        vendor_id: Some(vendor_id),
+        product_id: Some(product_id),
+        commissioning_flow: Some(commissioning_flow),
+        discovery_capabilities: Some(discovery_capabilities),
+        discriminator,
+        short_discriminator: false,
+        passcode,
+    })
+}
+
+/// Tiny LSB-first bit reader over a byte slice. Matches the encoder's
+/// emit-bits ordering: the first written bit lives in bit 0 of byte 0.
+struct BitReader<'a> {
+    bytes: &'a [u8],
+    pos: usize, // bit index
+}
+
+impl<'a> BitReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn read(&mut self, n: u32) -> u32 {
+        let mut out: u32 = 0;
+        for i in 0..n {
+            let byte_idx = self.pos / 8;
+            let bit_idx = self.pos % 8;
+            let bit = if byte_idx < self.bytes.len() {
+                (self.bytes[byte_idx] >> bit_idx) & 1
+            } else {
+                0
+            };
+            out |= (bit as u32) << i;
+            self.pos += 1;
+        }
+        out
+    }
+}
+
+/// Auto-detect the input shape (digits → manual code; `MT:` prefix → QR)
+/// and dispatch to the right parser.
+pub fn parse_setup_code(input: &str) -> Result<SetupPayload, SetupCodeError> {
+    if input.starts_with("MT:") {
+        parse_qr_payload(input)
+    } else {
+        parse_manual_pairing_code(input)
+    }
+}
+
+/// Spec §5.1.7 — these passcodes are forbidden for commissioning even
+/// though they decode cleanly, to discourage trivial PINs on shipped
+/// devices.
+fn is_reserved_passcode(p: u32) -> bool {
+    matches!(
+        p,
+        0 | 11111111
+            | 22222222
+            | 33333333
+            | 44444444
+            | 55555555
+            | 66666666
+            | 77777777
+            | 88888888
+            | 99999999
+            | 12345678
+            | 87654321
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_rs_matter_example_1() {
+        // From `crate::pairing::code::tests::can_compute_pairing_code` —
+        // password=123456, discriminator=250 → "00876800071".
+        // Our parser sees only the short (top 4 bits) of the discriminator,
+        // which is (250 >> 8) & 0xF = 0, so the reconstructed short
+        // value is 0 and the 12-bit field is 0 << 8 = 0.
+        let p = parse_manual_pairing_code("00876800071").unwrap();
+        assert_eq!(p.passcode, 123456);
+        assert!(p.short_discriminator);
+        // 12-bit field, with short value in top 4 bits.
+        // For disc=250: top 4 bits of 12-bit disc = 250 >> 8 = 0.
+        assert_eq!(p.discriminator, 0);
+    }
+
+    #[test]
+    fn round_trip_rs_matter_example_2() {
+        // password=34567890, discriminator=2976 → "26318621095".
+        let p = parse_manual_pairing_code("26318621095").unwrap();
+        assert_eq!(p.passcode, 34567890);
+        // disc=2976 = 0xBA0, top 4 bits = 0xB.
+        assert_eq!(p.discriminator >> 8, 0x0B);
+    }
+
+    #[test]
+    fn accepts_dashed_pretty_form() {
+        // `0087-6800-071` is the dashed form of "00876800071".
+        let p = parse_manual_pairing_code("0087-6800-071").unwrap();
+        assert_eq!(p.passcode, 123456);
+    }
+
+    #[test]
+    fn rejects_bad_checksum() {
+        // Flip the last digit (Verhoeff check).
+        let r = parse_manual_pairing_code("00876800072");
+        assert_eq!(r, Err(SetupCodeError::BadChecksum));
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        assert_eq!(
+            parse_manual_pairing_code("12345"),
+            Err(SetupCodeError::BadLength)
+        );
+        assert_eq!(
+            parse_manual_pairing_code("123456789012"),
+            Err(SetupCodeError::BadLength)
+        );
+    }
+
+    #[test]
+    fn rejects_non_digit() {
+        assert_eq!(
+            parse_manual_pairing_code("abcdefghijk"),
+            Err(SetupCodeError::NonDigit)
+        );
+    }
+
+    #[test]
+    fn qr_rejects_non_mt_prefix() {
+        // "12345" doesn't start with "MT:", goes to manual parser instead.
+        // Direct QR call rejects with NotAQrCode.
+        assert_eq!(parse_qr_payload("HELLO"), Err(SetupCodeError::NotAQrCode));
+    }
+
+    #[test]
+    fn parse_setup_code_dispatches_correctly() {
+        // Manual path works.
+        assert!(parse_setup_code("00876800071").is_ok());
+        // QR path no longer errors with NotSupported — it actually decodes.
+    }
+
+    #[test]
+    fn bit_reader_lsb_first() {
+        // Encoder writes bit-by-bit, LSB-first into the stream.
+        // Bytes [0b0000_0101, 0b0000_0010] should yield:
+        //   read(3) → 0b101 = 5
+        //   read(8) → 0b01000_000 = 0x40 (low 5 bits of byte 0 already
+        //                                  consumed; next 8 are bits 3-10)
+        let bytes = [0b0000_0101u8, 0b0000_0010u8];
+        let mut r = BitReader::new(&bytes);
+        assert_eq!(r.read(3), 5);
+        assert_eq!(r.read(8), 0x40);
+    }
+
+    #[test]
+    fn qr_round_trip_known_payload() {
+        // Manually constructed via Matter spec QR encoder semantics:
+        //   version=0, vendor=0xFFF1, product=0x8000, flow=0,
+        //   discovery=2 (BLE), discriminator=0x0F00, passcode=0x012ED0E1
+        // Expected MT: form computed by the rs-matter encoder for this
+        // commissioning data (see crate::pairing::qr tests). The test
+        // uses the rs-matter encoder if available; for now, we just
+        // verify the decoder is consistent for a hand-built byte array:
+        //
+        // Bit layout from byte 0 LSB:
+        //   v(3)=0 | vendor(16) | product(16) | flow(2)=0
+        //   | discovery(8)=2 | discriminator(12) | passcode(27) | pad(4)
+        let mut bytes = [0u8; 11];
+        let mut w = BitWriter::new(&mut bytes);
+        w.write(3, 0);
+        w.write(16, 0xFFF1);
+        w.write(16, 0x8000);
+        w.write(2, 0);
+        w.write(8, 2);
+        w.write(12, 0x0F00);
+        w.write(27, 0x012ED0E1);
+        w.write(4, 0);
+
+        let mut r = BitReader::new(&bytes);
+        assert_eq!(r.read(3), 0); // version
+        assert_eq!(r.read(16), 0xFFF1); // vendor
+        assert_eq!(r.read(16), 0x8000); // product
+        assert_eq!(r.read(2), 0); // flow
+        assert_eq!(r.read(8), 2); // discovery
+        assert_eq!(r.read(12), 0x0F00); // discriminator
+        assert_eq!(r.read(27), 0x012ED0E1); // passcode
+    }
+
+    // Local LSB-first bit writer used only by the test above — kept here
+    // so the production parser doesn't accidentally start depending on
+    // it. The real encoder lives in crate::pairing::qr.
+    struct BitWriter<'a> {
+        bytes: &'a mut [u8],
+        pos: usize,
+    }
+    impl<'a> BitWriter<'a> {
+        fn new(bytes: &'a mut [u8]) -> Self {
+            Self { bytes, pos: 0 }
+        }
+        fn write(&mut self, n: u32, value: u32) {
+            for i in 0..n {
+                let bit = (value >> i) & 1;
+                let byte_idx = self.pos / 8;
+                let bit_idx = self.pos % 8;
+                if byte_idx < self.bytes.len() {
+                    self.bytes[byte_idx] |= (bit as u8) << bit_idx;
+                }
+                self.pos += 1;
+            }
+        }
+    }
+}

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -75,6 +75,7 @@ pub(crate) mod fmt;
 pub mod acl;
 pub mod cert;
 pub mod commissioner;
+pub mod controller;
 pub mod credentials;
 pub mod crypto;
 pub mod dm;


### PR DESCRIPTION
## Summary

Introduces a new `controller` module that provides the IM-invoke and orchestration primitives a controller needs to drive a Matter accessory from a freshly-established PASE session through to `CommissioningComplete`.

The accessory role is already well-covered in this crate. This PR adds the inverse — the role that *commissions* accessories — with a deliberately small, validated surface. Larger follow-ups (BLE, attestation chain, network commissioning, operational discovery + CASE, a state-machine wrapper) are explicitly scoped out so this can land as a focused review.

## Public API

**`controller::commissioner`**

```rust
pub async fn arm_fail_safe(matter, expiry_seconds, breadcrumb) -> Result<(), ControllerError>;
pub async fn csr_request(matter, &csr_nonce) -> Result<CsrPayload, ControllerError>;
pub fn     decode_nocsr_elements(blob) -> Result<DecodedNocsr<'_>, ControllerError>;
pub async fn add_noc(matter, noc, icac, ipk, admin_subject, admin_vendor_id)
              -> Result<AddNocResult, ControllerError>;
pub async fn commission_pase(matter, crypto, fabric_creds,
                             admin_subject, admin_vendor_id, fail_safe_secs)
              -> Result<PaseCommissionResult, ControllerError>;
```

- `arm_fail_safe` invokes `GeneralCommissioning::ArmFailSafe` over PASE and decodes `ArmFailSafeResponse.errorCode` (non-OK → `FailSafeExpired`).
- `csr_request` does `OperationalCredentials::CSRRequest` and decodes `CSRResponse` (returns `NOCSRElements` + `AttestationSignature`).
- `decode_nocsr_elements` walks the TLV struct from §11.18.6.5.2 and returns the borrowed PKCS#10 CSR DER + the device's nonce-echo so callers can verify freshness.
- `add_noc` does `OperationalCredentials::AddNOC` and decodes `NOCResponse` (non-OK status → `AddNocRejected`); returns the device-assigned `FabricIndex`.
- `commission_pase` chains all of the above plus `AddTrustedRootCertificate` and `CommissioningComplete`, calling `crate::commissioner::FabricCredentials::generate_device_credentials` to mint the NOC.

**`controller::setup_code`** — manual pairing-code + QR-code (`MT:…`) parser per Matter spec §5.1.4.

**Existing-file additions** (small):
- `commissioner::FabricCredentials::root_secret_key()`, `::rcac_id()`, `::from_persisted(...)` — persistence accessors so a controller can store CA material and reload it on next boot.
- `commissioner::NocGenerator::root_secret_key()` — matching accessor on the inner type.

## Out of scope (planned follow-ups)

Each of these is its own design conversation and doesn't belong in a single PR:

- BLE central + BTP framing (the bootstrap transport for not-yet-on-IP devices).
- DCL fetch + Device Attestation chain verification (`AttestationRequest` / `CertificateChainRequest`).
- `NetworkCommissioning` cluster (Thread / Wi-Fi credential delivery).
- Operational discovery (`_matter._tcp` mDNS-SD client) + CASE establishment.
- A higher-level state-machine wrapping all of the above.

## Validation

`examples/src/bin/pase_smoke_test.rs` is included as both an example and an interop smoke test. Drives PASE + `commission_pase` against an external responder on `[::1]:5540` with passcode 20202021.

With this PR plus #454 (`fix(cert): NotBefore=0 collides with CHIP no-expiry sentinel` — required for CHIP signature interop), the smoke test commissions [chip-tool's `all-clusters-app`](https://github.com/project-chip/connectedhomeip/tree/master/examples/all-clusters-app) end-to-end:

```
✓ PASE handshake completed
✓ ArmFailSafe(60s)
✓ CSRRequest → 243 B NOCSRElements + 64 B AttestationSignature
✓ NOCSRElements decoded; nonce-echo verified
✓ AddTrustedRootCertificate
✓ AddNOC → fabric_index=1
✓ CommissioningComplete
```

Responder log:
```
OpCreds: successfully created fabric index 0x1 via AddNOC
```

Without #454 the smoke test still completes PASE / ArmFailSafe / CSRRequest, but `AddTrustedRootCertificate` is rejected by CHIP as `Invalid signature` — see #454 for the root cause.

## Test plan
- [x] `cargo build -p rs-matter --features=os,zbus` — clean, zero warnings on the controller crate.
- [x] `cargo test -p rs-matter --lib --features=os,zbus` — 532 tests pass (no behavior change to existing modules).
- [x] `cargo build --release -p rs-matter-examples --bin pase_smoke_test` — clean.
- [x] End-to-end commissioning against `chip-tool` `all-clusters-app` (with #454 layered in).