### PR TITLE
fix: substraction issue in transport

### DIFF
--- a/rs-matter/src/transport/dedup.rs
+++ b/rs-matter/src/transport/dedup.rs
@@ -45,7 +45,7 @@ impl RxCtrState {
     /// The method will return `false` if the message is detected to be duplicate, and therefore,
     /// the RX state had not been updated.
     pub fn post_recv(&mut self, msg_ctr: u32, is_encrypted: bool) -> bool {
-        let idiff = (msg_ctr as i32) - (self.max_ctr as i32);
+        let idiff = (msg_ctr as i32).wrapping_sub(self.max_ctr as i32);
         let udiff = idiff.unsigned_abs();
 
         if msg_ctr == self.max_ctr {

--- a/rs-matter/src/transport/dedup.rs
+++ b/rs-matter/src/transport/dedup.rs
@@ -45,7 +45,7 @@ impl RxCtrState {
     /// The method will return `false` if the message is detected to be duplicate, and therefore,
     /// the RX state had not been updated.
     pub fn post_recv(&mut self, msg_ctr: u32, is_encrypted: bool) -> bool {
-        let idiff = (msg_ctr as i32).wrapping_sub(self.max_ctr as i32);
+        let idiff = msg_ctr.wrapping_sub(self.max_ctr) as i32;
         let udiff = idiff.unsigned_abs();
 
         if msg_ctr == self.max_ctr {


### PR DESCRIPTION
Please cnsider this small AI generated fix that has solved my problem with commissioning. Thanks.

# Fix: Wrapping Subtraction in Message Counter Dedup

## Problem

`RxCtrState::post_recv` in `src/transport/dedup.rs` computed the signed difference
between two message counters using plain `as i32` casts followed by subtraction:

```rust
let idiff = (msg_ctr as i32) - (self.max_ctr as i32);
```

Matter message counters are `u32` values initialised to a random number. When
`max_ctr` is larger than `i32::MAX` (2 147 483 647), casting it to `i32` produces
a negative value. Subtracting that negative from a small positive `msg_ctr` can
exceed `i32::MAX`, which causes a panic in Rust debug builds
(`attempt to subtract with overflow`).

In practice this was triggered during CASE (Sigma) session establishment right
after a successful commissioning sequence (ArmFailSafe ? CSR ? AddTrustedRootCert
? AddNOC), because the new operational session started with a fresh random counter
that happened to land in the problematic range relative to the stored `max_ctr`.

## Fix

Changed the subtraction to use `wrapping_sub`, which matches the intended modular
counter arithmetic and is safe for all `u32` input values:

```rust
let idiff = (msg_ctr as i32).wrapping_sub(self.max_ctr as i32);
```

This produces the correct signed distance between the two counters across the
entire `u32` range without panicking in debug mode or producing undefined behaviour
in release mode.
