### PR TITLE
Comment why tag compression is not implemented; remove all Matter Core Spec sections' references

### DIFF
--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -462,7 +462,7 @@ pub struct AccessDesc<'a> {
     // TODO: Currently this is Access, but we need a way to represent the 'invoke' somehow too
     operation: Access,
     /// The device types of the endpoint hosting `path`. Used by ACL `Target`
-    /// entries that filter by `DeviceType` (Matter Core spec section 9.10.5.4).
+    /// entries that filter by `DeviceType` (Matter Core spec).
     /// Empty when the access target's endpoint is unknown / not yet expanded.
     device_types: &'a [DeviceType],
 }
@@ -669,7 +669,7 @@ impl AclEntry {
                         }
 
                         if matches!(auth_mode, AccessControlEntryAuthModeEnum::Group) {
-                            // Per Matter Core spec section 9.10.5.1: for Group auth mode, the
+                            // Per Matter Core spec: for Group auth mode, the
                             // subject SHALL be a valid 16-bit Group ID. Group ID 0 is reserved
                             // and MUST NOT be used; values larger than `u16::MAX` are also invalid.
                             if subject == 0 || subject > u16::MAX as u64 {
@@ -698,7 +698,7 @@ impl AclEntry {
 
                         let target = target?;
 
-                        // Matter Core spec section 9.10.5.4 (AccessControlTargetStruct):
+                        // Matter Core spec (AccessControlTargetStruct):
                         // - At least one of cluster, endpoint or deviceType SHALL be present.
                         // - If endpoint is present, deviceType SHALL NOT be present (and vice
                         //   versa). cluster may be combined with either endpoint or deviceType.
@@ -873,7 +873,7 @@ impl AclEntry {
                     let cluster_match = t.cluster.is_none() || t.cluster == object.path.cluster;
                     // When `Target.device_type` is set, the access target's endpoint
                     // must declare a matching device type in its `DeviceTypeList`
-                    // (Matter Core spec section 9.10.5.4).
+                    // (Matter Core spec).
                     let device_type_match = match t.device_type {
                         Some(dt) => object
                             .device_types

--- a/rs-matter/src/attest.rs
+++ b/rs-matter/src/attest.rs
@@ -21,7 +21,7 @@
 //! during commissioning. It includes:
 //!
 //! - [`cd`]: Certification Declaration (CD) parsing, signature verification, and
-//!   content validation per Matter Spec Section 6.3.1.
+//!   content validation per Matter Spec.
 //! - [`cd_keys`]: Well-known CSA CD signing key trust store.
 
 pub mod cd;

--- a/rs-matter/src/attest/cd.rs
+++ b/rs-matter/src/attest/cd.rs
@@ -27,7 +27,7 @@
 //! - DER-encoded ECDSA signature to raw (r || s) conversion
 //! - CD TLV payload decoding into [`CertificationElements`]
 //! - Signature verification using the [`Crypto`] trait
-//! - CD content validation against device identity (Matter Spec 6.3.1)
+//! - CD content validation against device identity (Matter Spec)
 //!
 //! Reference: connectedhomeip `src/credentials/CertificationDeclaration.cpp`
 
@@ -310,7 +310,7 @@ impl<'a> CmsSignedData<'a> {
     /// Parse a CMS SignedData message, extracting the signer key ID,
     /// encapsulated CD content, and ECDSA signature (converted from DER to raw).
     ///
-    /// Expects the profiled CMS structure used by Matter CDs (Matter Spec 6.3.1):
+    /// Expects the profiled CMS structure used by Matter CDs (Matter Spec):
     /// https://www.rfc-editor.org/rfc/rfc5652#section-5.2
     /// ```text
     /// ContentInfo ::= SEQUENCE {
@@ -365,7 +365,7 @@ impl<'a> CmsSignedData<'a> {
     }
 }
 
-/// Matter TLV context tags for CD elements (Matter Spec 6.3.1)
+/// Matter TLV context tags for CD elements (Matter Spec)
 const CD_TAG_FORMAT_VERSION: u8 = 0;
 const CD_TAG_VENDOR_ID: u8 = 1;
 const CD_TAG_PRODUCT_ID_ARRAY: u8 = 2;
@@ -388,7 +388,7 @@ pub const CERTIFICATE_ID_LEN: usize = 19;
 /// Maximum number of authorized PAA entries in a CD
 pub const MAX_AUTHORIZED_PAA_LIST: usize = 10;
 
-/// Certification type (Matter Spec 6.3.1.)
+/// Certification type (Matter Spec.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
@@ -413,7 +413,7 @@ impl CertificationType {
     }
 }
 
-/// Decoded Certification Declaration payload (Matter Spec 6.3.1.)
+/// Decoded Certification Declaration payload (Matter Spec.)
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CertificationElements {
@@ -653,7 +653,7 @@ impl CertificationElements {
 
     /// Validate CD content against device identity.
     ///
-    /// Implements the CD validation rules (Matter Spec Section 6.3.1).
+    /// Implements the CD validation rules (Matter Spec).
     ///
     /// # Validation rules
     ///

--- a/rs-matter/src/attest/trust_store.rs
+++ b/rs-matter/src/attest/trust_store.rs
@@ -31,13 +31,13 @@ use crate::crypto::{CanonPkcPublicKeyRef, Crypto, CryptoSensitive, Digest, SHA1_
 use crate::error::{Error, ErrorCode};
 
 /// Matter certificate key identifier (SKID/AKID): 20-byte SHA-1 hash of the public key.
-/// Matter spec Section 6.1.2 mandates 20 octets, per RFC 5280 method (1).
+/// Matter spec mandates 20 octets, per RFC 5280 method (1).
 // TODO: This does not belong here
 pub type KeyId = [u8; 20];
 
 /// Compute the Subject Key Identifier (SHA-1 hash of public key, 20 bytes).
 ///
-/// Per RFC 5280 section 4.2.1.2 and the Matter spec 6.5.11.(4-5),
+/// Per RFC 5280 section 4.2.1.2 and the Matter spec,
 /// the key identifier is the 160-bit SHA-1 hash of the public key.
 // TODO: This does not belong here
 pub fn compute_key_id<C: Crypto>(

--- a/rs-matter/src/cert.rs
+++ b/rs-matter/src/cert.rs
@@ -37,9 +37,9 @@ pub mod gen;
 mod printer;
 pub mod x509;
 
-/// As per section 6.1.3 "Certificate Sizes" of the Matter 1.1 spec
+/// As per "Certificate Sizes" of the Matter spec
 pub const MAX_CERT_TLV_LEN: usize = 400;
-/// As per section 6.1.3 "Certificate Sizes" of the Matter 1.1 spec, DER formatted DAC and NOC
+/// As per "Certificate Sizes" of the Matter spec, DER formatted DAC and NOC
 /// chains must not be longer than this size
 pub const MAX_CERT_ASN1_LEN: usize = 600;
 /// Must be large enough to hold both TLV encoding and intermediate ASN.1 encoding during building
@@ -209,7 +209,7 @@ impl<'a> Extension<'a> {
                 Self::encode_extension_end(w)?;
             }
             Extension::FutureExtensions(t) => {
-                // Per Matter Spec 6.5.11.5, the `future-extensions` TLV field
+                // Per Matter Spec, the `future-extensions` TLV field
                 // carries one or more ASN.1 DER-encoded X.509 `Extension`
                 // structures verbatim. They MUST be reproduced byte-for-byte
                 // inside the TBS extensions SEQUENCE so that the
@@ -664,7 +664,7 @@ impl<'a> CertRef<'a> {
     /// Subject CA-ID — the `RootCaId` of an RCAC or the `IcaId` of an
     /// ICAC. Matter-issued RCACs always carry exactly one `RootCaId`
     /// in their subject DN; ICACs always carry exactly one `IcaId`
-    /// (spec §6.5). Returns the first matching value; errors out if
+    /// (spec). Returns the first matching value; errors out if
     /// neither tag is present.
     pub fn get_ca_id(&self) -> Result<u64, Error> {
         let dn = self
@@ -709,7 +709,7 @@ impl<'a> CertRef<'a> {
 
     /// Whether this certificate is self-signed (its `AuthorityKeyId` matches
     /// its `SubjectKeyId`). Matter-issued RCACs are always self-signed; an
-    /// ICAC or NOC must not be (Matter Core spec section 6.5).
+    /// ICAC or NOC must not be (Matter Core spec).
     pub fn is_self_signed(&self) -> Result<bool, Error> {
         self.is_authority(self)
     }
@@ -726,7 +726,7 @@ impl<'a> CertRef<'a> {
     /// [`CertVerifier::add_cert`], and the self-signed root via
     /// [`CertVerifier::finalise`]) is checked against `lkg_utc_secs`
     /// for its `NotBefore` / `NotAfter` validity window, per Matter
-    /// Core spec §3.5.6 which mandates use of the Last-Known-Good UTC
+    /// Core spec which mandates use of the Last-Known-Good UTC
     /// Time when no live trusted real-time-clock value is available.
     /// Callers snapshot the value from
     /// [`crate::Matter::last_known_utc_time`] (Matter-epoch seconds).
@@ -850,9 +850,8 @@ impl<'a, C: Crypto> CertVerifier<'a, C> {
         }
 
         // Validity-period check against the Last-Known-Good UTC Time
-        // (Matter Core spec §3.5.6). `NotBefore` / `NotAfter` are u32
-        // Matter-epoch seconds; `NotAfter = 0` means unconstrained per
-        // §6.5.5.
+        // (Matter Core spec). `NotBefore` / `NotAfter` are u32
+        // Matter-epoch seconds; `NotAfter = 0` means unconstrained.
         let not_before = self.cert.not_before()? as u64;
         let not_after = self.cert.not_after()?;
 

--- a/rs-matter/src/cert/gen.rs
+++ b/rs-matter/src/cert/gen.rs
@@ -151,7 +151,7 @@ impl<'a> CertGenerator<'a> {
         )?;
 
         // Convert TBS to ASN1 format for signing
-        // According to the Matter Spec 6.5.2. "Matter certificate", the signature is over the
+        // According to the Matter Spec. "Matter certificate", the signature is over the
         // "corresponding X.509 certificate, not a signature of the preceding Matter TLV data."
         let (tlv_buf, asn1_buf) = self.buf.split_at_mut(tbs_len);
         let tbs_cert_ref = CertRef::new(TLVElement::new(tlv_buf));

--- a/rs-matter/src/cert/x509/cert.rs
+++ b/rs-matter/src/cert/x509/cert.rs
@@ -208,7 +208,7 @@ impl<'a> ParsedExtensionFields<'a> {
                 // the certificate if it encounters a critical extension it does not recognize
                 // or a critical extension that contains information that it cannot process.
                 //
-                // Matter spec section 6.2.2 allows other non-critical extensions from RFC 5280 that don't
+                // Matter spec allows other non-critical extensions from RFC 5280 that don't
                 // violate size limitations, but all unrecognized critical extensions must be rejected.
                 if critical {
                     return Err(der::ErrorKind::Failed.into());
@@ -228,7 +228,7 @@ impl<'a> ParsedExtensionFields<'a> {
 
 /// Trait for certificate types (DAC, PAI, PAA).
 ///
-/// Each certificate type has different requirements (Matter Spec 6.2).
+/// Each certificate type has different requirements (Matter Spec).
 /// Implementations must:
 /// - Parse extensions from DER-encoded data
 /// - Validate requirements during parsing (fail if invalid)
@@ -257,7 +257,7 @@ pub trait CertType<'a>: DecodeValue<'a> + der::FixedTag + der::EncodeValue {
 
 /// DAC (Device Attestation Certificate) Extensions
 ///
-/// A DAC SHALL have (Matter Spec 6.2.2.3):
+/// A DAC SHALL have (Matter Spec):
 /// - Basic Constraints: critical=TRUE, cA=FALSE
 /// - Key Usage: critical=TRUE, only digitalSignature bit set
 /// - Authority Key Identifier: present
@@ -350,7 +350,7 @@ impl<'a> CertType<'a> for DacExtensions<'a> {
         _issuer_raw: &[u8],
         _subject_raw: &[u8],
     ) -> der::Result<()> {
-        // DAC requirements (Matter Spec 6.2.2.3):
+        // DAC requirements (Matter Spec):
         // Issuer:
         // - SHALL have exactly one VendorID value present
         // - SHALL have exactly zero or one ProductID value present
@@ -383,7 +383,7 @@ impl<'a> CertType<'a> for DacExtensions<'a> {
 
 /// PAI (Product Attestation Intermediate) Certificate Extensions
 ///
-/// A PAI SHALL have (Matter Spec 6.2.2.4):
+/// A PAI SHALL have (Matter Spec):
 /// - Basic Constraints: critical=TRUE, cA=TRUE, pathLen=0
 /// - Key Usage: critical=TRUE, keyCertSign and cRLSign bits set, digitalSignature MAY be set
 /// - Authority Key Identifier: present
@@ -477,7 +477,7 @@ impl<'a> CertType<'a> for PaiExtensions<'a> {
         _issuer_raw: &[u8],
         _subject_raw: &[u8],
     ) -> der::Result<()> {
-        // PAI requirements (Matter Spec 6.2.2.4):
+        // PAI requirements (Matter Spec):
         // Issuer:
         // - SHALL have exactly zero or one VendorID value present
         // (VendorID is optional in issuer)
@@ -501,7 +501,7 @@ impl<'a> CertType<'a> for PaiExtensions<'a> {
 
 /// PAA (Product Attestation Authority) Certificate Extensions
 ///
-/// A PAA SHALL have (Matter Spec 6.2.2.4):
+/// A PAA SHALL have (Matter Spec):
 /// - Basic Constraints: critical=TRUE, cA=TRUE, pathLen MAY be present and if so must be 1
 /// - Key Usage: critical=TRUE, keyCertSign and cRLSign bits set, digitalSignature MAY be set
 /// - Subject Key Identifier: present
@@ -600,7 +600,7 @@ impl<'a> CertType<'a> for PaaExtensions<'a> {
         issuer_raw: &[u8],
         subject_raw: &[u8],
     ) -> der::Result<()> {
-        // PAA requirements (Matter Spec 6.2.2.5):
+        // PAA requirements (Matter Spec):
         // Issuer:
         // - SHALL have exactly zero or one VendorID value present
         // Subject:

--- a/rs-matter/src/dm.rs
+++ b/rs-matter/src/dm.rs
@@ -171,7 +171,7 @@ where
     /// `BasicInformation` cluster's dataver via this `DataModel`'s
     /// [`AttrChangeNotifier`]).
     ///
-    /// Per Matter Core Spec §7.7.2 / §9.2.11, callers MUST invoke this
+    /// Per Matter Core Spec, callers MUST invoke this
     /// whenever the node's exposed fixed-quality surface changes —
     /// typically after a firmware update that adds or removes
     /// functionality, after an internal reconfiguration that changes
@@ -330,7 +330,7 @@ where
 
         // Honor the `fabricFiltered` flag on the originating Read request.
         // When set, fabric-sensitive events emitted on other fabrics are
-        // dropped before they reach the wire (Matter Core spec section 8.5.2).
+        // dropped before they reach the wire (Matter Core spec).
         let fabric_filtered = req.fabric_filtered().unwrap_or(true);
 
         let mut resp = ReportDataResponder::new(
@@ -360,7 +360,7 @@ where
 
     /// Per-spec validation of an `AttrPath` that may contain wildcards.
     ///
-    /// Per Matter spec section 8.9.2.3, when a path uses a wildcard cluster
+    /// Per Matter spec, when a path uses a wildcard cluster
     /// but specifies a concrete attribute id, that attribute id must be a
     /// global (system) attribute. Any other combination must be rejected with
     /// `INVALID_ACTION`.
@@ -456,7 +456,7 @@ where
                 return Self::send_status(exchange, IMStatusCode::InvalidAction).await;
             }
 
-            // Per Matter Core spec section 8.9.4: when an `InvokeRequestMessage`
+            // Per Matter Core spec: when an `InvokeRequestMessage`
             // carries multiple `CommandDataIB` entries, each MUST include a unique
             // `CommandRef` and the request paths SHALL be unique. `count` is bounded
             // by `max_paths_per_invoke` (typically a single-digit number), so the
@@ -659,7 +659,7 @@ where
 
                             // The session the subscription was accepted on was
                             // torn down (eviction, explicit close, peer-side
-                            // CASE re-handshake, ...). Per Matter spec §8.5.1
+                            // CASE re-handshake, ...). Per Matter spec
                             // subscriptions are scoped to the session they
                             // were established on, and the publisher can no
                             // longer route reports to the subscriber. Drop
@@ -825,7 +825,7 @@ where
 
         // Honor the `fabricFiltered` flag on the originating Subscribe request.
         // When set, fabric-sensitive events emitted on other fabrics are
-        // dropped before they reach the wire (Matter Core spec section 8.5.2).
+        // dropped before they reach the wire (Matter Core spec).
         let fabric_filtered = req.fabric_filtered().unwrap_or(true);
 
         let mut resp = ReportDataResponder::new(

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -204,7 +204,7 @@ impl ClusterHandler for AclHandler {
             match value {
                 ArrayAttributeWrite::Replace(list) => {
                     // Snapshot old entries so we can diff against the new list per index
-                    // (Matter Core spec section 9.10.7 mandates one event per entry change,
+                    // (Matter Core spec mandates one event per entry change,
                     // with `LatestValue` populated). `MAX_ACL_ENTRIES_PER_FABRIC` is small
                     // (default 4), so a stack-allocated snapshot is cheap.
                     let mut old_entries: heapless::Vec<AclEntry, MAX_ACL_ENTRIES_PER_FABRIC> =

--- a/rs-matter/src/dm/clusters/adm_comm.rs
+++ b/rs-matter/src/dm/clusters/adm_comm.rs
@@ -31,16 +31,16 @@ pub use crate::dm::clusters::decl::administrator_commissioning::*;
 use crate::transport::exchange::ExchangeId;
 use crate::transport::session::SessionMode;
 
-/// PAKE iteration count bounds (Matter Core spec section 11.18.6.1.4).
+/// PAKE iteration count bounds (Matter Core spec).
 const MIN_PBKDF_ITERATIONS: u32 = 1000;
 const MAX_PBKDF_ITERATIONS: u32 = 100_000;
 
-/// PAKE salt length bounds (Matter Core spec section 11.18.6.1.4 / 5.1.6.1).
+/// PAKE salt length bounds (Matter Core spec).
 const MIN_PAKE_SALT_LEN: usize = 16;
 const MAX_PAKE_SALT_LEN: usize = 32;
 
 /// SPAKE2+ verifier length: W0 (32) || L (65) = 97 octets
-/// (Matter Core spec section 3.10).
+/// (Matter Core spec).
 const PAKE_VERIFIER_LEN: usize = 97;
 
 /// Stash an `AdministratorCommissioning` cluster-specific status on the
@@ -170,7 +170,7 @@ impl ClusterHandler for AdminCommHandler {
 
         // Validate the PAKE parameters up front so we can surface
         // `PAKEParameterError` as the cluster-specific status (Matter Core
-        // spec section 11.18.6.1.4).
+        // spec).
         let iterations = request.iterations()?;
         if !(MIN_PBKDF_ITERATIONS..=MAX_PBKDF_ITERATIONS).contains(&iterations) {
             return Err(cluster_status_err(&ctx, StatusCode::PAKEParameterError));
@@ -256,7 +256,7 @@ impl ClusterHandler for AdminCommHandler {
         let notify_mdns = || ctx.exchange().matter().notify_mdns_changed();
         let notify_change = |_, _| ctx.notify_own_cluster_changed();
 
-        // Per Matter Core spec section 11.18.6.2 (and CHIP's
+        // Per Matter Core spec (and CHIP's
         // `AdministratorCommissioningLogic::RevokeCommissioning`), revoking
         // the commissioning window also:
         //
@@ -315,7 +315,7 @@ impl ClusterHandler for AdminCommHandler {
 
 /// Map errors returned by `Pase::open_*_comm_window` to
 /// `AdministratorCommissioning` cluster-specific status codes (Matter Core
-/// spec section 11.18.6). `Busy` is the only cluster status the open paths
+/// spec). `Busy` is the only cluster status the open paths
 /// surface today; other transport-level errors (e.g. invalid timeout) bubble
 /// up unchanged so the IM layer turns them into the generic `InvalidCommand`.
 fn map_open_window_err(ctx: &impl InvokeContext, err: Error) -> Error {

--- a/rs-matter/src/dm/clusters/app/cam_av_stream.rs
+++ b/rs-matter/src/dm/clusters/app/cam_av_stream.rs
@@ -403,8 +403,8 @@ where
     ///
     /// Panics if `features` advertises `AUDIO` but
     /// `config.mic_capabilities` is `None`. The `MicrophoneCapabilities`
-    /// attribute is mandatory whenever `AUDIO` is enabled (Matter 1.5
-    /// ) and must be supplied at construction.
+    /// attribute is mandatory whenever `AUDIO` is enabled (per Matter Spec)
+    /// and must be supplied at construction.
     pub const fn new(
         dataver: Dataver,
         endpoint_id: EndptId,

--- a/rs-matter/src/dm/clusters/app/cam_av_stream.rs
+++ b/rs-matter/src/dm/clusters/app/cam_av_stream.rs
@@ -404,7 +404,7 @@ where
     /// Panics if `features` advertises `AUDIO` but
     /// `config.mic_capabilities` is `None`. The `MicrophoneCapabilities`
     /// attribute is mandatory whenever `AUDIO` is enabled (Matter 1.5
-    /// §1.16) and must be supplied at construction.
+    /// ) and must be supplied at construction.
     pub const fn new(
         dataver: Dataver,
         endpoint_id: EndptId,

--- a/rs-matter/src/dm/clusters/app/level_control.rs
+++ b/rs-matter/src/dm/clusters/app/level_control.rs
@@ -57,7 +57,7 @@ pub enum OutOfBandMessage {
     Update(u8),
     /// Initiates a MoveToLevel command.
     /// This will change the state of the device if and when appropriate according to Matter logic.
-    /// See Matter Application Clusters specification section 1.6.7.1.
+    /// See Matter Application Clusters specification.
     MoveToLevel {
         with_on_off: bool,
         level: u8,
@@ -67,7 +67,7 @@ pub enum OutOfBandMessage {
     },
     /// Initiates a Move command.
     /// This will change the state of the device if and when appropriate according to Matter logic.
-    /// See Matter Application Clusters specification section 1.6.7.2.
+    /// See Matter Application Clusters specification.
     Move {
         with_on_off: bool,
         move_mode: MoveModeEnum,
@@ -77,7 +77,7 @@ pub enum OutOfBandMessage {
     },
     /// Initiates a Step command.
     /// This will change the state of the device if and when appropriate according to Matter logic.
-    /// See Matter Application Clusters specification section 1.6.7.3.
+    /// See Matter Application Clusters specification.
     Step {
         with_on_off: bool,
         step_mode: StepModeEnum,
@@ -335,7 +335,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
         }
 
         if H::CLUSTER.feature_map & level_control::Feature::LIGHTING.bits() != 0 {
-            // From section 1.6.4.2
+            // From the spec
             // A value of 0x00 SHALL NOT be used.
             // A value of 0x01 SHALL indicate the minimum level that can be attained on a device.
             // A value of 0xFE SHALL indicate the maximum level that can be attained on a device.
@@ -481,7 +481,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
     /// Checks if a command should proceed beyond the Options processing.
     /// Returns true if execution of the command should continue, false otherwise.
     //
-    // From section 1.6.6.9
+    // From the spec
     // Command execution SHALL NOT continue beyond the Options processing if all of these criteria are true:
     // - The command is one of the ‘without On/Off’ commands: Move, Move to Level, Step, or Stop.
     // - The On/Off cluster exists on the same endpoint as this cluster.
@@ -567,7 +567,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
         self.task_signal.signal(Task::OnOffStateChange { on });
     }
 
-    // From section 1.6.4.1.1
+    // From the spec
     // ## On
     // Temporarily store CurrentLevel.
     // Set CurrentLevel to the minimum level allowed for the device.
@@ -672,11 +672,11 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
 
     /// Updates the OnOff attribute of the coupled OnOff cluster based on the current level and command type.
     //
-    // From section 1.6.4.1.2
+    // From the spec
     // When the level is reduced to its minimum the OnOff attribute is automatically turned to FALSE,
     // and when the level is increased above its minimum the OnOff attribute is automatically turned to TRUE.
     fn update_coupled_on_off(&self, current_level: u8, with_on_off: bool) -> Result<(), Error> {
-        // From section 1.6.4.1.2.
+        // From the spec.
         // There are two sets of commands provided in the Level Control cluster. These are identical, except
         // that the first set (MoveToLevel, Move and Step commands) SHALL NOT affect the OnOff attribute,
         // whereas the second set ('with On/Off' variants) SHALL.
@@ -943,7 +943,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
         options_mask: OptionsBitmap,
         options_override: OptionsBitmap,
     ) -> Result<(), Error> {
-        // From Section 1.6.7.2.2
+        // From the spec
         //
         // If the Rate field is null, then the value of the
         // DefaultMoveRate attribute SHALL be used if that attribute is supported and its value is not null. If
@@ -1063,7 +1063,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
         options_mask: OptionsBitmap,
         options_override: OptionsBitmap,
     ) -> Result<(), Error> {
-        // From section 1.6.7.3.4
+        // From the spec
         //
         // if the StepSize field has a value of zero, the command has no effect and
         // a response SHALL be returned with the status code set to INVALID_COMMAND.
@@ -1085,7 +1085,7 @@ impl<'a, H: LevelControlHooks, OH: OnOffHooks> LevelControlHandler<'a, H, OH> {
             StepModeEnum::Down => current_level.saturating_sub(step_size).max(H::MIN_LEVEL),
         };
 
-        // From section 1.6.7.3.4. Effect on Receipt
+        // From the spec. Effect on Receipt
         // Increase/Decrease CurrentLevel by StepSize units, or until
         // it reaches the maximum/minimum level allowed for the
         // device if this reached in the process. In the latter

--- a/rs-matter/src/dm/clusters/app/on_off.rs
+++ b/rs-matter/src/dm/clusters/app/on_off.rs
@@ -336,7 +336,7 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
             );
         }
 
-        // LevelControl coupling logic defined in section 1.6.4.1.1
+        // LevelControl coupling logic defined in the spec
         if !level_control_initiated {
             if let Some(level_control_handler) = self.level_control_handler.lock(|h| h.get()) {
                 level_control_handler.coupled_on_off_cluster_on_off_state_change(true);
@@ -387,7 +387,7 @@ impl<'a, H: OnOffHooks, LH: LevelControlHooks> OnOffHandler<'a, H, LH> {
 
         let on_time_updated = Self::update_attr_off(state);
 
-        // LevelControl coupling logic defined in section 1.6.4.1.1
+        // LevelControl coupling logic defined in the spec
         let level_control_handler = self.level_control_handler.lock(|h| h.get());
         if let Some(level_control_handler) = level_control_handler {
             if !level_control_initiated {
@@ -1146,7 +1146,7 @@ pub mod test {
     }
 
     impl OnOffHooks for TestOnOffDeviceLogic {
-        // The On/Off Light device type (Matter Device Library §4.1.5) requires
+        // The On/Off Light device type (Matter Device Library) requires
         // the `LT` (Lighting) feature on the OnOff cluster, which gates the
         // `GlobalSceneControl`/`OnTime`/`OffWaitTime`/`StartUpOnOff` attributes
         // and the `OffWithEffect`/`OnWithRecallGlobalScene`/`OnWithTimedOff`

--- a/rs-matter/src/dm/clusters/app/webrtc_prov.rs
+++ b/rs-matter/src/dm/clusters/app/webrtc_prov.rs
@@ -281,8 +281,8 @@ pub trait WebRtcHooks {
     /// `WebRTCTransportRequestor::Offer`) or `deferred = true` (Offer
     /// pushed when the media source becomes ready).
     ///
-    /// `SolicitOfferResponse` itself does NOT carry an SDP — see Matter 1.5
-    ///  — so this hook never returns Offer bytes inline.
+    /// `SolicitOfferResponse` itself does NOT carry an SDP — see Matter Spec -
+    /// so this hook never returns Offer bytes inline.
     async fn on_solicit_offer(
         &self,
         session_id: u16,

--- a/rs-matter/src/dm/clusters/app/webrtc_prov.rs
+++ b/rs-matter/src/dm/clusters/app/webrtc_prov.rs
@@ -282,7 +282,7 @@ pub trait WebRtcHooks {
     /// pushed when the media source becomes ready).
     ///
     /// `SolicitOfferResponse` itself does NOT carry an SDP — see Matter 1.5
-    /// §1.16 — so this hook never returns Offer bytes inline.
+    ///  — so this hook never returns Offer bytes inline.
     async fn on_solicit_offer(
         &self,
         session_id: u16,

--- a/rs-matter/src/dm/clusters/basic_info.rs
+++ b/rs-matter/src/dm/clusters/basic_info.rs
@@ -79,7 +79,7 @@ bitflags! {
         /// for use by a Device that does not have knowledge of the user's language preference.
         const CUSTOM_INSTRUCTION = 0x0000_0010;
         /// The Device Manual provides special instructions to put the Device
-        /// into Commissioning Mode (see Section 11.23.5.8, "UserManualUrl" in the Core Spec).
+        /// into Commissioning Mode (see "UserManualUrl" in the Core Spec).
         /// This is a catchall option to capture user interactions that are not codified by
         /// other options in this flags type.
         const DEVICE_MANUAL = 0x0000_0020;
@@ -209,7 +209,7 @@ pub struct BasicInfoConfig<'a> {
     /// Whether the device supports TCP transport.
     ///
     /// Not a real attribute; advertised via the `T` TXT record key in mDNS.
-    /// Per the Matter Core Spec Section 4.3.1.14, `T` is a bitmap: bit 2 (value 4)
+    /// Per the Matter Core Spec, `T` is a bitmap: bit 2 (value 4)
     /// indicates TCP server support. Required for large payloads such as WebRTC SDP
     /// exchanges and camera snapshots.
     pub tcp_supported: bool,
@@ -317,11 +317,11 @@ pub struct BasicInfoSettings {
     pub location_type: RegulatoryLocationTypeEnum,
     pub local_config_disabled: bool,
     /// `BasicInformation::ConfigurationVersion` (Matter Core Spec
-    /// §11.1.5.24). Non-volatile, monotonically increasing, minimum 1.
+    /// ). Non-volatile, monotonically increasing, minimum 1.
     /// Bumped by application code via
     /// `DataModel::bump_configuration_version` whenever the node's
     /// fixed-quality surface (Server/Parts list, device types, software
-    /// version, …) changes — see Matter Core Spec §7.7.2 and §9.2.11.
+    /// version, …) changes — see Matter Core Spec.
     pub configuration_version: u32,
 }
 
@@ -334,7 +334,7 @@ impl BasicInfoSettings {
             location_type: RegulatoryLocationTypeEnum::IndoorOutdoor,
             local_config_disabled: false,
             // Spec fallback for `ConfigurationVersion` is 1 (`min 1`,
-            // Core Spec §11.1.5).
+            // Core Spec).
             configuration_version: 1,
         }
     }

--- a/rs-matter/src/dm/clusters/basic_info.rs
+++ b/rs-matter/src/dm/clusters/basic_info.rs
@@ -316,8 +316,8 @@ pub struct BasicInfoSettings {
     pub location: Option<heapless::String<2>>, // Max location as per the spec
     pub location_type: RegulatoryLocationTypeEnum,
     pub local_config_disabled: bool,
-    /// `BasicInformation::ConfigurationVersion` (Matter Core Spec
-    /// ). Non-volatile, monotonically increasing, minimum 1.
+    /// `BasicInformation::ConfigurationVersion` (Matter Core Spec).
+    /// Non-volatile, monotonically increasing, minimum 1.
     /// Bumped by application code via
     /// `DataModel::bump_configuration_version` whenever the node's
     /// fixed-quality surface (Server/Parts list, device types, software

--- a/rs-matter/src/dm/clusters/binding.rs
+++ b/rs-matter/src/dm/clusters/binding.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-//! Binding cluster handler (Matter Core spec §9.6).
+//! Binding cluster handler (Matter Core spec).
 //!
 //! Per-endpoint, fabric-scoped, **persistent** list of `TargetStruct`
 //! entries each describing a unicast `(node, endpoint, cluster?)` or
@@ -31,8 +31,8 @@
 //!
 //! # Persistence
 //!
-//! Spec §9.6.6.1 marks the `Binding` attribute with the `N` quality
-//! bit (Non-Volatile, Matter Core §7.13.2) — values **SHALL** survive
+//! Spec marks the `Binding` attribute with the `N` quality
+//! bit (Non-Volatile, Matter Core) — values **SHALL** survive
 //! reboots. We re-serialise the whole registry under [`BINDINGS_KEY`]
 //! after every successful write, and re-hydrate on startup via
 //! [`Bindings::load_persist`].
@@ -47,7 +47,7 @@
 //!
 //! # Validation
 //!
-//! Per spec §9.6.5.1:
+//! Per spec:
 //! - `Group` and `Endpoint` are mutually exclusive (one of the two
 //!   identifies the target).
 //! - `Node` is required when `Endpoint` is present.
@@ -102,7 +102,7 @@ struct StoredBinding {
 /// fabric. Persisted as a single TLV blob under [`BINDINGS_KEY`].
 ///
 /// `N` bounds the total number of entries the device can hold. Per
-/// Matter Core spec §9.6.1, device-type definitions may prescribe a
+/// Matter Core spec, device-type definitions may prescribe a
 /// minimum-per-fabric; the spec also says the total must be
 /// `min_per_fabric × supported_fabrics` — pick `N` accordingly.
 pub struct Bindings<const N: usize> {
@@ -156,7 +156,7 @@ impl<const N: usize> Bindings<N> {
         persist.run()
     }
 
-    /// Validate a `TargetStruct` against spec §9.6.5.1 and return a
+    /// Validate a `TargetStruct` against spec and return a
     /// fully-built `StoredBinding`. `endpoint_id` and `fab_idx` come
     /// from the dispatch context (they are not on the wire entry for
     /// this attribute write — the framework auto-injects fab_idx).
@@ -170,7 +170,7 @@ impl<const N: usize> Bindings<N> {
         let endpoint = t.endpoint()?;
         let cluster = t.cluster()?;
 
-        // Spec §9.6.5.1 — the conformance columns say Group is
+        // Spec — the conformance columns say Group is
         // `!Endpoint` and Endpoint is `!Group`, so **exactly one** of
         // them must identify the target. Node's conformance is
         // `Endpoint`, i.e. Node is mandatory whenever Endpoint is

--- a/rs-matter/src/dm/clusters/fixed_label.rs
+++ b/rs-matter/src/dm/clusters/fixed_label.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-//! FixedLabel cluster handler (Matter Application Cluster spec §9.8).
+//! FixedLabel cluster handler (Matter Application Cluster spec).
 //!
 //! Per-endpoint **read-only** list of `(label, value)` string pairs
 //! that the manufacturer bakes into the device firmware — typical use
@@ -24,7 +24,7 @@
 //! writable counterpart used by commissioners.
 //!
 //! The list is **fixed** in the F-quality sense (Matter Core spec
-//! §7.13.2): it never changes for the lifetime of the device firmware,
+//! ): it never changes for the lifetime of the device firmware,
 //! so we don't need a persistence layer, a mutex, or any per-entry
 //! storage. [`FixedLabelHandler`] just borrows a static slice of
 //! [`FixedLabelEntry`] from the application and iterates it on read.
@@ -63,7 +63,7 @@ pub const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
 
 /// One entry in a `LabelList`.
 ///
-/// Per Matter Application Cluster spec §9.6.4 (`LabelStruct`), each
+/// Per Matter Application Cluster spec (`LabelStruct`), each
 /// field is at most 16 characters. We don't enforce this here — the
 /// application is responsible for supplying spec-compliant data, and
 /// `TC_FLABEL_2_1` step 2 sanity-checks the lengths on the read path.
@@ -77,7 +77,7 @@ pub struct FixedLabelEntry<'a> {
 ///
 /// Per-endpoint instance: each endpoint that advertises FixedLabel
 /// must own its own handler so the per-cluster-instance `Dataver`
-/// stays granular (Matter Core spec §7.13.2.1). The entries slice is
+/// stays granular (Matter Core spec). The entries slice is
 /// borrowed — typically a `&'static [FixedLabelEntry<'static>]` —
 /// because the list is part of the device's firmware identity and
 /// doesn't change at runtime.

--- a/rs-matter/src/dm/clusters/fixed_label.rs
+++ b/rs-matter/src/dm/clusters/fixed_label.rs
@@ -23,8 +23,8 @@
 //! `"hwrev"` → `"B"`. Compare with [`super::user_label`], the
 //! writable counterpart used by commissioners.
 //!
-//! The list is **fixed** in the F-quality sense (Matter Core spec
-//! ): it never changes for the lifetime of the device firmware,
+//! The list is **fixed** in the F-quality sense (Matter Core spec):
+//! it never changes for the lifetime of the device firmware,
 //! so we don't need a persistence layer, a mutex, or any per-entry
 //! storage. [`FixedLabelHandler`] just borrows a static slice of
 //! [`FixedLabelEntry`] from the application and iterates it on read.

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -171,7 +171,7 @@ impl<'a> GenCommHandler<'a> {
 
     /// Return whether the supplied `NewRegulatoryConfig` value is allowed
     /// given the device's `LocationCapability`. Mirrors the matrix in Matter
-    /// Core spec section 11.10.7.2.1.
+    /// Core spec.
     fn is_regulatory_config_supported(
         policy: &dyn CommPolicy,
         new_config: RegulatoryLocationTypeEnum,
@@ -286,7 +286,7 @@ impl ClusterHandler for GenCommHandler<'_> {
         );
 
         // `ArmFailSafe(0)` means "force-expire the fail-safe context" per
-        // Matter Core spec section 11.10.7.1: if the fail-safe is armed,
+        // Matter Core spec: if the fail-safe is armed,
         // the device SHALL roll back any uncommitted fabric / network state
         // and reset the breadcrumb. Route through `force_expiry` so that
         // in-flight `AddNOC` / `SetRegulatoryConfig` changes are reverted —
@@ -345,7 +345,7 @@ impl ClusterHandler for GenCommHandler<'_> {
             return Err(ErrorCode::ConstraintError.into());
         }
 
-        // Per Matter Core spec section 11.10.7.2.1, `NewRegulatoryConfig`
+        // Per Matter Core spec, `NewRegulatoryConfig`
         // SHALL be one of the values supported by the device's
         // `LocationCapability`:
         //
@@ -407,7 +407,7 @@ impl ClusterHandler for GenCommHandler<'_> {
         let status =
             CommissioningErrorEnum::map(Self::with_armed_failsafe(&ctx, |state, notify_mdns| {
                 let sess = ctx.exchange().id().session(&mut state.sessions);
-                // Spec V1.3 §5.5 / V1.4 §11.10.7.4: on
+                // Spec: on
                 // `CommissioningComplete` the PASE session SHALL be
                 // terminated. The current command is being delivered over
                 // that PASE, so mark it `expired` (response can still go

--- a/rs-matter/src/dm/clusters/gen_diag.rs
+++ b/rs-matter/src/dm/clusters/gen_diag.rs
@@ -293,7 +293,7 @@ impl ClusterHandler for GenDiagHandler<'_> {
         // to `GenDiag::uptime_ms`.
         let system_time_ms = self.diag.uptime_ms()?;
 
-        // `PosixTimeMs` (Matter Core spec §11.12.7.3): SHALL be null only
+        // `PosixTimeMs` (Matter Core spec): SHALL be null only
         // when the device doesn't support the TimeSynchronization cluster
         // (we do) or when its `UTCTime` attribute is null. We read the
         // Matter-wide current UTC time directly from `Matter::utc_time`

--- a/rs-matter/src/dm/clusters/grp_key_mgmt.rs
+++ b/rs-matter/src/dm/clusters/grp_key_mgmt.rs
@@ -426,7 +426,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
             let fabric = state.fabrics.fabric(fab_idx)?;
 
             // KeySet ID 0 is the IPK (Identity Protection Key); per Matter
-            // Core spec section 11.2.7.5 it is always present once the
+            // Core spec it is always present once the
             // fabric has been added (`AddNOC`) and is reported here with
             // its epoch keys redacted to null. The IPK isn't kept in the
             // generic `key_sets` list — it lives on the fabric directly.

--- a/rs-matter/src/dm/clusters/identify.rs
+++ b/rs-matter/src/dm/clusters/identify.rs
@@ -99,8 +99,7 @@ pub enum IdentifyAction {
 /// state via attribute subscriptions instead.
 pub trait IdentifyHooks {
     /// Return the kind of identification mechanism this endpoint provides.
-    /// Reported as the `IdentifyType` attribute (per App Cluster spec
-    /// ).
+    /// Reported as the `IdentifyType` attribute (per App Cluster spec).
     fn identify_type(&self) -> IdentifyTypeEnum;
 
     /// Drive the application's identify hardware in response to a state

--- a/rs-matter/src/dm/clusters/identify.rs
+++ b/rs-matter/src/dm/clusters/identify.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-//! Identify cluster handler (Matter Application Cluster spec §1.2).
+//! Identify cluster handler (Matter Application Cluster spec).
 //!
 //! The Identify cluster lets a controller put an endpoint into an
 //! identification state — typically blinking an LED, beeping, or playing a
@@ -23,7 +23,7 @@
 //! just commissioned among several visually-identical ones. It is a
 //! mandatory cluster on most application device types (e.g. On/Off Light,
 //! Dimmable Light, Color Temperature Light), see Matter Device Library
-//! §4.1.4 for the On/Off Light requirements.
+//!  for the On/Off Light requirements.
 //!
 //! [`IdentifyHandler`] is generic over an [`IdentifyHooks`] hardware-hook
 //! trait. The library handler owns all the boring bookkeeping —
@@ -100,7 +100,7 @@ pub enum IdentifyAction {
 pub trait IdentifyHooks {
     /// Return the kind of identification mechanism this endpoint provides.
     /// Reported as the `IdentifyType` attribute (per App Cluster spec
-    /// §1.2.5.2).
+    /// ).
     fn identify_type(&self) -> IdentifyTypeEnum;
 
     /// Drive the application's identify hardware in response to a state
@@ -164,7 +164,7 @@ struct Session {
 /// `IdentifyTime` write) arrives, and computes the *remaining* seconds
 /// on-demand whenever the framework reads the attribute. This is
 /// observably equivalent to a physical countdown per Matter App Cluster
-/// spec §1.2.5.1 (which constrains the attribute's observable value, not
+/// spec (which constrains the attribute's observable value, not
 /// the implementation's internal storage), but it avoids 60 wakeups for
 /// a 60-second identify — the [run task](Handler::run) only schedules a
 /// single `Timer::at(deadline)` per identify cycle, fires the final-zero
@@ -321,7 +321,7 @@ where
         let time = request.identify_time()?;
         self.set_identify_time_internal(ctx.cmd().endpoint_id, time);
         // The Identify command mutates an attribute that lives on the
-        // *same* cluster as the command (App Cluster §1.2.6.1), so use the
+        // *same* cluster as the command (App Cluster), so use the
         // `OwnAttrChangeNotifier` shortcut to notify against
         // `(ctx.cmd().endpoint_id, ctx.cmd().cluster_id, IdentifyTime)`.
         ctx.notify_own_attr_changed(AttributeId::IdentifyTime as _);
@@ -389,7 +389,7 @@ where
                     // reads of `IdentifyTime` return 0, dispatch the
                     // application-visible `Cancel` action, and notify
                     // subscribers of the final-zero transition (Q-quality
-                    // reportable per App Cluster spec §1.2.5.1). The
+                    // reportable per App Cluster spec). The
                     // framework auto-bumps the cluster dataver through
                     // the `bump_dataver` chain as a side effect.
                     self.session.lock(|cell| cell.set(None));

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -57,7 +57,7 @@ impl NodeOperationalCertStatusEnum {
                 ErrorCode::NocMissingCsr => Ok(Self::MissingCsr),
                 // Bare `ConstraintError` from `FailSafe::check_state`
                 // (e.g. "AddNOC received twice in the same fail-safe
-                // context", spec section 11.18.6.6) is reported as an
+                // context", spec) is reported as an
                 // IM-level status code per the spec, not as a
                 // `NodeOperationalCertStatusEnum` cluster status — let it
                 // propagate.
@@ -145,7 +145,7 @@ impl ClusterHandler for NocHandler {
             // the inner-loop checks that used to gate every entry on
             // `attr.fab_idx == fabric.fab_idx().get()` were therefore
             // hiding non-accessing fabrics from a deliberately
-            // non-fabric-filtered read. Per Matter Core spec §11.18.5.1
+            // non-fabric-filtered read. Per Matter Core spec
             // (NOCStruct, post-1.4.2) `noc` / `icac` are no longer
             // fabric-sensitive, so a non-fabric-filtered read MUST return
             // every fabric's NOC.
@@ -293,7 +293,7 @@ impl ClusterHandler for NocHandler {
     ) -> Result<P, Error> {
         info!("Got Attestation Request");
 
-        // Per Matter Core spec §11.18.6.3, the `AttestationNonce` field MUST
+        // Per Matter Core spec, the `AttestationNonce` field MUST
         // be exactly 32 octets. Anything else is rejected with
         // `INVALID_COMMAND`. TC_DA_1_2 steps 13/14 cover the >32 / <32 cases.
         const ATTESTATION_NONCE_LEN: usize = 32;
@@ -315,9 +315,9 @@ impl ClusterHandler for NocHandler {
             // writer.start_struct(&CmdDataWriter::TAG)?;
 
             // Attestation timestamp (`AttestationElements.timestamp`,
-            // Matter Core spec §11.18.5.5) — Matter-epoch seconds.
+            // Matter Core spec) — Matter-epoch seconds.
             // Sourced from the device's Last-Known-Good UTC Time
-            // (§3.5.6.1); on a freshly-flashed device with no
+            // ; on a freshly-flashed device with no
             // `SetUTCTime` yet, this is the firmware build timestamp.
             // Read directly from the already-held `state` — re-entering
             // `Matter::with_state` here would deadlock the inner mutex.
@@ -397,7 +397,7 @@ impl ClusterHandler for NocHandler {
     ) -> Result<P, Error> {
         info!("Got CSR Request");
 
-        // Per Matter Core spec §11.18.6.5, the `CSRNonce` field MUST be
+        // Per Matter Core spec, the `CSRNonce` field MUST be
         // exactly 32 octets — anything else is rejected with
         // `INVALID_COMMAND`. TC_DA_1_5 steps 11/12 cover the <32 / >32 cases.
         const CSR_NONCE_LEN: usize = 32;
@@ -411,7 +411,7 @@ impl ClusterHandler for NocHandler {
         GenCommHandler::with_armed_failsafe(&ctx, |state, _| {
             let sess = ctx.exchange().id().session(&mut state.sessions);
 
-            // Per Matter Core spec section 11.18.6.5 (`CSRRequest`),
+            // Per Matter Core spec (`CSRRequest`),
             // `isForUpdateNOC=true` is only valid over CASE — UpdateNOC
             // can never run over PASE. A CSRRequest of that flavour over
             // PASE is rejected with IM `INVALID_COMMAND` rather than
@@ -493,7 +493,7 @@ impl ClusterHandler for NocHandler {
         let mut added_fab_idx = None;
         // Captured inside the closure so we can emit `AccessControlEntryChanged`
         // for the auto-created admin ACL entry *after* the failsafe-armed
-        // closure unwinds successfully (Matter Core spec section 9.10.7).
+        // closure unwinds successfully (Matter Core spec).
         let mut admin_acl_entry: Option<AclEntry> = None;
 
         let buf = response.writer().available_space();
@@ -552,7 +552,7 @@ impl ClusterHandler for NocHandler {
 
         // Emit the `AccessControlEntryChanged` event for the auto-created admin
         // entry. AddNOC happens over PASE during commissioning, so per Matter
-        // Core spec 9.10.7 the event has `adminNodeID = null` and
+        // Core spec the event has `adminNodeID = null` and
         // `adminPasscodeID = 0`.
         if let (Some(fab_idx), Some(entry)) = (added_fab_idx, &admin_acl_entry) {
             emit_acl_entry_changed(
@@ -708,7 +708,7 @@ impl ClusterHandler for NocHandler {
 
                 persist.remove(fab_idx)?;
 
-                // Matter Core spec §11.17.8.7: if the removed fabric is the
+                // Matter Core spec: if the removed fabric is the
                 // one that installed the TrustedTimeSource, the device SHALL
                 // clear the attribute (and emit `MissingTrustedTimeSource`).
                 if state.rtc.trusted_time_source().map(|tts| tts.fab_idx) == Some(fab_idx) {
@@ -725,7 +725,7 @@ impl ClusterHandler for NocHandler {
                 // If the removed fabric was the one that opened the current
                 // commissioning window, `AdminFabricIndex` (and `AdminVendorId`)
                 // transition to null and subscribers must be notified — see
-                // Matter Core spec section 11.18.7.
+                // Matter Core spec.
                 let opener_fabric_removed = state
                     .pase
                     .comm_window()
@@ -796,14 +796,14 @@ impl ClusterHandler for NocHandler {
         let vvs = request.vid_verification_statement()?;
         let vvsc = request.vvsc()?;
 
-        // Spec section 11.18.6.15 (`SetVIDVerificationStatement`): at
+        // Spec (`SetVIDVerificationStatement`): at
         // least one field must be present, otherwise the command SHALL
         // be rejected with `INVALID_COMMAND`.
         if vendor_id.is_none() && vvs.is_none() && vvsc.is_none() {
             return Err(ErrorCode::InvalidCommand.into());
         }
 
-        // Per Matter Core spec section 6.2.1, valid VendorIDs are
+        // Per Matter Core spec, valid VendorIDs are
         // 0x0001..=0xFFF4. 0xFFF5..=0xFFFF are reserved or test/CSA
         // values not allowed for SetVIDVerificationStatement.
         if let Some(vid) = vendor_id {
@@ -839,7 +839,7 @@ impl ClusterHandler for NocHandler {
             let fabric = state.fabrics.fabric_mut(fab_idx)?;
 
             // A VVSC may only be present on a fabric whose chain has no
-            // ICAC (Matter Core spec section 6.5.7): the VVSC takes the
+            // ICAC (Matter Core spec): the VVSC takes the
             // ICAC's slot in the cert chain, the two are mutually
             // exclusive. Reject any non-empty VVSC against a fabric
             // that already carries an ICAC.
@@ -855,7 +855,7 @@ impl ClusterHandler for NocHandler {
                 vvsc.as_ref().map(|v| v.0),
             )?;
 
-            // Persist semantics (Matter Core spec section 11.18.6.15):
+            // Persist semantics (Matter Core spec):
             //   * If `AddNOC` / `UpdateNOC` was already received in this
             //     fail-safe context, the VID-verification state is part
             //     of the pending fabric mutation. Don't persist yet —
@@ -891,7 +891,7 @@ impl ClusterHandler for NocHandler {
     ) -> Result<P, Error> {
         info!("Got Sign VID Verification Request");
 
-        // Spec section 11.18.6.16: `FabricIndex` must be in [1..254];
+        // Spec: `FabricIndex` must be in [1..254];
         // 0 / 255 are constraint errors.
         let fab_idx_raw = request.fabric_index()?;
         let fab_idx = NonZeroU8::new(fab_idx_raw)
@@ -918,7 +918,7 @@ impl ClusterHandler for NocHandler {
                 .ok_or(ErrorCode::ConstraintError)?;
 
             // Build VendorFabricBindingMessage (Matter Core spec
-            // section 6.5.6.2):
+            // the spec):
             //   1B fabric_binding_version || 65B root_pub_key
             //   || 8B fabric_id BE || 2B vendor_id BE
             let root_ref = CertRef::new(TLVElement::new(fabric.root_ca()));
@@ -985,7 +985,7 @@ impl ClusterHandler for NocHandler {
     }
 }
 
-/// Matter Core spec section 6.5.6.2: `FabricBindingVersion` constant
+/// Matter Core spec: `FabricBindingVersion` constant
 /// for V1 of the `VendorFabricBindingMessage` and `VIDVerificationTBS`.
 const FABRIC_BINDING_VERSION_1: u8 = 1;
 

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -316,8 +316,8 @@ impl ClusterHandler for NocHandler {
 
             // Attestation timestamp (`AttestationElements.timestamp`,
             // Matter Core spec) — Matter-epoch seconds.
-            // Sourced from the device's Last-Known-Good UTC Time
-            // ; on a freshly-flashed device with no
+            // Sourced from the device's Last-Known-Good UTC Time;
+            // on a freshly-flashed device with no
             // `SetUTCTime` yet, this is the firmware build timestamp.
             // Read directly from the already-held `state` — re-entering
             // `Matter::with_state` here would deadlock the inner mutex.
@@ -917,8 +917,7 @@ impl ClusterHandler for NocHandler {
                 .get(fab_idx)
                 .ok_or(ErrorCode::ConstraintError)?;
 
-            // Build VendorFabricBindingMessage (Matter Core spec
-            // the spec):
+            // Build VendorFabricBindingMessage (Matter Core spec):
             //   1B fabric_binding_version || 65B root_pub_key
             //   || 8B fabric_id BE || 2B vendor_id BE
             let root_ref = CertRef::new(TLVElement::new(fabric.root_ca()));

--- a/rs-matter/src/dm/clusters/sw_diag.rs
+++ b/rs-matter/src/dm/clusters/sw_diag.rs
@@ -85,7 +85,7 @@ bitflags! {
     pub struct Options: u8 {
         /// Advertise the heap counters `CurrentHeapFree` and
         /// `CurrentHeapUsed`. Independently optional per Matter Core
-        /// spec §11.13.
+        /// spec.
         const HEAP = 0x1;
         /// Claim the Matter `WATERMARKS` feature — adds
         /// `CurrentHeapHighWatermark` + the `ResetWatermarks`

--- a/rs-matter/src/dm/clusters/time_sync.rs
+++ b/rs-matter/src/dm/clusters/time_sync.rs
@@ -123,7 +123,7 @@ impl UtcTime {
 }
 
 /// Last-Known-Good UTC Time tracking for the device (Matter Core spec
-/// §3.5.6.1).
+/// ).
 ///
 /// The persisted `utc_us` field is the spec-mandated stored
 /// fallback used by cert path validation when no live time
@@ -136,7 +136,7 @@ impl UtcTime {
 /// recent [`Matter::set_utc_time`] call. After reboot, `anchor` is
 /// `None` (no live current-time tracking is active), so the TimeSync
 /// cluster reports `UTCTime = Null`, `Granularity = NoTimeGranularity`
-/// and `TimeSource = None` (per §11.17.8.2 / §11.17.8.3) — while
+/// and `TimeSource = None` (per spec / ) — while
 /// `utc_us` still carries the persisted LKG value for cert validity.
 pub struct Rtc {
     /// Last-Known-Good UTC time, Matter-epoch microseconds.
@@ -144,8 +144,8 @@ pub struct Rtc {
     /// Same as `utc_us` except always equal to the last persisted value.
     utc_us_persisted: u64,
     /// Granularity at the time of the last `set_utc_time` call, with
-    /// §11.17.9.1's "one level lower than supplied" step-down already
-    /// applied and floored at `MinutesGranularity` (§11.17.8.2).
+    /// 's "one level lower than supplied" step-down already
+    /// applied and floored at `MinutesGranularity` .
     /// **Not persisted** — resets to `NoTimeGranularity` at boot,
     /// matching the `anchor = None` post-reboot state.
     granularity: GranularityEnum,
@@ -156,7 +156,7 @@ pub struct Rtc {
     /// Volatile — `None` after reboot until next set.
     anchor: Option<embassy_time::Instant>,
     /// Configured Trusted Time Source for the device (Matter Core spec
-    /// §11.17.8.7 / §11.17.9.7). At most one entry; the fabric that
+    /// ). At most one entry; the fabric that
     /// installed it owns it and is cleared on fabric removal.
     /// Persisted under [`crate::persist::TRUSTED_TIME_SOURCE_KEY`].
     trusted_time_source: Option<TrustedTimeSource>,
@@ -217,7 +217,7 @@ impl Rtc {
 
         // Load the persisted Last-Known-Good UTC Time, if any.
         // Floor at `FIRMWARE_BUILD_MATTER_US` per Matter Core spec
-        // §3.5.6.1 — the on-disk value must never regress us
+        //  — the on-disk value must never regress us
         // below the build timestamp (the documented lower bound
         // we never adjust backwards past).
         if let Some(data) = kv.load(LKG_UTC_KEY, buf)? {
@@ -237,13 +237,13 @@ impl Rtc {
     }
 
     /// Return the configured Trusted Time Source, or `None` if unset
-    /// (Matter Core spec §11.17.8.7).
+    /// (Matter Core spec).
     pub fn trusted_time_source(&self) -> Option<TrustedTimeSource> {
         self.trusted_time_source
     }
 
     /// Install or clear the Trusted Time Source (Matter Core spec
-    /// §11.17.9.7). `fab_idx` is the fabric performing the change —
+    /// ). `fab_idx` is the fabric performing the change —
     /// recorded so that fabric removal can clear an entry it owns.
     pub fn set_trusted_time_source<E: EventEmitter>(
         &mut self,
@@ -262,7 +262,7 @@ impl Rtc {
                 AttributeId::TrustedTimeSource as _,
             );
 
-            // Matter Core spec §11.17.10.1: emit `MissingTrustedTimeSource`
+            // Matter Core spec: emit `MissingTrustedTimeSource`
             // when SetTrustedTimeSource clears a previously-set entry (null
             // request payload, transitioning from `Some(..)` → `None`).
             if self.trusted_time_source.is_none() && previous.is_some() {
@@ -274,7 +274,7 @@ impl Rtc {
     }
 
     /// Install or clear the Trusted Time Source (Matter Core spec
-    /// §11.17.9.7). `fab_idx` is the fabric performing the change —
+    /// ). `fab_idx` is the fabric performing the change —
     /// recorded so that fabric removal can clear an entry it owns.
     /// `source = None` clears any existing entry.
     ///
@@ -323,7 +323,7 @@ impl Rtc {
     /// recent [`Self::set_utc_time`] (with the spec-required
     /// step-down and floor already applied) — or `NoTimeGranularity`
     /// if no `set_utc_time` has been called since boot (per
-    /// §11.17.8.2, which forbids `NoTimeGranularity` only while
+    /// , which forbids `NoTimeGranularity` only while
     /// `UTCTime ≠ Null`).
     pub fn utc_time_granularity(&self) -> GranularityEnum {
         if self.anchor.is_some() {
@@ -335,7 +335,7 @@ impl Rtc {
 
     /// Return the TimeSource reported on the wire for the TimeSync
     /// cluster's `TimeSource` attribute — `None` until the first
-    /// [`Self::set_utc_time`] (per §11.17.8.3).
+    /// [`Self::set_utc_time`] (per spec).
     pub fn utc_time_source(&self) -> TimeSourceEnum {
         if self.anchor.is_some() {
             self.source
@@ -345,12 +345,12 @@ impl Rtc {
     }
 
     /// Update the Last-Known-Good UTC Time (Matter Core spec
-    /// §3.5.6.1), capturing a fresh monotonic anchor so subsequent
+    /// ), capturing a fresh monotonic anchor so subsequent
     /// [`Self::utc_time`] reads advance from the supplied value.
     ///
-    /// Per §11.17.9.1: the supplied `granularity` is recorded
+    /// Per : the supplied `granularity` is recorded
     /// stepped-down by one level (with a floor of
-    /// `MinutesGranularity` per §11.17.8.2); the supplied `source`
+    /// `MinutesGranularity` per spec); the supplied `source`
     /// is recorded verbatim.
     ///
     /// The new value is written to the in-memory state immediately.
@@ -370,7 +370,7 @@ impl Rtc {
             GranularityEnum::MicrosecondsGranularity => GranularityEnum::MillisecondsGranularity,
             GranularityEnum::MillisecondsGranularity => GranularityEnum::SecondsGranularity,
             GranularityEnum::SecondsGranularity => GranularityEnum::MinutesGranularity,
-            // Minutes / NoTime → floor at Minutes (§11.17.8.2 forbids
+            // Minutes / NoTime → floor at Minutes ( forbids
             // NoTime while UTCTime is non-null).
             _ => GranularityEnum::MinutesGranularity,
         };
@@ -433,7 +433,7 @@ impl Rtc {
     }
 }
 
-/// Persisted Trusted Time Source descriptor (Matter Core spec §11.17.8.7).
+/// Persisted Trusted Time Source descriptor (Matter Core spec).
 /// Records which fabric configured the source so that fabric removal can
 /// clear it and emit `MissingTrustedTimeSource`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, FromTLV, ToTLV)]
@@ -783,9 +783,9 @@ const fn time_sync_cmds<const OPTS: u8>(cmd: &Command, _: u16, _: u32) -> bool {
     use CommandId as C;
 
     // `SetUTCTime` is mandatory whenever the cluster is present
-    // (Matter Core spec §11.17.9, conformance `M`), independent of
+    // (Matter Core spec, conformance `M`), independent of
     // features. Devices reporting `Granularity = NoTimeGranularity`
-    // are additionally required by §11.17.9.1 to accept it.
+    // are additionally required by  to accept it.
     if cmd.id == C::SetUTCTime as u32 {
         return true;
     }
@@ -915,7 +915,7 @@ impl ClusterHandler for TimeSyncHandler<'_> {
     // ---- Feature-gated reads
 
     // Served directly from the Matter-wide TrustedTimeSource state
-    // (Matter Core spec §11.17.8.7) — fabric-scoped storage lives on
+    // (Matter Core spec) — fabric-scoped storage lives on
     // `MatterState::rtc`, not on the user-supplied `TimeSync` provider.
     fn trusted_time_source<P: TLVBuilderParent>(
         &self,
@@ -1066,7 +1066,7 @@ impl ClusterHandler for TimeSyncHandler<'_> {
         ctx: impl InvokeContext,
         request: SetUTCTimeRequest<'_>,
     ) -> Result<(), Error> {
-        // Matter Core spec §11.17.9.1: regardless of the optional
+        // Matter Core spec: regardless of the optional
         // `TimeSource` field in the request, the device SHALL set
         // `TimeSource` to `Admin` when `SetUTCTime` populates UTCTime.
         let utc_us = request.utc_time()?;
@@ -1080,10 +1080,10 @@ impl ClusterHandler for TimeSyncHandler<'_> {
         Ok(())
     }
 
-    // Matter Core spec §11.17.9.7 — installs or clears the per-device
+    // Matter Core spec — installs or clears the per-device
     // Trusted Time Source. The fabric performing the change is
     // recorded so that fabric removal can clear an entry it owns
-    // (§11.17.8.7) and emit `MissingTrustedTimeSource` (§11.17.10.1).
+    // and emit `MissingTrustedTimeSource` .
     fn handle_set_trusted_time_source(
         &self,
         ctx: impl InvokeContext,

--- a/rs-matter/src/dm/clusters/time_sync.rs
+++ b/rs-matter/src/dm/clusters/time_sync.rs
@@ -122,8 +122,7 @@ impl UtcTime {
     }
 }
 
-/// Last-Known-Good UTC Time tracking for the device (Matter Core spec
-/// ).
+/// Last-Known-Good UTC Time tracking for the device (Matter Core spec).
 ///
 /// The persisted `utc_us` field is the spec-mandated stored
 /// fallback used by cert path validation when no live time
@@ -136,7 +135,7 @@ impl UtcTime {
 /// recent [`Matter::set_utc_time`] call. After reboot, `anchor` is
 /// `None` (no live current-time tracking is active), so the TimeSync
 /// cluster reports `UTCTime = Null`, `Granularity = NoTimeGranularity`
-/// and `TimeSource = None` (per spec / ) — while
+/// and `TimeSource = None` (per spec) — while
 /// `utc_us` still carries the persisted LKG value for cert validity.
 pub struct Rtc {
     /// Last-Known-Good UTC time, Matter-epoch microseconds.
@@ -144,7 +143,7 @@ pub struct Rtc {
     /// Same as `utc_us` except always equal to the last persisted value.
     utc_us_persisted: u64,
     /// Granularity at the time of the last `set_utc_time` call, with
-    /// 's "one level lower than supplied" step-down already
+    /// the "one level lower than supplied" step-down already
     /// applied and floored at `MinutesGranularity` .
     /// **Not persisted** — resets to `NoTimeGranularity` at boot,
     /// matching the `anchor = None` post-reboot state.
@@ -155,8 +154,8 @@ pub struct Rtc {
     /// `Instant::now()` captured at the last `set_utc_time` call.
     /// Volatile — `None` after reboot until next set.
     anchor: Option<embassy_time::Instant>,
-    /// Configured Trusted Time Source for the device (Matter Core spec
-    /// ). At most one entry; the fabric that
+    /// Configured Trusted Time Source for the device (Matter Core spec).
+    /// At most one entry; the fabric that
     /// installed it owns it and is cleared on fabric removal.
     /// Persisted under [`crate::persist::TRUSTED_TIME_SOURCE_KEY`].
     trusted_time_source: Option<TrustedTimeSource>,
@@ -242,8 +241,8 @@ impl Rtc {
         self.trusted_time_source
     }
 
-    /// Install or clear the Trusted Time Source (Matter Core spec
-    /// ). `fab_idx` is the fabric performing the change —
+    /// Install or clear the Trusted Time Source (Matter Core spec).
+    /// `fab_idx` is the fabric performing the change —
     /// recorded so that fabric removal can clear an entry it owns.
     pub fn set_trusted_time_source<E: EventEmitter>(
         &mut self,
@@ -273,8 +272,8 @@ impl Rtc {
         Ok(())
     }
 
-    /// Install or clear the Trusted Time Source (Matter Core spec
-    /// ). `fab_idx` is the fabric performing the change —
+    /// Install or clear the Trusted Time Source (Matter Core spec).
+    /// `fab_idx` is the fabric performing the change —
     /// recorded so that fabric removal can clear an entry it owns.
     /// `source = None` clears any existing entry.
     ///
@@ -323,7 +322,7 @@ impl Rtc {
     /// recent [`Self::set_utc_time`] (with the spec-required
     /// step-down and floor already applied) — or `NoTimeGranularity`
     /// if no `set_utc_time` has been called since boot (per
-    /// , which forbids `NoTimeGranularity` only while
+    /// the spec, which forbids `NoTimeGranularity` only while
     /// `UTCTime ≠ Null`).
     pub fn utc_time_granularity(&self) -> GranularityEnum {
         if self.anchor.is_some() {
@@ -344,11 +343,11 @@ impl Rtc {
         }
     }
 
-    /// Update the Last-Known-Good UTC Time (Matter Core spec
-    /// ), capturing a fresh monotonic anchor so subsequent
+    /// Update the Last-Known-Good UTC Time (Matter Core spec),
+    /// capturing a fresh monotonic anchor so subsequent
     /// [`Self::utc_time`] reads advance from the supplied value.
     ///
-    /// Per : the supplied `granularity` is recorded
+    /// Per the spec: the supplied `granularity` is recorded
     /// stepped-down by one level (with a floor of
     /// `MinutesGranularity` per spec); the supplied `source`
     /// is recorded verbatim.
@@ -370,8 +369,8 @@ impl Rtc {
             GranularityEnum::MicrosecondsGranularity => GranularityEnum::MillisecondsGranularity,
             GranularityEnum::MillisecondsGranularity => GranularityEnum::SecondsGranularity,
             GranularityEnum::SecondsGranularity => GranularityEnum::MinutesGranularity,
-            // Minutes / NoTime → floor at Minutes ( forbids
-            // NoTime while UTCTime is non-null).
+            // Minutes / NoTime → floor at Minutes
+            // (spec forbids NoTime while UTCTime is non-null).
             _ => GranularityEnum::MinutesGranularity,
         };
 
@@ -785,7 +784,7 @@ const fn time_sync_cmds<const OPTS: u8>(cmd: &Command, _: u16, _: u32) -> bool {
     // `SetUTCTime` is mandatory whenever the cluster is present
     // (Matter Core spec, conformance `M`), independent of
     // features. Devices reporting `Granularity = NoTimeGranularity`
-    // are additionally required by  to accept it.
+    // are additionally required to accept it.
     if cmd.id == C::SetUTCTime as u32 {
         return true;
     }
@@ -1083,7 +1082,7 @@ impl ClusterHandler for TimeSyncHandler<'_> {
     // Matter Core spec — installs or clears the per-device
     // Trusted Time Source. The fabric performing the change is
     // recorded so that fabric removal can clear an entry it owns
-    // and emit `MissingTrustedTimeSource` .
+    // and emit `MissingTrustedTimeSource`.
     fn handle_set_trusted_time_source(
         &self,
         ctx: impl InvokeContext,

--- a/rs-matter/src/dm/clusters/time_sync.rs
+++ b/rs-matter/src/dm/clusters/time_sync.rs
@@ -144,7 +144,7 @@ pub struct Rtc {
     utc_us_persisted: u64,
     /// Granularity at the time of the last `set_utc_time` call, with
     /// the "one level lower than supplied" step-down already
-    /// applied and floored at `MinutesGranularity` .
+    /// applied and floored at `MinutesGranularity`.
     /// **Not persisted** — resets to `NoTimeGranularity` at boot,
     /// matching the `anchor = None` post-reboot state.
     granularity: GranularityEnum,
@@ -215,8 +215,8 @@ impl Rtc {
         self.reset();
 
         // Load the persisted Last-Known-Good UTC Time, if any.
-        // Floor at `FIRMWARE_BUILD_MATTER_US` per Matter Core spec
-        //  — the on-disk value must never regress us
+        // Floor at `FIRMWARE_BUILD_MATTER_US` per Matter Core spec -
+        // the on-disk value must never regress us
         // below the build timestamp (the documented lower bound
         // we never adjust backwards past).
         if let Some(data) = kv.load(LKG_UTC_KEY, buf)? {

--- a/rs-matter/src/dm/clusters/time_sync/client.rs
+++ b/rs-matter/src/dm/clusters/time_sync/client.rs
@@ -15,13 +15,13 @@
  *    limitations under the License.
  */
 
-//! Time Synchronization initiator-side client (Matter Core spec §11.17.13).
+//! Time Synchronization initiator-side client (Matter Core spec).
 //!
 //! Refreshes the device's
 //! [Last-Known-Good UTC Time](crate::Matter::last_known_utc_time) by
 //! opening a CASE-secured exchange to the configured
 //! [Trusted Time Source](crate::Matter::trusted_time_source) (set via
-//! the `SetTrustedTimeSource` command, Matter Core spec §11.17.9.7),
+//! the `SetTrustedTimeSource` command, Matter Core spec),
 //! reading its `UTCTime` attribute, and calling
 //! [`Matter::set_utc_time`] with the result.
 //!
@@ -49,7 +49,7 @@ use crate::Matter;
 
 /// Initiator-side TimeSync client. Periodically reads `UTCTime` from
 /// the configured trusted source and stores it as the device's new
-/// Last-Known-Good UTC Time (Matter Core spec §3.5.6.1 / §11.17.13).
+/// Last-Known-Good UTC Time (Matter Core spec).
 ///
 /// Holds a borrow of the [`Matter`] instance for its lifetime; the
 /// `run` / `refresh_once` methods take the KV-store handle and the
@@ -99,7 +99,7 @@ impl<'a> TimeSyncClient<'a> {
     ///   on the configured `endpoint`, and on a non-null result calls
     ///   [`Matter::set_utc_time`] with
     ///   `Granularity = SecondsGranularity` and
-    ///   `TimeSource = NodeTimeCluster` (per §11.17.13.2 — the source
+    ///   `TimeSource = NodeTimeCluster` (per spec — the source
     ///   that this device used to sync its time was another node's
     ///   TimeSync cluster).
     pub async fn refresh_once<S, N>(&self, kv: S, notify: &N) -> Result<(), Error>

--- a/rs-matter/src/dm/clusters/user_label.rs
+++ b/rs-matter/src/dm/clusters/user_label.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-//! UserLabel cluster handler (Matter Application Cluster spec §9.7).
+//! UserLabel cluster handler (Matter Application Cluster spec).
 //!
 //! The UserLabel cluster lets a commissioner persist a free-form list of
 //! `(label, value)` string pairs on an endpoint — typical use is the
@@ -25,13 +25,13 @@
 //! sees the same list (subject to the usual ACL rules — `LabelList` reads
 //! at view-privilege, writes at manage-privilege).
 //!
-//! Spec §9.7.5 requires the `LabelList` to persist across reboots.
+//! Spec requires the `LabelList` to persist across reboots.
 //! Persistence is implemented by [`UserLabels`], a registry that holds
 //! every endpoint's `LabelList` and serialises the lot under a single
 //! KV key ([`USER_LABELS_KEY`]) on every mutation. Each endpoint that
 //! advertises the UserLabel cluster gets its own [`UserLabelHandler`]
 //! facade (so the per-cluster-instance `Dataver` stays granular per
-//! Matter Core spec §7.13.2.1), and all facades share one `UserLabels`
+//! Matter Core spec), and all facades share one `UserLabels`
 //! by reference.
 //!
 //! Application wiring:
@@ -72,11 +72,11 @@ pub use crate::persist::USER_LABELS_KEY;
 pub const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
 
 /// Maximum length of a single `label` string, in characters.
-/// Per Matter Application Cluster spec §9.6.4 (`LabelStruct`): 16 chars.
+/// Per Matter Application Cluster spec (`LabelStruct`): 16 chars.
 pub const MAX_LABEL_LEN: usize = 16;
 
 /// Maximum length of a single `value` string, in characters.
-/// Per Matter Application Cluster spec §9.6.4 (`LabelStruct`): 16 chars.
+/// Per Matter Application Cluster spec (`LabelStruct`): 16 chars.
 pub const MAX_VALUE_LEN: usize = 16;
 
 /// One entry in a `LabelList`.
@@ -429,7 +429,7 @@ impl<const E: usize, const N: usize> ClusterHandler for UserLabelHandler<'_, E, 
             ArrayAttributeWrite::Add(entry) => {
                 self.labels.add_entry(&ctx, self.endpoint_id, &entry)
             }
-            // The Matter Core spec (V1.4.2 §10.6.4.3.1) does not yet
+            // The Matter Core spec does not yet
             // support per-element list update / remove writes — the
             // framework already converts these to `InvalidAction` before
             // the value reaches us, but match exhaustively to be safe.

--- a/rs-matter/src/dm/devices.rs
+++ b/rs-matter/src/dm/devices.rs
@@ -21,11 +21,11 @@ pub mod test;
 
 /// A constant representing the device type for the root (ep0) endpoint in Matter.
 ///
-/// Matter Device Library §2.1.1 revision history: rev 1 was initial; rev 2
+/// Matter Device Library revision history: rev 1 was initial; rev 2
 /// added Power Source (conditional, optional); rev 3 added MNGD-feature
 /// restriction on Access Control; rev 4 added conditions and cluster
 /// requirements for Time Sync, TLS Certificate/Client Management. All four
-/// rev-2..4 additions are either conditional or `O` (optional) per §2.1.5;
+/// rev-2..4 additions are either conditional or `O` (optional) per spec;
 /// rs-matter implements the rev-1 mandatory set (BasicInfo, AccessControl,
 /// GeneralCommissioning, NetworkCommissioning, GeneralDiagnostics,
 /// AdminCommissioning, OperationalCredentials, GroupKeyManagement) and is
@@ -50,7 +50,7 @@ pub const DEV_TYPE_AGGREGATOR: DeviceType = DeviceType {
 
 /// A constant representing the On/Off Light device in Matter.
 ///
-/// Matter Device Library §4.1.1 revision history: rev 1 was Zigbee-3.0
+/// Matter Device Library revision history: rev 1 was Zigbee-3.0
 /// initial; rev 2 was the new data-model-format/notation rewrite; rev 3
 /// swapped the deprecated Scenes cluster (0x0005) for Scenes Management
 /// (0x0062). Conformance tests (TC_DeviceConformance::test_TC_IDM_10_5/_6)

--- a/rs-matter/src/dm/events.rs
+++ b/rs-matter/src/dm/events.rs
@@ -156,7 +156,7 @@ impl<const N: usize> Events<N> {
             // TODO: Support `EpochTimestamp` / `PosixTimestamp` variants too
             // for devices that have a real-time clock available, gated on a
             // future wall-clock hook. `SystemTimestamp` (ms since boot) is
-            // spec-compliant per Matter Core §10.7.3.5 and always available
+            // spec-compliant per Matter Core and always available
             // via the monotonic clock.
             let timestamp = EventDataTimestamp::SystemTimestamp(Instant::now().as_millis());
 

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -1106,8 +1106,8 @@ const WILDCARD_ENDPOINT: EndptId = EndptId::MAX;
 
 /// Sentinel value for "any cluster" inside a [`ChangedAttr`] entry.
 ///
-/// Matter cluster ids are Manufacturer Extensible Identifiers (MEIs, Core Spec
-/// ): `(vendor_prefix << 16) | suffix` with `0xFFFF` reserved as an
+/// Matter cluster ids are Manufacturer Extensible Identifiers (MEIs, Core Spec):
+/// `(vendor_prefix << 16) | suffix` with `0xFFFF` reserved as an
 /// invalid vendor prefix. `0xFFFF_FFFF` therefore cannot be a legitimate
 /// cluster id and is safe to use as an internal "wildcard" marker. The CHIP
 /// reference SDK uses the same value as `kInvalidClusterId`.

--- a/rs-matter/src/dm/subscriptions.rs
+++ b/rs-matter/src/dm/subscriptions.rs
@@ -834,7 +834,7 @@ impl Subscription {
     /// wakes immediately to deliver the priming report.
     ///
     /// Never earlier than the min-interval gate `reported_at + min_int`, before
-    /// which a report SHALL NOT be sent (Matter 1.5.1 §8.5). Subject to that
+    /// which a report SHALL NOT be sent (Matter spec). Subject to that
     /// gate, it is:
     /// - `reported_at + min_int` when a change or event is already pending, so
     ///   the wake lands at the end of the quiet period; otherwise
@@ -1107,7 +1107,7 @@ const WILDCARD_ENDPOINT: EndptId = EndptId::MAX;
 /// Sentinel value for "any cluster" inside a [`ChangedAttr`] entry.
 ///
 /// Matter cluster ids are Manufacturer Extensible Identifiers (MEIs, Core Spec
-/// §7.18.2): `(vendor_prefix << 16) | suffix` with `0xFFFF` reserved as an
+/// ): `(vendor_prefix << 16) | suffix` with `0xFFFF` reserved as an
 /// invalid vendor prefix. `0xFFFF_FFFF` therefore cannot be a legitimate
 /// cluster id and is safe to use as an internal "wildcard" marker. The CHIP
 /// reference SDK uses the same value as `kInvalidClusterId`.

--- a/rs-matter/src/dm/types/attribute.rs
+++ b/rs-matter/src/dm/types/attribute.rs
@@ -222,7 +222,7 @@ impl<T, E> ArrayAttributeWrite<T, E> {
         match index.map(Nullable::into_option) {
             Some(Some(_index)) => {
                 // Index is present and non-null => this is an item update or removal
-                // Note that this is not supported by the Matter Core spec yet (section 10.6.4.3.1 "Lists" in V1.4.2), so we return an error instead
+                // Note that this is not supported by the Matter Core spec yet ("Lists" in V1.4.2), so we return an error instead
 
                 // if data.null().is_ok() {
                 //     // Data is null - item removal

--- a/rs-matter/src/dm/types/cluster.rs
+++ b/rs-matter/src/dm/types/cluster.rs
@@ -602,7 +602,7 @@ impl defmt::Format for Cluster<'_> {
 ///
 /// The Groups cluster is intentionally *not* included in any of these presets:
 /// Root Node (Matter Device Library) does not list Groups, and Groups
-/// (Matter Application Cluster Specification ) is scoped to per-endpoint
+/// (Matter Application Cluster Specification) is scoped to per-endpoint
 /// group membership which has no defined behavior on the Root Node. Wire
 /// `GroupsHandler::CLUSTER` onto the application endpoint(s) where it actually
 /// has meaning instead.

--- a/rs-matter/src/dm/types/cluster.rs
+++ b/rs-matter/src/dm/types/cluster.rs
@@ -213,7 +213,7 @@ impl<'a> Cluster<'a> {
             Err(IMStatusCode::NeedsTimedInteraction)?;
         }
 
-        // Per Matter Core spec section 8.9.4 (Invoke Interaction): "Else if
+        // Per Matter Core spec (Invoke Interaction): "Else if
         // the command in the path is fabric-scoped and there is no accessing
         // fabric, a CommandStatusIB SHALL be generated with the
         // UNSUPPORTED_ACCESS Status Code." This is the catch for fabric-scoped
@@ -601,8 +601,8 @@ impl defmt::Format for Cluster<'_> {
 /// merged into the slice — e.g. `clusters!(eth, sw_diag(heap); my_cluster)`.
 ///
 /// The Groups cluster is intentionally *not* included in any of these presets:
-/// Root Node (Matter Device Library §2.1.5) does not list Groups, and Groups
-/// (Matter Application Cluster Specification §1.3) is scoped to per-endpoint
+/// Root Node (Matter Device Library) does not list Groups, and Groups
+/// (Matter Application Cluster Specification ) is scoped to per-endpoint
 /// group membership which has no defined behavior on the Root Node. Wire
 /// `GroupsHandler::CLUSTER` onto the application endpoint(s) where it actually
 /// has meaning instead.

--- a/rs-matter/src/dm/types/endpoint.rs
+++ b/rs-matter/src/dm/types/endpoint.rs
@@ -40,7 +40,7 @@ pub struct Endpoint<'a> {
     /// client clusters (e.g. `OnOffLightSwitch = 0x0103` lists
     /// `OnOff` as a mandatory client). No `Cluster<'a>` value is
     /// needed because a client cluster has no attribute/command
-    /// surface of its own — see Matter Core spec §9.5.4 for the
+    /// surface of its own — see Matter Core spec for the
     /// `Descriptor::ClientList` semantics.
     pub client_clusters: &'a [ClusterId],
 }

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -42,7 +42,7 @@ use super::{AttrDetails, ClusterId, CmdDetails, EndptId};
 ///    lists must not change. Whole endpoints may still be added or
 ///    removed at runtime. Mutating a cluster's attribute or server
 ///    list is a change to F-quality metadata (Matter Core spec
-///    §7.13.2.2 `AttributeList`, §7.13.2.4 `ServerList`) and must be
+///    `AttributeList` / `ServerList`) and must be
 ///    accompanied by a `ConfigurationVersion` bump, which in practice
 ///    means a restart of the `rs-matter` service and likely - of the
 ///    whole process anyway.
@@ -603,7 +603,7 @@ struct PathExpander<'a, T, I, F> {
     ///
     /// This is the mechanism that resolves the "DeleteAll + Add×N on the
     /// ACL cluster within one WriteRequest" tension (Matter Core spec
-    /// §10.6.4): chip-tool serializes a list-replace as `DeleteAll`
+    /// ): chip-tool serializes a list-replace as `DeleteAll`
     /// followed by N per-element `Add`s, all targeting the **same**
     /// concrete attribute path. The first op authorizes against the
     /// fabric's current ACL; subsequent same-path ops cache-hit and

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -602,8 +602,8 @@ struct PathExpander<'a, T, I, F> {
     /// expanded leaf matches this triple, the access check is bypassed.
     ///
     /// This is the mechanism that resolves the "DeleteAll + Add×N on the
-    /// ACL cluster within one WriteRequest" tension (Matter Core spec
-    /// ): chip-tool serializes a list-replace as `DeleteAll`
+    /// ACL cluster within one WriteRequest" tension (Matter Core spec):
+    /// chip-tool serializes a list-replace as `DeleteAll`
     /// followed by N per-element `Add`s, all targeting the **same**
     /// concrete attribute path. The first op authorizes against the
     /// fabric's current ACL; subsequent same-path ops cache-hit and

--- a/rs-matter/src/dm/types/reply.rs
+++ b/rs-matter/src/dm/types/reply.rs
@@ -309,7 +309,7 @@ pub struct EventReader {
     /// Whether the originating Read/Subscribe request had `fabricFiltered=true`.
     /// When set, fabric-sensitive events (those whose payload carries a
     /// `FabricIndex` context-tag 254) are dropped if their fabric index does
-    /// not match the accessor's. See Matter Core spec section 8.5.2.
+    /// not match the accessor's. See Matter Core spec.
     fabric_filtered: bool,
 }
 
@@ -388,7 +388,7 @@ impl EventReader {
         }
     }
 
-    /// Per Matter Core spec section 8.5.2 (Fabric-Sensitive Reporting):
+    /// Per Matter Core spec (Fabric-Sensitive Reporting):
     /// When `fabricFiltered=true`, fabric-sensitive events (those whose payload
     /// carries a `FabricIndex` field at context tag 254) SHALL only be reported
     /// to the requesting fabric.

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -326,8 +326,8 @@ pub struct Fabric {
     root_ca: Vec<u8, { MAX_CERT_TLV_LEN }>,
     /// Either the Intermediate CA certificate (`vvsc_set == false`) or the
     /// Vendor Verification Signing Cert (`vvsc_set == true`). The two are
-    /// mutually exclusive in the cert chain (Matter Core spec section
-    /// 6.5.7) — a fabric with an ICAC cannot also carry a VVSC and vice
+    /// mutually exclusive in the cert chain (Matter Core spec) —
+    /// a fabric with an ICAC cannot also carry a VVSC and vice
     /// versa — so we share one buffer instead of paying for both. Empty
     /// means neither is set; in that case `vvsc_set` is meaningless.
     icac_or_vvsc: Vec<u8, { MAX_CERT_TLV_LEN }>,
@@ -344,7 +344,7 @@ pub struct Fabric {
     acl: Vec<AclEntry, { acl::MAX_ACL_ENTRIES_PER_FABRIC }>,
     /// Fabric group information
     groups: Groups,
-    /// VID Verification Statement (Matter Core spec section 6.2.4 / 11.18.6.15).
+    /// VID Verification Statement (Matter Core spec).
     /// Either empty (not set) or exactly `VID_VERIFICATION_STATEMENT_LEN`
     /// bytes long; the cluster XML enforces both bounds at the schema
     /// level (`length="85" minLength="85"`).
@@ -391,7 +391,7 @@ impl Fabric {
     /// when the NOC of the fabric needs to be updated.
     ///
     /// `root_ca` is `None` when called from the `UpdateNOC` flow — Matter
-    /// Core spec section 11.18.6.7 keeps the fabric's root cert unchanged
+    /// Core spec keeps the fabric's root cert unchanged
     /// across `UpdateNOC`, and re-passing the existing bytes here would
     /// require a (large) caller-side copy of `self.root_ca`. `Some(...)`
     /// is used by the initial `AddNOC` flow, where the cert was just
@@ -503,7 +503,7 @@ impl Fabric {
 
     /// Compute the destination identifier for a target node on this fabric.
     ///
-    /// Used by the CASE initiator to build Sigma1 (spec 4.14.2.4).
+    /// Used by the CASE initiator to build Sigma1 (spec).
     /// destinationMessage = initiatorRandom || rootPublicKey || fabricId(LE) || nodeId(LE)
     /// destinationIdentifier = Crypto_HMAC(key=IPK, message=destinationMessage)
     ///
@@ -605,11 +605,11 @@ impl Fabric {
         &mut self.groups
     }
 
-    /// Return the fabric's VVSC bytes (Matter Core spec section 6.5.7).
+    /// Return the fabric's VVSC bytes (Matter Core spec).
     /// Empty when `SetVIDVerificationStatement` has never been called with
     /// a non-empty VVSC for this fabric, or when the fabric instead carries
     /// an ICAC (see `icac()`) — VVSC and ICAC share storage and are
-    /// mutually exclusive per spec section 6.5.7.
+    /// mutually exclusive per spec.
     pub fn vvsc(&self) -> &[u8] {
         if self.vvsc_set {
             &self.icac_or_vvsc
@@ -619,7 +619,7 @@ impl Fabric {
     }
 
     /// Return the fabric's VID Verification Statement bytes (Matter Core
-    /// spec section 6.2.4 / 11.18.6.15). Either empty (not set) or
+    /// spec). Either empty (not set) or
     /// exactly `VID_VERIFICATION_STATEMENT_LEN` bytes.
     pub fn vid_verification_statement(&self) -> &[u8] {
         &self.vid_verification_statement
@@ -651,7 +651,7 @@ impl Fabric {
 
         if let Some(v) = vvsc {
             // VVSC and ICAC share `icac_or_vvsc`. Clearing the VVSC must
-            // not stomp on an existing ICAC: per spec section 6.5.7 the
+            // not stomp on an existing ICAC: per spec the
             // two never coexist on the same fabric, so an empty-VVSC
             // request against a fabric that holds an ICAC is a no-op
             // here. The cluster handler still rejects a *non-empty* VVSC
@@ -1003,7 +1003,7 @@ impl Fabrics {
     /// Update an existing fabric with the provided data (usually, as a result of an `UpdateNOC` IM command).
     ///
     /// The fabric's existing root cert is preserved across this call —
-    /// `UpdateNOC` per Matter Core spec section 11.18.6.7 is not allowed
+    /// `UpdateNOC` per Matter Core spec is not allowed
     /// to change the root, and re-passing the bytes would force the
     /// caller to take a (large) heap-less copy of `Fabric::root_ca`.
     ///

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -420,7 +420,7 @@ impl FailSafe {
         // Validate the candidate RCAC by checking its self-signature (a Matter
         // RCAC is self-issued, so the certificate's own public key must verify
         // the certificate's signature). Any decode or signature failure must
-        // surface as `INVALID_COMMAND` per Matter Core spec section 11.18.6.13
+        // surface as `INVALID_COMMAND` per Matter Core spec
         // (`AddTrustedRootCertificate`), not as the generic `Failure` we'd
         // otherwise get from `ErrorCode::InvalidSignature`.
         {
@@ -501,7 +501,7 @@ impl FailSafe {
 
         // `UpdateNOC` only requires the corresponding `CSRRequest` (with
         // `isForUpdateNOC=true`) to have been processed in this fail-safe
-        // context. Per Matter Core spec section 11.18.6.7 it must NOT
+        // context. Per Matter Core spec it must NOT
         // have been preceded by `AddTrustedRootCertificate`, `AddNOC`,
         // `UpdateNOC`, or a CSRRequest of the wrong kind — those go in
         // `absent`. `validate_certs` further down uses the *committed*
@@ -529,13 +529,13 @@ impl FailSafe {
             // Validate the certs first. A chain that doesn't pass
             // signature verification (or that doesn't chain back to the
             // staged root) is reported as `kInvalidNOC` cluster status per
-            // Matter Core spec section 11.18.6.7 (`UpdateNOC`).
+            // Matter Core spec (`UpdateNOC`).
             Self::validate_certs(&crypto, time, &noc_ref, icac_ref.as_ref(), &root_ref, buf)
                 .map_err(|_| ErrorCode::NocInvalidNoc)?;
 
             // The NOC's public key must match the public key derived from
             // the most recent `CSRRequest(isForUpdateNOC=true)` (Matter
-            // Core spec section 11.18.6.7).
+            // Core spec).
             let mut csr_pubkey = crate::crypto::CanonPkcPublicKey::new();
             crypto
                 .secret_key(self.secret_key.reference())?
@@ -605,7 +605,7 @@ impl FailSafe {
         )?;
 
         // CaseAdminSubject must be either a valid Operational Node ID or a
-        // CASE Authenticated Tag (CAT) — Matter Core spec section 11.18.6.6
+        // CASE Authenticated Tag (CAT) — Matter Core spec
         // (`AddNOC`). Anything else (most commonly 0) is reported as
         // `kInvalidAdminSubject` cluster status.
         if !crate::acl::is_node(case_admin_subject) && !crate::acl::is_noc_cat(case_admin_subject) {
@@ -620,13 +620,13 @@ impl FailSafe {
             // Validate the certs first. A chain that doesn't pass
             // signature verification (or that doesn't chain back to the
             // staged root) is reported as `kInvalidNOC` cluster status per
-            // Matter Core spec section 11.18.6.6 (`AddNOC`).
+            // Matter Core spec (`AddNOC`).
             Self::validate_certs(&crypto, time, &noc_ref, icac_ref.as_ref(), &root_ref, buf)
                 .map_err(|_| ErrorCode::NocInvalidNoc)?;
 
             // The NOC's public key must match the public key derived from
-            // the most recent `CSRRequest` (Matter Core spec section
-            // 11.18.6.6). The CSR's secret key is stashed in
+            // the most recent `CSRRequest` (Matter Core spec). The CSR's
+            // secret key is stashed in
             // `self.secret_key` by `add_csr_req` / `update_csr_req`.
             let mut csr_pubkey = crate::crypto::CanonPkcPublicKey::new();
             crypto
@@ -717,7 +717,7 @@ impl FailSafe {
         if let Some(icac) = icac {
             // If ICAC is present handle it. Reject the case where the
             // commissioner re-uses the RCAC as the ICAC: Matter Core spec
-            // section 6.5 requires the ICAC to be a separate CA cert
+            // the spec requires the ICAC to be a separate CA cert
             // (i.e. not self-signed).
             if icac.is_self_signed()? {
                 return Err(ErrorCode::InvalidData.into());
@@ -765,8 +765,7 @@ impl FailSafe {
                 // State is not what is expected for that concrete command.
                 //
                 // Disambiguate "no CSR at all" from "wrong CSR type" per
-                // Matter Core spec sections 11.18.6.6 (`AddNOC`) and
-                // 11.18.6.7 (`UpdateNOC`):
+                // Matter Core spec, `AddNOC` / `UpdateNOC`:
                 //   * No `CSRRequest` of either kind seen yet for this
                 //     fail-safe context → `kMissingCsr` cluster status.
                 //   * A CSR was issued but with the opposite
@@ -787,8 +786,7 @@ impl FailSafe {
                 // State is not what is expected for that concrete command.
                 //
                 // Two flavours both surface as IM `CONSTRAINT_ERROR` per
-                // Matter Core spec sections 11.18.6.6 (`AddNOC`) and
-                // 11.18.6.7 (`UpdateNOC`):
+                // Matter Core spec, `AddNOC` / `UpdateNOC`:
                 //   * the same `Add`/`UpdateNOC` was already received in
                 //     this fail-safe context
                 //   * the most recent `CSRRequest` had the wrong

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -716,7 +716,7 @@ impl FailSafe {
 
         if let Some(icac) = icac {
             // If ICAC is present handle it. Reject the case where the
-            // commissioner re-uses the RCAC as the ICAC: Matter Core spec
+            // commissioner re-uses the RCAC as the ICAC:
             // the spec requires the ICAC to be a separate CA cert
             // (i.e. not self-signed).
             if icac.is_self_signed()? {

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -60,8 +60,7 @@ pub const PROTO_ID_INTERACTION_MODEL: u16 = 0x01;
 /// (= `0xFF`).
 ///
 /// `13` has been the spec-mandated value since Matter 1.3; see the
-/// Matter 1.5 Core Specification, §8.1.1 ("Revision History"), p. 545
-/// (doc 23-27349-009_Matter-1.5-Core-Specification.pdf).
+/// "Revision History" of the Matter Core Specification.
 pub const IM_REVISION: u8 = 13;
 
 /// An enumeration of all possible error codes that can be returned by the Interaction Model.

--- a/rs-matter/src/im/attr.rs
+++ b/rs-matter/src/im/attr.rs
@@ -43,6 +43,28 @@ mod write_builder;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(datatype = "list")]
 pub struct AttrPath {
+    /// `EnableTagCompression` per Matter Core spec §10.6.2. When set
+    /// to `true`, the spec defines a "tag compression scheme" whereby
+    /// omitted fields in this `AttrPath` should be inherited from the
+    /// previous `AttrPath` in the same list (rather than treated as
+    /// wildcards).
+    ///
+    /// **rs-matter parses this bit but does not act on it.**
+    /// Omitted fields are always treated as wildcards regardless of value.
+    ///
+    /// This matches the de-facto behaviour of every other Matter
+    /// implementation in the wild:
+    ///   - chip's `AttributePathIB::Parser::ParsePath` reads the bit
+    ///     and ignores its semantics, treating omitted = wildcard.
+    ///   - matter.js explicitly leaves it unimplemented with a TODO
+    ///     comment "or likely remove it".
+    ///   - per <https://github.com/project-chip/connectedhomeip/issues/29359>,
+    ///     neither chip-tool nor Google's controllers handle
+    ///     tag-compressed reports either, and the spec feature is
+    ///     widely expected to be removed rather than implemented.
+    ///
+    /// If/when that landscape changes, real inheritance semantics
+    /// would slot into `PathExpanderIterator` in `dm/types/node.rs`.
     pub tag_compression: Option<bool>,
     pub node: Option<NodeId>,
     pub endpoint: Option<EndptId>,

--- a/rs-matter/src/im/attr.rs
+++ b/rs-matter/src/im/attr.rs
@@ -43,7 +43,7 @@ mod write_builder;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(datatype = "list")]
 pub struct AttrPath {
-    /// `EnableTagCompression` per Matter Core spec §10.6.2. When set
+    /// `EnableTagCompression` per Matter Core spec. When set
     /// to `true`, the spec defines a "tag compression scheme" whereby
     /// omitted fields in this `AttrPath` should be inherited from the
     /// previous `AttrPath` in the same list (rather than treated as
@@ -74,7 +74,7 @@ pub struct AttrPath {
 }
 
 /// Tags corresponding to the fields in the `AttributePathIB` TLV
-/// structure (Matter Core spec §10.6.2). `AttrPath` is encoded as a
+/// structure (Matter Core spec). `AttrPath` is encoded as a
 /// TLV *list* with positional context tags 0..5. Used by callers that
 /// need to perform low-level TLV serde on `AttrPath` data.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/rs-matter/src/im/attr/read_builder.rs
+++ b/rs-matter/src/im/attr/read_builder.rs
@@ -28,7 +28,7 @@
 //!
 //! # Layout
 //!
-//! Per Matter Core spec §10.7.2 `ReadRequestMessage` is an
+//! Per Matter Core spec `ReadRequestMessage` is an
 //! anonymous-tagged struct with five fields:
 //!
 //! | Tag | Field             | Type             | Required |
@@ -336,7 +336,7 @@ where
     P: TLVBuilderParent,
 {
     /// Write the mandatory-on-the-wire `InteractionModelRevision`
-    /// field (Matter Core §8.1.1, p. 545: value is `13` since Matter
+    /// field (Matter Core: value is `13` since Matter
     /// 1.3, unchanged in 1.4 and 1.5). Optional at the API level —
     /// omit and `end()` injects [`IM_REVISION`] automatically. Set
     /// explicitly only when speaking a non-default revision is

--- a/rs-matter/src/im/attr/subscribe.rs
+++ b/rs-matter/src/im/attr/subscribe.rs
@@ -110,7 +110,7 @@ impl defmt::Format for SubscribeReq<'_> {
 }
 
 /// Tags corresponding to the fields in the `SubscribeRequestMessage`
-/// TLV structure (Matter Core spec §10.7.8). Used by the streaming
+/// TLV structure (Matter Core spec). Used by the streaming
 /// subscribe-request builder and any low-level TLV serde callers.
 ///
 /// Note the gap at tag 6 — the spec leaves it reserved and the

--- a/rs-matter/src/im/attr/subscribe_builder.rs
+++ b/rs-matter/src/im/attr/subscribe_builder.rs
@@ -31,7 +31,7 @@
 //!
 //! # Layout
 //!
-//! Per Matter Core spec §10.7.8 `SubscribeRequestMessage` is an
+//! Per Matter Core spec `SubscribeRequestMessage` is an
 //! anonymous-tagged struct with seven fields plus a reserved gap at
 //! tag 6:
 //!
@@ -173,7 +173,7 @@ where
     /// Write the mandatory `MaxIntervalCeiling` field (seconds). The
     /// peer MUST report no less frequently than this even if nothing
     /// has changed (heartbeat). The server may pick any interval at
-    /// or below this ceiling — see Matter Core spec §8.5.3.
+    /// or below this ceiling — see Matter Core spec.
     pub fn max_int_ceil(mut self, value: u16) -> Result<SubscribeReqBuilder<P, 3>, Error> {
         self.p
             .writer()
@@ -405,7 +405,7 @@ where
     P: TLVBuilderParent,
 {
     /// Write the mandatory-on-the-wire `InteractionModelRevision`
-    /// field (Matter Core §8.1.1, p. 545: value is `13` since Matter
+    /// field (Matter Core: value is `13` since Matter
     /// 1.3, unchanged in 1.4 and 1.5). Optional at the API level —
     /// omit and `end()` injects [`IM_REVISION`] automatically.
     pub fn interaction_model_revision(

--- a/rs-matter/src/im/attr/write_builder.rs
+++ b/rs-matter/src/im/attr/write_builder.rs
@@ -31,7 +31,7 @@
 //!
 //! # Layout
 //!
-//! Per Matter Core spec §10.7.5 `WriteRequestMessage` is an
+//! Per Matter Core spec `WriteRequestMessage` is an
 //! anonymous-tagged struct with four fields:
 //!
 //! | Tag | Field             | Type                |
@@ -291,7 +291,7 @@ where
     P: TLVBuilderParent,
 {
     /// Write the mandatory-on-the-wire `InteractionModelRevision`
-    /// field (Matter Core §8.1.1, p. 545: value is `13` since Matter
+    /// field (Matter Core: value is `13` since Matter
     /// 1.3, unchanged in 1.4 and 1.5). Optional at the API level —
     /// omit and `end()` injects [`IM_REVISION`] automatically.
     pub fn interaction_model_revision(mut self, value: u8) -> Result<WriteReqBuilder<P, 5>, Error> {
@@ -534,7 +534,7 @@ where
     /// Write the concrete `(endpoint, cluster, attribute)` path. This
     /// is the typical shape for attribute writes; wildcards aren't
     /// generally meaningful for writes and aren't exposed here. The
-    /// path is encoded as a *list* (per spec §10.6.2 `AttributePathIB`).
+    /// path is encoded as a *list* (per spec `AttributePathIB`).
     pub fn path(
         mut self,
         endpoint: EndptId,
@@ -574,7 +574,7 @@ where
 {
     /// Write the attribute value into the `Data` slot.
     ///
-    /// Per Matter Core spec §10.6.2 `AttributeDataIB.Data` is "any
+    /// Per Matter Core spec `AttributeDataIB.Data` is "any
     /// TLV value." The closure receives the parent's `TLVWrite` and
     /// **must** emit exactly one TLV element tagged
     /// `TLVTag::Context(2)` (i.e. `AttrDataTag::Data`). The IM-level

--- a/rs-matter/src/im/client.rs
+++ b/rs-matter/src/im/client.rs
@@ -635,7 +635,7 @@ impl<'a> defmt::Format for WriteSenderSlot<'a> {
 /// ACK-ed the request and the response is parsed.
 ///
 /// Unlike [`InvokeRespChunk`] / [`ReadRespChunk`], `WriteResponse`
-/// is a single message per Matter Core spec §10.7.6 — no chunk
+/// is a single message per Matter Core spec — no chunk
 /// iteration is needed; just call [`response`](Self::response) to
 /// inspect the parsed [`WriteResp`].
 pub struct WriteRespHandle<'a> {
@@ -871,7 +871,7 @@ impl<'a> defmt::Format for InvokeSenderSlot<'a> {
 /// caller can iterate; otherwise it returns `None` and drops the
 /// exchange.
 ///
-/// Per Matter Core spec §10.7.10, a server MAY reply to a command
+/// Per Matter Core spec, a server MAY reply to a command
 /// declared with `DefaultSuccess` (no explicit response struct) by
 /// sending a plain `StatusResponse(Success)` instead of a full
 /// `InvokeResponse`. In that case the chunk is *status-only*:
@@ -942,12 +942,12 @@ impl<'a> InvokeRespChunk<'a> {
     /// it as `Some(next)`. Otherwise (final chunk, or status-only)
     /// drop the exchange and return `None`.
     ///
-    /// Chunking flow control (Matter Core §10.7.10.3): on receipt of
+    /// Chunking flow control (Matter Core): on receipt of
     /// any `InvokeResponseMessage` with `MoreChunkedResponses=true`,
     /// the receiver SHALL reply with `StatusResponse(Success)` and
     /// the sender SHALL await that ACK before transmitting the next
     /// chunk. On the **final** chunk (`MoreChunks=false`) no trailer
-    /// is sent — per §8.8.3.1 the `SuppressResponse` field on an
+    /// is sent — per spec the `SuppressResponse` field on an
     /// `InvokeResponseMessage` is *ignored by the client*, and Matter
     /// "does not support responses to InvokeResponse actions" at the
     /// action layer. So the terminal-chunk branch is MRP-ack only,
@@ -972,7 +972,7 @@ impl<'a> InvokeRespChunk<'a> {
         };
 
         if more_chunks {
-            // §10.7.10.1: if MoreChunkedMessages is true,
+            // : if MoreChunkedMessages is true,
             // SuppressResponse SHALL be false. A peer that
             // violates this is malformed — abort the chain.
             if suppress_response {
@@ -980,7 +980,7 @@ impl<'a> InvokeRespChunk<'a> {
                 return Err(ErrorCode::InvalidData.into());
             }
 
-            // Per §10.7.10.3 — flow-control ACK between chunks.
+            // Per  — flow-control ACK between chunks.
             self.exchange
                 .send_with(|_, wb| {
                     StatusResp::write(wb, IMStatusCode::Success)?;
@@ -996,7 +996,7 @@ impl<'a> InvokeRespChunk<'a> {
 
             Ok(Some(self))
         } else {
-            // Final (or only) chunk. Per §8.8.3.1, Matter does not
+            // Final (or only) chunk. Per , Matter does not
             // support responses to InvokeResponse actions — the
             // SuppressResponse field is ignored by the client. MRP
             // -ack only.
@@ -1304,12 +1304,12 @@ pub enum SubscribeOutcome<'a> {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SubscribeEstablished {
     /// Subscription identifier chosen by the peer (Matter Core spec
-    /// §8.5.2). Combined with the accessing fabric and the peer
+    /// ). Combined with the accessing fabric and the peer
     /// node id, this is the lookup key for the active subscription.
     pub subscription_id: u32,
     /// Maximum reporting interval (seconds) the peer committed to.
     /// The peer MUST report no less frequently than this — see
-    /// Matter Core spec §8.5.3. Use this to drive a watchdog if the
+    /// Matter Core spec. Use this to drive a watchdog if the
     /// caller wants to detect a silently-broken subscription.
     pub max_int: u16,
 }

--- a/rs-matter/src/im/client.rs
+++ b/rs-matter/src/im/client.rs
@@ -972,7 +972,7 @@ impl<'a> InvokeRespChunk<'a> {
         };
 
         if more_chunks {
-            // : if MoreChunkedMessages is true,
+            // If MoreChunkedMessages is true,
             // SuppressResponse SHALL be false. A peer that
             // violates this is malformed — abort the chain.
             if suppress_response {
@@ -980,7 +980,7 @@ impl<'a> InvokeRespChunk<'a> {
                 return Err(ErrorCode::InvalidData.into());
             }
 
-            // Per  — flow-control ACK between chunks.
+            // Per the spec — flow-control ACK between chunks.
             self.exchange
                 .send_with(|_, wb| {
                     StatusResp::write(wb, IMStatusCode::Success)?;
@@ -996,7 +996,7 @@ impl<'a> InvokeRespChunk<'a> {
 
             Ok(Some(self))
         } else {
-            // Final (or only) chunk. Per , Matter does not
+            // Final (or only) chunk. Per the spec, Matter does not
             // support responses to InvokeResponse actions — the
             // SuppressResponse field is ignored by the client. MRP
             // -ack only.
@@ -1303,8 +1303,8 @@ pub enum SubscribeOutcome<'a> {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SubscribeEstablished {
-    /// Subscription identifier chosen by the peer (Matter Core spec
-    /// ). Combined with the accessing fabric and the peer
+    /// Subscription identifier chosen by the peer (Matter Core spec).
+    /// Combined with the accessing fabric and the peer
     /// node id, this is the lookup key for the active subscription.
     pub subscription_id: u32,
     /// Maximum reporting interval (seconds) the peer committed to.

--- a/rs-matter/src/im/invoke.rs
+++ b/rs-matter/src/im/invoke.rs
@@ -343,7 +343,7 @@ impl<'a> InvokeResp<'a> {
     /// `FromTLV` over `'a` and plug in directly.
     ///
     /// Multi-response: single-command invokes per Matter Core spec
-    ///  carry concrete paths only, but batched invokes
+    /// carry concrete paths only, but batched invokes
     /// (multiple `CommandDataIB`s in one `InvokeRequestMessage`) can
     /// produce multiple matching entries — the iterator yields one
     /// per match, in wire order.

--- a/rs-matter/src/im/invoke.rs
+++ b/rs-matter/src/im/invoke.rs
@@ -41,7 +41,7 @@ pub struct CmdPath {
 }
 
 /// Tags corresponding to the fields in the `CommandPathIB` TLV
-/// structure (Matter Core spec §10.6.7). `CmdPath` is encoded as a
+/// structure (Matter Core spec). `CmdPath` is encoded as a
 /// TLV *list* with positional context tags 0..2. Used by callers that
 /// need to perform low-level TLV serde on `CmdPath` data.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -343,7 +343,7 @@ impl<'a> InvokeResp<'a> {
     /// `FromTLV` over `'a` and plug in directly.
     ///
     /// Multi-response: single-command invokes per Matter Core spec
-    /// §8.2.5 carry concrete paths only, but batched invokes
+    ///  carry concrete paths only, but batched invokes
     /// (multiple `CommandDataIB`s in one `InvokeRequestMessage`) can
     /// produce multiple matching entries — the iterator yields one
     /// per match, in wire order.

--- a/rs-matter/src/im/invoke_builder.rs
+++ b/rs-matter/src/im/invoke_builder.rs
@@ -26,7 +26,7 @@
 //!
 //! # Layout
 //!
-//! Per Matter Core spec §10.7.9 `InvokeRequestMessage` is an
+//! Per Matter Core spec `InvokeRequestMessage` is an
 //! anonymous-tagged struct with three fields:
 //!
 //! | Tag | Field            | Type           | Required |
@@ -93,7 +93,7 @@ use crate::tlv::{TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite, ToTLV};
 ///
 /// All three top-level fields (`SuppressResponse`, `TimedRequest`,
 /// `InvokeRequests`) are mandatory on the wire per Matter Core spec
-/// §8.8.5, and the builder always emits all three. The two booleans
+/// , and the builder always emits all three. The two booleans
 /// are *optional at the API level* though — skipping either setter
 /// causes the builder to write the field with its default value
 /// (`false`) before opening the next state. This matches the
@@ -245,7 +245,7 @@ where
     P: TLVBuilderParent,
 {
     /// Write the mandatory-on-the-wire `InteractionModelRevision`
-    /// field (Matter Core §8.1.1, p. 545: value is `13` since Matter
+    /// field (Matter Core: value is `13` since Matter
     /// 1.3, unchanged in 1.4 and 1.5). Optional at the API level —
     /// omit and `end()` injects [`IM_REVISION`] automatically.
     pub fn interaction_model_revision(mut self, value: u8) -> Result<InvReqBuilder<P, 4>, Error> {
@@ -433,7 +433,7 @@ where
     /// Write the concrete `(endpoint, cluster, command)` path.
     /// Wildcards aren't meaningful for invokes — every send targets a
     /// concrete `(endpoint, cluster, command)` triple. The path is
-    /// encoded as a *list* per spec §10.6.7 `CommandPathIB`.
+    /// encoded as a *list* per spec `CommandPathIB`.
     pub fn path(
         mut self,
         endpoint: EndptId,
@@ -470,7 +470,7 @@ where
 {
     /// Write the command request body into the `Data` slot.
     ///
-    /// Per Matter Core spec §10.6.8 `CommandDataIB.Data` is the
+    /// Per Matter Core spec `CommandDataIB.Data` is the
     /// command's request payload — any TLV element tagged
     /// `TLVTag::Context(1)` (= `CmdDataTag::Data`). For commands
     /// with no request fields (e.g. `OnOff::On`, `OnOff::Toggle`)
@@ -539,7 +539,7 @@ where
 {
     /// Write the optional `CommandRef` field. **Mandatory** when the
     /// `InvokeRequests` array carries more than one entry (per spec
-    /// §8.8.5 — the server echoes this back so the client can
+    ///  — the server echoes this back so the client can
     /// correlate responses to requests). For single-command invokes,
     /// omit (go straight to `.end()`).
     pub fn command_ref(mut self, value: u16) -> Result<CmdDataBuilder<P, 3>, Error> {

--- a/rs-matter/src/im/invoke_builder.rs
+++ b/rs-matter/src/im/invoke_builder.rs
@@ -92,8 +92,8 @@ use crate::tlv::{TLVBuilder, TLVBuilderParent, TLVTag, TLVWrite, ToTLV};
 /// so the compiler enforces in-order field writes.
 ///
 /// All three top-level fields (`SuppressResponse`, `TimedRequest`,
-/// `InvokeRequests`) are mandatory on the wire per Matter Core spec
-/// , and the builder always emits all three. The two booleans
+/// `InvokeRequests`) are mandatory on the wire per Matter Core spec,
+/// and the builder always emits all three. The two booleans
 /// are *optional at the API level* though — skipping either setter
 /// causes the builder to write the field with its default value
 /// (`false`) before opening the next state. This matches the
@@ -538,8 +538,8 @@ where
     P: TLVBuilderParent,
 {
     /// Write the optional `CommandRef` field. **Mandatory** when the
-    /// `InvokeRequests` array carries more than one entry (per spec
-    ///  — the server echoes this back so the client can
+    /// `InvokeRequests` array carries more than one entry (per spec -
+    /// the server echoes this back so the client can
     /// correlate responses to requests). For single-command invokes,
     /// omit (go straight to `.end()`).
     pub fn command_ref(mut self, value: u16) -> Result<CmdDataBuilder<P, 3>, Error> {

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -424,7 +424,7 @@ impl<'a> Matter<'a> {
     /// the new value via `kv`, and route an attribute-change
     /// notification to subscribers via `notify`.
     ///
-    /// Per Matter Core Spec §7.7.2 / §9.2.11, the device MUST bump
+    /// Per Matter Core Spec, the device MUST bump
     /// this attribute on any change to its exposed fixed-quality
     /// surface (a firmware update that adds or removes functionality,
     /// internal reconfiguration that changes any `F`-quality attribute,
@@ -646,7 +646,7 @@ pub struct MatterState {
     failsafe: FailSafe,
     /// The mutable basic information settings
     basic_info_settings: BasicInfoSettings,
-    /// Real Time Clock state and Last-Known-Good UTC Time tracking (Matter Core spec §3.5.6.1).
+    /// Real Time Clock state and Last-Known-Good UTC Time tracking (Matter Core spec).
     rtc: Rtc,
 }
 

--- a/rs-matter/src/onboard.rs
+++ b/rs-matter/src/onboard.rs
@@ -55,7 +55,7 @@
 //! [`Commissioner::commission`] (over PASE) and
 //! [`Commissioner::complete_via_case`] (over CASE) are split because
 //! the rs-matter device responder requires `CommissioningComplete` to
-//! arrive over a CASE session (Matter Core spec §11.10.6.6 — and
+//! arrive over a CASE session (Matter Core spec — and
 //! enforced by `Failsafe::disarm` which calls `get_case_fab_idx`).
 
 use core::num::NonZeroU8;
@@ -77,7 +77,7 @@ use crate::Matter;
 pub mod cac;
 pub mod noc;
 
-/// NOCSRElements ([Matter Core spec §11.18.6.5.2]) is a struct with:
+/// NOCSRElements ([Matter Core spec]) is a struct with:
 ///   ctx(0) = `csr` (PKCS#10 CertificationRequest, DER-encoded)
 ///   ctx(1) = `CSRNonce` (32 bytes — must echo what we sent)
 ///   ctx(2..4) = vendor-reserved (ignored here)

--- a/rs-matter/src/onboard/cac.rs
+++ b/rs-matter/src/onboard/cac.rs
@@ -40,7 +40,7 @@
 //! factory / HSM path where each function might run on a different
 //! machine.
 //!
-//! All certs follow Matter Core spec §6.5 cert layout: subject DN
+//! All certs follow Matter Core spec cert layout: subject DN
 //! carries the fabric ID and the CA's own subject ID
 //! (`RootCaId` / `IcaId`); issuer DN carries the parent's subject ID
 //! (with `is_rcac` set when the parent is the RCAC itself).

--- a/rs-matter/src/onboard/noc.rs
+++ b/rs-matter/src/onboard/noc.rs
@@ -153,8 +153,7 @@ impl<'a> NocGenerator<'a> {
         validity: Validity,
     ) -> Result<&[u8], Error> {
         // Matter spec caps subject CAT IDs at three. Each CAT
-        // ID must have a non-zero version (upper 16 bits), per
-        // .
+        // ID must have a non-zero version (upper 16 bits), per the spec.
         if cat_ids.len() > 3 {
             return Err(ErrorCode::InvalidData.into());
         }
@@ -232,8 +231,8 @@ impl<'a> NocGenerator<'a> {
         self.signing_privkey
     }
 
-    /// ASN.1 DER `INTEGER` encoding of a 64-bit serial per X.690
-    ///  — strip leading zero bytes, then prepend a single `0x00`
+    /// ASN.1 DER `INTEGER` encoding of a 64-bit serial per X.690 -
+    /// strip leading zero bytes, then prepend a single `0x00`
     /// if the top bit of the result is set (to keep the value positive).
     fn encode_serial_asn1(serial: u64) -> heapless::Vec<u8, 9> {
         let serial_bytes_full = serial.to_be_bytes();

--- a/rs-matter/src/onboard/noc.rs
+++ b/rs-matter/src/onboard/noc.rs
@@ -23,7 +23,7 @@
 //! once (often offline, with HSM-controlled RCAC keys), NOC signing
 //! happens many times at runtime as new devices are commissioned.
 //!
-//! Supports both Matter PKI shapes per spec §6.5:
+//! Supports both Matter PKI shapes per spec:
 //!
 //! 1. **ICAC tier** (recommended for any real deployment) — `icac_id`
 //!    is `Some(_)`; the `signing_privkey` is the ICAC private key.
@@ -152,9 +152,9 @@ impl<'a> NocGenerator<'a> {
         cat_ids: &[u32],
         validity: Validity,
     ) -> Result<&[u8], Error> {
-        // Matter spec §6.5.6 caps subject CAT IDs at three. Each CAT
+        // Matter spec caps subject CAT IDs at three. Each CAT
         // ID must have a non-zero version (upper 16 bits), per
-        // §6.6.2.1.1.
+        // .
         if cat_ids.len() > 3 {
             return Err(ErrorCode::InvalidData.into());
         }
@@ -233,7 +233,7 @@ impl<'a> NocGenerator<'a> {
     }
 
     /// ASN.1 DER `INTEGER` encoding of a 64-bit serial per X.690
-    /// §8.3 — strip leading zero bytes, then prepend a single `0x00`
+    ///  — strip leading zero bytes, then prepend a single `0x00`
     /// if the top bit of the result is set (to keep the value positive).
     fn encode_serial_asn1(serial: u64) -> heapless::Vec<u8, 9> {
         let serial_bytes_full = serial.to_be_bytes();

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -26,7 +26,7 @@ use crate::utils::storage::WriteBuf;
 
 use super::*;
 
-// See section 5.1.2. QR Code in the Matter specification
+// See the spec. QR Code in the Matter specification
 const LONG_BITS: usize = 12;
 const VERSION_FIELD_LENGTH_IN_BITS: usize = 3;
 const VENDOR_IDFIELD_LENGTH_IN_BITS: usize = 16;
@@ -47,7 +47,7 @@ const TOTAL_PAYLOAD_DATA_SIZE_IN_BITS: usize = VERSION_FIELD_LENGTH_IN_BITS
 
 pub const TOTAL_PAYLOAD_DATA_SIZE_IN_BYTES: usize = TOTAL_PAYLOAD_DATA_SIZE_IN_BITS / 8;
 
-// Spec 5.1.4.2 CHIP-Common Reserved Tags
+// Spec CHIP-Common Reserved Tags
 pub const SERIAL_NUMBER_TAG: u8 = 0x00;
 pub const PBKDFITERATIONS_TAG: u8 = 0x01;
 pub const BPKFSALT_TAG: u8 = 0x02;

--- a/rs-matter/src/persist.rs
+++ b/rs-matter/src/persist.rs
@@ -52,13 +52,13 @@ pub const USER_LABELS_KEY: u16 = NETWORKS_KEY + 1;
 pub const BINDINGS_KEY: u16 = USER_LABELS_KEY + 1;
 
 /// The key used for storing the Last-Known-Good UTC Time value
-/// (Matter Core spec §3.5.6.1). A single u64 Matter-epoch microseconds
+/// (Matter Core spec). A single u64 Matter-epoch microseconds
 /// payload, updated synchronously from
 /// [`crate::Matter::set_utc_time`].
 pub const LKG_UTC_KEY: u16 = BINDINGS_KEY + 1;
 
 /// The key used for storing the Trusted Time Source configured by
-/// the `SetTrustedTimeSource` command (Matter Core spec §11.17.9.7).
+/// the `SetTrustedTimeSource` command (Matter Core spec).
 /// A single 11-byte payload: `[fab_idx:1 | node_id:8 (LE) | endpoint:2 (LE)]`,
 /// updated synchronously from [`crate::Matter::set_trusted_time_source`].
 /// The key is absent on disk when no trusted source is configured.

--- a/rs-matter/src/sc/case/casep.rs
+++ b/rs-matter/src/sc/case/casep.rs
@@ -38,12 +38,12 @@ pub const CASE_RESUMPTION_ID_LEN: usize = 16;
 
 pub const CASE_SESSION_KEYS_LEN: usize = AEAD_CANON_KEY_LEN * 3;
 
-// TBEData2_Nonce per spec 4.14.2.3: "NCASE_Sigma2N"
+// TBEData2_Nonce per spec: "NCASE_Sigma2N"
 const SIGMA2_NONCE: AeadNonceRef = AeadNonceRef::new(&[
     0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x32, 0x4e,
 ]);
 
-// TBEData3_Nonce per spec 4.14.2.3: "NCASE_Sigma3N"
+// TBEData3_Nonce per spec: "NCASE_Sigma3N"
 const SIGMA3_NONCE: AeadNonceRef = AeadNonceRef::new(&[
     0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x33, 0x4e,
 ]);

--- a/rs-matter/src/sc/case/responder.rs
+++ b/rs-matter/src/sc/case/responder.rs
@@ -117,7 +117,7 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
 
         let req = Sigma1Req::from_tlv(&get_root_node_struct(exchange.rx()?.payload())?)?;
 
-        // Matter Core spec section 4.13.2.1.1: `resumptionID` and
+        // Matter Core spec: `resumptionID` and
         // `initiatorResumeMIC` SHALL either both be present or both be
         // absent. A mismatched pair is a malformed Sigma1 and the
         // responder MUST reject it with `INVALID_PARAMETER` and stop

--- a/rs-matter/src/sc/pase.rs
+++ b/rs-matter/src/sc/pase.rs
@@ -96,7 +96,7 @@ pub struct CommWindow {
     /// The window expiry instant
     window_expiry: Instant,
     /// Number of failed PAKE handshake attempts within this window.
-    /// Per Matter Core spec section 11.18.6.1.5, the window SHALL be
+    /// Per Matter Core spec, the window SHALL be
     /// revoked after 20 unsuccessful handshakes.
     pake_failures: u8,
 }
@@ -353,7 +353,7 @@ impl Pase {
     /// Record a failed PAKE handshake against the currently-open
     /// commissioning window, and revoke the window if the limit is reached.
     ///
-    /// Per Matter Core spec section 11.18.6.1.5, after 20 unsuccessful PAKE
+    /// Per Matter Core spec, after 20 unsuccessful PAKE
     /// attempts the device SHALL revoke the open commissioning window.
     ///
     /// Also clears the in-progress PASE establishment timeout so that the

--- a/rs-matter/src/sc/pase/responder.rs
+++ b/rs-matter/src/sc/pase/responder.rs
@@ -73,7 +73,7 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
     pub async fn handle(&mut self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
         let result = self.handle_inner(exchange).await;
 
-        // Per Matter Core spec section 11.18.6.1.5, every unsuccessful PAKE
+        // Per Matter Core spec, every unsuccessful PAKE
         // handshake within the open commissioning window must be counted; the
         // window SHALL be revoked after 20. We charge a failure for any path
         // that errored mid-handshake or returned `Ok(false)` from
@@ -247,7 +247,7 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
         } else {
             // No commissioning window open: silently ignore so the
             // initiator times out (RFC 6762 §6.7-style "no response").
-            // Per Matter Core Spec §11.18 a PASE attempt outside the
+            // Per Matter Core Spec a PASE attempt outside the
             // commissioning window is not a wrong-passcode failure and
             // therefore must not count toward the 20-failure limit, so
             // we report `Ok(false)` (drop) rather than an error.

--- a/rs-matter/src/tlv/traits/builder.rs
+++ b/rs-matter/src/tlv/traits/builder.rs
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2025 Project CHIP Authors
+ *    Copyright (c) 2025-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/rs-matter/src/tlv/traits/builder.rs
+++ b/rs-matter/src/tlv/traits/builder.rs
@@ -35,13 +35,13 @@
 //! {
 //!     pub fn new(mut p: P, tag: &TLVTag) -> Result<Self, Error> {
 //!         p.writer().start_struct(tag)?;
-//!        
+//!
 //!         Ok(Self { p })
 //!     }
 //!
 //!     pub fn field1(mut self, value: i32) -> Result<FooBuilder<P, 1>, Error> {
 //!         self.p.writer().i32(&TLVTag::Context(0), value)?;
-//!        
+//!
 //!         Ok(FooBuilder {
 //!             p: self.p,
 //!         })
@@ -164,7 +164,7 @@
 //! {
 //!     pub fn new(mut p: P, tag: &TLVTag) -> Result<Self, Error> {
 //!         p.writer().start_struct(tag)?;
-//!        
+//!
 //!         Ok(Self { p })
 //!     }
 //!

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -278,10 +278,10 @@ impl Transport {
                 .sessions
                 .add(rand.next_u32(), false, peer_addr, None)?;
 
-            // Generate ephemeral initiator node ID per spec 4.13.2.1:
+            // Generate ephemeral initiator node ID per spec:
             // "Randomly selected for each session by the initiator from the Operational Node ID range"
             // Operational Node ID range is 0x0000_0000_0000_0001 to 0xFFFF_FFEF_FFFF_FFFF
-            // (spec Table 4, Section 2.5.5).
+            // (Matter Core spec).
             const MAX_OPERATIONAL_NODE_ID: u64 = 0xFFFF_FFEF_FFFF_FFFF;
             let mut ephemeral_id = rand.next_u64();
             while ephemeral_id == 0 || ephemeral_id > MAX_OPERATIONAL_NODE_ID {
@@ -735,7 +735,7 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                 );
             }
             Err(e) if matches!(e.code(), ErrorCode::NoSession) => {
-                // Per Matter Core spec section 4.7.1.3, when a session-bearing
+                // Per Matter Core spec, when a session-bearing
                 // message arrives for which we have no matching secure session
                 // (e.g. after a reboot has wiped the session table while the
                 // peer still believes the old session is alive), we reply with

--- a/rs-matter/src/transport/dedup.rs
+++ b/rs-matter/src/transport/dedup.rs
@@ -343,7 +343,7 @@ mod tests {
 
         #[test]
         fn rollover_accepts_counter_past_u32_max() {
-            // Spec §4.6.5.2.2: forward iff (msg - max) mod 2^32 in [1, 2^31 - 1].
+            // Spec: forward iff (msg - max) mod 2^32 in [1, 2^31 - 1].
             // max near u32::MAX, msg just past zero is still forward.
             let mut store = GroupCtrStore::new();
             assert!(store.post_recv(1, 0x1111, u32::MAX - 1));

--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -294,7 +294,7 @@ impl RecvWindow {
             .unwrap_or(true)
         {
             warn!(
-                "RX data integrity failure: Data packets must have a sequence number which is equal to the last one received + 1; expected={}, actual={:?}", 
+                "RX data integrity failure: Data packets must have a sequence number which is equal to the last one received + 1; expected={}, actual={:?}",
                 self.ack_seq.wrapping_add(1),
                 hdr.get_seq());
             return Err(ErrorCode::InvalidData.into());

--- a/rs-matter/src/transport/network/mdns.rs
+++ b/rs-matter/src/transport/network/mdns.rs
@@ -550,7 +550,7 @@ impl MatterService {
                 let (name, mut wb) =
                     write_split!(wb, "{:016X}-{:016X}", compressed_fabric_id, node_id)?;
 
-                // Operational fabric subtype per Matter Core Spec §4.3.2:
+                // Operational fabric subtype per Matter Core Spec:
                 // `_I<compressed_fabric_id>._sub._matter._tcp.local.` lets a
                 // controller browse for nodes of a given fabric without
                 // already knowing each node's id.
@@ -566,7 +566,7 @@ impl MatterService {
                     ("", wb)
                 };
 
-                // Per Matter Core Spec Section 4.3.1.14, T is a bitmap:
+                // Per Matter Core Spec, T is a bitmap:
                 // bit 1 (value 2) = TCP client, bit 2 (value 4) = TCP server
                 let txt_kvs = [
                     ("SAI", txt_sai),

--- a/rs-matter/src/transport/network/mdns/builtin/proto.rs
+++ b/rs-matter/src/transport/network/mdns/builtin/proto.rs
@@ -107,7 +107,7 @@ impl Host<'_> {
     /// data itself, or in the data of one of its services.
     ///
     /// Per RFC 6762 §18.1 the message ID for unsolicited multicast responses
-    /// is set to zero; per §10.2 records that we are authoritative for carry
+    /// is set to zero; per spec records that we are authoritative for carry
     /// the cache-flush bit.
     pub fn broadcast<'a, S, T>(
         &self,

--- a/rs-matter/src/transport/network/tcp.rs
+++ b/rs-matter/src/transport/network/tcp.rs
@@ -23,7 +23,7 @@
 //! traits, hiding the connection-oriented nature of TCP behind the connectionless `NetworkSend`/`NetworkReceive`
 //! abstractions used by the Matter transport layer.
 //!
-//! Per the Matter Core Specification (Section 4.7), TCP messages are framed with a 4-byte little-endian
+//! Per the Matter Core Specification, TCP messages are framed with a 4-byte little-endian
 //! message length prefix. This module handles the framing/de-framing transparently.
 //!
 //! # Connection Management
@@ -104,7 +104,7 @@ pub const DEFAULT_MAX_TCP_CONNECTIONS: usize = 8;
 
 /// Size of the TCP framing header (4-byte little-endian message length prefix).
 ///
-/// Per the Matter Core Specification (Section 4.7.2).
+/// Per the Matter Core Specification.
 const FRAME_HDR_LEN: usize = 4;
 
 /// Maximum size of the per-connection receive buffer.
@@ -126,7 +126,7 @@ const MAX_RX_BUF_SIZE: usize = MAX_RX_LARGE_PACKET_SIZE + FRAME_HDR_LEN;
 /// enabling full-duplex operation where sending and receiving happen concurrently on the same
 /// `TcpNetwork` instance.
 ///
-/// Per the Matter Core Specification (Section 4.7), TCP messages are framed with a 4-byte
+/// Per the Matter Core Specification, TCP messages are framed with a 4-byte
 /// little-endian message length prefix. This is handled transparently by this implementation.
 pub struct TcpNetwork<const N: usize = DEFAULT_MAX_TCP_CONNECTIONS> {
     /// The TCP listener for accepting incoming connections.

--- a/rs-matter/src/transport/proto_hdr.rs
+++ b/rs-matter/src/transport/proto_hdr.rs
@@ -375,7 +375,7 @@ fn get_iv(
 ) -> Result<(), Error> {
     // The IV is the source address (64-bit) followed by the message counter (32-bit)
     let mut write_buf = WriteBuf::new(iv.access_mut());
-    // First byte is the Security Flags from the plain header (Matter spec Section 4.7.2)
+    // First byte is the Security Flags from the plain header (Matter spec)
     write_buf.le_u8(sec_flags)?;
     write_buf.le_u32(recvd_ctr)?;
     write_buf.le_u64(peer_nodeid)?;

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -269,7 +269,7 @@ impl Session {
 
         // For unsecured sessions, also match by destination node ID (the echoed
         // ephemeral initiator node ID) to disambiguate multiple unsecured sessions
-        // for the same peer (spec 4.13.2.1).
+        // for the same peer (spec).
         let dest_nodeid_matches = self.is_encrypted()
             || self.local_nodeid == 0
             || rx_plain.get_dst_unicast_nodeid().is_none()
@@ -338,7 +338,7 @@ impl Session {
             }
 
             if self.expired {
-                // Per Matter Core spec section 4.7.1.3, an expired session must not
+                // Per Matter Core spec, an expired session must not
                 // accept new inbound messages. Skipping expired sessions here lets the
                 // caller surface a `SessionNotFound` to the peer rather than running
                 // the request through ACL checks against a removed fabric.
@@ -379,7 +379,7 @@ impl Session {
         tx_header.plain.sess_id = self.get_peer_sess_id();
         tx_header.plain.ctr = ctr.unwrap_or_else(|| self.get_msg_ctr());
         // For unsecured initiator sessions, set Source Node ID to our ephemeral
-        // initiator node ID (spec 4.13.2.1: "enclosed by initiator as Source Node ID").
+        // initiator node ID (spec: "enclosed by initiator as Source Node ID").
         // Encrypted sessions and responder unsecured sessions (local_nodeid=0) send no Source.
         tx_header.plain.set_src_nodeid(
             (!self.is_encrypted() && self.local_nodeid != 0).then_some(self.local_nodeid),
@@ -1200,13 +1200,13 @@ impl Sessions {
     /// fabric. Used by:
     ///
     /// * `RevokeCommissioning` and a fail-safe expiry over a PASE
-    ///   session (Matter Core spec section 11.18.6.2): when the
+    ///   session (Matter Core spec): when the
     ///   commissioning window is torn down, any in-flight PASE sessions
     ///   associated with it must be terminated. A PASE that was
     ///   promoted via `AddNOC` is rolled back by the same fail-safe
     ///   expiry, so its session must go too.
-    /// * `CommissioningComplete` (spec V1.3 section 5.5 / V1.4 section
-    ///   11.10.7.4): once the device transitions to operational state,
+    /// * `CommissioningComplete` (Matter Core spec): once the device
+    ///   transitions to operational state,
     ///   all PASE sessions SHALL be terminated. Without this each
     ///   commissioning round leaks the promoted PASE it ran on, and
     ///   the session table eventually exhausts — visible as `BUSY` on
@@ -1258,7 +1258,7 @@ impl fmt::Display for Sessions {
 
 /// Derive the Group Session ID from an operational group key.
 ///
-/// Per Matter Spec Section 4.17.3.6:
+/// Per Matter Spec:
 /// ```text
 /// GroupKeyHash = Crypto_KDF(
 ///     InputKey = OperationalGroupKey,

--- a/rs-matter/src/utils/epoch.rs
+++ b/rs-matter/src/utils/epoch.rs
@@ -25,7 +25,7 @@
 //! timestamp, …) reads / writes the Last-Known-Good UTC Time on the
 //! [`crate::Matter`] object via [`crate::Matter::last_known_utc_time`]
 //! / [`crate::Matter::utc_time`] / [`crate::Matter::set_utc_time`].
-//! That value is persisted (per Matter Core spec §3.5.6.1), seeded
+//! That value is persisted (per Matter Core spec), seeded
 //! from [`FIRMWARE_BUILD_MATTER_US`] on a freshly-flashed device, and
 //! is the single source of truth — application code that has access
 //! to a real-time clock or NTP samples should feed those into

--- a/rs-matter/src/utils/storage/vec.rs
+++ b/rs-matter/src/utils/storage/vec.rs
@@ -43,7 +43,6 @@ use crate::utils::init::{init_from_closure, Init, InitDefault};
 /// ```
 /// use heapless::Vec;
 ///
-///
 /// // A vector with a fixed capacity of 8 elements allocated on the stack
 /// let mut vec = Vec::<_, 8>::new();
 /// vec.push(1);


### PR DESCRIPTION
Two commits, both concerning comments only:

#### Tag Compression comment

A new comment justifying why tag compression is not implemented (because nobody does, and it should've been optional or even removed from the spec anyway)

#### Remove Matter Core Spec sections' numbers 

... from the comments. Two reasons:

- The sections numbers tend to drift with each new release of the spec
- When the comment was authored with AI, the AI tends to make up these sections numbers if it was not explicitly instructed to consult the Core Spec PDF during development
