### PR TITLE
Switch to the new mbedtls-rs dep

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -160,7 +160,7 @@ pinned-init = { version = "0.0.8", default-features = false }
 # crypto
 openssl = { version = "0.10", optional = true }
 foreign-types = { version = "0.3", optional = true }
-mbedtls-rs-sys = { git = "https://github.com/esp-rs/mbedtls-rs", optional = true }
+mbedtls-rs-sys = { git = "https://github.com/esp-rs/mbedtls-rs", default-features = false, features = ["matter"], optional = true }
 
 # rust-crypto
 # Generic traits and traitified structures

--- a/rs-matter/src/crypto/backend/mbedtls.rs
+++ b/rs-matter/src/crypto/backend/mbedtls.rs
@@ -1643,13 +1643,3 @@ unsafe extern "C" fn mbedtls_platform_entropy_source<T: RngCore>(
 
     0
 }
-
-/// MbedTLS platform zeroize function.
-// TODO: Make it user-provided
-#[cfg(not(target_os = "espidf"))]
-#[no_mangle]
-unsafe extern "C" fn mbedtls_platform_zeroize(dst: *mut c_uchar, len: u32) {
-    for i in 0..len as isize {
-        dst.offset(i).write_volatile(0);
-    }
-}


### PR DESCRIPTION
Subject says it all. We need to do it or else the nightly CI will break against the new mbedtls-rs-sys