### PR TITLE
A connect utility to aid when doing non-concurrent commissioning

### DIFF
--- a/rs-matter/src/dm/networks/wireless/mgr.rs
+++ b/rs-matter/src/dm/networks/wireless/mgr.rs
@@ -22,7 +22,7 @@ use core::pin::pin;
 use embassy_futures::select::select;
 use embassy_time::Timer;
 
-use crate::dm::clusters::net_comm::{self, NetCtlError, WirelessCreds};
+use crate::dm::clusters::net_comm::{self, NetCtlError, NetworksError, WirelessCreds};
 use crate::dm::clusters::wifi_diag;
 use crate::error::{Error, ErrorCode};
 use crate::utils::select::Coalesce;
@@ -82,6 +82,41 @@ where
         }
     }
 
+    /// Perform a single, one-shot connect to the network with the given ID.
+    ///
+    /// Unlike [`WirelessMgr::run`] - which is the operational connectivity
+    /// maintainer and therefore only acts once the device is commissioned - this
+    /// method connects immediately, regardless of the commissioning status.
+    ///
+    /// It exists to support **non-concurrent** commissioning over BLE: there, the
+    /// commissioner's `ConnectNetwork` command arrives while the operational
+    /// (Wifi/Thread) network cannot yet run (the radio is busy with BLE), so the
+    /// actual connect must be *deferred* and replayed once BLE is torn down and
+    /// the operational network is brought up - but still *before* commissioning
+    /// completes (the commissioner re-establishes a CASE session over the
+    /// operational network and only then sends `CommissioningComplete`).
+    ///
+    /// The credentials are looked up by `network_id` from the networks storage
+    /// (they were stored earlier by the commissioner's `AddOrUpdate*Network`
+    /// command). Returns `Ok(())` on a successful connect; the same retry/backoff
+    /// as the operational loop is applied before giving up.
+    pub async fn connect_once(&mut self, network_id: &[u8]) -> Result<(), Error> {
+        let creds = Self::creds(&self.networks, network_id, self.buf)?;
+
+        let Some(creds) = creds else {
+            warn!("No network with the requested ID found; cannot perform the deferred connect");
+            return Err(ErrorCode::InvalidData.into());
+        };
+
+        match Self::connect(&self.net_ctl, &creds).await {
+            Ok(()) => Ok(()),
+            // Surface the underlying error verbatim, or map a typed connection
+            // failure to a generic "no network interface" error.
+            Err(NetCtlError::Other(e)) => Err(e),
+            Err(_) => Err(ErrorCode::NoNetworkInterface.into()),
+        }
+    }
+
     async fn run_connect(networks: &W, net_ctl: &T, buf: &mut [u8]) -> Result<(), Error> {
         // Try to connect to the networks in a round-robin fashion until we succeed or the commissioning status changes.
 
@@ -137,59 +172,104 @@ where
         }
     }
 
+    /// Look up the credentials for a specific `network_id`, copying them into
+    /// `buf` and returning a `WirelessCreds` borrowing from it (or `None` if no
+    /// such network is recorded). Mirrors [`WirelessMgr::next_creds`] but selects
+    /// a network by ID rather than by round-robin position.
+    fn creds<'d>(
+        networks: &W,
+        network_id: &[u8],
+        buf: &'d mut [u8],
+    ) -> Result<Option<WirelessCreds<'d>>, Error> {
+        let mut offsets = None;
+
+        let found = networks.access(|networks| {
+            networks.creds(network_id, &mut |creds| {
+                offsets = Some(Self::copy_creds(buf, creds)?);
+
+                Ok(())
+            })
+        });
+
+        // A missing network is not an error here - the caller decides what to do.
+        if matches!(found, Err(NetworksError::NetworkIdNotFound)) {
+            return Ok(None);
+        }
+
+        found.map_err(|e| match e {
+            NetworksError::Other(e) => e,
+            _ => ErrorCode::InvalidData.into(),
+        })?;
+
+        Ok(offsets.map(|offsets| Self::rebuild_creds(buf, offsets)))
+    }
+
     fn next_creds<'d>(
         networks: &W,
         last_network_id: Option<&[u8]>,
         buf: &'d mut [u8],
     ) -> Result<Option<WirelessCreds<'d>>, Error> {
-        let mut next_creds_offsets = None;
+        let mut offsets = None;
 
         networks.access(|networks| {
             networks.next_creds(last_network_id, &mut |creds| {
-                match creds {
-                    WirelessCreds::Wifi { ssid, pass } => {
-                        if ssid.len() + pass.len() > buf.len() {
-                            error!("SSID and password too large");
-                            return Err(ErrorCode::InvalidData.into());
-                        }
-
-                        buf[..ssid.len()].copy_from_slice(ssid);
-                        buf[ssid.len()..][..pass.len()].copy_from_slice(pass);
-
-                        next_creds_offsets = Some((ssid.len(), Some(pass.len())))
-                    }
-                    WirelessCreds::Thread { dataset_tlv } => {
-                        if dataset_tlv.len() > buf.len() {
-                            error!("Dataset TLV too large");
-                            return Err(ErrorCode::InvalidData.into());
-                        }
-
-                        buf[..dataset_tlv.len()].copy_from_slice(dataset_tlv);
-
-                        next_creds_offsets = Some((dataset_tlv.len(), None))
-                    }
-                }
+                offsets = Some(Self::copy_creds(buf, creds)?);
 
                 Ok(())
             })
         })?;
 
-        let next_creds = if let Some((len1, len2)) = next_creds_offsets {
-            Some(if let Some(len2) = len2 {
-                WirelessCreds::Wifi {
-                    ssid: &buf[..len1],
-                    pass: &buf[len1..][..len2],
-                }
-            } else {
-                WirelessCreds::Thread {
-                    dataset_tlv: &buf[..len1],
-                }
-            })
-        } else {
-            None
-        };
+        Ok(offsets.map(|offsets| Self::rebuild_creds(buf, offsets)))
+    }
 
-        Ok(next_creds)
+    /// Copy the credentials yielded by a `Networks` accessor into `buf`,
+    /// returning the byte offsets of the copied fields: `(len1, Some(len2))` for
+    /// WiFi (`ssid` then `pass`), or `(len1, None)` for Thread (the dataset TLV).
+    ///
+    /// The yielded `WirelessCreds` borrow from the (locked) networks storage, so
+    /// they cannot outlive the accessor; copying into the caller's `buf` lets the
+    /// credentials be used (e.g. passed to `connect`) outside the lock. Pair with
+    /// [`WirelessMgr::rebuild_creds`] to turn the offsets back into a borrowing
+    /// `WirelessCreds`.
+    fn copy_creds(buf: &mut [u8], creds: &WirelessCreds) -> Result<(usize, Option<usize>), Error> {
+        match creds {
+            WirelessCreds::Wifi { ssid, pass } => {
+                if ssid.len() + pass.len() > buf.len() {
+                    error!("SSID and password too large");
+                    return Err(ErrorCode::InvalidData.into());
+                }
+
+                buf[..ssid.len()].copy_from_slice(ssid);
+                buf[ssid.len()..][..pass.len()].copy_from_slice(pass);
+
+                Ok((ssid.len(), Some(pass.len())))
+            }
+            WirelessCreds::Thread { dataset_tlv } => {
+                if dataset_tlv.len() > buf.len() {
+                    error!("Dataset TLV too large");
+                    return Err(ErrorCode::InvalidData.into());
+                }
+
+                buf[..dataset_tlv.len()].copy_from_slice(dataset_tlv);
+
+                Ok((dataset_tlv.len(), None))
+            }
+        }
+    }
+
+    /// Reconstruct a `WirelessCreds` borrowing from `buf`, given the offsets
+    /// returned by [`WirelessMgr::copy_creds`].
+    fn rebuild_creds(buf: &[u8], (len1, len2): (usize, Option<usize>)) -> WirelessCreds<'_> {
+        if let Some(len2) = len2 {
+            WirelessCreds::Wifi {
+                ssid: &buf[..len1],
+                pass: &buf[len1..][..len2],
+            }
+        } else {
+            WirelessCreds::Thread {
+                dataset_tlv: &buf[..len1],
+            }
+        }
     }
 
     async fn connect(net_ctl: &T, creds: &WirelessCreds<'_>) -> Result<(), NetCtlError> {

--- a/rs-matter/src/dm/networks/wireless/mgr.rs
+++ b/rs-matter/src/dm/networks/wireless/mgr.rs
@@ -574,4 +574,61 @@ mod tests {
             assert!(result.is_ok());
         });
     }
+
+    // ── creds-by-id / connect_once tests (deferred non-concurrent connect) ──
+
+    #[test]
+    fn creds_by_id_returns_matching_or_none() {
+        let networks = make_networks(
+            &[(b"MySSID", b"MyPass"), (b"OtherSSID", b"OtherPass")],
+            false,
+        );
+        let mut buf = [0u8; MAX_CREDS_SIZE];
+
+        // An existing network is looked up by id.
+        let creds = TestMgr::creds(&networks, b"MySSID", &mut buf)
+            .unwrap()
+            .unwrap();
+        match creds {
+            WirelessCreds::Wifi { ssid, pass } => {
+                assert_eq!(ssid, b"MySSID");
+                assert_eq!(pass, b"MyPass");
+            }
+            _ => panic!("Expected WiFi creds"),
+        }
+
+        // A missing network is `Ok(None)` (not found), not an error.
+        assert!(TestMgr::creds(&networks, b"NonExistent", &mut buf)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn connect_once_connects_to_named_network() {
+        let networks = make_networks(&[(b"MySSID", b"MyPass")], false);
+        let net_ctl = FakeNetCtl::new();
+        let mut buf = [0u8; MAX_CREDS_SIZE];
+        // `new` takes the networks/net_ctl by value, so the manager owns them;
+        // `Ok` already implies `FakeNetCtl::connect` ran (its only `Ok` path
+        // sets `connected = true`), so there's no need to inspect it afterwards.
+        let mut mgr = TestMgr::new(networks, net_ctl, &mut buf);
+
+        embassy_futures::block_on(async {
+            assert!(mgr.connect_once(b"MySSID").await.is_ok());
+        });
+    }
+
+    #[test]
+    fn connect_once_unknown_network_is_invalid_data() {
+        let networks = make_networks(&[], false);
+        let net_ctl = FakeNetCtl::new();
+        let mut buf = [0u8; MAX_CREDS_SIZE];
+        let mut mgr = TestMgr::new(networks, net_ctl, &mut buf);
+
+        embassy_futures::block_on(async {
+            // No matching network -> a deferred connect can't proceed.
+            let err = mgr.connect_once(b"MySSID").await.unwrap_err();
+            assert!(matches!(err.code(), ErrorCode::InvalidData));
+        });
+    }
 }

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -293,7 +293,12 @@ impl Transport {
 
     /// Responder-side: await the next pending mDNS resolve request, marking it
     /// in-flight.
-    pub(crate) async fn wait_mdns_resolve_request(&self) -> MatterRemoteService {
+    ///
+    /// Part of the public responder contract: a third-party mDNS responder
+    /// (living outside this crate) drives the resolve use case by awaiting a
+    /// request here, issuing its own query, and depositing any answers via
+    /// [`Transport::try_deposit_mdns_resolve`].
+    pub async fn wait_mdns_resolve_request(&self) -> MatterRemoteService {
         self.mdns_resolve
             .wait(|state| match state {
                 MdnsResolveState::Requested { service } => {
@@ -310,10 +315,10 @@ impl Transport {
 
     /// Whether an operational resolve is currently in flight.
     ///
-    /// Used by the OS-backed mDNS implementations to poll-drive their resolve
+    /// Used by mDNS implementations to poll-drive their resolve
     /// loop only while a request is outstanding.
     #[allow(dead_code)]
-    pub(crate) fn mdns_resolve_in_flight(&self) -> bool {
+    pub fn mdns_resolve_in_flight(&self) -> bool {
         self.mdns_resolve
             .modify(|state| (false, matches!(state, MdnsResolveState::InFlight { .. })))
     }
@@ -323,10 +328,11 @@ impl Transport {
     /// matches. Best-effort: a non-matching, address-less, or absent request is
     /// a no-op.
     ///
-    /// The single resolve-deposit entry point shared by the builtin parser and
-    /// the OS-backed responders - both hand it an [`MdnsRemoteService`] (the
-    /// former lazily over the packet, the latter over their native records).
-    pub(crate) fn try_deposit_mdns_resolve<'a, I, A, T>(&self, answer: &MdnsRemoteService<I, A, T>)
+    /// The single resolve-deposit entry point shared by the builtin parser, the
+    /// OS-backed responders, and any third-party responder - all hand it an
+    /// [`MdnsRemoteService`] (the builtin lazily over the packet, the others over
+    /// their native records).
+    pub fn try_deposit_mdns_resolve<'a, I, A, T>(&self, answer: &MdnsRemoteService<I, A, T>)
     where
         I: ToLabelIter,
         A: Iterator<Item = IpAddr> + Clone,
@@ -441,7 +447,12 @@ impl Transport {
     /// Responder-side: await the next pending mDNS browse request, marking it
     /// in-flight. Returns the filter to query for (the exclude set is consulted
     /// later, at deposit time).
-    pub(crate) async fn wait_mdns_browse_request(&self) -> CommissionableFilter {
+    ///
+    /// Part of the public responder contract: a third-party mDNS responder
+    /// (living outside this crate) drives the commissionable-browse use case by
+    /// awaiting a request here, issuing its own query, and depositing matches via
+    /// [`Transport::try_deposit_mdns_browse`].
+    pub async fn wait_mdns_browse_request(&self) -> CommissionableFilter {
         self.mdns_browse
             .wait(|state| match state {
                 MdnsBrowseState::Requested { filter, exclude } => {
@@ -460,10 +471,10 @@ impl Transport {
 
     /// Whether a commissionable browse is currently in flight.
     ///
-    /// Used by the OS-backed mDNS implementations to poll-drive their browse
+    /// Used by mDNS implementations to poll-drive their browse
     /// loop only while a request is outstanding.
     #[allow(dead_code)]
-    pub(crate) fn mdns_browse_in_flight(&self) -> bool {
+    pub fn mdns_browse_in_flight(&self) -> bool {
         self.mdns_browse
             .modify(|state| (false, matches!(state, MdnsBrowseState::InFlight { .. })))
     }
@@ -473,9 +484,10 @@ impl Transport {
     /// its TXT records match the filter. Best-effort: a non-matching, excluded,
     /// address-less, or absent request is a no-op.
     ///
-    /// The single browse-deposit entry point shared by the builtin parser and
-    /// the OS-backed responders - both hand it an [`MdnsRemoteService`].
-    pub(crate) fn try_deposit_mdns_browse<'a, I, A, T>(&self, answer: &MdnsRemoteService<I, A, T>)
+    /// The single browse-deposit entry point shared by the builtin parser, the
+    /// OS-backed responders, and any third-party responder - all hand it an
+    /// [`MdnsRemoteService`].
+    pub fn try_deposit_mdns_browse<'a, I, A, T>(&self, answer: &MdnsRemoteService<I, A, T>)
     where
         I: ToLabelIter,
         A: Iterator<Item = IpAddr> + Clone,


### PR DESCRIPTION
Since some time, `WirelssMgr::run` would ONLY trigger its (re)connection loop when it detects that rs-matter is in "commissioned" mode.

And there is a good reason for that - I don't think the manager should cycle through registered connections and do re-connection by itself while the device is still being commissioned. The philosophy is - during commissioning, it is **the responsibility of the commissioner** to call the "connect" cmd and thus connect the device to the wireless network.

If - during commissioning - the device loses access to the wireless network - well, bad luck, commissioning should start all-over again. But during that time, WirelessMgr is "hands off".

So far, so good, and this is what was implemented some time ago.

What this PR does, is to introduce a mini helper method `WirelessMgr::connect_once`, which connects to a specified network. We need this for the non-concurrent commissioning case, where when the commissioner invokes the "connect" command, we should reply to it "ok" **without** connecting (as we don't have thread/wifi up yet), then remember the network id from the command, bring down ble, bring up thread/wifi _and only then_ performing the connect with the remembered network ID.