### PR TITLE
BDX protocol messages

### DIFF
--- a/rs-matter/src/bdx.rs
+++ b/rs-matter/src/bdx.rs
@@ -24,6 +24,7 @@
 
 use num_derive::FromPrimitive;
 
+use crate::sc::{GeneralCode, StatusReport};
 use crate::transport::exchange::MessageMeta;
 
 pub use block::*;
@@ -75,5 +76,38 @@ impl OpCode {
 impl From<OpCode> for MessageMeta {
     fn from(op: OpCode) -> Self {
         op.meta()
+    }
+}
+
+/// An enumeration of all possible error codes that can be returned by the BDX protocol.
+#[derive(FromPrimitive, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum BdxStatusCode {
+    LengthTooLarge = 0x0012,
+    LengthTooShort = 0x0013,
+    LengthMismatch = 0x0014,
+    LengthRequired = 0x0015,
+    BadMessageContents = 0x0016,
+    BadBlockCounter = 0x0017,
+    UnexpectedMessage = 0x0018,
+    ResponderBusy = 0x0019,
+    TransferFailedUnknownError = 0x001F,
+    TransferMethodNotSupported = 0x0050,
+    FileDesignatorUnknown = 0x0051,
+    StartOffsetNotSupported = 0x0052,
+    VersionNotSupported = 0x0053,
+    Unknown = 0x005F,
+}
+
+impl BdxStatusCode {
+    /// Build the `StatusReport` that carries this BDX status code.
+    pub fn as_report(&self) -> StatusReport<'static> {
+        StatusReport {
+            // BDX `StatusReport` always denote a failure, see 11.22.3.2 in Core Spec
+            general_code: GeneralCode::Failure,
+            proto_id: PROTO_ID_BDX as u32,
+            proto_code: *self as u16,
+            proto_data: &[],
+        }
     }
 }

--- a/rs-matter/src/bdx.rs
+++ b/rs-matter/src/bdx.rs
@@ -26,8 +26,10 @@ use num_derive::FromPrimitive;
 
 use crate::transport::exchange::MessageMeta;
 
+pub use block::*;
 pub use init::*;
 
+mod block;
 mod init;
 
 /// BDX Protocol ID, as per the Matter Core Spec.

--- a/rs-matter/src/bdx.rs
+++ b/rs-matter/src/bdx.rs
@@ -1,0 +1,77 @@
+/*
+ *
+ *    Copyright (c) 2022-2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Implementation of the Bulk Data Exchange (BDX) protocol, as per the Matter Spec.
+//!
+//! BDX runs as its own protocol (proto ID `0x0002`) inside ordinary Matter exchanges,
+//! alongside Secure Channel ([`crate::sc`]) and the Interaction Model ([`crate::im`]).
+//! Unlike most Matter messages, BDX messages are NOT TLV-encoded - they use a bespoke,
+//! little-endian binary layout (only the trailing `Metadata` blob is TLV).
+
+use num_derive::FromPrimitive;
+
+use crate::transport::exchange::MessageMeta;
+
+pub use init::*;
+
+mod init;
+
+/// BDX Protocol ID, as per the Matter Core Spec.
+pub const PROTO_ID_BDX: u16 = 0x02;
+
+/// The BDX protocol version is pinned to 0 per 11.22.5.1 in Matter Core Spec
+/// (a bit hidden, it's in the first paragraph about the PTC field)
+pub const BDX_VERSION: u8 = 0;
+
+/// BDX message opcodes, as per the Matter Core Spec, 11.22.3.1
+#[derive(FromPrimitive, Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OpCode {
+    SendInit = 0x01,
+    SendAccept = 0x02,
+    ReceiveInit = 0x04,
+    ReceiveAccept = 0x05,
+    BlockQuery = 0x10,
+    Block = 0x11,
+    BlockEOF = 0x12,
+    BlockAck = 0x13,
+    BlockAckEOF = 0x14,
+    BlockQueryWithSkip = 0x15,
+}
+
+impl OpCode {
+    pub fn meta(&self) -> MessageMeta {
+        MessageMeta {
+            proto_id: PROTO_ID_BDX,
+            proto_opcode: *self as u8,
+            // All BDX messages are sent over the reliable (MRP) exchange.
+            reliable: true,
+        }
+    }
+
+    /// BDX messages use a bespoke binary encoding rather than a TLV envelope;
+    /// Done like this to be consistent with im.rs and sc.rs.
+    pub fn is_tlv(&self) -> bool {
+        false
+    }
+}
+
+impl From<OpCode> for MessageMeta {
+    fn from(op: OpCode) -> Self {
+        op.meta()
+    }
+}

--- a/rs-matter/src/bdx/block.rs
+++ b/rs-matter/src/bdx/block.rs
@@ -1,0 +1,162 @@
+/*
+ *
+ *    Copyright (c) 2022-2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! This module defines the BDX block-transfer control messages: `BlockQuery`, `BlockAck`,
+//! `BlockAckEOF` and `BlockQueryWithSkip`, per the Matter Core Spec. 
+
+use core::borrow::Borrow;
+
+use crate::error::Error;
+use crate::utils::storage::{ReadBuf, WriteBuf};
+
+/// A BDX block counter: a 32-bit index identifying a block within a transfer.
+///
+/// Block counters advance with modulo-2^32 arithmetic, so the counter following `0xFFFF_FFFF`
+/// is `0x0000_0000` (Matter Core Spec, 11.22.6.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BlockCounter(pub u32);
+
+impl BlockCounter {
+    pub fn read<T>(pb: &mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        Ok(Self(pb.le_u32()?))
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        wb.le_u32(self.0)
+    }
+}
+
+/// A BDX `BlockQuery` message the receiver requests the block at this BlockCounter
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockQuery(pub BlockCounter);
+
+impl BlockQuery {
+    pub fn read<T>(pb: &mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        Ok(Self(BlockCounter::read(pb)?))
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        self.0.write(wb)
+    }
+}
+
+/// A BDX `BlockAck` message acknowledges the `Block` with the matching BlockCounter
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockAck(pub BlockCounter);
+
+impl BlockAck {
+    pub fn read<T>(pb: &mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        Ok(Self(BlockCounter::read(pb)?))
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        self.0.write(wb)
+    }
+}
+
+/// A BDX `BlockAckEOF` message, acknowledges the final `BlockEOF`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockAckEOF(pub BlockCounter);
+
+impl BlockAckEOF {
+    pub fn read<T>(pb: &mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        Ok(Self(BlockCounter::read(pb)?))
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        self.0.write(wb)
+    }
+}
+
+/// A BDX `BlockQueryWithSkip` message; like BlockQuery but asks to skip N bytes
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockQueryWithSkip {
+    /// The counter of the block being requested.
+    pub block_counter: BlockCounter,
+    /// The number of bytes the sender should skip before sending the next block.
+    pub bytes_to_skip: u64,
+}
+
+impl BlockQueryWithSkip {
+    pub fn read<T>(pb: &mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        Ok(Self {
+            block_counter: BlockCounter::read(pb)?,
+            bytes_to_skip: pb.le_u64()?,
+        })
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        self.block_counter.write(wb)?;
+        wb.le_u64(self.bytes_to_skip)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::storage::{ReadBuf, WriteBuf};
+
+    use super::*;
+
+    // Unlike im.rs, we can't lean on the TLV layer for testing, hence little suite for BDX serialization
+
+    #[test]
+    fn block_query_roundtrip() {
+        // Use the wraparound edge value as the counter.
+        let msg = BlockQuery(BlockCounter(0xFFFF_FFFF));
+
+        let mut buf = [0; 16];
+        let mut wb = WriteBuf::new(&mut buf);
+        msg.write(&mut wb).unwrap();
+        let len = wb.as_slice().len();
+
+        let mut rb = ReadBuf::new(&buf[..len]);
+        assert_eq!(msg, BlockQuery::read(&mut rb).unwrap());
+    }
+
+    #[test]
+    fn block_query_with_skip_roundtrip() {
+        // `bytes_to_skip` > u32::MAX to confirm the full 64-bit field round-trips.
+        let msg = BlockQueryWithSkip {
+            block_counter: BlockCounter(7),
+            bytes_to_skip: u64::from(u32::MAX) + 1,
+        };
+
+        let mut buf = [0; 16];
+        let mut wb = WriteBuf::new(&mut buf);
+        msg.write(&mut wb).unwrap();
+        let len = wb.as_slice().len();
+
+        let mut rb = ReadBuf::new(&buf[..len]);
+        assert_eq!(msg, BlockQueryWithSkip::read(&mut rb).unwrap());
+    }
+}

--- a/rs-matter/src/bdx/block.rs
+++ b/rs-matter/src/bdx/block.rs
@@ -15,8 +15,9 @@
  *    limitations under the License.
  */
 
-//! This module defines the BDX block-transfer control messages: `BlockQuery`, `BlockAck`,
-//! `BlockAckEOF` and `BlockQueryWithSkip`, per the Matter Core Spec. 
+//! This module defines the BDX block-transfer messages: the data-carrying `Block` and
+//! `BlockEOF`, plus the control messages `BlockQuery`, `BlockQueryWithSkip`, `BlockAck` and
+//! `BlockAckEOF`, per the Matter Core Spec.
 
 use core::borrow::Borrow;
 
@@ -121,6 +122,71 @@ impl BlockQueryWithSkip {
     }
 }
 
+/// A block of data being transferred by a `Block` and `BlockEOF` message
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataBlock<'a> {
+    /// The counter of this block.
+    pub block_counter: BlockCounter,
+    /// The block's data
+    pub data: &'a [u8],
+}
+
+impl<'a> DataBlock<'a> {
+    pub fn read<T>(pb: &'a mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        let block_counter = BlockCounter::read(pb)?;
+        // The data is the remainder of the message.
+        let data = pb.as_slice();
+
+        Ok(Self {
+            block_counter,
+            data,
+        })
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        self.block_counter.write(wb)?;
+        wb.copy_from_slice(self.data)?;
+        Ok(())
+    }
+}
+
+/// A BDX `Block` message, carries one block of transfer data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Block<'a>(pub DataBlock<'a>);
+
+impl<'a> Block<'a> {
+    pub fn read<T>(pb: &'a mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        Ok(Self(DataBlock::read(pb)?))
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        self.0.write(wb)
+    }
+}
+
+/// A BDX `BlockEOF` message, carries the final block of transfer data
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockEOF<'a>(pub DataBlock<'a>);
+
+impl<'a> BlockEOF<'a> {
+    pub fn read<T>(pb: &'a mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        Ok(Self(DataBlock::read(pb)?))
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        self.0.write(wb)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::utils::storage::{ReadBuf, WriteBuf};
@@ -158,5 +224,38 @@ mod tests {
 
         let mut rb = ReadBuf::new(&buf[..len]);
         assert_eq!(msg, BlockQueryWithSkip::read(&mut rb).unwrap());
+    }
+
+    #[test]
+    fn block_roundtrip() {
+        let msg = Block(DataBlock {
+            block_counter: BlockCounter(3),
+            data: b"some block data",
+        });
+
+        let mut buf = [0; 64];
+        let mut wb = WriteBuf::new(&mut buf);
+        msg.write(&mut wb).unwrap();
+        let len = wb.as_slice().len();
+
+        let mut rb = ReadBuf::new(&buf[..len]);
+        assert_eq!(msg, Block::read(&mut rb).unwrap());
+    }
+
+    // `BlockEOF` shares `DataBlock` with `Block`, but unlike `Block` its data may be empty
+    #[test]
+    fn block_eof_empty_roundtrip() {
+        let msg = BlockEOF(DataBlock {
+            block_counter: BlockCounter(9),
+            data: &[],
+        });
+
+        let mut buf = [0; 64];
+        let mut wb = WriteBuf::new(&mut buf);
+        msg.write(&mut wb).unwrap();
+        let len = wb.as_slice().len();
+
+        let mut rb = ReadBuf::new(&buf[..len]);
+        assert_eq!(msg, BlockEOF::read(&mut rb).unwrap());
     }
 }

--- a/rs-matter/src/bdx/init.rs
+++ b/rs-matter/src/bdx/init.rs
@@ -19,7 +19,7 @@
 //! `ReceiveInit` and `ReceiveAccept`. They share the `TransferInit`/`TransferAccept` wire
 //! format defined here.
 //!
-//! Currently only `SendInit` is implemented.
+//! Currently `SendInit` and `ReceiveInit` are implemented.
 
 use core::borrow::Borrow;
 
@@ -56,26 +56,27 @@ bitflags::bitflags! {
     }
 }
 
-/// A BDX `SendInit` message as per the Matter Core Spec.
+/// The shared payload of the BDX `SendInit` and `ReceiveInit` messages, as per the Matter
+/// Core Spec. Both messages have an identical wire format except for opcode, so we combine them here.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SendInit<'a> {
+pub struct TransferInit<'a> {
     /// The proposed transfer-control mode(s) (sender-drive / receiver-drive / async).
     pub transfer_ctl: TransferControlFlags,
     /// The highest BDX version supported by the sender (0..=15). Currently always 0.
     pub version: u8,
     /// The proposed maximum block size for the transfer.
     pub max_block_size: u16,
-    /// Optional proposed start offset of the data; `None` if this 
+    /// Optional proposed start offset of the data; `None` if absent.
     pub start_offset: Option<u64>,
     /// The proposed maximum length of the data; `None` for an indefinite-length transfer.
     pub max_length: Option<u64>,
-    /// The file designator, opaque byte string
+    /// The file designator, opaque byte string.
     pub file_designator: &'a [u8],
     /// Optional trailing metadata, as a TLV element; `None` if absent.
     pub metadata: Option<TLVElement<'a>>,
 }
 
-impl<'a> SendInit<'a> {
+impl<'a> TransferInit<'a> {
     pub fn read<T>(pb: &'a mut ReadBuf<T>) -> Result<Self, Error>
     where
         T: Borrow<[u8]>,
@@ -173,16 +174,90 @@ impl<'a> SendInit<'a> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SendInit<'a>(pub TransferInit<'a>);
+
+impl<'a> SendInit<'a> {
+    pub fn read<T>(pb: &'a mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        Ok(Self(TransferInit::read(pb)?))
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        self.0.write(wb)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReceiveInit<'a>(pub TransferInit<'a>);
+
+impl<'a> ReceiveInit<'a> {
+    pub fn read<T>(pb: &'a mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        Ok(Self(TransferInit::read(pb)?))
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        self.0.write(wb)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::utils::storage::{ReadBuf, WriteBuf};
 
     use super::*;
 
-    // Unlike im.rs, we can't lean on the tlv layer doing serialization, so we keep a little
+    // Unlike im.rs, we can't lean on the TLV layer doing serialization, so we keep a little
     // suite here that checks the BDX-custom serialization works.
 
-    /// Write `msg`, read it back, and assert the result is identical to the original.
+    
+    #[test]
+    fn send_init_minimal() {
+        check_roundtrip_send_init(SendInit(TransferInit {
+            transfer_ctl: TransferControlFlags::SENDER_DRIVE,
+            version: 1,
+            max_block_size: 1024,
+            start_offset: None,
+            max_length: None,
+            file_designator: b"my-file",
+            metadata: None,
+        }));
+    }
+
+    #[test]
+    fn send_init_with_range_and_metadata() {
+        check_roundtrip_send_init(SendInit(TransferInit {
+            transfer_ctl: TransferControlFlags::RECEIVER_DRIVE,
+            version: 1,
+            max_block_size: 512,
+            start_offset: Some(42),
+            max_length: Some(100_000),
+            file_designator: b"ota.bin",
+            // An (empty) anonymous TLV structure: 0x15 = struct start, 0x18 = end-of-container.
+            metadata: Some(TLVElement::new(&[0x15, 0x18])),
+        }));
+    }
+
+    #[test]
+    fn send_init_widerange() {
+        check_roundtrip_send_init(SendInit(TransferInit {
+            transfer_ctl: TransferControlFlags::SENDER_DRIVE,
+            version: 1,
+            max_block_size: 1280,
+            start_offset: Some(8),
+            max_length: Some(u64::from(u32::MAX) + 1),
+            file_designator: b"big",
+            metadata: None,
+        }));
+    }
+
+    // Utilities for roundtrip testing
+
     fn check_roundtrip_send_init(msg: SendInit) {
         let mut buf = [0; 256];
 
@@ -196,43 +271,4 @@ mod tests {
         assert_eq!(msg, parsed);
     }
 
-    #[test]
-    fn send_init_minimal() {
-        check_roundtrip_send_init(SendInit {
-            transfer_ctl: TransferControlFlags::SENDER_DRIVE,
-            version: 1,
-            max_block_size: 1024,
-            start_offset: None,
-            max_length: None,
-            file_designator: b"my-file",
-            metadata: None,
-        });
-    }
-
-    #[test]
-    fn send_init_with_range_and_metadata() {
-        check_roundtrip_send_init(SendInit {
-            transfer_ctl: TransferControlFlags::RECEIVER_DRIVE,
-            version: 1,
-            max_block_size: 512,
-            start_offset: Some(42),
-            max_length: Some(100_000),
-            file_designator: b"ota.bin",
-            // An (empty) anonymous TLV structure: 0x15 = struct start, 0x18 = end-of-container.
-            metadata: Some(TLVElement::new(&[0x15, 0x18])),
-        });
-    }
-
-    #[test]
-    fn send_init_widerange() {
-        check_roundtrip_send_init(SendInit {
-            transfer_ctl: TransferControlFlags::SENDER_DRIVE,
-            version: 1,
-            max_block_size: 1280,
-            start_offset: Some(8),
-            max_length: Some(u64::from(u32::MAX) + 1),
-            file_designator: b"big",
-            metadata: None,
-        });
-    }
 }

--- a/rs-matter/src/bdx/init.rs
+++ b/rs-matter/src/bdx/init.rs
@@ -336,8 +336,7 @@ mod tests {
 
     use super::*;
 
-    // Unlike im.rs, we can't lean on the TLV layer doing serialization, so we keep a little
-    // suite here that checks the BDX-custom serialization works.
+    // Unlike im.rs, we can't lean on the TLV layer for testing, hence little suite for BDX serialization
 
     
     #[test]

--- a/rs-matter/src/bdx/init.rs
+++ b/rs-matter/src/bdx/init.rs
@@ -1,0 +1,238 @@
+/*
+ *
+ *    Copyright (c) 2022-2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! This module defines the BDX transfer-initiation messages: `SendInit`, `SendAccept`,
+//! `ReceiveInit` and `ReceiveAccept`. They share the `TransferInit`/`TransferAccept` wire
+//! format defined here.
+//!
+//! Currently only `SendInit` is implemented.
+
+use core::borrow::Borrow;
+
+use crate::error::{Error, ErrorCode};
+use crate::tlv::TLVElement;
+use crate::utils::storage::{ReadBuf, WriteBuf};
+
+/// The number of low bits in the Transfer Control byte reserved for the BDX version.
+const VERSION_MASK: u8 = 0x0f;
+
+bitflags::bitflags! {
+    /// Transfer control flags used in `SendInit`/`ReceiveInit`/`*Accept` messages
+    #[repr(transparent)]
+    #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Hash)]
+    pub struct TransferControlFlags: u8 {
+        const SENDER_DRIVE = 0x10;
+        const RECEIVER_DRIVE = 0x20;
+        const ASYNC = 0x40;
+    }
+}
+
+bitflags::bitflags! {
+    /// The Range Control flags carried in the second byte of a `SendInit`/`ReceiveInit`
+    /// message. These indicate presence of optional length/offset fields and their width.
+    #[repr(transparent)]
+    #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Hash)]
+    pub struct RangeControlFlags: u8 {
+        /// The `max_length` field is present.
+        const DEF_LEN = 0x01;
+        /// The `start_offset` field is present.
+        const START_OFFSET = 0x02;
+        /// The `start_offset`/`max_length` fields are 64-bit (rather than 32-bit) wide.
+        const WIDERANGE = 0x10;
+    }
+}
+
+/// A BDX `SendInit` message as per the Matter Core Spec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SendInit<'a> {
+    /// The proposed transfer-control mode(s) (sender-drive / receiver-drive / async).
+    pub transfer_ctl: TransferControlFlags,
+    /// The highest BDX version supported by the sender (0..=15). Currently always 0.
+    pub version: u8,
+    /// The proposed maximum block size for the transfer.
+    pub max_block_size: u16,
+    /// Optional proposed start offset of the data; `None` if this 
+    pub start_offset: Option<u64>,
+    /// The proposed maximum length of the data; `None` for an indefinite-length transfer.
+    pub max_length: Option<u64>,
+    /// The file designator, opaque byte string
+    pub file_designator: &'a [u8],
+    /// Optional trailing metadata, as a TLV element; `None` if absent.
+    pub metadata: Option<TLVElement<'a>>,
+}
+
+impl<'a> SendInit<'a> {
+    pub fn read<T>(pb: &'a mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        let transfer_ctl_byte = pb.le_u8()?;
+        let version = transfer_ctl_byte & VERSION_MASK;
+        let transfer_ctl = TransferControlFlags::from_bits_truncate(transfer_ctl_byte & !VERSION_MASK);
+
+        let range_ctl = RangeControlFlags::from_bits_truncate(pb.le_u8()?);
+        let max_block_size = pb.le_u16()?;
+
+        let widerange = range_ctl.contains(RangeControlFlags::WIDERANGE);
+
+        let start_offset = range_ctl
+            .contains(RangeControlFlags::START_OFFSET)
+            .then(|| Self::read_range_field(pb, widerange))
+            .transpose()?;
+
+        let max_length = range_ctl
+            .contains(RangeControlFlags::DEF_LEN)
+            .then(|| Self::read_range_field(pb, widerange))
+            .transpose()?;
+
+        let file_des_len = pb.le_u16()? as usize;
+
+        // The file designator and the (optional) trailing metadata occupy the rest of the
+        // buffer; the metadata is simply whatever follows the file designator.
+        let rest = pb.as_slice();
+        if rest.len() < file_des_len {
+            Err(ErrorCode::TruncatedPacket)?;
+        }
+
+        let file_designator = &rest[..file_des_len];
+        let metadata = (rest.len() > file_des_len).then(|| TLVElement::new(&rest[file_des_len..]));
+
+        Ok(Self {
+            transfer_ctl,
+            version,
+            max_block_size,
+            start_offset,
+            max_length,
+            file_designator,
+            metadata,
+        })
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        // `WIDERANGE` is shared by both range fields, so it is set if *either* needs 64 bits.
+        let widerange = self.start_offset.is_some_and(|v| v > u32::MAX as u64)
+            || self.max_length.is_some_and(|v| v > u32::MAX as u64);
+
+        let mut range_ctl = RangeControlFlags::empty();
+        range_ctl.set(RangeControlFlags::DEF_LEN, self.max_length.is_some());
+        range_ctl.set(RangeControlFlags::START_OFFSET, self.start_offset.is_some());
+        range_ctl.set(RangeControlFlags::WIDERANGE, widerange);
+
+        wb.le_u8((self.version & VERSION_MASK) | self.transfer_ctl.bits())?;
+        wb.le_u8(range_ctl.bits())?;
+        wb.le_u16(self.max_block_size)?;
+
+        if let Some(start_offset) = self.start_offset {
+            Self::write_range_field(wb, start_offset, widerange)?;
+        }
+        if let Some(max_length) = self.max_length {
+            Self::write_range_field(wb, max_length, widerange)?;
+        }
+
+        wb.le_u16(self.file_designator.len() as u16)?;
+        wb.copy_from_slice(self.file_designator)?;
+
+        if let Some(metadata) = &self.metadata {
+            wb.copy_from_slice(metadata.raw_data())?;
+        }
+
+        Ok(())
+    }
+
+    fn read_range_field<T>(pb: &mut ReadBuf<T>, widerange: bool) -> Result<u64, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        if widerange {
+            pb.le_u64()
+        } else {
+            pb.le_u32().map(|v| v as u64)
+        }
+    }
+
+    fn write_range_field(wb: &mut WriteBuf, value: u64, widerange: bool) -> Result<(), Error> {
+        if widerange {
+            wb.le_u64(value)
+        } else {
+            wb.le_u32(value as u32)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::storage::{ReadBuf, WriteBuf};
+
+    use super::*;
+
+    // Unlike im.rs, we can't lean on the tlv layer doing serialization, so we keep a little
+    // suite here that checks the BDX-custom serialization works.
+
+    /// Write `msg`, read it back, and assert the result is identical to the original.
+    fn check_roundtrip_send_init(msg: SendInit) {
+        let mut buf = [0; 256];
+
+        let mut wb = WriteBuf::new(&mut buf);
+        msg.write(&mut wb).unwrap();
+        let len = wb.as_slice().len();
+
+        let mut rb = ReadBuf::new(&buf[..len]);
+        let parsed = SendInit::read(&mut rb).unwrap();
+
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn send_init_minimal() {
+        check_roundtrip_send_init(SendInit {
+            transfer_ctl: TransferControlFlags::SENDER_DRIVE,
+            version: 1,
+            max_block_size: 1024,
+            start_offset: None,
+            max_length: None,
+            file_designator: b"my-file",
+            metadata: None,
+        });
+    }
+
+    #[test]
+    fn send_init_with_range_and_metadata() {
+        check_roundtrip_send_init(SendInit {
+            transfer_ctl: TransferControlFlags::RECEIVER_DRIVE,
+            version: 1,
+            max_block_size: 512,
+            start_offset: Some(42),
+            max_length: Some(100_000),
+            file_designator: b"ota.bin",
+            // An (empty) anonymous TLV structure: 0x15 = struct start, 0x18 = end-of-container.
+            metadata: Some(TLVElement::new(&[0x15, 0x18])),
+        });
+    }
+
+    #[test]
+    fn send_init_widerange() {
+        check_roundtrip_send_init(SendInit {
+            transfer_ctl: TransferControlFlags::SENDER_DRIVE,
+            version: 1,
+            max_block_size: 1280,
+            start_offset: Some(8),
+            max_length: Some(u64::from(u32::MAX) + 1),
+            file_designator: b"big",
+            metadata: None,
+        });
+    }
+}

--- a/rs-matter/src/bdx/init.rs
+++ b/rs-matter/src/bdx/init.rs
@@ -16,10 +16,7 @@
  */
 
 //! This module defines the BDX transfer-initiation messages: `SendInit`, `SendAccept`,
-//! `ReceiveInit` and `ReceiveAccept`. They share the `TransferInit`/`TransferAccept` wire
-//! format defined here.
-//!
-//! Currently `SendInit` and `ReceiveInit` are implemented.
+//! `ReceiveInit` and `ReceiveAccept`, per the Matter Core Spec.
 
 use core::borrow::Borrow;
 
@@ -53,6 +50,27 @@ bitflags::bitflags! {
         const START_OFFSET = 0x02;
         /// The `start_offset`/`max_length` fields are 64-bit (rather than 32-bit) wide.
         const WIDERANGE = 0x10;
+    }
+}
+
+/// Several messages use fields with variable size (4 or 8 bytes); this reads those fields
+fn read_range_field<T>(pb: &mut ReadBuf<T>, widerange: bool) -> Result<u64, Error>
+where
+    T: Borrow<[u8]>,
+{
+    if widerange {
+        pb.le_u64()
+    } else {
+        pb.le_u32().map(|v| v as u64)
+    }
+}
+
+/// Several messages use fields with variable size (4 or 8 bytes); this writes those fields
+fn write_range_field(wb: &mut WriteBuf, value: u64, widerange: bool) -> Result<(), Error> {
+    if widerange {
+        wb.le_u64(value)
+    } else {
+        wb.le_u32(value as u32)
     }
 }
 
@@ -92,12 +110,12 @@ impl<'a> TransferInit<'a> {
 
         let start_offset = range_ctl
             .contains(RangeControlFlags::START_OFFSET)
-            .then(|| Self::read_range_field(pb, widerange))
+            .then(|| read_range_field(pb, widerange))
             .transpose()?;
 
         let max_length = range_ctl
             .contains(RangeControlFlags::DEF_LEN)
-            .then(|| Self::read_range_field(pb, widerange))
+            .then(|| read_range_field(pb, widerange))
             .transpose()?;
 
         let file_des_len = pb.le_u16()? as usize;
@@ -138,10 +156,10 @@ impl<'a> TransferInit<'a> {
         wb.le_u16(self.max_block_size)?;
 
         if let Some(start_offset) = self.start_offset {
-            Self::write_range_field(wb, start_offset, widerange)?;
+            write_range_field(wb, start_offset, widerange)?;
         }
         if let Some(max_length) = self.max_length {
-            Self::write_range_field(wb, max_length, widerange)?;
+            write_range_field(wb, max_length, widerange)?;
         }
 
         wb.le_u16(self.file_designator.len() as u16)?;
@@ -152,25 +170,6 @@ impl<'a> TransferInit<'a> {
         }
 
         Ok(())
-    }
-
-    fn read_range_field<T>(pb: &mut ReadBuf<T>, widerange: bool) -> Result<u64, Error>
-    where
-        T: Borrow<[u8]>,
-    {
-        if widerange {
-            pb.le_u64()
-        } else {
-            pb.le_u32().map(|v| v as u64)
-        }
-    }
-
-    fn write_range_field(wb: &mut WriteBuf, value: u64, widerange: bool) -> Result<(), Error> {
-        if widerange {
-            wb.le_u64(value)
-        } else {
-            wb.le_u32(value as u32)
-        }
     }
 }
 
@@ -203,6 +202,131 @@ impl<'a> ReceiveInit<'a> {
 
     pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
         self.0.write(wb)
+    }
+}
+
+/// A BDX `SendAccept` message, as per the Matter Core Spec.
+///
+/// Sent by a node accepting a peer's `ReceiveInit`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SendAccept<'a> {
+    /// The chosen transfer-control mode (exactly one of sender-drive / receiver-drive / async).
+    pub transfer_ctl: TransferControlFlags,
+    /// The chosen BDX version for the transfer (0..=15). Currently always 0.
+    pub version: u8,
+    /// The chosen maximum block size for the transfer.
+    pub max_block_size: u16,
+    /// Optional trailing metadata, as a TLV element
+    pub metadata: Option<TLVElement<'a>>,
+}
+
+impl<'a> SendAccept<'a> {
+    pub fn read<T>(pb: &'a mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        let transfer_ctl_byte = pb.le_u8()?;
+        let version = transfer_ctl_byte & VERSION_MASK;
+        let transfer_ctl = TransferControlFlags::from_bits_truncate(transfer_ctl_byte & !VERSION_MASK);
+
+        let max_block_size = pb.le_u16()?;
+
+        // Whatever follows is metadata (possibly empty).
+        let rest = pb.as_slice();
+        let metadata = (!rest.is_empty()).then(|| TLVElement::new(rest));
+
+        Ok(Self {
+            transfer_ctl,
+            version,
+            max_block_size,
+            metadata,
+        })
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        wb.le_u8((self.version & VERSION_MASK) | self.transfer_ctl.bits())?;
+        wb.le_u16(self.max_block_size)?;
+
+        if let Some(metadata) = &self.metadata {
+            wb.copy_from_slice(metadata.raw_data())?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A BDX `ReceiveAccept` message, as per the Matter Core Spec (Table 100).
+///
+/// Sent by a node accepting a peer's `SendInit`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReceiveAccept<'a> {
+    /// The chosen transfer-control mode (exactly one of sender-drive / receiver-drive / async).
+    pub transfer_ctl: TransferControlFlags,
+    /// The chosen BDX version for the transfer (0..=15). Currently always 0.
+    pub version: u8,
+    /// The chosen maximum block size for the transfer.
+    pub max_block_size: u16,
+    /// The chosen length of the transfer; `None` for an indefinite-length transfer.
+    pub length: Option<u64>,
+    /// Optional trailing metadata, as a TLV element
+    pub metadata: Option<TLVElement<'a>>,
+
+    // n.b. the C++ SDK has an additional "start_offset" field on this message, but the Core Spec 
+    // has no such field, see Table 100.
+}
+
+impl<'a> ReceiveAccept<'a> {
+    pub fn read<T>(pb: &'a mut ReadBuf<T>) -> Result<Self, Error>
+    where
+        T: Borrow<[u8]>,
+    {
+        let transfer_ctl_byte = pb.le_u8()?;
+        let version = transfer_ctl_byte & VERSION_MASK;
+        let transfer_ctl = TransferControlFlags::from_bits_truncate(transfer_ctl_byte & !VERSION_MASK);
+
+        let range_ctl = RangeControlFlags::from_bits_truncate(pb.le_u8()?);
+        let max_block_size = pb.le_u16()?;
+
+        let widerange = range_ctl.contains(RangeControlFlags::WIDERANGE);
+
+        let length = range_ctl
+            .contains(RangeControlFlags::DEF_LEN)
+            .then(|| read_range_field(pb, widerange))
+            .transpose()?;
+
+        // Whatever follows is metadata (possibly empty).
+        let rest = pb.as_slice();
+        let metadata = (!rest.is_empty()).then(|| TLVElement::new(rest));
+
+        Ok(Self {
+            transfer_ctl,
+            version,
+            max_block_size,
+            length,
+            metadata,
+        })
+    }
+
+    pub fn write(&self, wb: &mut WriteBuf) -> Result<(), Error> {
+        let widerange = self.length.is_some_and(|v| v > u32::MAX as u64);
+
+        let mut range_ctl = RangeControlFlags::empty();
+        range_ctl.set(RangeControlFlags::DEF_LEN, self.length.is_some());
+        range_ctl.set(RangeControlFlags::WIDERANGE, widerange);
+
+        wb.le_u8((self.version & VERSION_MASK) | self.transfer_ctl.bits())?;
+        wb.le_u8(range_ctl.bits())?;
+        wb.le_u16(self.max_block_size)?;
+
+        if let Some(length) = self.length {
+            write_range_field(wb, length, widerange)?;
+        }
+
+        if let Some(metadata) = &self.metadata {
+            wb.copy_from_slice(metadata.raw_data())?;
+        }
+
+        Ok(())
     }
 }
 
@@ -256,6 +380,39 @@ mod tests {
         }));
     }
 
+    #[test]
+    fn send_accept_roundtrip() {
+        check_roundtrip_send_accept(SendAccept {
+            transfer_ctl: TransferControlFlags::SENDER_DRIVE,
+            version: 1,
+            max_block_size: 1024,
+            // An (empty) anonymous TLV structure: 0x15 = struct start, 0x18 = end-of-container.
+            metadata: Some(TLVElement::new(&[0x15, 0x18])),
+        });
+    }
+
+    #[test]
+    fn receive_accept_with_length_and_metadata() {
+        check_roundtrip_receive_accept(ReceiveAccept {
+            transfer_ctl: TransferControlFlags::RECEIVER_DRIVE,
+            version: 1,
+            max_block_size: 512,
+            length: Some(100_000),
+            metadata: Some(TLVElement::new(&[0x15, 0x18])),
+        });
+    }
+
+    #[test]
+    fn receive_accept_widerange() {
+        check_roundtrip_receive_accept(ReceiveAccept {
+            transfer_ctl: TransferControlFlags::RECEIVER_DRIVE,
+            version: 1,
+            max_block_size: 1280,
+            length: Some(u64::from(u32::MAX) + 1),
+            metadata: None,
+        });
+    }
+
     // Utilities for roundtrip testing
 
     fn check_roundtrip_send_init(msg: SendInit) {
@@ -267,6 +424,32 @@ mod tests {
 
         let mut rb = ReadBuf::new(&buf[..len]);
         let parsed = SendInit::read(&mut rb).unwrap();
+
+        assert_eq!(msg, parsed);
+    }
+
+    fn check_roundtrip_send_accept(msg: SendAccept) {
+        let mut buf = [0; 256];
+
+        let mut wb = WriteBuf::new(&mut buf);
+        msg.write(&mut wb).unwrap();
+        let len = wb.as_slice().len();
+
+        let mut rb = ReadBuf::new(&buf[..len]);
+        let parsed = SendAccept::read(&mut rb).unwrap();
+
+        assert_eq!(msg, parsed);
+    }
+
+    fn check_roundtrip_receive_accept(msg: ReceiveAccept) {
+        let mut buf = [0; 256];
+
+        let mut wb = WriteBuf::new(&mut buf);
+        msg.write(&mut wb).unwrap();
+        let len = wb.as_slice().len();
+
+        let mut rb = ReadBuf::new(&buf[..len]);
+        let parsed = ReceiveAccept::read(&mut rb).unwrap();
 
         assert_eq!(msg, parsed);
     }

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -68,6 +68,7 @@ pub(crate) mod fmt;
 
 pub mod acl;
 pub mod attest;
+pub mod bdx;
 pub mod cert;
 pub mod crypto;
 pub mod dm;

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -27,6 +27,7 @@ use crate::acl::Accessor;
 use crate::crypto::Crypto;
 use crate::dm::NodeId;
 use crate::error::{Error, ErrorCode};
+use crate::bdx::{self, PROTO_ID_BDX};
 use crate::im::{self, PROTO_ID_INTERACTION_MODEL};
 use crate::sc::{self, PROTO_ID_SECURE_CHANNEL};
 use crate::transport::session::Sessions;
@@ -543,6 +544,11 @@ impl MessageMeta {
                 .ok()
                 .map(|op| op.is_tlv())
                 .unwrap_or(false),
+            PROTO_ID_BDX => self
+                .opcode::<bdx::OpCode>()
+                .ok()
+                .map(|op| op.is_tlv())
+                .unwrap_or(false),
             _ => false,
         }
     }
@@ -590,6 +596,13 @@ impl Display for MessageMeta {
                     write!(f, "IM::{:02x}", self.proto_opcode)
                 }
             }
+            PROTO_ID_BDX => {
+                if let Ok(opcode) = self.opcode::<bdx::OpCode>() {
+                    write!(f, "BDX::{:?}", opcode)
+                } else {
+                    write!(f, "BDX::{:02x}", self.proto_opcode)
+                }
+            }
             _ => write!(f, "{:02x}::{:02x}", self.proto_id, self.proto_opcode),
         }
     }
@@ -611,6 +624,13 @@ impl defmt::Format for MessageMeta {
                     defmt::write!(f, "IM::{:?}", opcode)
                 } else {
                     defmt::write!(f, "IM::{:02x}", self.proto_opcode)
+                }
+            }
+            PROTO_ID_BDX => {
+                if let Ok(opcode) = self.opcode::<bdx::OpCode>() {
+                    defmt::write!(f, "BDX::{:?}", opcode)
+                } else {
+                    defmt::write!(f, "BDX::{:02x}", self.proto_opcode)
                 }
             }
             _ => defmt::write!(f, "{:02x}::{:02x}", self.proto_id, self.proto_opcode),


### PR DESCRIPTION
Should've synced on Matrix before writing this up but at the same time I think *this* part is pretty uncontroversial. 

This implements the message layer - serialization and deserialization - for all messages involved in the BDX protocol. I've added it in the same structural style as im.rs and sc.rs, since it's yet another "top level" Matter protocol. 

My hope is to be able to contribute a complete BDX implementation - either by working on this PR until we're happy, or piecemeal in follow up PRs if that's preferred; this seems like a reasonable place to start :) 