### PR TITLE
Canonicalize IP addrs; fix mDNS resolvers to return ipv6 with preference

### DIFF
--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -376,15 +376,25 @@ impl Transport {
             // single-slot) but not yet consumed: keep the better-scoring address
             // so a later IPv6 deposit can upgrade an earlier IPv4 one (e.g.
             // zeroconf surfaces one address per family at a time).
-            MdnsResolveState::Resolved { ip: cur_ip, .. }
-                if score_ip_address(&ip) > score_ip_address(cur_ip) =>
-            {
+            //
+            // Preserve any session params already resolved: a per-address deposit
+            // may carry no TXT (e.g. zeroconf's `ServiceDiscovery.txt` is
+            // optional and can arrive only on a different callback than the
+            // address), in which case `sii`/`sai`/`sat` are `None` here and would
+            // otherwise clobber the good values from the earlier deposit.
+            MdnsResolveState::Resolved {
+                ip: cur_ip,
+                sii: cur_sii,
+                sai: cur_sai,
+                sat: cur_sat,
+                ..
+            } if score_ip_address(&ip) > score_ip_address(cur_ip) => {
                 *state = MdnsResolveState::Resolved {
                     ip,
                     port,
-                    sii,
-                    sai,
-                    sat,
+                    sii: sii.or(*cur_sii),
+                    sai: sai.or(*cur_sai),
+                    sat: sat.or(*cur_sat),
                 };
                 (true, ())
             }

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -357,8 +357,8 @@ impl Transport {
 
         let (sii, sai, sat) = answer.session_params();
 
-        self.mdns_resolve.modify(|state| {
-            if let MdnsResolveState::InFlight { service } = state {
+        self.mdns_resolve.modify(|state| match state {
+            MdnsResolveState::InFlight { service } => {
                 if service.matches_instance(&answer.instance_name) {
                     *state = MdnsResolveState::Resolved {
                         ip,
@@ -367,10 +367,28 @@ impl Transport {
                         sai,
                         sat,
                     };
-                    return (true, ());
+                    (true, ())
+                } else {
+                    (false, ())
                 }
             }
-            (false, ())
+            // Already resolved (same in-flight target — the rendezvous is
+            // single-slot) but not yet consumed: keep the better-scoring address
+            // so a later IPv6 deposit can upgrade an earlier IPv4 one (e.g.
+            // zeroconf surfaces one address per family at a time).
+            MdnsResolveState::Resolved { ip: cur_ip, .. }
+                if score_ip_address(&ip) > score_ip_address(cur_ip) =>
+            {
+                *state = MdnsResolveState::Resolved {
+                    ip,
+                    port,
+                    sii,
+                    sai,
+                    sat,
+                };
+                (true, ())
+            }
+            _ => (false, ()),
         });
     }
 
@@ -513,14 +531,29 @@ impl Transport {
             return;
         };
 
-        self.mdns_browse.modify(|state| {
-            if let MdnsBrowseState::InFlight { filter, exclude } = state {
+        self.mdns_browse.modify(|state| match state {
+            MdnsBrowseState::InFlight { filter, exclude } => {
                 if !exclude.contains(&id) && filter.matches(answer) {
                     *state = MdnsBrowseState::Found { ip, port, id };
-                    return (true, ());
+                    (true, ())
+                } else {
+                    (false, ())
                 }
             }
-            (false, ())
+            // Already matched this same instance but not yet consumed: keep the
+            // better-scoring address. Backends that surface one address per
+            // family at a time (e.g. zeroconf fires a callback per A/AAAA record)
+            // can thus still yield the preferred IPv6 address even if the IPv4
+            // one was deposited first.
+            MdnsBrowseState::Found {
+                ip: cur_ip,
+                id: cur_id,
+                ..
+            } if *cur_id == id && score_ip_address(&ip) > score_ip_address(cur_ip) => {
+                *state = MdnsBrowseState::Found { ip, port, id };
+                (true, ())
+            }
+            _ => (false, ()),
         });
     }
 

--- a/rs-matter/src/transport/network.rs
+++ b/rs-matter/src/transport/network.rs
@@ -159,6 +159,30 @@ impl Address {
         matches!(self, Self::Btp(_))
     }
 
+    /// Return this address with its IP canonicalized: an IPv4-mapped IPv6
+    /// address (`::ffff:a.b.c.d`) is rewritten to its true IPv4 form, leaving
+    /// genuine IPv4 / IPv6 / BTP addresses unchanged.
+    ///
+    /// This matters because a dual-stack IPv6 socket reports an IPv4 peer's
+    /// packets to `recv_from` in IPv4-mapped form, whereas the same peer is
+    /// usually *sent to* (and stored on the session) as a plain `V4` address.
+    /// `Address` derives `PartialEq`/`Eq` over the `SocketAddr` (family
+    /// included), so without canonicalization `V4(x)` and `V6(::ffff:x)` would
+    /// compare unequal and session lookup by peer address would fail (PASE then
+    /// reports "PAKE session not found").
+    ///
+    /// This is used only when *comparing* a session's peer address against a
+    /// received one (see `Session::is_for_rx` / `is_pase_for_addr`); the address
+    /// stored on the session is left untouched so it still routes replies to the
+    /// exact address the peer was reached at.
+    pub fn canonical(self) -> Self {
+        match self {
+            Self::Udp(addr) => Self::Udp(canonical_sockaddr(addr)),
+            Self::Tcp(addr) => Self::Tcp(canonical_sockaddr(addr)),
+            other => other,
+        }
+    }
+
     pub const fn udp(self) -> Option<SocketAddr> {
         match self {
             Self::Udp(addr) => Some(addr),
@@ -178,6 +202,21 @@ impl Address {
             Self::Btp(addr) => Some(addr),
             _ => None,
         }
+    }
+}
+
+/// Canonicalize a [`SocketAddr`]: an IPv4-mapped IPv6 address
+/// (`::ffff:a.b.c.d`) is rewritten to its true IPv4 form (preserving port),
+/// everything else is returned unchanged. See [`Address::canonical`].
+fn canonical_sockaddr(addr: SocketAddr) -> SocketAddr {
+    match addr {
+        SocketAddr::V6(v6) => match v6.ip().to_canonical() {
+            // `IpAddr::to_canonical` (stable since Rust 1.75) maps
+            // `::ffff:a.b.c.d` to `a.b.c.d` and leaves true IPv6 untouched.
+            IpAddr::V4(v4) => SocketAddr::new(IpAddr::V4(v4), v6.port()),
+            IpAddr::V6(_) => addr,
+        },
+        SocketAddr::V4(_) => addr,
     }
 }
 

--- a/rs-matter/src/transport/network/mdns/astro.rs
+++ b/rs-matter/src/transport/network/mdns/astro.rs
@@ -27,7 +27,7 @@ use embassy_time::Timer;
 use crate::utils::select::Coalesce;
 
 use std::collections::{HashMap, HashSet};
-use std::net::ToSocketAddrs;
+use std::net::{IpAddr, ToSocketAddrs};
 use std::time::Duration;
 
 use crate::error::{Error, ErrorCode};
@@ -121,14 +121,15 @@ impl AstroMdns {
             while matter.transport().mdns_resolve_in_flight() {
                 match browser.recv_timeout(Duration::ZERO) {
                     Ok(svc) if svc.name == label => {
+                        // Collect *all* resolved addresses; the transport picks
+                        // the most preferred (IPv6 first) via `score_ip_address`.
                         let host_with_port = format!("{}:{}", svc.hostname, svc.port);
-                        let ip = host_with_port
+                        let ips: Vec<IpAddr> = host_with_port
                             .to_socket_addrs()
-                            .ok()
-                            .and_then(|mut addrs| addrs.next())
-                            .map(|addr| addr.ip());
+                            .map(|addrs| addrs.map(|addr| addr.ip()).collect())
+                            .unwrap_or_default();
 
-                        if let Some(ip) = ip {
+                        if !ips.is_empty() {
                             let mut txt: Vec<(&str, &str)> = Vec::new();
                             if let Some(ref txt_record) = svc.txt_record {
                                 for (key, value) in txt_record {
@@ -141,7 +142,7 @@ impl AstroMdns {
                                 .try_deposit_mdns_resolve(&MdnsRemoteService {
                                     instance_name: DottedName(name_buf.as_str()),
                                     port: Some(svc.port),
-                                    addrs: core::iter::once(ip),
+                                    addrs: ips.iter().copied(),
                                     txt: txt.iter().copied(),
                                 });
                         }
@@ -179,14 +180,15 @@ impl AstroMdns {
                     // happen inside the deposit. `to_socket_addrs` is a brief
                     // blocking lookup, acceptable on the commissioning-browse path.
                     Ok(service) => {
+                        // Collect *all* resolved addresses (see the resolve path);
+                        // the transport prefers IPv6 via `score_ip_address`.
                         let host_with_port = format!("{}:{}", service.hostname, service.port);
-                        let ip = host_with_port
+                        let ips: Vec<IpAddr> = host_with_port
                             .to_socket_addrs()
-                            .ok()
-                            .and_then(|mut addrs| addrs.next())
-                            .map(|addr| addr.ip());
+                            .map(|addrs| addrs.map(|addr| addr.ip()).collect())
+                            .unwrap_or_default();
 
-                        if let Some(ip) = ip {
+                        if !ips.is_empty() {
                             let mut txt: Vec<(&str, &str)> = Vec::new();
                             if let Some(ref txt_record) = service.txt_record {
                                 for (key, value) in txt_record {
@@ -199,7 +201,7 @@ impl AstroMdns {
                                 .try_deposit_mdns_browse(&MdnsRemoteService {
                                     instance_name: DottedName(service.name.as_str()),
                                     port: Some(service.port),
-                                    addrs: core::iter::once(ip),
+                                    addrs: ips.iter().copied(),
                                     txt: txt.iter().copied(),
                                 });
                         } else {

--- a/rs-matter/src/transport/network/mdns/avahi.rs
+++ b/rs-matter/src/transport/network/mdns/avahi.rs
@@ -45,6 +45,14 @@ use crate::Matter;
 const AVAHI_IF_UNSPEC: i32 = -1;
 /// Avahi constant for "any protocol" (IPv4 or IPv6)
 const AVAHI_PROTO_UNSPEC: i32 = -1;
+/// Avahi address-family constants. `ResolveService` returns a single address in
+/// the requested family, so to gather both (and let the transport prefer IPv6 —
+/// see `score_ip_address`) we resolve once per family.
+const AVAHI_PROTO_INET: i32 = 0;
+const AVAHI_PROTO_INET6: i32 = 1;
+/// Resolve in IPv6-then-IPv4 order so that, on a single-address consumer, the
+/// preferred family is tried first.
+const AVAHI_RESOLVE_PROTOS: [i32; 2] = [AVAHI_PROTO_INET6, AVAHI_PROTO_INET];
 
 /// Interval (ms) at which a running browse re-checks whether it is still in
 /// flight (first match consumed, or caller timed out / dropped).
@@ -127,53 +135,22 @@ impl AvahiMdns {
             let avahi = Server2Proxy::new(connection).await?;
 
             while matter.transport().mdns_resolve_in_flight() {
-                match avahi
-                    .resolve_service(
-                        AVAHI_IF_UNSPEC,
-                        AVAHI_PROTO_UNSPEC,
-                        &label,
-                        service_type,
-                        "local",
-                        AVAHI_PROTO_UNSPEC,
-                        0,
-                    )
-                    .await
-                {
-                    Ok((
-                        _if,
-                        _proto,
-                        _name,
-                        _type,
-                        _domain,
-                        _host,
-                        _ap,
-                        address,
-                        port,
-                        txt,
-                        _fl,
-                    )) => {
-                        if let Ok(ip) = address.parse::<IpAddr>() {
-                            let mut txt_pairs: Vec<(&str, &str)> = Vec::new();
-                            for entry in &txt {
-                                if let Ok(s) = core::str::from_utf8(entry) {
-                                    match s.find('=') {
-                                        Some(eq) => txt_pairs.push((&s[..eq], &s[eq + 1..])),
-                                        None => txt_pairs.push((s, "")),
-                                    }
-                                }
-                            }
-                            // Match is by the full instance name we requested.
-                            matter
-                                .transport()
-                                .try_deposit_mdns_resolve(&MdnsRemoteService {
-                                    instance_name: DottedName(name_buf.as_str()),
-                                    port: Some(port),
-                                    addrs: core::iter::once(ip),
-                                    txt: txt_pairs.iter().copied(),
-                                });
-                        }
-                    }
-                    Err(e) => debug!("Avahi resolve of {} failed: {:?}", label, e),
+                // Resolve both address families (Avahi returns one address per
+                // call) and deposit them together; the transport prefers IPv6
+                // (link-local → ULA → global → IPv4) via `score_ip_address`.
+                let (ips, port, txt) =
+                    resolve_all_families(&avahi, AVAHI_IF_UNSPEC, &label, service_type).await;
+                if !ips.is_empty() {
+                    let txt_pairs = txt_pairs(&txt);
+                    // Match is by the full instance name we requested.
+                    matter
+                        .transport()
+                        .try_deposit_mdns_resolve(&MdnsRemoteService {
+                            instance_name: DottedName(name_buf.as_str()),
+                            port: Some(port),
+                            addrs: ips.iter().copied(),
+                            txt: txt_pairs.iter().copied(),
+                        });
                 }
 
                 Timer::after(Duration::from_millis(BROWSE_POLL_INTERVAL_MS)).await;
@@ -218,51 +195,27 @@ impl AvahiMdns {
 
                 let Ok(args) = signal.args() else { continue };
 
-                if let Ok((
-                    _if,
-                    _proto,
-                    name,
-                    _type,
-                    _domain,
-                    _host,
-                    _ap,
-                    address,
-                    port,
-                    txt,
-                    _fl,
-                )) = avahi
-                    .resolve_service(
-                        args.interface,
-                        args.protocol,
-                        args.name,
-                        args.type_,
-                        args.domain,
-                        AVAHI_PROTO_UNSPEC,
-                        0,
-                    )
-                    .await
-                {
-                    let Ok(ip) = address.parse::<IpAddr>() else {
-                        warn!("Could not parse IP address: {}", address);
-                        continue;
-                    };
+                // Resolve both families for this browsed instance and deposit all
+                // addresses together (transport prefers IPv6 via
+                // `score_ip_address`).
+                let (name, ips, port, txt) = resolve_browsed_all_families(
+                    &avahi,
+                    args.interface,
+                    args.protocol,
+                    args.name,
+                    args.type_,
+                    args.domain,
+                )
+                .await;
 
-                    let mut txt_pairs: Vec<(&str, &str)> = Vec::new();
-                    for entry in &txt {
-                        if let Ok(s) = core::str::from_utf8(entry) {
-                            match s.find('=') {
-                                Some(eq) => txt_pairs.push((&s[..eq], &s[eq + 1..])),
-                                None => txt_pairs.push((s, "")),
-                            }
-                        }
-                    }
-
+                if !ips.is_empty() {
+                    let txt_pairs = txt_pairs(&txt);
                     matter
                         .transport()
                         .try_deposit_mdns_browse(&MdnsRemoteService {
                             instance_name: DottedName(&name),
                             port: Some(port),
-                            addrs: core::iter::once(ip),
+                            addrs: ips.iter().copied(),
                             txt: txt_pairs.iter().copied(),
                         });
                 }
@@ -400,4 +353,108 @@ impl AvahiMdns {
 
         Ok(())
     }
+}
+
+/// Parse Avahi TXT entries (`key=value` / bare `key` byte strings) into borrowed
+/// `(key, value)` pairs.
+fn txt_pairs(txt: &[Vec<u8>]) -> Vec<(&str, &str)> {
+    let mut pairs: Vec<(&str, &str)> = Vec::new();
+    for entry in txt {
+        if let Ok(s) = core::str::from_utf8(entry) {
+            match s.find('=') {
+                Some(eq) => pairs.push((&s[..eq], &s[eq + 1..])),
+                None => pairs.push((s, "")),
+            }
+        }
+    }
+    pairs
+}
+
+/// Resolve an instance (`label`.`service_type`.local) across both address
+/// families, returning all resolved IPs plus the port and TXT (from the first
+/// successful family). Avahi's `ResolveService` returns a single address per
+/// call, so we call it once per family — see [`AVAHI_RESOLVE_PROTOS`].
+async fn resolve_all_families(
+    avahi: &Server2Proxy<'_>,
+    interface: i32,
+    label: &str,
+    service_type: &str,
+) -> (Vec<IpAddr>, u16, Vec<Vec<u8>>) {
+    let mut ips: Vec<IpAddr> = Vec::new();
+    let mut port = 0u16;
+    let mut txt: Vec<Vec<u8>> = Vec::new();
+
+    for aproto in AVAHI_RESOLVE_PROTOS {
+        match avahi
+            .resolve_service(
+                interface,
+                AVAHI_PROTO_UNSPEC,
+                label,
+                service_type,
+                "local",
+                aproto,
+                0,
+            )
+            .await
+        {
+            Ok((_if, _proto, _name, _type, _domain, _host, _ap, address, p, t, _fl)) => {
+                if let Ok(ip) = address.parse::<IpAddr>() {
+                    if !ips.contains(&ip) {
+                        ips.push(ip);
+                    }
+                    port = p;
+                    if txt.is_empty() {
+                        txt = t;
+                    }
+                }
+            }
+            Err(e) => debug!("Avahi resolve of {label} (aproto {aproto}) failed: {e:?}"),
+        }
+    }
+
+    (ips, port, txt)
+}
+
+/// Like [`resolve_all_families`] but for a *browsed* instance (identified by the
+/// browser's `name`/`type_`/`domain`), also returning the resolved instance
+/// name. The browser's own `protocol` is passed through for interface/family
+/// scoping; the per-call `aprotocol` still varies to gather both families.
+#[allow(clippy::type_complexity)]
+async fn resolve_browsed_all_families(
+    avahi: &Server2Proxy<'_>,
+    interface: i32,
+    protocol: i32,
+    name: &str,
+    type_: &str,
+    domain: &str,
+) -> (String, Vec<IpAddr>, u16, Vec<Vec<u8>>) {
+    let mut instance_name = String::new();
+    let mut ips: Vec<IpAddr> = Vec::new();
+    let mut port = 0u16;
+    let mut txt: Vec<Vec<u8>> = Vec::new();
+
+    for aproto in AVAHI_RESOLVE_PROTOS {
+        match avahi
+            .resolve_service(interface, protocol, name, type_, domain, aproto, 0)
+            .await
+        {
+            Ok((_if, _proto, rname, _type, _domain, _host, _ap, address, p, t, _fl)) => {
+                if let Ok(ip) = address.parse::<IpAddr>() {
+                    if !ips.contains(&ip) {
+                        ips.push(ip);
+                    }
+                    instance_name = rname;
+                    port = p;
+                    if txt.is_empty() {
+                        txt = t;
+                    }
+                } else {
+                    warn!("Could not parse IP address: {address}");
+                }
+            }
+            Err(e) => debug!("Avahi resolve (browsed, aproto {aproto}) failed: {e:?}"),
+        }
+    }
+
+    (instance_name, ips, port, txt)
 }

--- a/rs-matter/src/transport/network/mdns/resolve.rs
+++ b/rs-matter/src/transport/network/mdns/resolve.rs
@@ -202,14 +202,18 @@ impl ResolveMdns {
         txt_data: &[Vec<u8>],
     ) {
         for (_p, _w, port, _host, addresses, _ch) in srv_data {
-            if let Some(ip) = first_address(addresses) {
+            // Deposit *all* resolved addresses; the transport picks the most
+            // preferred one (IPv6 link-local → ULA → global → IPv4) via
+            // `score_ip_address`.
+            let ips = all_addresses(addresses);
+            if !ips.is_empty() {
                 let txt = txt_iter(txt_data);
                 matter
                     .transport()
                     .try_deposit_mdns_browse(&MdnsRemoteService {
                         instance_name: DottedName(instance_name),
                         port: Some(*port),
-                        addrs: core::iter::once(ip),
+                        addrs: ips.iter().copied(),
                         txt: txt.iter().copied(),
                     });
             }
@@ -225,14 +229,16 @@ impl ResolveMdns {
         txt_data: &[Vec<u8>],
     ) {
         for (_p, _w, port, _host, addresses, _ch) in srv_data {
-            if let Some(ip) = first_address(addresses) {
+            // Deposit *all* resolved addresses (see `deposit_browse`).
+            let ips = all_addresses(addresses);
+            if !ips.is_empty() {
                 let txt = txt_iter(txt_data);
                 matter
                     .transport()
                     .try_deposit_mdns_resolve(&MdnsRemoteService {
                         instance_name: DottedName(instance_name),
                         port: Some(*port),
-                        addrs: core::iter::once(ip),
+                        addrs: ips.iter().copied(),
                         txt: txt.iter().copied(),
                     });
             }
@@ -321,12 +327,14 @@ impl ResolveMdns {
     }
 }
 
-/// The first parseable IP address from a systemd-resolved address list
-/// (`(ifindex, family, bytes)` triples), best-effort.
-fn first_address(addresses: &[(i32, i32, Vec<u8>)]) -> Option<IpAddr> {
+/// All parseable IP addresses from a systemd-resolved address list
+/// (`(ifindex, family, bytes)` triples), best-effort. The caller deposits these
+/// and lets `score_ip_address` pick the most preferred (IPv6 first).
+fn all_addresses(addresses: &[(i32, i32, Vec<u8>)]) -> Vec<IpAddr> {
     addresses
         .iter()
-        .find_map(|(_ifindex, family, bytes)| parse_ip_address(*family, bytes))
+        .filter_map(|(_ifindex, family, bytes)| parse_ip_address(*family, bytes))
+        .collect()
 }
 
 /// Borrowed `(key, value)` view over systemd-resolved TXT records (each a

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -347,7 +347,7 @@ impl Session {
     /// several PASE sessions (to different devices) in flight at once.
     pub(crate) fn is_pase_for_addr(&self, peer_addr: &Address) -> bool {
         matches!(self.mode, SessionMode::Pase { .. })
-            && self.peer_addr == *peer_addr
+            && self.peer_addr.canonical() == peer_addr.canonical()
             && !self.reserved
     }
 
@@ -367,7 +367,13 @@ impl Session {
         nodeid_matches
             && dest_nodeid_matches
             && self.local_sess_id == rx_plain.sess_id
-            && self.peer_addr == *rx_peer
+            // Compare canonically: a dual-stack socket may report a peer as
+            // `::ffff:a.b.c.d` on receive while the session stored the plain
+            // `V4` address it was created with (or vice versa). Canonicalizing
+            // only the *comparison* (not the stored address) lets the two match
+            // without disturbing the address used for reply routing. See
+            // `Address::canonical`.
+            && self.peer_addr.canonical() == rx_peer.canonical()
             && self.is_encrypted() == rx_plain.is_encrypted()
             && !self.reserved
     }


### PR DESCRIPTION
Two bugfixes:
- In `Session` - when looking for a session matching a given peer address, the peer address in the session and the incoming one are compared _after_ their canonicalization (a topic when the device runs on top of a dual-stack OS). 
- When browsing / resolving over mDNS for commissionable devices, make sure ALL their IP addresses are returned by the mDNS resolver and the Ipv6 ones (if available) are taken with priority over the Ipv4 ones