### PR TITLE
Implement From/ToTLV for certain alloc types

### DIFF
--- a/rs-matter/src/tlv/traits/octets.rs
+++ b/rs-matter/src/tlv/traits/octets.rs
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2024-2025 Project CHIP Authors
+ *    Copyright (c) 2024-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@
 
 //! TLV support for octet strings (i.e. byte arrays).
 //!
-//! Support is provided via two dedicated newtypes:
+//! Support is provided via dedicated newtypes:
 //! - `Octets<'a>` newtype which wraps an ordinary `&[u8]` - for borrowed byte arrays
 //! - `OctetsOwned<const N>` newtype which wraps a `Vec<u8, N>` for owned byte arrays of fixed length N
+//! - `OctetsVec` newtype which wraps an `alloc::vec::Vec<u8>` for owned, unbounded byte
+//!   arrays (requires the `alloc` feature)
 //!
 //! Newtype wrapping is necessary because naked Rust slices, arrays and the naked `Vec` type
 //! serialize and deserialize as TLV arrays, rather than as octet strings.
@@ -162,6 +164,85 @@ impl<'a, const N: usize> FromTLV<'a> for OctetsOwned<N> {
 }
 
 impl<const N: usize> ToTLV for OctetsOwned<N> {
+    fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, mut tw: W) -> Result<(), Error> {
+        tw.str(tag, &self.vec)
+    }
+
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
+        TLV::str(tag, self.vec.as_slice()).into_tlv_iter()
+    }
+}
+
+/// Newtype for owned, **unbounded** (heap-allocated) byte arrays, backed by
+/// `alloc::vec::Vec<u8>`.
+///
+/// The `alloc` analog of [`OctetsOwned`]: use it for owned octet strings whose
+/// length is not known at compile time (e.g. certificate chains). Like the other
+/// octet newtypes, it serializes as a TLV octet string — *not* as a TLV array of
+/// `u8` (which is what a naked `Vec<u8>` would do).
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
+#[repr(transparent)]
+pub struct OctetsVec {
+    pub vec: alloc::vec::Vec<u8>,
+}
+
+#[cfg(feature = "alloc")]
+impl OctetsVec {
+    /// Create a new empty `OctetsVec` instance.
+    pub const fn new() -> Self {
+        Self {
+            vec: alloc::vec::Vec::new(),
+        }
+    }
+
+    /// Wrap an existing `Vec<u8>`.
+    pub const fn from_vec(vec: alloc::vec::Vec<u8>) -> Self {
+        Self { vec }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl Borrow<[u8]> for OctetsVec {
+    fn borrow(&self) -> &[u8] {
+        &self.vec
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl BorrowMut<[u8]> for OctetsVec {
+    fn borrow_mut(&mut self) -> &mut [u8] {
+        &mut self.vec
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl Deref for OctetsVec {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.vec
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl DerefMut for OctetsVec {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.vec
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> FromTLV<'a> for OctetsVec {
+    fn from_tlv(element: &TLVElement<'a>) -> Result<Self, Error> {
+        Ok(Self {
+            vec: element.str()?.into(),
+        })
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl ToTLV for OctetsVec {
     fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, mut tw: W) -> Result<(), Error> {
         tw.str(tag, &self.vec)
     }

--- a/rs-matter/src/tlv/traits/str.rs
+++ b/rs-matter/src/tlv/traits/str.rs
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2024-2025 Project CHIP Authors
+ *    Copyright (c) 2024-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -69,6 +69,24 @@ impl<'a, const N: usize> FromTLV<'a> for String<N> {
 }
 
 impl<const N: usize> ToTLV for String<N> {
+    fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, mut tw: W) -> Result<(), Error> {
+        tw.utf8(tag, self)
+    }
+
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
+        TLV::utf8(tag, self.as_str()).into_tlv_iter()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> FromTLV<'a> for alloc::string::String {
+    fn from_tlv(element: &TLVElement<'a>) -> Result<alloc::string::String, Error> {
+        element.utf8().map(alloc::string::String::from)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl ToTLV for alloc::string::String {
     fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, mut tw: W) -> Result<(), Error> {
         tw.utf8(tag, self)
     }

--- a/rs-matter/src/tlv/traits/vec.rs
+++ b/rs-matter/src/tlv/traits/vec.rs
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2024-2025 Project CHIP Authors
+ *    Copyright (c) 2024-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -63,6 +63,38 @@ where
 }
 
 impl<T, const N: usize> ToTLV for Vec<T, N>
+where
+    T: ToTLV,
+{
+    fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, tw: W) -> Result<(), Error> {
+        self.as_slice().to_tlv(tag, tw)
+    }
+
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
+        tlv_array_iter(tag, self.iter())
+    }
+}
+
+/// TLV support for the heap-allocated `alloc::vec::Vec<T>` (unbounded, no `N`).
+/// Serialized/deserialized as a TLV array, like the bounded `Vec<T, N>` above.
+#[cfg(feature = "alloc")]
+impl<'a, T> FromTLV<'a> for alloc::vec::Vec<T>
+where
+    T: FromTLV<'a> + 'a,
+{
+    fn from_tlv(element: &TLVElement<'a>) -> Result<Self, Error> {
+        let mut vec = alloc::vec::Vec::new();
+
+        for item in TLVArray::new(element.clone())? {
+            vec.push(item?);
+        }
+
+        Ok(vec)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T> ToTLV for alloc::vec::Vec<T>
 where
     T: ToTLV,
 {


### PR DESCRIPTION
This is not necessary for `rs-matter` per se - which is no-alloc.

However, deriving `FromTLV` / `ToTLV` downstream on user types becomes difficult if those types are using e.g. the `String` and `Vec` types from Rust's `alloc` crate.

Hence we implement `FromTLV` / `ToTLV` for `alloc::string::String`, `alloc::vec::Vec` and a new - `alloc::vec::Vec`-based octet string type similar to the existing `OctetsOwned` - `OctetsVec`.