### PR TITLE
Make sure mDNS resovers return the interface scope ID

### DIFF
--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -272,12 +272,13 @@ impl Transport {
             MdnsResolveState::Resolved {
                 ip,
                 port,
+                scope_id,
                 sii,
                 sai,
                 sat,
             } => {
                 let node = ResolvedNode {
-                    addr: SocketAddr::new(*ip, *port),
+                    addr: Self::scoped_socket_addr(*ip, *port, *scope_id),
                     sii: *sii,
                     sai: *sai,
                     sat: *sat,
@@ -354,6 +355,7 @@ impl Transport {
         let Some(port) = answer.port else {
             return;
         };
+        let scope_id = answer.scope_id;
 
         let (sii, sai, sat) = answer.session_params();
 
@@ -364,6 +366,7 @@ impl Transport {
                 *state = MdnsResolveState::Resolved {
                     ip,
                     port,
+                    scope_id,
                     sii,
                     sai,
                     sat,
@@ -390,6 +393,7 @@ impl Transport {
                 *state = MdnsResolveState::Resolved {
                     ip,
                     port,
+                    scope_id,
                     sii: sii.or(*cur_sii),
                     sai: sai.or(*cur_sai),
                     sat: sat.or(*cur_sat),
@@ -460,8 +464,16 @@ impl Transport {
 
         // 3. Wait for the first matching, non-excluded commissionable node, or time out.
         let mut wait = pin!(self.mdns_browse.wait(|state| match state {
-            MdnsBrowseState::Found { ip, port, id } => {
-                let found = (Address::Udp(SocketAddr::new(*ip, *port)), *id);
+            MdnsBrowseState::Found {
+                ip,
+                port,
+                scope_id,
+                id,
+            } => {
+                let found = (
+                    Address::Udp(Self::scoped_socket_addr(*ip, *port, *scope_id)),
+                    *id,
+                );
                 *state = MdnsBrowseState::Idle;
                 Some(found)
             }
@@ -538,12 +550,18 @@ impl Transport {
         let Some(port) = answer.port else {
             return;
         };
+        let scope_id = answer.scope_id;
 
         self.mdns_browse.modify(|state| match state {
             MdnsBrowseState::InFlight { filter, exclude }
                 if !exclude.contains(&id) && filter.matches(answer) =>
             {
-                *state = MdnsBrowseState::Found { ip, port, id };
+                *state = MdnsBrowseState::Found {
+                    ip,
+                    port,
+                    scope_id,
+                    id,
+                };
                 (true, ())
             }
             // Already matched this same instance but not yet consumed: keep the
@@ -556,7 +574,12 @@ impl Transport {
                 id: cur_id,
                 ..
             } if *cur_id == id && score_ip_address(&ip) > score_ip_address(cur_ip) => {
-                *state = MdnsBrowseState::Found { ip, port, id };
+                *state = MdnsBrowseState::Found {
+                    ip,
+                    port,
+                    scope_id,
+                    id,
+                };
                 (true, ())
             }
             _ => (false, ()),
@@ -884,6 +907,22 @@ impl Transport {
         F: Fn(&Packet<N>) -> bool,
     {
         PacketAccess(packet_mutex.lock_if(f).await, false)
+    }
+
+    /// Build a `SocketAddr` from a resolved `(ip, port)`, attaching the IPv6
+    /// `scope_id` (interface zone) so a **link-local** destination (`fe80::/10`)
+    /// is routable.
+    ///
+    /// The scope is only meaningful — and only applied — for link-local IPv6;
+    /// for any other address it is irrelevant and `SocketAddr::new` is used
+    /// as-is.
+    fn scoped_socket_addr(ip: IpAddr, port: u16, scope_id: u32) -> SocketAddr {
+        match ip {
+            IpAddr::V6(v6) if v6.is_unicast_link_local() => {
+                SocketAddr::V6(SocketAddrV6::new(v6, port, 0, scope_id))
+            }
+            _ => SocketAddr::new(ip, port),
+        }
     }
 }
 
@@ -2368,6 +2407,7 @@ mod resolve_tests {
                     port: Some(1234),
                     addrs: [IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5))].into_iter(),
                     txt: [("SII", "300"), ("SAI", "4000"), ("SAT", "5000")].into_iter(),
+                    scope_id: 0,
                 };
 
                 matter.transport().try_deposit_mdns_resolve(&answer);
@@ -2414,6 +2454,7 @@ mod resolve_tests {
             port: Some(1234),
             addrs: [IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9))].into_iter(),
             txt: core::iter::empty::<(&str, &str)>(),
+            scope_id: 0,
         };
         matter.transport().try_deposit_mdns_resolve(&answer);
 
@@ -2461,6 +2502,7 @@ mod browse_tests {
                     port: Some(5540),
                     addrs: [IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))].into_iter(),
                     txt: [("D", "2650"), ("VP", "9999+1"), ("CM", "1")].into_iter(),
+                    scope_id: 0,
                 };
                 matter.transport().try_deposit_mdns_browse(&other);
 
@@ -2470,6 +2512,7 @@ mod browse_tests {
                     port: Some(5541),
                     addrs: [IpAddr::V4(Ipv4Addr::new(10, 0, 0, 7))].into_iter(),
                     txt: [("D", "2650"), ("VP", "65521+42"), ("CM", "1")].into_iter(),
+                    scope_id: 0,
                 };
                 matter.transport().try_deposit_mdns_browse(&answer);
             };
@@ -2533,6 +2576,7 @@ mod browse_tests {
                     port: Some(5540),
                     addrs: [IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))].into_iter(),
                     txt: [("D", "2578"), ("CM", "1")].into_iter(), // 0xA12, short 0xA
+                    scope_id: 0,
                 };
                 // Excluded id -> ignored.
                 matter.transport().try_deposit_mdns_browse(&node_a);
@@ -2542,6 +2586,7 @@ mod browse_tests {
                     port: Some(5541),
                     addrs: [IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))].into_iter(),
                     txt: [("D", "2815"), ("CM", "1")].into_iter(), // 0xAFF, short 0xA
+                    scope_id: 0,
                 };
                 matter.transport().try_deposit_mdns_browse(&node_b);
             };

--- a/rs-matter/src/transport/network/mdns.rs
+++ b/rs-matter/src/transport/network/mdns.rs
@@ -383,6 +383,12 @@ pub struct MdnsRemoteService<I, A, T> {
     pub addrs: A,
     /// The raw TXT key/value pairs.
     pub txt: T,
+    /// The IPv6 scope (zone) id — the interface index the service was discovered
+    /// on. Required to make a **link-local** (`fe80::/10`) address routable: the
+    /// kernel cannot pick an egress interface for a link-local destination
+    /// without it. `0` (the kernel's own "unscoped" sentinel) when the backend
+    /// can't supply it; only relevant for link-local IPv6 results.
+    pub scope_id: u32,
 }
 
 impl<'a, I, A, T> MdnsRemoteService<I, A, T>
@@ -675,6 +681,9 @@ pub(crate) enum MdnsResolveState {
     Resolved {
         ip: IpAddr,
         port: u16,
+        /// IPv6 scope (zone) id for a link-local `ip`; 0 otherwise. See
+        /// [`MdnsRemoteService::scope_id`].
+        scope_id: u32,
         sii: Option<u32>,
         sai: Option<u32>,
         sat: Option<u16>,
@@ -714,7 +723,14 @@ pub(crate) enum MdnsBrowseState {
         exclude: BrowseExclude,
     },
     /// The responder deposited the first matching, non-excluded commissionable node.
-    Found { ip: IpAddr, port: u16, id: u64 },
+    Found {
+        ip: IpAddr,
+        port: u16,
+        /// IPv6 scope (zone) id for a link-local `ip`; 0 otherwise. See
+        /// [`MdnsRemoteService::scope_id`].
+        scope_id: u32,
+        id: u64,
+    },
 }
 
 /// Score an IP address for prioritization.

--- a/rs-matter/src/transport/network/mdns/astro.rs
+++ b/rs-matter/src/transport/network/mdns/astro.rs
@@ -144,6 +144,9 @@ impl AstroMdns {
                                     port: Some(svc.port),
                                     addrs: ips.iter().copied(),
                                     txt: txt.iter().copied(),
+                                    // DNS-SD reports the interface index; use it
+                                    // as the scope id for a link-local result.
+                                    scope_id: link_local_scope_id(&ips, svc.interface_index),
                                 });
                         }
                     }
@@ -203,6 +206,9 @@ impl AstroMdns {
                                     port: Some(service.port),
                                     addrs: ips.iter().copied(),
                                     txt: txt.iter().copied(),
+                                    // DNS-SD reports the interface index; use it
+                                    // as the scope id for a link-local result.
+                                    scope_id: link_local_scope_id(&ips, service.interface_index),
                                 });
                         } else {
                             warn!("Could not resolve hostname: {}", service.hostname);
@@ -281,5 +287,20 @@ impl AstroMdns {
         let svc = builder.register().map_err(|_| ErrorCode::MdnsError)?;
 
         Ok(svc)
+    }
+}
+
+/// The IPv6 scope id (interface index) to attach to a resolved result, or `0`
+/// (the unscoped sentinel) when not applicable. The scope only matters for a
+/// link-local (`fe80::`) IPv6 address, so it is taken from the DNS-SD service's
+/// reported `interface_index` only when one of the resolved `ips` is link-local.
+fn link_local_scope_id(ips: &[IpAddr], interface_index: Option<u32>) -> u32 {
+    let has_link_local = ips
+        .iter()
+        .any(|ip| matches!(ip, IpAddr::V6(v6) if v6.is_unicast_link_local()));
+
+    match interface_index {
+        Some(idx) if has_link_local && idx > 0 => idx,
+        _ => 0,
     }
 }

--- a/rs-matter/src/transport/network/mdns/avahi.rs
+++ b/rs-matter/src/transport/network/mdns/avahi.rs
@@ -138,7 +138,7 @@ impl AvahiMdns {
                 // Resolve both address families (Avahi returns one address per
                 // call) and deposit them together; the transport prefers IPv6
                 // (link-local → ULA → global → IPv4) via `score_ip_address`.
-                let (ips, port, txt) =
+                let (ips, port, txt, scope_id) =
                     resolve_all_families(&avahi, AVAHI_IF_UNSPEC, &label, service_type).await;
                 if !ips.is_empty() {
                     let txt_pairs = txt_pairs(&txt);
@@ -150,6 +150,7 @@ impl AvahiMdns {
                             port: Some(port),
                             addrs: ips.iter().copied(),
                             txt: txt_pairs.iter().copied(),
+                            scope_id,
                         });
                 }
 
@@ -198,7 +199,7 @@ impl AvahiMdns {
                 // Resolve both families for this browsed instance and deposit all
                 // addresses together (transport prefers IPv6 via
                 // `score_ip_address`).
-                let (name, ips, port, txt) = resolve_browsed_all_families(
+                let (name, ips, port, txt, scope_id) = resolve_browsed_all_families(
                     &avahi,
                     args.interface,
                     args.protocol,
@@ -217,6 +218,7 @@ impl AvahiMdns {
                             port: Some(port),
                             addrs: ips.iter().copied(),
                             txt: txt_pairs.iter().copied(),
+                            scope_id,
                         });
                 }
             }
@@ -379,10 +381,14 @@ async fn resolve_all_families(
     interface: i32,
     label: &str,
     service_type: &str,
-) -> (Vec<IpAddr>, u16, Vec<Vec<u8>>) {
+) -> (Vec<IpAddr>, u16, Vec<Vec<u8>>, u32) {
     let mut ips: Vec<IpAddr> = Vec::new();
     let mut port = 0u16;
     let mut txt: Vec<Vec<u8>> = Vec::new();
+    // The interface index of the link-local result, used as the IPv6 scope id so
+    // a `fe80::` address is routable. Avahi returns the interface per resolve;
+    // only link-local needs it.
+    let mut scope_id = 0u32;
 
     for aproto in AVAHI_RESOLVE_PROTOS {
         match avahi
@@ -397,8 +403,11 @@ async fn resolve_all_families(
             )
             .await
         {
-            Ok((_if, _proto, _name, _type, _domain, _host, _ap, address, p, t, _fl)) => {
+            Ok((iface, _proto, _name, _type, _domain, _host, _ap, address, p, t, _fl)) => {
                 if let Ok(ip) = address.parse::<IpAddr>() {
+                    if is_link_local_v6(&ip) && iface > 0 {
+                        scope_id = iface as u32;
+                    }
                     if !ips.contains(&ip) {
                         ips.push(ip);
                     }
@@ -412,7 +421,7 @@ async fn resolve_all_families(
         }
     }
 
-    (ips, port, txt)
+    (ips, port, txt, scope_id)
 }
 
 /// Like [`resolve_all_families`] but for a *browsed* instance (identified by the
@@ -427,19 +436,25 @@ async fn resolve_browsed_all_families(
     name: &str,
     type_: &str,
     domain: &str,
-) -> (String, Vec<IpAddr>, u16, Vec<Vec<u8>>) {
+) -> (String, Vec<IpAddr>, u16, Vec<Vec<u8>>, u32) {
     let mut instance_name = String::new();
     let mut ips: Vec<IpAddr> = Vec::new();
     let mut port = 0u16;
     let mut txt: Vec<Vec<u8>> = Vec::new();
+    // Interface index of the link-local result → IPv6 scope id (see
+    // `resolve_all_families`).
+    let mut scope_id = 0u32;
 
     for aproto in AVAHI_RESOLVE_PROTOS {
         match avahi
             .resolve_service(interface, protocol, name, type_, domain, aproto, 0)
             .await
         {
-            Ok((_if, _proto, rname, _type, _domain, _host, _ap, address, p, t, _fl)) => {
+            Ok((iface, _proto, rname, _type, _domain, _host, _ap, address, p, t, _fl)) => {
                 if let Ok(ip) = address.parse::<IpAddr>() {
+                    if is_link_local_v6(&ip) && iface > 0 {
+                        scope_id = iface as u32;
+                    }
                     if !ips.contains(&ip) {
                         ips.push(ip);
                     }
@@ -456,5 +471,11 @@ async fn resolve_browsed_all_families(
         }
     }
 
-    (instance_name, ips, port, txt)
+    (instance_name, ips, port, txt, scope_id)
+}
+
+/// `true` for a unicast link-local IPv6 address (`fe80::/10`) — the only kind
+/// that needs an interface scope id to be routable.
+fn is_link_local_v6(ip: &IpAddr) -> bool {
+    matches!(ip, IpAddr::V6(v6) if v6.is_unicast_link_local())
 }

--- a/rs-matter/src/transport/network/mdns/builtin.rs
+++ b/rs-matter/src/transport/network/mdns/builtin.rs
@@ -463,7 +463,7 @@ impl BuiltinMdns {
                 if is_response {
                     // Deposit any answer that matches an in-flight resolve or
                     // browse request.
-                    match parse_into_answer(packet) {
+                    match parse_into_answer(packet, ipv6_interface) {
                         Ok(Some(answer)) => {
                             matter.transport().try_deposit_mdns_resolve(&answer);
                             matter.transport().try_deposit_mdns_browse(&answer);

--- a/rs-matter/src/transport/network/mdns/builtin/query.rs
+++ b/rs-matter/src/transport/network/mdns/builtin/query.rs
@@ -188,9 +188,17 @@ impl<'a> Iterator for MdnsTxt<'a> {
 /// `addrs`/`txt` walk the records on demand (see [`MdnsAddrs`] / [`MdnsTxt`]).
 /// Records split across multiple packets are not merged - see
 /// [`MdnsRemoteService`] for the rationale.
+///
+/// `ipv6_scope` is the interface index the builtin backend listens on (its
+/// configured `ipv6_interface`); it is stamped onto the result as the IPv6
+/// scope id so a link-local (`fe80::`) AAAA record becomes routable. It is the
+/// only interface the builtin mDNS sends/receives on, so any link-local result
+/// is necessarily reachable through it. `None` (no specific interface) maps to
+/// the unscoped sentinel `0`.
 #[allow(clippy::type_complexity)]
 pub fn parse_into_answer(
     data: &[u8],
+    ipv6_scope: Option<u32>,
 ) -> Result<Option<MdnsRemoteService<ParsedName<&[u8]>, MdnsAddrs<'_>, MdnsTxt<'_>>>, Error> {
     let msg = Message::from_octets(data)?;
 
@@ -262,6 +270,10 @@ pub fn parse_into_answer(
             yielded: 0,
         },
         txt,
+        // The builtin backend listens on a single configured interface, so a
+        // link-local AAAA result is reachable through it: stamp that interface
+        // index as the IPv6 scope id (`0` = unscoped, when none was configured).
+        scope_id: ipv6_scope.unwrap_or(0),
     }))
 }
 
@@ -330,7 +342,7 @@ mod tests {
         let len =
             build_browse_query(NameSlice::new(["_matterc", "_udp", "local"]), &mut buf).unwrap();
 
-        assert!(parse_into_answer(&buf[..len]).unwrap().is_none());
+        assert!(parse_into_answer(&buf[..len], None).unwrap().is_none());
     }
 
     #[test]
@@ -338,7 +350,9 @@ mod tests {
         let mut buf = [0u8; 1024];
         let len = commissionable_response(&mut buf, &["_L1234", "_S3", "_CM"]);
 
-        let answer = parse_into_answer(&buf[..len]).unwrap().unwrap();
+        // A configured IPv6 interface index is threaded through as the scope id.
+        let answer = parse_into_answer(&buf[..len], Some(7)).unwrap().unwrap();
+        assert_eq!(answer.scope_id, 7);
 
         assert_eq!(
             name_str(answer.instance_name).as_str(),
@@ -379,9 +393,11 @@ mod tests {
         // "no usable TXT" path we assert the parsed pairs are empty instead.
         let len = host().broadcast(&service, &mut buf, 60, 60).unwrap();
 
-        let answer = parse_into_answer(&buf[..len]).unwrap().unwrap();
+        // No interface configured → unscoped (scope id 0).
+        let answer = parse_into_answer(&buf[..len], None).unwrap().unwrap();
 
         assert_eq!(answer.port, Some(5540));
+        assert_eq!(answer.scope_id, 0);
         assert_eq!(answer.txt.count(), 0);
     }
 }

--- a/rs-matter/src/transport/network/mdns/resolve.rs
+++ b/rs-matter/src/transport/network/mdns/resolve.rs
@@ -215,6 +215,10 @@ impl ResolveMdns {
                         port: Some(*port),
                         addrs: ips.iter().copied(),
                         txt: txt.iter().copied(),
+                        // systemd-resolved reports the interface index per
+                        // address; use the link-local IPv6 one as the scope id
+                        // so a `fe80::` result is routable.
+                        scope_id: link_local_scope_id(addresses),
                     });
             }
         }
@@ -240,6 +244,10 @@ impl ResolveMdns {
                         port: Some(*port),
                         addrs: ips.iter().copied(),
                         txt: txt.iter().copied(),
+                        // systemd-resolved reports the interface index per
+                        // address; use the link-local IPv6 one as the scope id
+                        // so a `fe80::` result is routable.
+                        scope_id: link_local_scope_id(addresses),
                     });
             }
         }
@@ -335,6 +343,24 @@ fn all_addresses(addresses: &[(i32, i32, Vec<u8>)]) -> Vec<IpAddr> {
         .iter()
         .filter_map(|(_ifindex, family, bytes)| parse_ip_address(*family, bytes))
         .collect()
+}
+
+/// The IPv6 scope id (interface index) for a link-local result, or `0` (the
+/// unscoped sentinel) if there is no link-local IPv6 address. systemd-resolved
+/// reports the interface index per address; for a `fe80::` address that index
+/// is the scope needed to make it routable. Returns the first link-local hit.
+fn link_local_scope_id(addresses: &[(i32, i32, Vec<u8>)]) -> u32 {
+    addresses
+        .iter()
+        .find_map(
+            |(ifindex, family, bytes)| match parse_ip_address(*family, bytes) {
+                Some(IpAddr::V6(v6)) if v6.is_unicast_link_local() && *ifindex > 0 => {
+                    Some(*ifindex as u32)
+                }
+                _ => None,
+            },
+        )
+        .unwrap_or(0)
 }
 
 /// Borrowed `(key, value)` view over systemd-resolved TXT records (each a

--- a/rs-matter/src/transport/network/mdns/zeroconf.rs
+++ b/rs-matter/src/transport/network/mdns/zeroconf.rs
@@ -144,6 +144,12 @@ impl ZeroconfMdns {
                                 port: Some(*svc.port()),
                                 addrs: core::iter::once(ip),
                                 txt: pairs.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+                                // The `zeroconf` crate's `ServiceDiscovery`
+                                // exposes no interface index, so this backend
+                                // can't supply an IPv6 scope id: link-local
+                                // (`fe80::`) results are unscoped here. Other
+                                // backends (avahi, resolve, astro) thread it.
+                                scope_id: 0,
                             });
                     }
                 });
@@ -174,6 +180,12 @@ impl ZeroconfMdns {
                                 port: Some(*svc.port()),
                                 addrs: core::iter::once(ip),
                                 txt: pairs.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+                                // The `zeroconf` crate's `ServiceDiscovery`
+                                // exposes no interface index, so this backend
+                                // can't supply an IPv6 scope id: link-local
+                                // (`fe80::`) results are unscoped here. Other
+                                // backends (avahi, resolve, astro) thread it.
+                                scope_id: 0,
                             });
                     }
                 });


### PR DESCRIPTION
~~Not strictly super-necessary, but why not?~~

Having the scope ID (= the interface where the mDNS resolver got replies from the peer) allows mDNS clients to construct a more precise ipv6 address, with a scope ID != 0. Useful on multi-homed network setups.