### PR TITLE
Separate the repo tagging into its own GH Action

### DIFF
--- a/.github/workflows/publish-crate-dry-run.yml
+++ b/.github/workflows/publish-crate-dry-run.yml
@@ -31,12 +31,3 @@ jobs:
           components: rust-src
       - name: Build | Publish Dry Run
         run: cd "${{ github.event.inputs.crate }}"; cargo publish --dry-run
-      - name: Get the crate version from cargo
-        run: |
-          version=$(cargo metadata --format-version=1 --no-deps | jq -r ".packages[] | select(.name == \"${{github.event.inputs.crate}}\") | .version")
-          echo "crate_version=$version" >> $GITHUB_ENV
-          echo "${{github.event.inputs.crate}} version: $version"
-      - name: Tag the new release (dry run)
-        run: |
-          echo "Would create tag: ${{github.event.inputs.crate}}-v${{env.crate_version}}"
-          echo "Would use message: Release ${{github.event.inputs.crate}} v${{env.crate_version}}"

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -19,11 +19,6 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    # `contents: write` is required so the "Tag the new release" step can push
-    # the git tag. The default GITHUB_TOKEN is read-only for repos/orgs whose
-    # default workflow permissions are "read", which is why tagging fails today.
-    permissions:
-      contents: write
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v4
@@ -38,13 +33,3 @@ jobs:
         run: cargo login ${{ secrets.crates_io_token }}
       - name: Build | Publish
         run: cd "${{ github.event.inputs.crate }}"; cargo publish
-      - name: Get the crate version from cargo
-        run: |
-          version=$(cargo metadata --format-version=1 --no-deps | jq -r ".packages[] | select(.name == \"${{github.event.inputs.crate}}\") | .version")
-          echo "crate_version=$version" >> $GITHUB_ENV
-          echo "${{github.event.inputs.crate}} version: $version"
-      - name: Tag the new release
-        uses: rickstaa/action-create-tag@v1
-        with:
-          tag: ${{github.event.inputs.crate}}-v${{env.crate_version}}
-          message: "Release ${{github.event.inputs.crate}} v${{env.crate_version}}"

--- a/.github/workflows/publish-tag-dry-run.yml
+++ b/.github/workflows/publish-tag-dry-run.yml
@@ -1,0 +1,26 @@
+name: PublishTagDryRun
+
+# Dry run of `PublishTag`: prints the `v<version>` tag that would be created,
+# without pushing anything.
+on:
+  workflow_dispatch
+
+env:
+  CRATE_NAME: rs-matter
+
+jobs:
+  tagdryrun:
+    name: Tag the release (dry run)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v4
+      - name: Get the release version from cargo
+        run: |
+          version=$(cargo metadata --format-version=1 --no-deps | jq -r ".packages[] | select(.name == \"${{env.CRATE_NAME}}\") | .version")
+          echo "crate_version=$version" >> $GITHUB_ENV
+          echo "release version: $version"
+      - name: Tag the new release (dry run)
+        run: |
+          echo "Would create tag: v${{env.crate_version}}"
+          echo "Would use message: Release v${{env.crate_version}}"

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -1,0 +1,40 @@
+name: PublishTag
+
+# Pushes a single `v<version>` repository tag for an rs-matter release.
+#
+# `rs-matter`, `rs-matter-macros` and `rs-matter-codegen` share one workspace
+# version and are released in lock-step, so a release gets ONE project tag — not
+# a per-crate tag. The `PublishCrate` workflow publishes the three crates
+# individually (codegen -> macros -> rs-matter, re-runnable per crate if one
+# fails); run THIS workflow once, after all three have been published to
+# crates.io, to tag the release.
+on:
+  workflow_dispatch
+
+env:
+  # The three crates share the workspace version; the main crate is the natural
+  # source of the release version.
+  CRATE_NAME: rs-matter
+
+jobs:
+  tag:
+    name: Tag the release
+    runs-on: ubuntu-latest
+    # `contents: write` is required so the tag step can push the git tag. The
+    # default GITHUB_TOKEN is read-only for repos/orgs whose default workflow
+    # permissions are "read".
+    permissions:
+      contents: write
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v4
+      - name: Get the release version from cargo
+        run: |
+          version=$(cargo metadata --format-version=1 --no-deps | jq -r ".packages[] | select(.name == \"${{env.CRATE_NAME}}\") | .version")
+          echo "crate_version=$version" >> $GITHUB_ENV
+          echo "release version: $version"
+      - name: Tag the new release
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: v${{env.crate_version}}
+          message: "Release v${{env.crate_version}}"


### PR DESCRIPTION
Reasoning is as follows:
1. `rs-matter`, `rs-matter-codegen` and `rs-matter-macros` are so inter-related, that they will always have the same single crate version, and will always be published in lock-step
2. Due to the above, it does not make sense to have per-crate `<crate>-vX.Y.Z` tagging of the repo post-publishing, but just `vX.Y.Z`. Therefore, the tagging script is now isolated as a separate GH action, because it needs to be run _once_ only, after all the 3 crates are published