### PR TITLE
btp: handle no-preference handshake MTU

### DIFF
--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -568,7 +568,7 @@ impl Session {
         let version = req.versions().min().unwrap_or(4);
 
         let mtu = if req.mtu == 0 {
-            min(gatt_mtu.unwrap_or(MIN_MTU), MAX_MTU)
+            gatt_mtu.map(|g| g.clamp(MIN_MTU, MAX_MTU)).unwrap_or(MIN_MTU)
         } else if gatt_mtu.map(|gatt_mtu| gatt_mtu != req.mtu).unwrap_or(true) {
             let mtu = if self.relaxed_mtu_nego {
                 // In the relaxed MTU negotiation mode, if the GATT MTU is not what the peer reports,

--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -568,7 +568,9 @@ impl Session {
         let version = req.versions().min().unwrap_or(4);
 
         let mtu = if req.mtu == 0 {
-            gatt_mtu.map(|g| g.clamp(MIN_MTU, MAX_MTU)).unwrap_or(MIN_MTU)
+            gatt_mtu
+                .map(|g| g.clamp(MIN_MTU, MAX_MTU))
+                .unwrap_or(MIN_MTU)
         } else if gatt_mtu.map(|gatt_mtu| gatt_mtu != req.mtu).unwrap_or(true) {
             let mtu = if self.relaxed_mtu_nego {
                 // In the relaxed MTU negotiation mode, if the GATT MTU is not what the peer reports,

--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -567,7 +567,9 @@ impl Session {
 
         let version = req.versions().min().unwrap_or(4);
 
-        let mtu = if gatt_mtu.map(|gatt_mtu| gatt_mtu != req.mtu).unwrap_or(true) {
+        let mtu = if req.mtu == 0 {
+            min(gatt_mtu.unwrap_or(MIN_MTU), MAX_MTU)
+        } else if gatt_mtu.map(|gatt_mtu| gatt_mtu != req.mtu).unwrap_or(true) {
             let mtu = if self.relaxed_mtu_nego {
                 // In the relaxed MTU negotiation mode, if the GATT MTU is not what the peer reports,
                 // we take as an MTU the minimum between our MTU and what the peer reports


### PR DESCRIPTION
Matter BTP specification for the handshake Requested MTU value states:

> Requested ATT_MTU is a 16-bit unsigned integer field containing the size of the GATT PDU (ATT_MTU) that can be received by the sender minus the size of the GATT header (3). This value is obtained via the standard ATT MTU exchange procedure (see Bluetooth® Core Specification 4.2 Vol 3, Part F, Section 3.4.2 "MTU Exchange") and is used to validate that both sides of the BLE connection are using the common minimum value. If BTP is not aware of the negotiated GATT MTU, the value shall be set to '23', indicating the minimum ATT_MTU defined by GATT. If the client has no preference, the value may be set to '0'.

SmartThings app on Android sends the value 0, which was previously not special cased and it resulted in a mismatch code path being taken and MTU set to 23 (minimum). This worked but the initial commissioning over BLE was slow. I cross-checked with [connectedhomeip project](
https://github.com/project-chip/connectedhomeip/blob/079e6f4e491c25a0eaa2276b40fbb0de295a9bb5/src/ble/BLEEndPoint.cpp#L990-L998) which handles the case by calling GetMTU() to get a value from platform-specific code. We already seem to have a reasonable value in `gatt_mtu`, so let's clip and use that.