### PR TITLE
Warn on packet retransmission

### DIFF
--- a/.github/actions/setup-size-reports/action.yaml
+++ b/.github/actions/setup-size-reports/action.yaml
@@ -8,7 +8,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - run: pip install numpy pandas humanfriendly pyelftools cxxfilt tabulate fastcore ghapi
+  # NOTE: `ghapi` is pinned to `<2` because 2.0.0 turned `ghapi.all.paged()`
+  # into an async generator, which breaks the sync `for i in ghapi.all.paged(...)`
+  # loops in `.github/scripts/memory/memdf/util/github.py`.
+  # `fastcore` is pinned to `<2` because 2.0.0 removed `L.starmap`, which
+  # `ghapi` 1.x still uses in `GhApi.__init__`.
+  # Upstream connectedhomeip pins `ghapi==1.0.3` and `fastcore==1.5.28`
+  # via `scripts/setup/constraints.txt`.
+  - run: pip install numpy pandas humanfriendly pyelftools cxxfilt tabulate 'fastcore<2' 'ghapi<2'
     shell: bash
   - name: Set up environment for size reports
     shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Warn on packet retransmission (#500)
+  * Breaking: rename feature `debug-tlv-payload` to `log-tlv-payload`
 * MCSP Protocol Implementation (#499)
 * BTP: handle no-preference handshake MTU of 0 (#497)
 

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -138,7 +138,8 @@ sync-mutex = []
 rustcrypto = ["alloc", "digest", "cipher", "ccm", "elliptic-curve", "primeorder", "ecdsa", "sec1", "signature", "hmac", "hkdf", "pbkdf2", "crypto-bigint", "sha1", "sha2", "aes", "p256", "x509-cert"]
 defmt = ["dep:defmt", "heapless/defmt", "embassy-time/defmt", "mbedtls-rs-sys?/defmt"]
 log = ["dep:log", "embassy-time/log"]
-debug-tlv-payload = []
+log-tlv-payload = [] # Enable `debug`-level logging of TLV payloads. This is very verbose and should only be used for debugging.
+log-mrp = [] # Promote MRP-diagnostic logs from `debug` to `warn` so they are visible under a typical `info`-level filter.
 large-buffers = [] # TCP support
 
 [dependencies]

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -1712,12 +1712,12 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
 
         if packet.tx_info.retransmission {
             mrp_log!(
-                "\n<<SND Re-sending\n      => {}",
+                "\n<<SND {}\n      => Re-sending",
                 Packet::<0>::display(&packet.peer, &packet.header),
             );
         } else {
             debug!(
-                "\n<<SND Sending\n      => {}",
+                "\n<<SND {}\n      => Sending",
                 Packet::<0>::display(&packet.peer, &packet.header),
             );
         }

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -59,6 +59,8 @@ use packet::PacketHdr;
 use proto_hdr::ProtoHdr;
 use session::{Session, Sessions};
 
+use self::mrp::mrp_log;
+
 mod dedup;
 
 pub mod exchange;
@@ -1246,14 +1248,14 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
             Err(e) if matches!(e.code(), ErrorCode::Duplicate) => {
                 if packet.header.plain.is_group_session() {
                     // Group messages are multicast and don't use MRP; silently discard duplicates
-                    debug!(
+                    mrp_log!(
                         "\n>>RCV {}\n      => Duplicate group message, discarding",
                         packet
                     );
                 } else if !packet.peer.is_reliable()
                     && !MessageMeta::from(&packet.header.proto).is_standalone_ack()
                 {
-                    debug!("\n>>RCV {}\n      => Duplicate, sending ACK", packet);
+                    mrp_log!("\n>>RCV {}\n      => Duplicate, sending ACK", packet);
 
                     self.matter.with_state(|state| {
                         // `unwrap` is safe because we know we have a session.
@@ -1278,7 +1280,7 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                     Self::netw_send(send, packet.peer, &packet.buf[packet.payload_start..], true)
                         .await?;
                 } else {
-                    debug!("\n>>RCV {}\n      => Duplicate, discarding", packet);
+                    mrp_log!("\n>>RCV {}\n      => Duplicate, discarding", packet);
                 }
             }
             Err(e) if matches!(e.code(), ErrorCode::NoSpaceSessions) => {
@@ -1357,7 +1359,7 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                     .await?;
             }
             Err(e) if matches!(e.code(), ErrorCode::NoExchange) => {
-                warn!(
+                mrp_log!(
                     "\n>>RCV {}\n      => No valid exchange found, dropping",
                     packet
                 );
@@ -1432,7 +1434,7 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                         if new_exchange { " (new exchange)" } else { "" }
                     );
 
-                    #[cfg(feature = "debug-tlv-payload")]
+                    #[cfg(feature = "log-tlv-payload")]
                     debug!(
                         "{}",
                         Packet::<0>::display_payload(
@@ -1441,7 +1443,7 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                         )
                     );
 
-                    #[cfg(not(feature = "debug-tlv-payload"))]
+                    #[cfg(not(feature = "log-tlv-payload"))]
                     trace!(
                         "{}",
                         Packet::<0>::display_payload(
@@ -1486,7 +1488,7 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                 return false;
             }
 
-            warn!(
+            mrp_log!(
                 "\n>>RCV {}\n => Accept timeout, marking exchange as dropped",
                 packet
             );
@@ -1509,14 +1511,14 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                 .sessions
                 .get_for_rx(&packet.peer, &packet.header.plain)
             else {
-                warn!("\n>>RCV {}\n => No session, dropping", packet);
+                mrp_log!("\n>>RCV {}\n => No session, dropping", packet);
 
                 packet.buf.clear();
                 return true;
             };
 
             let Some(exch_index) = session.get_exch_for_rx(&packet.header.proto) else {
-                warn!("\n>>RCV {}\n => No exchange, dropping", packet);
+                mrp_log!("\n>>RCV {}\n => No exchange, dropping", packet);
 
                 packet.buf.clear();
                 return true;
@@ -1526,7 +1528,7 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
             let exchange = unwrap!(session.exchanges[exch_index].as_mut());
 
             if exchange.role.is_dropped_state() {
-                warn!(
+                mrp_log!(
                     "\n>>RCV {}\n => Owned by orphaned dropped {}, dropping packet",
                     packet,
                     ExchangeId::new(session.id, exch_index)
@@ -1708,17 +1710,19 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
 
         let payload_end = packet.buf.len();
 
-        debug!(
-            "\n<<SND {}\n      => {}",
-            Packet::<0>::display(&packet.peer, &packet.header),
-            if packet.tx_info.retransmission {
-                "Re-sending"
-            } else {
-                "Sending"
-            }
-        );
+        if packet.tx_info.retransmission {
+            mrp_log!(
+                "\n<<SND Re-sending\n      => {}",
+                Packet::<0>::display(&packet.peer, &packet.header),
+            );
+        } else {
+            debug!(
+                "\n<<SND Sending\n      => {}",
+                Packet::<0>::display(&packet.peer, &packet.header),
+            );
+        }
 
-        #[cfg(feature = "debug-tlv-payload")]
+        #[cfg(feature = "log-tlv-payload")]
         debug!(
             "{}",
             Packet::<0>::display_payload(
@@ -1727,7 +1731,7 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
             )
         );
 
-        #[cfg(not(feature = "debug-tlv-payload"))]
+        #[cfg(not(feature = "log-tlv-payload"))]
         trace!(
             "{}",
             Packet::<0>::display_payload(

--- a/rs-matter/src/transport/mrp.rs
+++ b/rs-matter/src/transport/mrp.rs
@@ -22,6 +22,36 @@ use crate::error::{Error, ErrorCode};
 
 use super::{plain_hdr::PlainHdr, proto_hdr::ProtoHdr};
 
+/// Emit an MRP-diagnostic log message.
+///
+/// A number of log call sites in the transport layer fire in normal
+/// operation on lossy channels — packet retransmissions, duplicate
+/// packet drops, retrans / ACK mismatches, orphaned or late packets.
+/// They are useful when investigating packet loss on Thread or Wi-Fi
+/// but are noise otherwise.
+///
+/// This macro:
+/// - expands to [`debug!`] by default — keeping this noise out of a
+///   typical `info`-level log,
+/// - expands to [`warn!`] when the `log-mrp` Cargo feature is
+///   enabled — making these events visible under any reasonable log
+///   filter (including the compile-time filters used by `defmt` and
+///   `esp-println` in MCU firmwares).
+///
+/// Terminal / genuinely-erroneous conditions caused by noise (e.g.
+/// "Too many retransmissions. Giving up") intentionally stay at
+/// [`error!`] and are not routed through this macro.
+macro_rules! mrp_log {
+    ($s:literal $(, $x:expr)* $(,)?) => {{
+        #[cfg(feature = "log-mrp")]
+        { warn!($s $(, $x)*); }
+        #[cfg(not(feature = "log-mrp"))]
+        { debug!($s $(, $x)*); }
+    }};
+}
+
+pub(crate) use mrp_log;
+
 //const MRP_STANDALONE_ACK_TIMEOUT_MS: u64 = 200;   // TODO: Use to pro-actively send ACKs
 const MRP_BASE_RETRY_INTERVAL_MS: u32 = 300;
 const MRP_MAX_TRANSMISSIONS: u16 = 10;
@@ -247,7 +277,7 @@ impl ReliableMessage {
             // Handle received Acks
             if let Some(entry) = &self.retrans {
                 if entry.get_msg_ctr() != ack_msg_ctr {
-                    warn!("Mismatch in retrans-table's msg counter and received msg counter: received {:x}, expected {:x}.", ack_msg_ctr, entry.msg_ctr);
+                    mrp_log!("Mismatch in retrans-table's msg counter and received msg counter: received {:x}, expected {:x}.", ack_msg_ctr, entry.msg_ctr);
 
                     // This can actually happen on a noisy channel, where we've just sent a reply to a message
                     // - yet - the other side is still retransmitting the original message and thus acknowledging

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -38,7 +38,7 @@ use crate::{Matter, MatterState};
 
 use super::dedup::{GroupCtrStore, RxCtrState};
 use super::exchange::{ExchangeState, MessageMeta, Role};
-use super::mrp::RetransEntry;
+use super::mrp::{mrp_log, RetransEntry};
 use super::network::Address;
 use super::packet::PacketHdr;
 use super::plain_hdr::PlainHdr;
@@ -628,7 +628,7 @@ impl Session {
             false
         } else if exchange.mrp.is_ack_pending() {
             exchange.role.set_dropped_state();
-            warn!(
+            mrp_log!(
                 "Exchange {}: Pending ACK. Marking as dropped",
                 exchange_id.display(self)
             );


### PR DESCRIPTION
A new feature - `log-mrp` which promotes a set of logs from `debug!` to `warn!`.

Purpose: a quick way to indicate noisy networks without turning on the whole `debug!` level machinery, which is quite noisy.