### PR TITLE
CASE Session Resumption

### DIFF
--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -697,8 +697,21 @@ impl ClusterHandler for NocHandler {
                 // If `expire_sess_id` is Some, the session will be expired instead of removed.
                 state.sessions.remove_for_fabric(fab_idx, expire_sess_id);
 
+                // Drop any CASE session resumption records that were
+                // scoped to this fabric so a subsequent CASE handshake
+                // to any peer that used to belong to it starts fresh.
+                state.resumption.remove_for_fabric(fab_idx);
+
                 // Notify that a session was removed
                 ctx.exchange().matter().transport().notify_session_removed();
+
+                // The resumption cache was just mutated — wake the
+                // background persist task so the on-disk copy sheds
+                // the removed fabric's records too.
+                ctx.exchange()
+                    .matter()
+                    .transport()
+                    .notify_resumption_dirty();
 
                 // Notify that our mDNS records might have changed
                 notify_mdns();

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -580,6 +580,7 @@ impl<'a> Matter<'a> {
                 state.fabrics.reset_persist(&mut store, buf)?;
                 state.basic_info_settings.reset_persist(&mut store, buf)?;
                 state.rtc.reset_persist(&mut store, buf)?;
+                state.resumption.reset_persist(&mut store, buf)?;
 
                 Ok::<_, Error>(())
             })
@@ -602,6 +603,7 @@ impl<'a> Matter<'a> {
                 state.fabrics.load_persist(&mut store, buf)?;
                 state.basic_info_settings.load_persist(&mut store, buf)?;
                 state.rtc.load_persist(&mut store, buf)?;
+                state.resumption.load_persist(&mut store, buf)?;
 
                 Ok::<_, Error>(())
             })
@@ -655,6 +657,11 @@ pub struct MatterState {
     pub fabrics: Fabrics,
     /// All sessions
     sessions: Sessions,
+    /// CASE session resumption cache (Matter Core spec §4.14.2.2).
+    ///
+    /// Persisted as a single TLV blob so the device can resume
+    /// previously-established CASE sessions across reboots.
+    resumption: crate::sc::case::ResumableSessions,
     /// The PASE session state
     pase: Pase,
     /// The Failsafe state
@@ -676,6 +683,7 @@ impl MatterState {
         Self {
             fabrics: Fabrics::new(),
             sessions: Sessions::new(),
+            resumption: crate::sc::case::ResumableSessions::new(),
             pase: Pase::new(),
             failsafe: FailSafe::new(),
             basic_info_settings: BasicInfoSettings::new(),
@@ -689,6 +697,7 @@ impl MatterState {
         init!(Self {
             fabrics <- Fabrics::init(),
             sessions <- Sessions::init(),
+            resumption <- crate::sc::case::ResumableSessions::init(),
             pase <- Pase::init(),
             failsafe <- FailSafe::init(),
             basic_info_settings <- BasicInfoSettings::init(),

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -618,10 +618,27 @@ impl<'a> Matter<'a> {
     /// to persistent storage whenever it is mutated.
     ///
     /// The task waits for a mutation event fired by the CASE handshake
-    /// paths (both full handshake and resumption), waits for a short
-    /// debounce interval so a burst of handshakes coalesces into one
+    /// paths (both full handshake and resumption), sleeps for
+    /// `min_interval` so a burst of handshakes coalesces into one
     /// write, and then serialises the current cache to `kv` under
     /// [`crate::persist::CASE_RESUMPTION_KEY`].
+    ///
+    /// `min_interval` therefore doubles as (a) a burst-coalescing
+    /// debounce and (b) a hard lower bound on the time between two
+    /// consecutive persists — a mutation‑storm cannot drive more than
+    /// one write per `min_interval` regardless of arrival rate. Pick
+    /// something appropriate for the underlying medium:
+    ///
+    /// - POSIX / dev builds: anything from a few hundred ms upwards is
+    ///   fine; `Duration::from_millis(500)` matches the pre‑existing
+    ///   hard‑coded behaviour.
+    /// - MCU firmwares writing to internal flash: prefer tens of
+    ///   seconds (e.g. `Duration::from_secs(30)`) so a
+    ///   commissioner-driven wave of CASE handshakes doesn't churn the
+    ///   flash write endurance budget. The cache is a soft cache — a
+    ///   power cut that loses the most recent entry only forces a
+    ///   full CASE handshake the next time the peer connects, which
+    ///   is the same fallback any resumption failure produces.
     ///
     /// Intended to be spawned alongside [`Matter::run`], for example
     /// via `embassy_futures::select` or a dedicated executor task. It
@@ -632,15 +649,16 @@ impl<'a> Matter<'a> {
     /// - `kv`: The key-value store access (obtained via [`Matter::kv`])
     ///   used to persist the cache. Provides both the store and the
     ///   scratch buffer.
-    pub async fn run_persist_resumption<K: KvBlobStoreAccess>(&self, kv: K) -> Result<(), Error> {
-        // Small debounce so a burst of near-simultaneous handshakes
-        // (e.g. commissioner reconnecting after network flap) folds
-        // into a single flash write.
-        const DEBOUNCE: embassy_time::Duration = embassy_time::Duration::from_millis(500);
-
+    /// - `min_interval`: Minimum time between two consecutive persists
+    ///   (see above).
+    pub async fn run_persist_resumption<K: KvBlobStoreAccess>(
+        &self,
+        kv: K,
+        min_interval: embassy_time::Duration,
+    ) -> Result<(), Error> {
         loop {
             self.transport().wait_resumption_dirty().await;
-            embassy_time::Timer::after(DEBOUNCE).await;
+            embassy_time::Timer::after(min_interval).await;
 
             self.with_state(|state| {
                 kv.access(|mut store, buf| state.resumption.store_persist(&mut store, buf))

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -46,6 +46,7 @@ use crate::pairing::qr::{
 };
 use crate::pairing::DiscoveryCapabilities;
 use crate::persist::{KvBlobStore, KvBlobStoreAccess, Persist, BASIC_INFO_KEY};
+use crate::sc::case::ResumableSessions;
 use crate::sc::pase::spake2p::{Spake2pVerifierPassword, SPAKE2P_VERIFIER_SALT_ZEROED};
 use crate::sc::pase::Pase;
 use crate::transport::network::MatterLocalService;
@@ -711,11 +712,10 @@ pub struct MatterState {
     pub fabrics: Fabrics,
     /// All sessions
     sessions: Sessions,
-    /// CASE session resumption cache.
+    /// CASE session resumption cache
     ///
-    /// Persisted as a single TLV blob so the device can resume
-    /// previously-established CASE sessions across reboots.
-    resumption: crate::sc::case::ResumableSessions,
+    /// Public for unit tests
+    pub resumption: ResumableSessions,
     /// The PASE session state
     pase: Pase,
     /// The Failsafe state
@@ -724,8 +724,7 @@ pub struct MatterState {
     basic_info_settings: BasicInfoSettings,
     /// Real Time Clock state and Last-Known-Good UTC Time tracking (Matter Core spec).
     rtc: Rtc,
-    /// The ICD operating mode advertised in the operational `ICD` DNS-SD TXT
-    /// key, or `None` when the device is not a Long-Idle-Time ICD (key omitted).
+    /// The ICD operating mode advertised in the operational `ICD` DNS-SD TXT key.
     /// The ICD Management handler keeps this in sync with its registration set.
     icd_mode: Option<OperatingModeEnum>,
 }
@@ -737,7 +736,7 @@ impl MatterState {
         Self {
             fabrics: Fabrics::new(),
             sessions: Sessions::new(),
-            resumption: crate::sc::case::ResumableSessions::new(),
+            resumption: ResumableSessions::new(),
             pase: Pase::new(),
             failsafe: FailSafe::new(),
             basic_info_settings: BasicInfoSettings::new(),

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -614,6 +614,42 @@ impl<'a> Matter<'a> {
         Ok(())
     }
 
+    /// Background task that flushes the CASE session resumption cache
+    /// to persistent storage whenever it is mutated.
+    ///
+    /// The task waits for a mutation event fired by the CASE handshake
+    /// paths (both full handshake and resumption), waits for a short
+    /// debounce interval so a burst of handshakes coalesces into one
+    /// write, and then serialises the current cache to `kv` under
+    /// [`crate::persist::CASE_RESUMPTION_KEY`].
+    ///
+    /// Intended to be spawned alongside [`Matter::run`], for example
+    /// via `embassy_futures::select` or a dedicated executor task. It
+    /// never returns on the happy path — a `Result` is only produced
+    /// if the KV backend errors.
+    ///
+    /// # Arguments
+    /// - `kv`: The key-value store access (obtained via [`Matter::kv`])
+    ///   used to persist the cache. Provides both the store and the
+    ///   scratch buffer.
+    pub async fn run_persist_resumption<K: KvBlobStoreAccess>(&self, kv: K) -> Result<(), Error> {
+        // Small debounce so a burst of near-simultaneous handshakes
+        // (e.g. commissioner reconnecting after network flap) folds
+        // into a single flash write.
+        const DEBOUNCE: embassy_time::Duration = embassy_time::Duration::from_millis(500);
+
+        loop {
+            self.transport().wait_resumption_dirty().await;
+            embassy_time::Timer::after(DEBOUNCE).await;
+
+            self.with_state(|state| {
+                kv.access(|mut store, buf| state.resumption.store_persist(&mut store, buf))
+            })?;
+
+            debug!("CASE session resumption cache persisted");
+        }
+    }
+
     /// Invoke the given closure for each currently published Matter mDNS service.
     pub fn mdns_services<F>(&self, mut f: F) -> Result<(), Error>
     where
@@ -657,7 +693,7 @@ pub struct MatterState {
     pub fabrics: Fabrics,
     /// All sessions
     sessions: Sessions,
-    /// CASE session resumption cache (Matter Core spec §4.14.2.2).
+    /// CASE session resumption cache.
     ///
     /// Persisted as a single TLV blob so the device can resume
     /// previously-established CASE sessions across reboots.

--- a/rs-matter/src/persist.rs
+++ b/rs-matter/src/persist.rs
@@ -120,6 +120,13 @@ pub const ICD_REGISTERED_CLIENTS_KEY: u16 = OTA_PROVIDERS_KEY + 1;
 /// resumes past every counter value the previous run may have used.
 pub const ICD_CHECK_IN_COUNTER_KEY: u16 = ICD_REGISTERED_CLIENTS_KEY + 1;
 
+/// The key used for storing the CASE session resumption cache — a
+/// single TLV blob holding up to
+/// [`MAX_RESUMPTION_RECORDS`](crate::sc::case::MAX_RESUMPTION_RECORDS)
+/// entries. Re-persisted by the background snapshot task whenever the
+/// in-memory cache diverges from what was last written.
+pub const CASE_RESUMPTION_KEY: u16 = ICD_CHECK_IN_COUNTER_KEY + 1;
+
 /// A trait representing a key-value BLOB storage.
 ///
 /// NOTE: For now, the trait is deliberately modeled as non-async, so that it can be used from

--- a/rs-matter/src/sc.rs
+++ b/rs-matter/src/sc.rs
@@ -176,7 +176,7 @@ pub enum GeneralCode {
 
 /// Represents the session parameters
 /// that might present in a "PBKDFParamRequest"/"PBKDFParamResponse" or "CASE-Sigma1"/"CASE-Sigma2" message
-#[derive(Default, FromTLV, ToTLV, Debug)]
+#[derive(Default, Clone, FromTLV, ToTLV, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(start = 1)]
 pub(crate) struct SessionParameters {

--- a/rs-matter/src/sc/case.rs
+++ b/rs-matter/src/sc/case.rs
@@ -24,10 +24,12 @@ use crate::cert::MAX_CERT_TLV_LEN;
 
 pub use initiator::CaseInitiator;
 pub use responder::CaseResponder;
+pub use resumption::{ResumableSession, ResumableSessions, MAX_RESUMPTION_RECORDS};
 
 pub(crate) mod casep;
 mod initiator;
 mod responder;
+pub mod resumption;
 
 // Two certificates (NOC and ICAC), plus ECDSA etc -> approx 950b, doing 1024 to be safe
 const CASE_LARGE_BUF_SIZE: usize = MAX_CERT_TLV_LEN * 2 + 224;

--- a/rs-matter/src/sc/case/casep.rs
+++ b/rs-matter/src/sc/case/casep.rs
@@ -81,6 +81,13 @@ pub struct CaseP<'a, C: Crypto + 'a> {
     our_pub_key: CanonPkcPublicKey,
     /// The peer's ephemeral public key
     peer_pub_key: CanonPkcPublicKey,
+    /// The `ResumptionID` in effect for this session — minted by the
+    /// responder in [`Self::start`] and left zeroed on the initiator
+    /// side. Retained here (rather than passed through as a local
+    /// argument) so that the responder can seed the resumption cache
+    /// after `Sigma3` validates in `handle_casesigma3`, without having
+    /// to plumb the value through as an extra parameter.
+    resumption_id: CaseResumptionId,
     /// The Transcript Hash
     tt: Optional<C::Hash<'a>>,
 }
@@ -96,6 +103,7 @@ impl<'a, C: Crypto + 'a> CaseP<'a, C> {
             shared_secret: PKC_SHARED_SECRET_ZEROED,
             our_pub_key: PKC_PUBLIC_KEY_ZEROED,
             peer_pub_key: PKC_PUBLIC_KEY_ZEROED,
+            resumption_id: CASE_RESUMPTION_ID_ZEROED,
             tt: Optional::none(),
         }
     }
@@ -109,6 +117,7 @@ impl<'a, C: Crypto + 'a> CaseP<'a, C> {
             shared_secret <- CanonPkcSharedSecret::init(),
             our_pub_key <- CanonPkcPublicKey::init(),
             peer_pub_key <- CanonPkcPublicKey::init(),
+            resumption_id <- CaseResumptionId::init(),
             tt <- Optional::init_none(),
         })
     }
@@ -147,6 +156,11 @@ impl<'a, C: Crypto + 'a> CaseP<'a, C> {
 
         rand.fill_bytes(our_random_out.access_mut());
         rand.fill_bytes(resumption_id_out.access_mut());
+        // Mirror onto `self.resumption_id` so `handle_casesigma3`
+        // (which fires after this method returns) can seed the
+        // resumption cache without having to smuggle the value through
+        // its call graph.
+        self.resumption_id.load(resumption_id_out.reference());
 
         self.tt = Optional::some(crypto.hash()?);
         self.update_tt(request)?;
@@ -265,11 +279,17 @@ impl<'a, C: Crypto + 'a> CaseP<'a, C> {
     /// (responder). Preserved on the completed [`Session`](crate::transport::session::Session)
     /// so the CASE resumption cache can populate its
     /// [`ResumableSession::shared_secret`](crate::sc::case::ResumableSession::shared_secret)
-    /// field (Matter Core spec \u00a74.14.2.2.1).
+    /// field.
     pub fn shared_secret(&self) -> crate::crypto::CanonPkcSharedSecretRef<'_> {
         self.shared_secret.reference()
     }
-
+    /// The `ResumptionID` minted by the responder in [`Self::start`].
+    /// Meaningful only on the responder side; on the initiator side the
+    /// resumption id is captured directly from `TBEData2` and never
+    /// touches [`Self::start`], so this returns a zeroed value.
+    pub fn resumption_id(&self) -> CaseResumptionIdRef<'_> {
+        self.resumption_id.reference()
+    }
     pub fn our_pub_key(&self) -> CanonPkcPublicKeyRef<'_> {
         self.our_pub_key.reference()
     }
@@ -729,7 +749,7 @@ impl<'a, C: Crypto + 'a> CaseP<'a, C> {
 }
 
 // ============================================================================
-// CASE session resumption primitives (Matter Core spec §4.14.2.2)
+// CASE session resumption primitives.
 //
 // These are module-scoped helpers (not methods on `CaseP`) because the
 // resumption path is stateless with respect to the transcript-hash /
@@ -739,27 +759,24 @@ impl<'a, C: Crypto + 'a> CaseP<'a, C> {
 // from the incoming `Sigma1.initiatorRandom`.
 // ============================================================================
 
-/// Nonce `NCASE_SigmaS1` (spec §4.14.2.3.4 step 7c) used for
-/// `InitiatorResume1MIC`.
+/// Nonce `NCASE_SigmaS1` used for `InitiatorResume1MIC`.
 pub(super) const RESUME1_MIC_NONCE: AeadNonceRef = AeadNonceRef::new(&[
     0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x53, 0x31,
 ]);
 
-/// Nonce `NCASE_SigmaS2` (spec §4.14.2.3.9 step 4) used for
-/// `Sigma2ResumeMIC`.
+/// Nonce `NCASE_SigmaS2` used for `Sigma2ResumeMIC`.
 pub(super) const RESUME2_MIC_NONCE: AeadNonceRef = AeadNonceRef::new(&[
     0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x53, 0x32,
 ]);
 
-/// KDF info string `"Sigma1_Resume"` (spec §4.14.2.6.5).
+/// KDF info string `"Sigma1_Resume"`.
 const S1RK_INFO: &[u8] = b"Sigma1_Resume";
 
-/// KDF info string `"Sigma2_Resume"` (spec §4.14.2.6.6).
+/// KDF info string `"Sigma2_Resume"`.
 const S2RK_INFO: &[u8] = b"Sigma2_Resume";
 
-/// KDF info string `"SessionResumptionKeys"` (spec §4.14.2.6.7) —
-/// distinct from the regular `"SessionKeys"` info used at the end of a
-/// full handshake.
+/// KDF info string `"SessionResumptionKeys"` — distinct from the
+/// regular `"SessionKeys"` info used at the end of a full handshake.
 const RESUMPTION_SEKEYS_INFO: &[u8] = b"SessionResumptionKeys";
 
 /// Which resumption AEAD key to derive.
@@ -783,7 +800,7 @@ impl ResumeKeyKind {
 /// Derive the 128-bit `S1RK`/`S2RK` resumption AEAD key from the
 /// long-lived `shared_secret`, `initiator_random` and the
 /// `resumption_id` in effect for that side (old ID for `S1RK`, new ID
-/// for `S2RK`). Salt = `initiator_random || resumption_id` per spec.
+/// for `S2RK`). Salt = `initiator_random || resumption_id`.
 pub(super) fn derive_resume_key<C: Crypto>(
     crypto: &C,
     kind: ResumeKeyKind,
@@ -806,9 +823,8 @@ pub(super) fn derive_resume_key<C: Crypto>(
 }
 
 /// Compute a `Resume{1,2}MIC` — the 16-byte AES-CCM tag over empty
-/// plaintext and empty AAD (spec §4.14.2.3.4 step 7c and §4.14.2.3.9
-/// step 4). AES-CCM with a zero-length plaintext returns a ciphertext
-/// that is exactly the tag.
+/// plaintext and empty AAD. AES-CCM with a zero-length plaintext
+/// returns a ciphertext that is exactly the tag.
 pub(super) fn compute_resume_mic<C: Crypto>(
     crypto: &C,
     key: CanonAeadKeyRef<'_>,
@@ -852,9 +868,9 @@ pub(super) fn verify_resume_mic<C: Crypto>(
 
 /// Derive the three resumption session keys (`I2RKey || R2IKey ||
 /// AttestationChallenge`) from the long-lived `shared_secret`,
-/// `initiator_random` and the **new** `resumption_id` (spec
-/// §4.14.2.6.7). Note the info string and salt differ from the
-/// regular `compute_session_keys` used at the end of a full handshake.
+/// `initiator_random` and the **new** `resumption_id`. Note the info
+/// string and salt differ from the regular `compute_session_keys` used
+/// at the end of a full handshake.
 pub(super) fn compute_resumption_session_keys<C: Crypto>(
     crypto: &C,
     shared_secret: crate::crypto::CanonPkcSharedSecretRef<'_>,

--- a/rs-matter/src/sc/case/casep.rs
+++ b/rs-matter/src/sc/case/casep.rs
@@ -727,3 +727,150 @@ impl<'a, C: Crypto + 'a> CaseP<'a, C> {
         Ok(())
     }
 }
+
+// ============================================================================
+// CASE session resumption primitives (Matter Core spec §4.14.2.2)
+//
+// These are module-scoped helpers (not methods on `CaseP`) because the
+// resumption path is stateless with respect to the transcript-hash /
+// shared-secret / ephemeral-key state that `CaseP` carries during a full
+// handshake — everything a resumption needs comes from the cached
+// [`ResumableSession`](crate::sc::case::ResumableSession) record and
+// from the incoming `Sigma1.initiatorRandom`.
+// ============================================================================
+
+/// Nonce `NCASE_SigmaS1` (spec §4.14.2.3.4 step 7c) used for
+/// `InitiatorResume1MIC`.
+pub(super) const RESUME1_MIC_NONCE: AeadNonceRef = AeadNonceRef::new(&[
+    0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x53, 0x31,
+]);
+
+/// Nonce `NCASE_SigmaS2` (spec §4.14.2.3.9 step 4) used for
+/// `Sigma2ResumeMIC`.
+pub(super) const RESUME2_MIC_NONCE: AeadNonceRef = AeadNonceRef::new(&[
+    0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x53, 0x32,
+]);
+
+/// KDF info string `"Sigma1_Resume"` (spec §4.14.2.6.5).
+const S1RK_INFO: &[u8] = b"Sigma1_Resume";
+
+/// KDF info string `"Sigma2_Resume"` (spec §4.14.2.6.6).
+const S2RK_INFO: &[u8] = b"Sigma2_Resume";
+
+/// KDF info string `"SessionResumptionKeys"` (spec §4.14.2.6.7) —
+/// distinct from the regular `"SessionKeys"` info used at the end of a
+/// full handshake.
+const RESUMPTION_SEKEYS_INFO: &[u8] = b"SessionResumptionKeys";
+
+/// Which resumption AEAD key to derive.
+#[derive(Copy, Clone)]
+pub(super) enum ResumeKeyKind {
+    /// `S1RK` — protects `InitiatorResume1MIC` on Sigma1.
+    S1rk,
+    /// `S2RK` — protects `Sigma2ResumeMIC` on Sigma2_Resume.
+    S2rk,
+}
+
+impl ResumeKeyKind {
+    const fn info(self) -> &'static [u8] {
+        match self {
+            Self::S1rk => S1RK_INFO,
+            Self::S2rk => S2RK_INFO,
+        }
+    }
+}
+
+/// Derive the 128-bit `S1RK`/`S2RK` resumption AEAD key from the
+/// long-lived `shared_secret`, `initiator_random` and the
+/// `resumption_id` in effect for that side (old ID for `S1RK`, new ID
+/// for `S2RK`). Salt = `initiator_random || resumption_id` per spec.
+pub(super) fn derive_resume_key<C: Crypto>(
+    crypto: &C,
+    kind: ResumeKeyKind,
+    shared_secret: crate::crypto::CanonPkcSharedSecretRef<'_>,
+    initiator_random: CaseRandomRef<'_>,
+    resumption_id: CaseResumptionIdRef<'_>,
+    out: &mut CanonAeadKey,
+) -> Result<(), Error> {
+    let mut salt = CryptoSensitive::<{ CASE_RANDOM_LEN + CASE_RESUMPTION_ID_LEN }>::new();
+    let salt_access: &mut [u8] = salt.access_mut();
+    salt_access[..CASE_RANDOM_LEN].copy_from_slice(initiator_random.access());
+    salt_access[CASE_RANDOM_LEN..].copy_from_slice(resumption_id.access());
+
+    crypto
+        .kdf()?
+        .expand(salt.access(), shared_secret, kind.info(), out)
+        .map_err(|_| ErrorCode::InvalidData)?;
+
+    Ok(())
+}
+
+/// Compute a `Resume{1,2}MIC` — the 16-byte AES-CCM tag over empty
+/// plaintext and empty AAD (spec §4.14.2.3.4 step 7c and §4.14.2.3.9
+/// step 4). AES-CCM with a zero-length plaintext returns a ciphertext
+/// that is exactly the tag.
+pub(super) fn compute_resume_mic<C: Crypto>(
+    crypto: &C,
+    key: CanonAeadKeyRef<'_>,
+    nonce: AeadNonceRef<'_>,
+    out: &mut [u8; AEAD_TAG_LEN],
+) -> Result<(), Error> {
+    let mut buf = [0u8; AEAD_TAG_LEN];
+    let mut cypher = crypto.aead()?;
+    let ct = cypher.encrypt_in_place(key, nonce, &[], &mut buf, 0)?;
+
+    // AES-CCM(plaintext="") produces `AEAD_TAG_LEN` bytes of tag and
+    // nothing else. Guard the invariant defensively.
+    if ct.len() != AEAD_TAG_LEN {
+        return Err(ErrorCode::InvalidData.into());
+    }
+    out.copy_from_slice(ct);
+
+    Ok(())
+}
+
+/// Verify a `Resume{1,2}MIC`. Returns `Ok(())` on success and an error
+/// (from the AEAD backend) on tag mismatch.
+pub(super) fn verify_resume_mic<C: Crypto>(
+    crypto: &C,
+    key: CanonAeadKeyRef<'_>,
+    nonce: AeadNonceRef<'_>,
+    mic: &[u8; AEAD_TAG_LEN],
+) -> Result<(), Error> {
+    let mut buf = [0u8; AEAD_TAG_LEN];
+    buf.copy_from_slice(mic);
+    let mut cypher = crypto.aead()?;
+    let pt = cypher.decrypt_in_place(key, nonce, &[], &mut buf)?;
+
+    // Empty plaintext expected.
+    if !pt.is_empty() {
+        return Err(ErrorCode::InvalidData.into());
+    }
+
+    Ok(())
+}
+
+/// Derive the three resumption session keys (`I2RKey || R2IKey ||
+/// AttestationChallenge`) from the long-lived `shared_secret`,
+/// `initiator_random` and the **new** `resumption_id` (spec
+/// §4.14.2.6.7). Note the info string and salt differ from the
+/// regular `compute_session_keys` used at the end of a full handshake.
+pub(super) fn compute_resumption_session_keys<C: Crypto>(
+    crypto: &C,
+    shared_secret: crate::crypto::CanonPkcSharedSecretRef<'_>,
+    initiator_random: CaseRandomRef<'_>,
+    resumption_id: CaseResumptionIdRef<'_>,
+    keys: &mut CaseSessionKeys,
+) -> Result<(), Error> {
+    let mut salt = CryptoSensitive::<{ CASE_RANDOM_LEN + CASE_RESUMPTION_ID_LEN }>::new();
+    let salt_access: &mut [u8] = salt.access_mut();
+    salt_access[..CASE_RANDOM_LEN].copy_from_slice(initiator_random.access());
+    salt_access[CASE_RANDOM_LEN..].copy_from_slice(resumption_id.access());
+
+    crypto
+        .kdf()?
+        .expand(salt.access(), shared_secret, RESUMPTION_SEKEYS_INFO, keys)
+        .map_err(|_| ErrorCode::InvalidData)?;
+
+    Ok(())
+}

--- a/rs-matter/src/sc/case/casep.rs
+++ b/rs-matter/src/sc/case/casep.rs
@@ -260,6 +260,16 @@ impl<'a, C: Crypto + 'a> CaseP<'a, C> {
         self.local_sessid
     }
 
+    /// The ECDH shared secret produced during Sigma1/2 by
+    /// [`Self::sigma2_decrypt`] (initiator) or [`Self::sigma1_decrypt`]
+    /// (responder). Preserved on the completed [`Session`](crate::transport::session::Session)
+    /// so the CASE resumption cache can populate its
+    /// [`ResumableSession::shared_secret`](crate::sc::case::ResumableSession::shared_secret)
+    /// field (Matter Core spec \u00a74.14.2.2.1).
+    pub fn shared_secret(&self) -> crate::crypto::CanonPkcSharedSecretRef<'_> {
+        self.shared_secret.reference()
+    }
+
     pub fn our_pub_key(&self) -> CanonPkcPublicKeyRef<'_> {
         self.our_pub_key.reference()
     }

--- a/rs-matter/src/sc/case/casep.rs
+++ b/rs-matter/src/sc/case/casep.rs
@@ -868,9 +868,10 @@ pub(super) fn verify_resume_mic<C: Crypto>(
 
 /// Derive the three resumption session keys (`I2RKey || R2IKey ||
 /// AttestationChallenge`) from the long-lived `shared_secret`,
-/// `initiator_random` and the **new** `resumption_id`. Note the info
-/// string and salt differ from the regular `compute_session_keys` used
-/// at the end of a full handshake.
+/// `initiator_random` and the Sigma1 `resumption_id` (the current
+/// pre-rotation ID). Note the info string and salt differ from the
+/// regular `compute_session_keys` used at the end of a full
+/// handshake.
 pub(super) fn compute_resumption_session_keys<C: Crypto>(
     crypto: &C,
     shared_secret: crate::crypto::CanonPkcSharedSecretRef<'_>,

--- a/rs-matter/src/sc/case/initiator.rs
+++ b/rs-matter/src/sc/case/initiator.rs
@@ -420,6 +420,7 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
                 Some(dec_key),
                 Some(enc_key),
                 Some(att_challenge),
+                Some(initiator.casep.shared_secret()),
             )?;
         }
 

--- a/rs-matter/src/sc/case/initiator.rs
+++ b/rs-matter/src/sc/case/initiator.rs
@@ -26,7 +26,8 @@ use core::num::NonZeroU8;
 use crate::alloc;
 use crate::cert::CertRef;
 use crate::crypto::{
-    CanonPkcPublicKeyRef, CanonPkcSignature, CanonPkcSignatureRef, Crypto, Hash, AEAD_CANON_KEY_LEN,
+    CanonAeadKey, CanonPkcPublicKeyRef, CanonPkcSignature, CanonPkcSignatureRef, Crypto, Hash,
+    AEAD_CANON_KEY_LEN, AEAD_TAG_LEN,
 };
 use crate::error::{Error, ErrorCode};
 use crate::sc::{complete_with_status, GeneralCode, OpCode, SCStatusCodes, StatusReport};
@@ -36,7 +37,12 @@ use crate::transport::session::{NocCatIds, ReservedSession, SessionMode};
 use crate::utils::init::InitMaybeUninit;
 use crate::utils::storage::ReadBuf;
 
-use super::casep::{CaseP, CaseRandom, CaseRandomRef, CaseSessionKeys, CASE_RESUMPTION_ID_ZEROED};
+use super::casep::{
+    compute_resume_mic, compute_resumption_session_keys, derive_resume_key, verify_resume_mic,
+    CaseP, CaseRandom, CaseRandomRef, CaseSessionKeys, ResumeKeyKind, CASE_RESUMPTION_ID_LEN,
+    CASE_RESUMPTION_ID_ZEROED, RESUME1_MIC_NONCE, RESUME2_MIC_NONCE,
+};
+use super::resumption::ResumableSession;
 use super::CASE_LARGE_BUF_SIZE;
 
 /// Sigma2 Response structure, parsed from the responder's Sigma2 message.
@@ -62,6 +68,25 @@ struct TBEData2Decrypt<'a> {
     responder_icac: Option<OctetStr<'a>>,
     signature: OctetStr<'a>,
     resumption_id: OctetStr<'a>,
+}
+
+/// Sigma2_Resume response, parsed from the responder's message when it
+/// accepts a Sigma1-with-Resumption. See Matter Core spec
+/// §4.14.2.3.9 for the wire format.
+#[derive(FromTLV, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[tlvargs(start = 1, lifetime = "'a")]
+struct Sigma2ResumeMsg<'a> {
+    /// The new `ResumptionID` minted by the responder.
+    resumption_id: OctetStr<'a>,
+    /// The 16-byte AEAD tag over empty plaintext with `S2RK`.
+    sigma2_resume_mic: OctetStr<'a>,
+    /// The responder's session ID.
+    responder_sessid: u16,
+    /// Optional responder MRP session parameters. Currently ignored
+    /// by rs-matter's initiator side (parity with the non-resumption
+    /// Sigma2 path).
+    _session_parameters: Option<crate::sc::SessionParameters>,
 }
 
 /// CASE Initiator for establishing secure sessions with Matter devices using operational
@@ -117,6 +142,18 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
 
         let mut initiator = Self::new(peer_node_id);
 
+        // Step 1a: Look up any cached CASE session resumption record for
+        // this peer. If present, we'll ask the responder for resumption
+        // by populating tags 6 and 7 on Sigma1; the responder either
+        // returns Sigma2_Resume (accepted) or Sigma2 (fell back to the
+        // full handshake) — both are handled below.
+        let cached_record: Option<ResumableSession> = exchange.with_state(|state| {
+            Ok(state
+                .resumption
+                .find_by_peer(fab_idx, peer_node_id)
+                .cloned())
+        })?;
+
         let mut random = MaybeUninit::<CaseRandom>::uninit();
         let random = random.init_with(CaseRandom::init());
 
@@ -143,6 +180,32 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
             Ok(local_sessid)
         })?;
 
+        // Step 2a: If we have a cached resumption record, precompute
+        // `Resume1MIC` so it can be spliced into Sigma1 below.
+        // `initiator_random` is available now (produced by
+        // `start_initiator`), so we can already derive `S1RK`.
+        let (resume_rid_bytes, resume_mic_bytes): (
+            Option<[u8; CASE_RESUMPTION_ID_LEN]>,
+            Option<[u8; AEAD_TAG_LEN]>,
+        ) = if let Some(ref record) = cached_record {
+            let mut s1rk = CanonAeadKey::new();
+            derive_resume_key(
+                crypto,
+                ResumeKeyKind::S1rk,
+                record.shared_secret.reference(),
+                random.reference(),
+                record.resumption_id.reference(),
+                &mut s1rk,
+            )?;
+
+            let mut mic = [0u8; AEAD_TAG_LEN];
+            compute_resume_mic(crypto, s1rk.reference(), RESUME1_MIC_NONCE, &mut mic)?;
+
+            (Some(*record.resumption_id.reference().access()), Some(mic))
+        } else {
+            (None, None)
+        };
+
         // Step 3: Build and send Sigma1
         let mut tt_updated = false;
         exchange
@@ -152,6 +215,17 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
                 tw.u16(&TLVTag::Context(2), local_sessid)?;
                 tw.str(&TLVTag::Context(3), dest_id.access())?;
                 tw.str(&TLVTag::Context(4), initiator.casep.our_pub_key().access())?;
+
+                // Sigma1 with Resumption: attach the cached `resumptionID`
+                // (tag 6) and the freshly-computed `Resume1MIC` (tag 7)
+                // per Matter Core spec §4.14.2.3.4.
+                if let (Some(rid), Some(mic)) =
+                    (resume_rid_bytes.as_ref(), resume_mic_bytes.as_ref())
+                {
+                    tw.str(&TLVTag::Context(6), rid)?;
+                    tw.str(&TLVTag::Context(7), mic)?;
+                }
+
                 tw.end_container()?;
 
                 if !tt_updated {
@@ -163,32 +237,51 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
             })
             .await?;
 
-        // Step 4: Receive Sigma2
+        // Step 4: Receive Sigma2, Sigma2_Resume, or an error StatusReport
         exchange.recv_fetch().await?;
 
-        {
+        let response_opcode = exchange.rx()?.meta().proto_opcode;
+
+        if response_opcode == OpCode::StatusReport as u8 {
             let rx = exchange.rx()?;
-            let meta = rx.meta();
+            let mut rb = ReadBuf::new(rx.payload());
+            let status = StatusReport::read(&mut rb)?;
+            error!(
+                "CASE Sigma1 failed: general={:?}, proto_code={}",
+                status.general_code, status.proto_code
+            );
+            return Err(ErrorCode::Invalid.into());
+        }
 
-            // Check for StatusReport error first
-            if meta.proto_opcode == OpCode::StatusReport as u8 {
-                let mut rb = ReadBuf::new(rx.payload());
-                let status = StatusReport::read(&mut rb)?;
-                error!(
-                    "CASE Sigma1 failed: general={:?}, proto_code={}",
-                    status.general_code, status.proto_code
-                );
+        if response_opcode == OpCode::CASESigma2Resume as u8 {
+            // Responder accepted our resumption request. Complete it
+            // via `finalize_sigma2_resume`. If we didn't request
+            // resumption, this response is a spec violation and we
+            // reject with `InvalidParameter`.
+            let Some(record) = cached_record else {
+                error!("Responder sent Sigma2_Resume but we did not request resumption");
+                complete_with_status(exchange, SCStatusCodes::InvalidParameter, &[]).await?;
                 return Err(ErrorCode::Invalid.into());
-            }
+            };
 
-            // Verify opcode is CASESigma2
-            if meta.proto_opcode != OpCode::CASESigma2 as u8 {
-                error!(
-                    "Unexpected opcode: expected CASESigma2, got {}",
-                    meta.proto_opcode
-                );
-                return Err(ErrorCode::InvalidOpcode.into());
-            }
+            return Self::finalize_sigma2_resume(
+                exchange,
+                crypto,
+                session,
+                fab_idx,
+                local_sessid,
+                record,
+                random,
+            )
+            .await;
+        }
+
+        if response_opcode != OpCode::CASESigma2 as u8 {
+            error!(
+                "Unexpected opcode: expected CASESigma2 or CASESigma2Resume, got {}",
+                response_opcode
+            );
+            return Err(ErrorCode::InvalidOpcode.into());
         }
 
         // Step 5: Decrypt Sigma2 TBE and validate
@@ -432,6 +525,168 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
             "CASE session established: local_sessid={}, peer_sessid={}",
             initiator.casep.local_sessid(),
             initiator.casep.peer_sessid()
+        );
+
+        Ok(())
+    }
+
+    /// Complete a CASE resumption from the initiator side, given that
+    /// we have just received a `Sigma2_Resume` in response to a Sigma1
+    /// that carried the resumption fields (Matter Core spec
+    /// §4.14.2.3.11 / §4.14.2.3.12 / §4.14.2.3.13).
+    ///
+    /// On success:
+    /// - Derives the resumption session keys.
+    /// - Populates the reserved session (rotating the `SharedSecret`
+    ///   into place along with the new keys).
+    /// - Marks the session live via `session.complete()`.
+    /// - Sends `SigmaFinished` (a StatusReport with
+    ///   `SessionEstablishmentSuccess`) which piggybacks the MRP ack
+    ///   for `Sigma2_Resume`, concluding the exchange.
+    /// - Rotates the cache entry: same peer, same `SharedSecret`, new
+    ///   `resumption_id`.
+    ///
+    /// On `Resume2MIC` verification failure the initiator sends
+    /// `InvalidParameter` per spec §4.14.2.3.11 step 3 and returns an
+    /// error; the reserved session is dropped uncomitted.
+    #[allow(clippy::too_many_arguments)]
+    async fn finalize_sigma2_resume(
+        exchange: &mut Exchange<'_>,
+        crypto: &'a C,
+        mut session: ReservedSession<'_>,
+        fab_idx: NonZeroU8,
+        local_sessid: u16,
+        record: ResumableSession,
+        initiator_random: &CaseRandom,
+    ) -> Result<(), Error> {
+        // ---- Parse Sigma2_Resume, copy out fields. ---------------------
+        //
+        // Same borrow-scoping pattern as the responder path: the parsed
+        // message borrows from the RX buffer, so we copy the small
+        // pieces out into stack storage and let the borrow drop before
+        // we send the SigmaFinished status report.
+        let (new_rid, resume2_mic, peer_sessid) = {
+            let payload = exchange.rx()?.payload();
+            let msg = Sigma2ResumeMsg::from_tlv(&get_root_node_struct(payload)?)?;
+
+            if msg.resumption_id.0.len() != CASE_RESUMPTION_ID_LEN
+                || msg.sigma2_resume_mic.0.len() != AEAD_TAG_LEN
+            {
+                error!(
+                    "Sigma2_Resume: bad field length \
+                     (resumption_id={}, sigma2_resume_mic={})",
+                    msg.resumption_id.0.len(),
+                    msg.sigma2_resume_mic.0.len()
+                );
+                complete_with_status(exchange, SCStatusCodes::InvalidParameter, &[]).await?;
+                return Err(ErrorCode::Invalid.into());
+            }
+
+            let rid_bytes: &[u8; CASE_RESUMPTION_ID_LEN] = msg
+                .resumption_id
+                .0
+                .try_into()
+                .map_err(|_| ErrorCode::InvalidData)?;
+            let mut new_rid = CASE_RESUMPTION_ID_ZEROED;
+            new_rid.load_from_array(rid_bytes);
+
+            let mut mic = [0u8; AEAD_TAG_LEN];
+            mic.copy_from_slice(msg.sigma2_resume_mic.0);
+
+            (new_rid, mic, msg.responder_sessid)
+        };
+
+        // ---- Derive S2RK and verify Resume2MIC. -----------------------
+        let mut s2rk = CanonAeadKey::new();
+        derive_resume_key(
+            crypto,
+            ResumeKeyKind::S2rk,
+            record.shared_secret.reference(),
+            initiator_random.reference(),
+            new_rid.reference(),
+            &mut s2rk,
+        )?;
+
+        if verify_resume_mic(crypto, s2rk.reference(), RESUME2_MIC_NONCE, &resume2_mic).is_err() {
+            error!("Sigma2_Resume: Resume2MIC verify failed");
+            complete_with_status(exchange, SCStatusCodes::InvalidParameter, &[]).await?;
+            return Err(ErrorCode::Invalid.into());
+        }
+
+        // ---- Derive resumption session keys (spec §4.14.2.6.7). --------
+        let mut session_keys = MaybeUninit::<CaseSessionKeys>::uninit();
+        let session_keys = session_keys.init_with(CaseSessionKeys::init());
+        compute_resumption_session_keys(
+            crypto,
+            record.shared_secret.reference(),
+            initiator_random.reference(),
+            new_rid.reference(),
+            session_keys,
+        )?;
+
+        // As initiator: enc_key = I2R, dec_key = R2I (mirror of the
+        // Sigma3 path — see the fall-through branch above).
+        let (enc_key, remaining) = session_keys
+            .reference()
+            .split::<AEAD_CANON_KEY_LEN, { AEAD_CANON_KEY_LEN * 2 }>();
+        let (dec_key, att_challenge) = remaining.split::<AEAD_CANON_KEY_LEN, AEAD_CANON_KEY_LEN>();
+
+        // ---- Populate the reserved session with new keys + secret. ----
+        let (peer_addr, local_nodeid) = exchange.with_state(|state| {
+            let sess = exchange.id().session(&mut state.sessions);
+            let fabric = state.fabrics.fabric(fab_idx)?;
+            Ok((sess.get_peer_addr(), fabric.node_id()))
+        })?;
+
+        session.update(
+            local_nodeid,
+            record.peer_nodeid,
+            peer_sessid,
+            local_sessid,
+            peer_addr,
+            SessionMode::Case {
+                fab_idx: record.fab_idx,
+                cat_ids: record.peer_cat_ids,
+            },
+            Some(dec_key),
+            Some(enc_key),
+            Some(att_challenge),
+            Some(record.shared_secret.reference()),
+        )?;
+
+        // Mark the session live *before* sending SigmaFinished so that
+        // if the responder immediately reuses the session for an
+        // application message, our receive path can already route it
+        // (the responder considers the session live as soon as it
+        // receives SigmaFinished).
+        session.complete();
+
+        // ---- Send SigmaFinished (piggybacks MRP ack for Sigma2_Resume).
+        complete_with_status(exchange, SCStatusCodes::SessionEstablishmentSuccess, &[]).await?;
+
+        // ---- Rotate the cache entry. ----------------------------------
+        //
+        // `SharedSecret` and peer identity are unchanged; only
+        // `resumption_id` rotates. `insert_or_update` refreshes the
+        // existing record for this peer and moves it to the tail (MRU).
+        exchange.with_state(|state| {
+            state.resumption.insert_or_update(ResumableSession {
+                fab_idx: record.fab_idx,
+                peer_nodeid: record.peer_nodeid,
+                peer_cat_ids: record.peer_cat_ids,
+                resumption_id: new_rid,
+                shared_secret: record.shared_secret.clone(),
+            });
+            Ok::<_, Error>(())
+        })?;
+
+        info!(
+            "CASE session resumed (initiator): local_sessid={}, peer_sessid={}, \
+             fabric={}, peer_nodeid=0x{:x}",
+            local_sessid,
+            peer_sessid,
+            record.fab_idx.get(),
+            record.peer_nodeid,
         );
 
         Ok(())

--- a/rs-matter/src/sc/case/initiator.rs
+++ b/rs-matter/src/sc/case/initiator.rs
@@ -71,8 +71,7 @@ struct TBEData2Decrypt<'a> {
 }
 
 /// Sigma2_Resume response, parsed from the responder's message when it
-/// accepts a Sigma1-with-Resumption. See Matter Core spec
-/// §4.14.2.3.9 for the wire format.
+/// accepts a Sigma1-with-Resumption.
 #[derive(FromTLV, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(start = 1, lifetime = "'a")]
@@ -217,8 +216,7 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
                 tw.str(&TLVTag::Context(4), initiator.casep.our_pub_key().access())?;
 
                 // Sigma1 with Resumption: attach the cached `resumptionID`
-                // (tag 6) and the freshly-computed `Resume1MIC` (tag 7)
-                // per Matter Core spec §4.14.2.3.4.
+                // (tag 6) and the freshly-computed `Resume1MIC` (tag 7).
                 if let (Some(rid), Some(mic)) =
                     (resume_rid_bytes.as_ref(), resume_mic_bytes.as_ref())
                 {
@@ -285,7 +283,7 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
         }
 
         // Step 5: Decrypt Sigma2 TBE and validate
-        let (peer_catids, _resumption_id) = {
+        let (peer_catids, peer_resumption_id) = {
             let rx = exchange.rx()?;
             let raw_sigma2_payload = rx.payload();
 
@@ -521,6 +519,25 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
 
         exchange.acknowledge().await?;
 
+        // Seed the resumption cache with this freshly-established full
+        // CASE session so a subsequent handshake with the same peer can
+        // attempt resumption. The `resumption_id` came from `TBEData2`
+        // in Sigma2 (`peer_resumption_id`); `SharedSecret`, peer id and
+        // peer CATs are what we just committed to the `Session`.
+        exchange.with_state(|state| {
+            state.resumption.insert_or_update(ResumableSession {
+                fab_idx,
+                peer_nodeid: peer_node_id,
+                peer_cat_ids: peer_catids,
+                resumption_id: peer_resumption_id,
+                shared_secret: crate::crypto::CanonPkcSharedSecret::new_from_ref(
+                    initiator.casep.shared_secret(),
+                ),
+            });
+            Ok::<_, Error>(())
+        })?;
+        exchange.matter().transport().notify_resumption_dirty();
+
         info!(
             "CASE session established: local_sessid={}, peer_sessid={}",
             initiator.casep.local_sessid(),
@@ -532,8 +549,7 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
 
     /// Complete a CASE resumption from the initiator side, given that
     /// we have just received a `Sigma2_Resume` in response to a Sigma1
-    /// that carried the resumption fields (Matter Core spec
-    /// §4.14.2.3.11 / §4.14.2.3.12 / §4.14.2.3.13).
+    /// that carried the resumption fields.
     ///
     /// On success:
     /// - Derives the resumption session keys.
@@ -547,8 +563,8 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
     ///   `resumption_id`.
     ///
     /// On `Resume2MIC` verification failure the initiator sends
-    /// `InvalidParameter` per spec §4.14.2.3.11 step 3 and returns an
-    /// error; the reserved session is dropped uncomitted.
+    /// `InvalidParameter` per Matter spec and returns an error; the
+    /// reserved session is dropped uncomitted.
     #[allow(clippy::too_many_arguments)]
     async fn finalize_sigma2_resume(
         exchange: &mut Exchange<'_>,
@@ -613,7 +629,7 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
             return Err(ErrorCode::Invalid.into());
         }
 
-        // ---- Derive resumption session keys (spec §4.14.2.6.7). --------
+        // ---- Derive resumption session keys. --------------------------
         let mut session_keys = MaybeUninit::<CaseSessionKeys>::uninit();
         let session_keys = session_keys.init_with(CaseSessionKeys::init());
         compute_resumption_session_keys(
@@ -679,6 +695,7 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
             });
             Ok::<_, Error>(())
         })?;
+        exchange.matter().transport().notify_resumption_dirty();
 
         info!(
             "CASE session resumed (initiator): local_sessid={}, peer_sessid={}, \

--- a/rs-matter/src/sc/case/initiator.rs
+++ b/rs-matter/src/sc/case/initiator.rs
@@ -258,12 +258,12 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
             // reject with `InvalidParameter`.
             let Some(record) = cached_record else {
                 error!("Responder sent Sigma2_Resume but we did not request resumption");
-                complete_with_status(exchange, SCStatusCodes::InvalidParameter, &[]).await?;
+                complete_with_status(&mut exchange, SCStatusCodes::InvalidParameter, &[]).await?;
                 return Err(ErrorCode::Invalid.into());
             };
 
             return Self::finalize_sigma2_resume(
-                exchange,
+                &mut exchange,
                 crypto,
                 session,
                 fab_idx,

--- a/rs-matter/src/sc/case/initiator.rs
+++ b/rs-matter/src/sc/case/initiator.rs
@@ -632,11 +632,13 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
         // ---- Derive resumption session keys. --------------------------
         let mut session_keys = MaybeUninit::<CaseSessionKeys>::uninit();
         let session_keys = session_keys.init_with(CaseSessionKeys::init());
+        // Derive session traffic keys from the resumption ID we sent in
+        // Sigma1 (the current ID), not from Sigma2_Resume's rotated ID.
         compute_resumption_session_keys(
             crypto,
             record.shared_secret.reference(),
             initiator_random.reference(),
-            new_rid.reference(),
+            record.resumption_id.reference(),
             session_keys,
         )?;
 

--- a/rs-matter/src/sc/case/responder.rs
+++ b/rs-matter/src/sc/case/responder.rs
@@ -17,19 +17,31 @@
 
 use core::{mem::MaybeUninit, num::NonZeroU8};
 
-use super::casep::{CaseP, CaseRandom, CaseResumptionId, CaseSessionKeys};
+use rand_core::RngCore;
+
+use super::casep::{
+    compute_resume_mic, compute_resumption_session_keys, derive_resume_key, verify_resume_mic,
+    CaseP, CaseRandom, CaseResumptionId, CaseSessionKeys, ResumeKeyKind, CASE_RANDOM_LEN,
+    CASE_RESUMPTION_ID_LEN, RESUME1_MIC_NONCE, RESUME2_MIC_NONCE,
+};
+use super::resumption::ResumableSession;
 use super::CASE_LARGE_BUF_SIZE;
 use crate::alloc;
 use crate::cert::CertRef;
-use crate::crypto::{CanonPkcSignature, CanonPkcSignatureRef, Crypto, Hash, AEAD_CANON_KEY_LEN};
-use crate::error::Error;
+use crate::crypto::{
+    CanonAeadKey, CanonPkcSignature, CanonPkcSignatureRef, Crypto, Hash, AEAD_CANON_KEY_LEN,
+    AEAD_TAG_LEN,
+};
+use crate::error::{Error, ErrorCode};
 use crate::sc::{
-    check_opcode, complete_with_status, sc_write, OpCode, SCStatusCodes, SessionParameters,
+    check_opcode, complete_with_status, sc_write, GeneralCode, OpCode, SCStatusCodes,
+    SessionParameters, StatusReport,
 };
 use crate::tlv::{get_root_node_struct, FromTLV, OctetStr, TLVElement, TLVTag, TLVWrite, ToTLV};
 use crate::transport::exchange::Exchange;
 use crate::transport::session::{NocCatIds, ReservedSession, SessionMode};
 use crate::utils::init::{init, Init, InitMaybeUninit};
+use crate::utils::storage::ReadBuf;
 
 /// Sigma1 Request structure
 #[derive(FromTLV, Debug)]
@@ -96,6 +108,19 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
     /// completed, been rejected, or aborted, and the exchange is dropped.
     pub async fn handle(&mut self, mut exchange: Exchange<'_>) -> Result<(), Error> {
         let mut session = ReservedSession::reserve(exchange.matter(), self.crypto).await?;
+
+        // Attempt session resumption first. If the peer's Sigma1 carries
+        // both `resumptionID` and `initiatorResumeMIC`, we have a cached
+        // record for that resumption id, and the MIC checks out, this
+        // shortcuts to Sigma2_Resume + SigmaFinished (spec §4.14.2.2).
+        // Any other case (fields absent, unknown id, MIC mismatch) falls
+        // through to the full Sigma1/2/3 flow.
+        if self
+            .try_handle_sigma1_resume(&mut exchange, &mut session)
+            .await?
+        {
+            return Ok(());
+        }
 
         self.handle_casesigma1(&mut exchange, &mut session).await?;
 
@@ -418,5 +443,310 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
         }
 
         complete_with_status(exchange, status, &[]).await
+    }
+
+    /// Try to handle the received Sigma1 as a session-resumption
+    /// request (Matter Core spec §4.14.2.2). Returns:
+    ///
+    /// - `Ok(true)` — the resumption path fully handled the exchange
+    ///   (whether successfully or with the initiator rejecting the
+    ///   resumption). The caller must not fall through to the normal
+    ///   Sigma1/2/3 flow.
+    /// - `Ok(false)` — the Sigma1 does not carry resumption fields, or
+    ///   we could not honour the resumption (unknown `resumptionID`,
+    ///   MIC verify failed, malformed fields). The caller must continue
+    ///   with the full handshake, treating this Sigma1 as if it had no
+    ///   resumption fields (spec §4.14.2.3.5 fall-through rule).
+    /// - `Err(_)` — a hard error unrelated to resumption (I/O,
+    ///   cryptographic backend failure). The exchange is aborted.
+    async fn try_handle_sigma1_resume(
+        &mut self,
+        exchange: &mut Exchange<'_>,
+        session: &mut ReservedSession<'_>,
+    ) -> Result<bool, Error> {
+        check_opcode(exchange, OpCode::CASESigma1)?;
+
+        // ---- Parse Sigma1 and copy out everything we need. -------------
+        //
+        // The parsed `Sigma1Req` borrows from the RX buffer, and we later
+        // need mutable access to the exchange (`send_with`) so we cannot
+        // hold that borrow across the send. Copy the small pieces into
+        // owned stack storage and let `req` drop before we send.
+        let (init_random, init_sessid, incoming_rid, incoming_mic, peer_params) = {
+            let payload = exchange.rx()?.payload();
+            let req = Sigma1Req::from_tlv(&get_root_node_struct(payload)?)?;
+
+            // Spec: both `resumptionID` and `initiatorResumeMIC` are
+            // present, or neither is. If only one is present the outer
+            // `handle_casesigma1` will produce INVALID_PARAMETER; we just
+            // decline resumption here.
+            let (Some(rid), Some(mic)) = (
+                req.resumption_id.as_ref(),
+                req.initiator_resume_mic.as_ref(),
+            ) else {
+                return Ok(false);
+            };
+
+            if rid.0.len() != CASE_RESUMPTION_ID_LEN || mic.0.len() != AEAD_TAG_LEN {
+                // Bad shape — let the full-handshake path reject it.
+                return Ok(false);
+            }
+
+            let random_bytes: &[u8; CASE_RANDOM_LEN] = req
+                .initiator_random
+                .0
+                .try_into()
+                .map_err(|_| ErrorCode::InvalidData)?;
+            let mut init_random = CaseRandom::new();
+            init_random.load_from_array(random_bytes);
+
+            let rid_bytes: &[u8; CASE_RESUMPTION_ID_LEN] =
+                rid.0.try_into().map_err(|_| ErrorCode::InvalidData)?;
+            let mut incoming_rid = CaseResumptionId::new();
+            incoming_rid.load_from_array(rid_bytes);
+
+            let mut incoming_mic = [0u8; AEAD_TAG_LEN];
+            incoming_mic.copy_from_slice(mic.0);
+
+            (
+                init_random,
+                req.initiator_sessid,
+                incoming_rid,
+                incoming_mic,
+                req.session_parameters.clone(),
+            )
+        };
+
+        // ---- Look up the cached resumption record. ---------------------
+        let record = exchange.with_state(|state| {
+            Ok::<_, Error>(
+                state
+                    .resumption
+                    .find_by_resumption_id(incoming_rid.reference().access())
+                    .cloned(),
+            )
+        })?;
+
+        let Some(record) = record else {
+            debug!(
+                "CASE Sigma1 resumption: no cached record for the requested resumption id; \
+                 falling back to full handshake"
+            );
+            return Ok(false);
+        };
+
+        // ---- Derive S1RK and verify Resume1MIC. ------------------------
+        let mut s1rk = CanonAeadKey::new();
+        derive_resume_key(
+            self.crypto,
+            ResumeKeyKind::S1rk,
+            record.shared_secret.reference(),
+            init_random.reference(),
+            record.resumption_id.reference(),
+            &mut s1rk,
+        )?;
+
+        if verify_resume_mic(
+            self.crypto,
+            s1rk.reference(),
+            RESUME1_MIC_NONCE,
+            &incoming_mic,
+        )
+        .is_err()
+        {
+            debug!(
+                "CASE Sigma1 resumption: Resume1MIC verify failed for peer node id \
+                 0x{:x} on fabric {}; falling back to full handshake",
+                record.peer_nodeid,
+                record.fab_idx.get()
+            );
+            return Ok(false);
+        }
+
+        // ---- Mint a new resumption id + derive S2RK + Resume2MIC. ------
+        let mut new_rid = CaseResumptionId::new();
+        self.crypto.rand()?.fill_bytes(new_rid.access_mut());
+
+        let mut s2rk = CanonAeadKey::new();
+        derive_resume_key(
+            self.crypto,
+            ResumeKeyKind::S2rk,
+            record.shared_secret.reference(),
+            init_random.reference(),
+            new_rid.reference(),
+            &mut s2rk,
+        )?;
+
+        let mut resume2_mic = [0u8; AEAD_TAG_LEN];
+        compute_resume_mic(
+            self.crypto,
+            s2rk.reference(),
+            RESUME2_MIC_NONCE,
+            &mut resume2_mic,
+        )?;
+
+        // ---- Prepare session context (peer id, IDs, MRP params). -------
+        let local_sessid = exchange.with_state(|state| Ok(state.sessions.get_next_sess_id()))?;
+
+        // Apply peer's Sigma1 MRP `session_parameters` to both the
+        // unsecured session that carries the handshake (so Sigma2_Resume
+        // retransmits use them) and to the reserved session that takes
+        // over after SigmaFinished. Mirrors the equivalent block in
+        // `handle_casesigma1`.
+        if let Some(ref params) = peer_params {
+            exchange.with_state(|state| {
+                exchange
+                    .id()
+                    .session(&mut state.sessions)
+                    .set_peer_session_params(params);
+                Ok::<_, Error>(())
+            })?;
+            session.set_peer_session_params(params)?;
+        }
+
+        // ---- Send Sigma2_Resume. --------------------------------------
+        let responder_session_params = SessionParameters {
+            max_paths_per_invoke: Some(exchange.matter().dev_det().max_paths_per_invoke),
+            ..Default::default()
+        };
+        let new_rid_bytes: [u8; CASE_RESUMPTION_ID_LEN] = *new_rid.reference().access();
+
+        exchange
+            .send_with(|_, tw| {
+                tw.start_struct(&TLVTag::Anonymous)?;
+                tw.str(&TLVTag::Context(1), &new_rid_bytes)?;
+                tw.str(&TLVTag::Context(2), &resume2_mic)?;
+                tw.u16(&TLVTag::Context(3), local_sessid)?;
+                responder_session_params.to_tlv(&TLVTag::Context(4), &mut *tw)?;
+                tw.end_container()?;
+
+                Ok(Some(OpCode::CASESigma2Resume.into()))
+            })
+            .await?;
+
+        // ---- Derive resumption session keys (spec §4.14.2.6.7). --------
+        let mut session_keys = MaybeUninit::<CaseSessionKeys>::uninit();
+        let session_keys = session_keys.init_with(CaseSessionKeys::init());
+        compute_resumption_session_keys(
+            self.crypto,
+            record.shared_secret.reference(),
+            init_random.reference(),
+            new_rid.reference(),
+            session_keys,
+        )?;
+
+        // As a responder: dec_key = I2R, enc_key = R2I (mirror of the
+        // Sigma3 path in `handle_casesigma3`).
+        let (dec_key, remaining) = session_keys
+            .reference()
+            .split::<AEAD_CANON_KEY_LEN, { AEAD_CANON_KEY_LEN * 2 }>();
+        let (enc_key, att_challenge) = remaining.split::<AEAD_CANON_KEY_LEN, AEAD_CANON_KEY_LEN>();
+
+        // ---- Load keys + identity into the reserved session. -----------
+        exchange.with_state(|state| {
+            let local_nodeid = state
+                .fabrics
+                .get(record.fab_idx)
+                .map(|f| f.node_id())
+                .ok_or(ErrorCode::Invalid)?;
+            let peer_addr = exchange.id().session(&mut state.sessions).get_peer_addr();
+
+            session.update_with_state(
+                state,
+                local_nodeid,
+                record.peer_nodeid,
+                init_sessid,
+                local_sessid,
+                peer_addr,
+                SessionMode::Case {
+                    fab_idx: record.fab_idx,
+                    cat_ids: record.peer_cat_ids,
+                },
+                Some(dec_key),
+                Some(enc_key),
+                Some(att_challenge),
+                Some(record.shared_secret.reference()),
+            )
+        })?;
+
+        // ---- Wait for SigmaFinished (StatusReport). --------------------
+        exchange.recv_fetch().await?;
+
+        let ok = {
+            let rx = exchange.rx()?;
+            let meta = rx.meta();
+            if meta.proto_opcode != OpCode::StatusReport as u8 {
+                warn!(
+                    "CASE resumption: expected StatusReport after Sigma2_Resume, got {}",
+                    meta.proto_opcode
+                );
+                false
+            } else {
+                let mut rb = ReadBuf::new(rx.payload());
+                match StatusReport::read(&mut rb) {
+                    Ok(status)
+                        if status.general_code == GeneralCode::Success
+                            && status.proto_code
+                                == SCStatusCodes::SessionEstablishmentSuccess as u16 =>
+                    {
+                        true
+                    }
+                    Ok(status) => {
+                        warn!(
+                            "CASE resumption: SigmaFinished failed: general={:?}, proto_code={}",
+                            status.general_code, status.proto_code
+                        );
+                        false
+                    }
+                    Err(e) => {
+                        warn!("CASE resumption: failed to parse SigmaFinished: {}", e);
+                        false
+                    }
+                }
+            }
+        };
+
+        if !ok {
+            // Initiator rejected the resumption (or sent a malformed
+            // SigmaFinished). The reserved session is dropped by
+            // `ReservedSession::drop` since we never call
+            // `session.complete()`. Do not fall through to the full
+            // handshake: this exchange has already produced Sigma2_Resume.
+            exchange.acknowledge().await?;
+            return Ok(true);
+        }
+
+        // Mark the session live *before* acknowledging SigmaFinished, so
+        // that if the initiator races an application-layer message right
+        // after its SigmaFinished, the receive path can already route it
+        // (mirrors the ordering in `handle_casesigma3`).
+        session.complete();
+        exchange.acknowledge().await?;
+
+        // ---- Update the cache with the rotated resumption id. ----------
+        //
+        // `SharedSecret` and peer identity are unchanged; only the
+        // `resumption_id` is rotated. `insert_or_update` refreshes the
+        // existing record for this peer and moves it to the tail (MRU).
+        exchange.with_state(|state| {
+            state.resumption.insert_or_update(ResumableSession {
+                fab_idx: record.fab_idx,
+                peer_nodeid: record.peer_nodeid,
+                peer_cat_ids: record.peer_cat_ids,
+                resumption_id: new_rid,
+                shared_secret: record.shared_secret.clone(),
+            });
+            Ok::<_, Error>(())
+        })?;
+
+        info!(
+            "CASE session resumed: local_sessid={}, peer_sessid={}, fabric={}, peer_nodeid=0x{:x}",
+            local_sessid,
+            init_sessid,
+            record.fab_idx.get(),
+            record.peer_nodeid,
+        );
+
+        Ok(true)
     }
 }

--- a/rs-matter/src/sc/case/responder.rs
+++ b/rs-matter/src/sc/case/responder.rs
@@ -112,9 +112,9 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
         // Attempt session resumption first. If the peer's Sigma1 carries
         // both `resumptionID` and `initiatorResumeMIC`, we have a cached
         // record for that resumption id, and the MIC checks out, this
-        // shortcuts to Sigma2_Resume + SigmaFinished (spec §4.14.2.2).
-        // Any other case (fields absent, unknown id, MIC mismatch) falls
-        // through to the full Sigma1/2/3 flow.
+        // shortcuts to Sigma2_Resume + SigmaFinished. Any other case
+        // (fields absent, unknown id, MIC mismatch) falls through to the
+        // full Sigma1/2/3 flow.
         if self
             .try_handle_sigma1_resume(&mut exchange, &mut session)
             .await?
@@ -149,11 +149,10 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
 
         let req = Sigma1Req::from_tlv(&get_root_node_struct(exchange.rx()?.payload())?)?;
 
-        // Matter Core spec: `resumptionID` and
-        // `initiatorResumeMIC` SHALL either both be present or both be
-        // absent. A mismatched pair is a malformed Sigma1 and the
-        // responder MUST reject it with `INVALID_PARAMETER` and stop
-        // processing (TC-SC-3.4 steps 1 and 2 cover this).
+        // Per Matter spec, `resumptionID` and `initiatorResumeMIC` must
+        // either both be present or both be absent. A mismatched pair
+        // is malformed and the responder rejects it with
+        // `INVALID_PARAMETER`.
         if req.resumption_id.is_some() != req.initiator_resume_mic.is_some() {
             error!("Sigma1 has mismatched resumptionID/initiatorResumeMIC presence; rejecting");
             complete_with_status(exchange, SCStatusCodes::InvalidParameter, &[]).await?;
@@ -199,12 +198,11 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
         )?;
 
         // Stash the initiator's advertised MRP `session_parameters`
-        // (Matter Core spec) so the responder uses the peer's
-        // SAI as the retransmission base interval for Sigma2 and any
-        // post-handshake traffic. We apply them both to the unsecured
-        // session that the handshake currently rides on (so Sigma2
-        // retransmits use them) and to the reserved CASE session that
-        // takes over after Sigma3.
+        // so the responder uses the peer's SAI as the retransmission
+        // base interval for Sigma2 and any post-handshake traffic. We
+        // apply them both to the unsecured session that the handshake
+        // currently rides on (so Sigma2 retransmits use them) and to
+        // the reserved CASE session that takes over after Sigma3.
         if let Some(params) = req.session_parameters.as_ref() {
             exchange.with_state(|state| {
                 exchange
@@ -424,6 +422,26 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
                         Some(self.casep.shared_secret()),
                     )?;
 
+                    // Seed the resumption cache with this freshly-established
+                    // full CASE session so a subsequent handshake with the
+                    // same peer can attempt resumption. `SharedSecret`,
+                    // fab_idx, peer_nodeid and peer CATs are the same as
+                    // what we just loaded into the `Session`; the
+                    // `resumption_id` was minted by the responder in
+                    // `casep.start` and is still held on `self.casep`.
+                    state.resumption.insert_or_update(ResumableSession {
+                        // Unwrap is safe: we are inside the `fabric` branch.
+                        fab_idx: unwrap!(NonZeroU8::new(self.casep.local_fabric_idx())),
+                        peer_nodeid: initiator_noc.get_node_id()?,
+                        peer_cat_ids: peer_catids,
+                        resumption_id: super::casep::CaseResumptionId::new_from_ref(
+                            self.casep.resumption_id(),
+                        ),
+                        shared_secret: crate::crypto::CanonPkcSharedSecret::new_from_ref(
+                            self.casep.shared_secret(),
+                        ),
+                    });
+
                     Ok(SCStatusCodes::SessionEstablishmentSuccess)
                 }
             } else {
@@ -440,13 +458,17 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
             // as it might start using it right after it receives the response, while it is still marked
             // as reserved.
             session.complete();
+
+            // The `state.resumption.insert_or_update` call above dirties
+            // the cache; wake the background persist task.
+            exchange.matter().transport().notify_resumption_dirty();
         }
 
         complete_with_status(exchange, status, &[]).await
     }
 
     /// Try to handle the received Sigma1 as a session-resumption
-    /// request (Matter Core spec §4.14.2.2). Returns:
+    /// request. Returns:
     ///
     /// - `Ok(true)` — the resumption path fully handled the exchange
     ///   (whether successfully or with the initiator rejecting the
@@ -456,7 +478,7 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
     ///   we could not honour the resumption (unknown `resumptionID`,
     ///   MIC verify failed, malformed fields). The caller must continue
     ///   with the full handshake, treating this Sigma1 as if it had no
-    ///   resumption fields (spec §4.14.2.3.5 fall-through rule).
+    ///   resumption fields (per Matter spec's fall-through rule).
     /// - `Err(_)` — a hard error unrelated to resumption (I/O,
     ///   cryptographic backend failure). The exchange is aborted.
     async fn try_handle_sigma1_resume(
@@ -624,7 +646,7 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
             })
             .await?;
 
-        // ---- Derive resumption session keys (spec §4.14.2.6.7). --------
+        // ---- Derive resumption session keys. --------------------------
         let mut session_keys = MaybeUninit::<CaseSessionKeys>::uninit();
         let session_keys = session_keys.init_with(CaseSessionKeys::init());
         compute_resumption_session_keys(
@@ -738,6 +760,7 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
             });
             Ok::<_, Error>(())
         })?;
+        exchange.matter().transport().notify_resumption_dirty();
 
         info!(
             "CASE session resumed: local_sessid={}, peer_sessid={}, fabric={}, peer_nodeid=0x{:x}",

--- a/rs-matter/src/sc/case/responder.rs
+++ b/rs-matter/src/sc/case/responder.rs
@@ -396,6 +396,7 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
                         Some(dec_key),
                         Some(enc_key),
                         Some(att_challenge),
+                        Some(self.casep.shared_secret()),
                     )?;
 
                     Ok(SCStatusCodes::SessionEstablishmentSuccess)

--- a/rs-matter/src/sc/case/responder.rs
+++ b/rs-matter/src/sc/case/responder.rs
@@ -649,11 +649,14 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
         // ---- Derive resumption session keys. --------------------------
         let mut session_keys = MaybeUninit::<CaseSessionKeys>::uninit();
         let session_keys = session_keys.init_with(CaseSessionKeys::init());
+        // Derive session traffic keys from the resumption ID carried in
+        // Sigma1 (the current ID), not the rotated `new_rid` from
+        // Sigma2_Resume.
         compute_resumption_session_keys(
             self.crypto,
             record.shared_secret.reference(),
             init_random.reference(),
-            new_rid.reference(),
+            record.resumption_id.reference(),
             session_keys,
         )?;
 

--- a/rs-matter/src/sc/case/resumption.rs
+++ b/rs-matter/src/sc/case/resumption.rs
@@ -30,7 +30,7 @@ use core::num::NonZeroU8;
 use crate::crypto::CanonPkcSharedSecret;
 use crate::error::Error;
 use crate::fabric::MAX_FABRICS;
-use crate::persist::{KvBlobStore, CASE_RESUMPTION_KEY};
+use crate::persist::{KvBlobStore, CASE_RESUMPTION_KEY, KV_BUF_SIZE};
 use crate::tlv::{FromTLV, TLVElement, TLVTag, ToTLV};
 use crate::transport::session::{NocCatIds, MAX_SESSIONS};
 use crate::utils::init::{init, Init};
@@ -38,23 +38,50 @@ use crate::utils::storage::{Vec, WriteBuf};
 
 use super::casep::CaseResumptionId;
 
-const fn min3(a: usize, b: usize, c: usize) -> usize {
-    let ab = if a < b { a } else { b };
-    if ab < c {
-        ab
+/// `usize::min` shim usable in `const` context (`Ord::min` is not yet
+/// const-stable; tracking rust-lang/rust#143874).
+const fn min(a: usize, b: usize) -> usize {
+    if a < b {
+        a
     } else {
-        c
+        b
     }
 }
+
+/// Defensive over-estimate of the TLV-encoded size of a single
+/// [`ResumableSession`] record. The real worst case is ~88 B; the
+/// extra headroom absorbs any future added tag or padding across
+/// backends and keeps [`MAX_RESUMPTION_RECORDS`] a compile-time
+/// constant without needing to introspect the derived TLV size.
+const RESUMPTION_RECORD_TLV_MAX: usize = 128;
+
+/// TLV overhead of the outer [`ResumableSessions`] envelope (an
+/// anonymous-tagged array header + footer). Small; the constant is
+/// generous.
+const RESUMPTION_ENVELOPE_TLV_MAX: usize = 16;
+
+/// How many records fit into the persistence scratch buffer, using the
+/// defensive per-record estimate above.
+const KV_BUDGET_CAP: usize = if KV_BUF_SIZE > RESUMPTION_ENVELOPE_TLV_MAX {
+    (KV_BUF_SIZE - RESUMPTION_ENVELOPE_TLV_MAX) / RESUMPTION_RECORD_TLV_MAX
+} else {
+    0
+};
 
 /// Capacity of the CASE session resumption cache.
 ///
 /// Matches the connectedhomeip default (`3 × MAX_FABRICS`), further
-/// capped by [`MAX_SESSIONS`] (never larger than the live-session
-/// pool) and by an absolute ceiling of 16 (so a large `max-fabrics-*`
-/// build cannot blow past the default 4 KiB KV buffer with the
-/// resumption blob alone).
-pub const MAX_RESUMPTION_RECORDS: usize = min3(3 * MAX_FABRICS, MAX_SESSIONS, 16);
+/// capped by:
+/// - [`MAX_SESSIONS`] — never larger than the live-session pool,
+/// - an absolute ceiling of 16 — belt-and-suspenders against unusual
+///   feature combos,
+/// - [`KV_BUDGET_CAP`] — so the serialized blob always fits into the
+///   [`KV_BUF_SIZE`](crate::persist::KV_BUF_SIZE) chosen by the
+///   `kv-blob-store-*` Cargo feature. Small MCUs building with
+///   `kv-blob-store-1024` therefore cap out at ~7 records regardless
+///   of `MAX_FABRICS`.
+pub const MAX_RESUMPTION_RECORDS: usize =
+    min(min(min(3 * MAX_FABRICS, MAX_SESSIONS), 16), KV_BUDGET_CAP);
 
 /// A single peer's CASE session resumption state.
 ///
@@ -211,6 +238,21 @@ impl ResumableSessions {
     /// Load the cache from `store` under [`CASE_RESUMPTION_KEY`].
     /// Missing key is not an error — the cache simply stays empty
     /// (first boot, or after [`Self::reset_persist`]).
+    ///
+    /// A blob that fails to parse is also **not** propagated as an
+    /// error. Because the resumption cache is a soft (rebuildable)
+    /// cache — losing it costs only one full CASE handshake per peer
+    /// the next time they connect — we prefer to keep the node
+    /// bootable over the theoretical safety of aborting the load.
+    /// The unparseable blob is dropped from storage so the failure
+    /// isn't sticky, and a warning is logged. Realistic causes:
+    ///
+    /// - A firmware update lowered `MAX_RESUMPTION_RECORDS` (feature
+    ///   flag change) below what's persisted, so
+    ///   `Vec::<_, N>::from_tlv` rejects "too many elements".
+    /// - The `ResumableSession` layout gains or loses a required
+    ///   field in a future release.
+    /// - The KV backend served corrupted bytes.
     pub fn load_persist<S: KvBlobStore>(
         &mut self,
         mut store: S,
@@ -218,20 +260,37 @@ impl ResumableSessions {
     ) -> Result<(), Error> {
         self.reset();
 
-        let Some(data) = store.load(CASE_RESUMPTION_KEY, buf)? else {
-            return Ok(());
+        // Scope-limit the borrow of `buf` (via `data`) so `buf` is
+        // freely reborrowable for the drop-on-error path below.
+        let parse_result: Result<Vec<ResumableSession, MAX_RESUMPTION_RECORDS>, Error> = {
+            let Some(data) = store.load(CASE_RESUMPTION_KEY, buf)? else {
+                return Ok(());
+            };
+            Vec::<ResumableSession, MAX_RESUMPTION_RECORDS>::from_tlv(&TLVElement::new(data))
         };
 
-        let loaded =
-            Vec::<ResumableSession, MAX_RESUMPTION_RECORDS>::from_tlv(&TLVElement::new(data))?;
-        self.records = loaded;
-
-        info!(
-            "Loaded {} CASE session resumption record(s) from storage",
-            self.records.len()
-        );
-
-        Ok(())
+        match parse_result {
+            Ok(records) => {
+                self.records = records;
+                info!(
+                    "Loaded {} CASE session resumption record(s) from storage",
+                    self.records.len()
+                );
+                Ok(())
+            }
+            Err(e) => {
+                warn!(
+                    "CASE session resumption cache is unparseable ({}); \
+                     dropping the persisted blob so the node can still boot",
+                    e
+                );
+                // Best-effort remove — if it also errors we've still
+                // logged the underlying cause. Next successful
+                // `store_persist` will overwrite the blob anyway.
+                let _ = store.remove(CASE_RESUMPTION_KEY, buf);
+                Ok(())
+            }
+        }
     }
 
     /// Serialise the current cache to `store` under

--- a/rs-matter/src/sc/case/resumption.rs
+++ b/rs-matter/src/sc/case/resumption.rs
@@ -16,14 +16,14 @@
  */
 
 //! Persisted state that lets a CASE session be resumed by its peer
-//! without a full Sigma1/2/3 exchange (Matter Core spec §4.14.2.2).
+//! without a full Sigma1/2/3 exchange.
 //!
-//! One [`ResumableSession`] holds exactly the five items the spec calls
-//! "Session Resumption State" — `SharedSecret`, local fabric index,
-//! peer node ID, peer CATs and the current `ResumptionID`. A bounded
-//! LRU collection ([`ResumableSessions`]) owns these records at
-//! runtime and mirrors them to a single KV blob under
-//! [`CASE_RESUMPTION_KEY`].
+//! One [`ResumableSession`] holds exactly the five items the Matter
+//! spec calls "Session Resumption State" — `SharedSecret`, local
+//! fabric index, peer node ID, peer CATs and the current
+//! `ResumptionID`. A bounded LRU collection ([`ResumableSessions`])
+//! owns these records at runtime and mirrors them to a single KV blob
+//! under [`CASE_RESUMPTION_KEY`].
 
 use core::num::NonZeroU8;
 
@@ -58,10 +58,11 @@ pub const MAX_RESUMPTION_RECORDS: usize = min3(3 * MAX_FABRICS, MAX_SESSIONS, 16
 
 /// A single peer's CASE session resumption state.
 ///
-/// Fields match §4.14.2.2.1 of the Matter Core spec (R1.5.1):
-/// SharedSecret, Local Fabric Index, Peer Node ID, Peer CATs,
-/// ResumptionID. TLV representation is a context-tagged struct so it
-/// is forward-compatible if we ever need to add an optional field.
+/// Fields carry exactly the "Session Resumption State" items from the
+/// Matter spec: SharedSecret, Local Fabric Index, Peer Node ID, Peer
+/// CATs, ResumptionID. TLV representation is a context-tagged struct
+/// so it is forward-compatible if we ever need to add an optional
+/// field.
 #[derive(Debug, Clone, FromTLV, ToTLV)]
 pub struct ResumableSession {
     /// Local fabric index the session belongs to.
@@ -79,7 +80,7 @@ pub struct ResumableSession {
     /// The ECDH shared secret from the original full CASE handshake.
     /// Kept unchanged for the lifetime of the record — successful
     /// resumption rotates only [`Self::resumption_id`], never the
-    /// secret (Matter Core spec §4.14.2.2).
+    /// secret.
     pub shared_secret: CanonPkcSharedSecret,
 }
 

--- a/rs-matter/src/sc/case/resumption.rs
+++ b/rs-matter/src/sc/case/resumption.rs
@@ -1,0 +1,364 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Persisted state that lets a CASE session be resumed by its peer
+//! without a full Sigma1/2/3 exchange (Matter Core spec §4.14.2.2).
+//!
+//! One [`ResumableSession`] holds exactly the five items the spec calls
+//! "Session Resumption State" — `SharedSecret`, local fabric index,
+//! peer node ID, peer CATs and the current `ResumptionID`. A bounded
+//! LRU collection ([`ResumableSessions`]) owns these records at
+//! runtime and mirrors them to a single KV blob under
+//! [`CASE_RESUMPTION_KEY`].
+
+use core::num::NonZeroU8;
+
+use crate::crypto::CanonPkcSharedSecret;
+use crate::error::Error;
+use crate::fabric::MAX_FABRICS;
+use crate::persist::{KvBlobStore, CASE_RESUMPTION_KEY};
+use crate::tlv::{FromTLV, TLVElement, TLVTag, ToTLV};
+use crate::transport::session::{NocCatIds, MAX_SESSIONS};
+use crate::utils::init::{init, Init};
+use crate::utils::storage::{Vec, WriteBuf};
+
+use super::casep::CaseResumptionId;
+
+const fn min3(a: usize, b: usize, c: usize) -> usize {
+    let ab = if a < b { a } else { b };
+    if ab < c {
+        ab
+    } else {
+        c
+    }
+}
+
+/// Capacity of the CASE session resumption cache.
+///
+/// Matches the connectedhomeip default (`3 × MAX_FABRICS`), further
+/// capped by [`MAX_SESSIONS`] (never larger than the live-session
+/// pool) and by an absolute ceiling of 16 (so a large `max-fabrics-*`
+/// build cannot blow past the default 4 KiB KV buffer with the
+/// resumption blob alone).
+pub const MAX_RESUMPTION_RECORDS: usize = min3(3 * MAX_FABRICS, MAX_SESSIONS, 16);
+
+/// A single peer's CASE session resumption state.
+///
+/// Fields match §4.14.2.2.1 of the Matter Core spec (R1.5.1):
+/// SharedSecret, Local Fabric Index, Peer Node ID, Peer CATs,
+/// ResumptionID. TLV representation is a context-tagged struct so it
+/// is forward-compatible if we ever need to add an optional field.
+#[derive(Debug, Clone, FromTLV, ToTLV)]
+pub struct ResumableSession {
+    /// Local fabric index the session belongs to.
+    pub fab_idx: NonZeroU8,
+    /// Peer's operational Node ID.
+    pub peer_nodeid: u64,
+    /// Peer's CASE Authenticated Tags (up to
+    /// [`MAX_CAT_IDS_PER_NOC`](crate::transport::session::MAX_CAT_IDS_PER_NOC);
+    /// zeroed slots mean absent).
+    pub peer_cat_ids: NocCatIds,
+    /// The `ResumptionID` last agreed with the peer. Rotated on every
+    /// successful resumption (the responder mints a new ID in
+    /// Sigma2_Resume and both sides overwrite this field).
+    pub resumption_id: CaseResumptionId,
+    /// The ECDH shared secret from the original full CASE handshake.
+    /// Kept unchanged for the lifetime of the record — successful
+    /// resumption rotates only [`Self::resumption_id`], never the
+    /// secret (Matter Core spec §4.14.2.2).
+    pub shared_secret: CanonPkcSharedSecret,
+}
+
+impl ResumableSession {
+    /// True if this record belongs to the peer identified by
+    /// `(fab_idx, peer_nodeid)`. Used by the initiator to decide
+    /// whether to attempt resumption before sending Sigma1.
+    pub fn is_for_peer(&self, fab_idx: NonZeroU8, peer_nodeid: u64) -> bool {
+        self.fab_idx == fab_idx && self.peer_nodeid == peer_nodeid
+    }
+
+    /// True if this record's [`Self::resumption_id`] equals `id`. Used
+    /// by the responder when it receives a Sigma1 with the optional
+    /// resumption fields.
+    pub fn has_resumption_id(&self, id: &[u8]) -> bool {
+        self.resumption_id.reference().access().as_slice() == id
+    }
+}
+
+/// Bounded LRU cache of [`ResumableSession`] records, persisted as a
+/// single TLV blob under [`CASE_RESUMPTION_KEY`].
+///
+/// Ordering invariant: **newest at the tail, oldest at the head**.
+/// [`Self::insert_or_update`] always ends with the freshly-written
+/// record at the tail, so eviction under pressure drops the record
+/// whose peer we have not spoken to for the longest.
+pub struct ResumableSessions {
+    records: Vec<ResumableSession, MAX_RESUMPTION_RECORDS>,
+}
+
+impl ResumableSessions {
+    /// Create a new, empty cache.
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self {
+            records: Vec::new(),
+        }
+    }
+
+    /// In-place initializer for a new, empty cache.
+    pub fn init() -> impl Init<Self> {
+        init!(Self {
+            records <- Vec::init(),
+        })
+    }
+
+    /// Number of records currently held.
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// True if there are no records.
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Iterate over the records in LRU order (oldest first).
+    pub fn iter(&self) -> impl Iterator<Item = &ResumableSession> {
+        self.records.iter()
+    }
+
+    /// Drop every record — in memory only, does not touch storage.
+    pub fn reset(&mut self) {
+        self.records.clear();
+    }
+
+    /// Look up a record by its resumption ID. Used by the responder on
+    /// receipt of a Sigma1 that carries the optional resumption
+    /// fields. Returns `None` if `resumption_id` has the wrong length
+    /// or no matching record is held.
+    pub fn find_by_resumption_id(&self, resumption_id: &[u8]) -> Option<&ResumableSession> {
+        self.records
+            .iter()
+            .find(|r| r.has_resumption_id(resumption_id))
+    }
+
+    /// Look up a record by peer identity. Used by the initiator before
+    /// building Sigma1 to decide whether to attempt resumption.
+    pub fn find_by_peer(&self, fab_idx: NonZeroU8, peer_nodeid: u64) -> Option<&ResumableSession> {
+        self.records
+            .iter()
+            .find(|r| r.is_for_peer(fab_idx, peer_nodeid))
+    }
+
+    /// Insert a fresh record or refresh an existing one identified by
+    /// `(fab_idx, peer_nodeid)`. In either case the record ends up at
+    /// the tail (most-recent). If the cache is at capacity, the head
+    /// (least-recent) record is evicted to make room.
+    ///
+    /// This is a no-op if [`MAX_RESUMPTION_RECORDS`] is zero.
+    pub fn insert_or_update(&mut self, record: ResumableSession) {
+        if MAX_RESUMPTION_RECORDS == 0 {
+            return;
+        }
+
+        // Drop any existing record for the same peer — the peer just
+        // completed a fresh handshake or a successful resumption, so
+        // any prior `resumption_id` / `shared_secret` for it is stale.
+        let key = (record.fab_idx, record.peer_nodeid);
+        self.records.retain(|r| (r.fab_idx, r.peer_nodeid) != key);
+
+        if self.records.is_full() {
+            // Evict the oldest record. `remove(0)` is O(N) on
+            // `heapless::Vec` but N is bounded by
+            // [`MAX_RESUMPTION_RECORDS`] (≤ 16) so the shuffle is
+            // negligible against the cost of a fresh CASE handshake.
+            self.records.remove(0);
+        }
+
+        // `push` cannot fail — either we started with room, or we just
+        // evicted one entry.
+        let _ = self.records.push(record);
+    }
+
+    /// Drop every record belonging to `fab_idx`. Call this from the
+    /// fabric-removal path so removed-fabric peers cannot resume onto
+    /// a fabric that no longer exists.
+    pub fn remove_for_fabric(&mut self, fab_idx: NonZeroU8) {
+        self.records.retain(|r| r.fab_idx != fab_idx);
+    }
+
+    /// Drop the record identified by peer identity, if any.
+    pub fn remove_by_peer(&mut self, fab_idx: NonZeroU8, peer_nodeid: u64) {
+        self.records
+            .retain(|r| !r.is_for_peer(fab_idx, peer_nodeid));
+    }
+
+    /// Load the cache from `store` under [`CASE_RESUMPTION_KEY`].
+    /// Missing key is not an error — the cache simply stays empty
+    /// (first boot, or after [`Self::reset_persist`]).
+    pub fn load_persist<S: KvBlobStore>(
+        &mut self,
+        mut store: S,
+        buf: &mut [u8],
+    ) -> Result<(), Error> {
+        self.reset();
+
+        let Some(data) = store.load(CASE_RESUMPTION_KEY, buf)? else {
+            return Ok(());
+        };
+
+        let loaded =
+            Vec::<ResumableSession, MAX_RESUMPTION_RECORDS>::from_tlv(&TLVElement::new(data))?;
+        self.records = loaded;
+
+        info!(
+            "Loaded {} CASE session resumption record(s) from storage",
+            self.records.len()
+        );
+
+        Ok(())
+    }
+
+    /// Serialise the current cache to `store` under
+    /// [`CASE_RESUMPTION_KEY`]. Called from the background snapshot
+    /// task whenever the in-memory cache diverges from what was last
+    /// persisted.
+    pub fn store_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+        // Serialise into `buf` first; then split it so the remainder
+        // can serve as the KV store's own scratch space. This mirrors
+        // the same split-and-lend pattern that [`Persist::store`] uses
+        // through its access closure.
+        let len = {
+            let mut wb = WriteBuf::new(buf);
+            self.records.to_tlv(&TLVTag::Anonymous, &mut wb)?;
+            wb.get_tail()
+        };
+
+        let (data, scratch) = buf.split_at_mut(len);
+        store.store(CASE_RESUMPTION_KEY, data, scratch)
+    }
+
+    /// Remove the persisted cache from `store` and wipe the in-memory
+    /// copy. Used from [`crate::Matter::reset_persist`].
+    pub fn reset_persist<S: KvBlobStore>(
+        &mut self,
+        mut store: S,
+        buf: &mut [u8],
+    ) -> Result<(), Error> {
+        self.reset();
+        store.remove(CASE_RESUMPTION_KEY, buf)?;
+
+        info!("Removed CASE session resumption cache from storage");
+
+        Ok(())
+    }
+}
+
+impl Default for ResumableSessions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::num::NonZeroU8;
+
+    use crate::crypto::CanonPkcSharedSecret;
+
+    use super::super::casep::CaseResumptionId;
+    use super::{ResumableSession, ResumableSessions, MAX_RESUMPTION_RECORDS};
+
+    fn rec(fab: u8, nodeid: u64, rid_first_byte: u8) -> ResumableSession {
+        let mut resumption_id = CaseResumptionId::new();
+        resumption_id.access_mut()[0] = rid_first_byte;
+
+        ResumableSession {
+            fab_idx: NonZeroU8::new(fab).unwrap(),
+            peer_nodeid: nodeid,
+            peer_cat_ids: [0; 3],
+            resumption_id,
+            shared_secret: CanonPkcSharedSecret::new(),
+        }
+    }
+
+    #[test]
+    fn insert_moves_to_tail_and_dedupes_by_peer() {
+        let mut cache = ResumableSessions::new();
+
+        cache.insert_or_update(rec(1, 100, 0xA0));
+        cache.insert_or_update(rec(1, 200, 0xB0));
+        assert_eq!(cache.len(), 2);
+
+        // Refreshing peer (1,100) with a new resumption_id should
+        // replace, not duplicate, and move it to the tail.
+        cache.insert_or_update(rec(1, 100, 0xC0));
+        assert_eq!(cache.len(), 2);
+
+        let ids: heapless::Vec<u8, 4> = cache
+            .iter()
+            .map(|r| r.resumption_id.reference().access()[0])
+            .collect();
+        assert_eq!(ids.as_slice(), &[0xB0, 0xC0]);
+    }
+
+    #[test]
+    fn find_by_peer_and_by_resumption_id() {
+        if MAX_RESUMPTION_RECORDS < 2 {
+            return; // small builds where the cache is too tight for this test
+        }
+
+        let mut cache = ResumableSessions::new();
+        cache.insert_or_update(rec(1, 100, 0xA0));
+        cache.insert_or_update(rec(2, 200, 0xB0));
+
+        assert!(cache
+            .find_by_peer(NonZeroU8::new(1).unwrap(), 100)
+            .is_some());
+        assert!(cache
+            .find_by_peer(NonZeroU8::new(2).unwrap(), 100)
+            .is_none());
+
+        let mut needle = [0u8; 16];
+        needle[0] = 0xB0;
+        assert!(cache.find_by_resumption_id(&needle).is_some());
+        needle[0] = 0xFF;
+        assert!(cache.find_by_resumption_id(&needle).is_none());
+
+        // Wrong-length id must not match.
+        assert!(cache.find_by_resumption_id(&[0xB0; 8]).is_none());
+    }
+
+    #[test]
+    fn remove_for_fabric_drops_only_that_fabric() {
+        if MAX_RESUMPTION_RECORDS < 3 {
+            return;
+        }
+
+        let mut cache = ResumableSessions::new();
+        cache.insert_or_update(rec(1, 100, 0xA0));
+        cache.insert_or_update(rec(2, 100, 0xB0));
+        cache.insert_or_update(rec(1, 200, 0xC0));
+        assert_eq!(cache.len(), 3);
+
+        cache.remove_for_fabric(NonZeroU8::new(1).unwrap());
+        assert_eq!(cache.len(), 1);
+        assert!(cache
+            .find_by_peer(NonZeroU8::new(2).unwrap(), 100)
+            .is_some());
+    }
+}

--- a/rs-matter/src/sc/pase/initiator.rs
+++ b/rs-matter/src/sc/pase/initiator.rs
@@ -396,6 +396,7 @@ impl<C: Crypto> PaseInitiator<C> {
             Some(dec_key),
             Some(enc_key),
             Some(att_challenge),
+            None,
         )?;
 
         // Complete the reserved session

--- a/rs-matter/src/sc/pase/responder.rs
+++ b/rs-matter/src/sc/pase/responder.rs
@@ -395,6 +395,7 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
                     Some(dec_key),
                     Some(enc_key),
                     Some(att_challenge),
+                    None,
                 )?;
 
                 // Complete the reserved session and thus make the `Session` instance

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -122,6 +122,10 @@ pub struct Transport {
     session_removed: Notification,
     /// A notification that the groups have been modified
     groups_modified: Notification,
+    /// A notification that the CASE session resumption cache has been
+    /// mutated and should be re-persisted by the background persist
+    /// task (see [`crate::Matter::run_persist_resumption`]).
+    resumption_dirty: Notification,
     /// Device SAI (Secure Association Identifier)
     device_sai: Option<u32>,
     /// Device SII (Secure Identity Identifier)
@@ -142,6 +146,7 @@ impl Transport {
             mdns_browse: Signal::new(MdnsBrowseState::Idle),
             session_removed: Notification::new(),
             groups_modified: Notification::new(),
+            resumption_dirty: Notification::new(),
             device_sai: dev_det.sai,
             device_sii: dev_det.sii,
         }
@@ -159,6 +164,7 @@ impl Transport {
             mdns_browse: Signal::new(MdnsBrowseState::Idle),
             session_removed: Notification::new(),
             groups_modified: Notification::new(),
+            resumption_dirty: Notification::new(),
             device_sai: dev_det.sai,
             device_sii: dev_det.sii,
         })
@@ -229,6 +235,21 @@ impl Transport {
     /// Wait until a session has been removed (see [`Transport::notify_session_removed`]).
     pub(crate) fn wait_session_removed(&self) -> impl Future<Output = ()> + '_ {
         self.session_removed.wait()
+    }
+
+    /// Notify that the CASE session resumption cache was mutated and
+    /// should be re-persisted. Fired from every code path that inserts,
+    /// rotates or evicts a [`crate::sc::case::ResumableSession`].
+    pub(crate) fn notify_resumption_dirty(&self) {
+        self.resumption_dirty.notify();
+    }
+
+    /// Wait until the CASE session resumption cache has been mutated
+    /// (see [`Transport::notify_resumption_dirty`]). Used by the
+    /// [`crate::Matter::run_persist_resumption`] background task to
+    /// know when to flush the cache to storage.
+    pub(crate) fn wait_resumption_dirty(&self) -> impl Future<Output = ()> + '_ {
+        self.resumption_dirty.wait()
     }
 
     /// Resolve a Matter service instance's address over mDNS.

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -819,7 +819,7 @@ impl<'a> ReservedSession<'a> {
         })
     }
 
-    pub fn complete(mut self) {
+    pub fn complete(&mut self) {
         self.complete = true;
     }
 }

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -336,8 +336,8 @@ impl Session {
     /// The ECDH shared secret from the original full CASE handshake,
     /// or `None` for non-CASE sessions. Consumed by the background
     /// snapshot task to build [`crate::sc::case::ResumableSession`]
-    /// records — the value that Matter Core spec §4.14.2.2.1 lists
-    /// as "SharedSecret" in the Session Resumption State.
+    /// records — the "SharedSecret" that the Matter spec lists as
+    /// part of the Session Resumption State.
     pub fn get_shared_secret(&self) -> Option<CanonPkcSharedSecretRef<'_>> {
         match self.mode {
             SessionMode::Case { .. } => Some(self.shared_secret.reference()),

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -23,7 +23,10 @@ use cfg_if::cfg_if;
 
 use rand_core::RngCore;
 
-use crate::crypto::{canon, CanonAeadKey, CanonAeadKeyRef, Crypto, CryptoSensitive, Kdf};
+use crate::crypto::{
+    canon, CanonAeadKey, CanonAeadKeyRef, CanonPkcSharedSecret, CanonPkcSharedSecretRef, Crypto,
+    CryptoSensitive, Kdf,
+};
 use crate::dm::clusters::basic_info::BasicInfoConfig;
 use crate::error::{Error, ErrorCode};
 use crate::fabric::Fabrics;
@@ -102,6 +105,12 @@ pub struct Session {
     // So, we might keep this as enc_key and dec_key for now
     dec_key: CanonAeadKey,
     enc_key: CanonAeadKey,
+    /// The ECDH shared secret computed during the original full CASE
+    /// handshake, retained on the session for the sole purpose of
+    /// populating [`crate::sc::case::ResumableSession`] records for
+    /// the resumption cache. Zeroed for non-CASE sessions. See
+    /// [`Self::get_shared_secret`].
+    shared_secret: CanonPkcSharedSecret,
     att_challenge: AttChallenge,
     local_sess_id: u16,
     peer_sess_id: u16,
@@ -148,6 +157,7 @@ impl Session {
             peer_nodeid,
             dec_key: CanonAeadKey::new(),
             enc_key: CanonAeadKey::new(),
+            shared_secret: CanonPkcSharedSecret::new(),
             att_challenge: AttChallenge::new(),
             peer_sess_id: 0,
             local_sess_id: 0,
@@ -182,6 +192,7 @@ impl Session {
             peer_nodeid,
             dec_key <- CanonAeadKey::init(),
             enc_key <- CanonAeadKey::init(),
+            shared_secret <- CanonPkcSharedSecret::init(),
             att_challenge <- AttChallenge::init(),
             peer_sess_id: 0,
             local_sess_id: 0,
@@ -319,6 +330,18 @@ impl Session {
                 Some(self.enc_key.reference())
             }
             SessionMode::PlainText => None,
+        }
+    }
+
+    /// The ECDH shared secret from the original full CASE handshake,
+    /// or `None` for non-CASE sessions. Consumed by the background
+    /// snapshot task to build [`crate::sc::case::ResumableSession`]
+    /// records — the value that Matter Core spec §4.14.2.2.1 lists
+    /// as "SharedSecret" in the Session Resumption State.
+    pub fn get_shared_secret(&self) -> Option<CanonPkcSharedSecretRef<'_>> {
+        match self.mode {
+            SessionMode::Case { .. } => Some(self.shared_secret.reference()),
+            SessionMode::Pase { .. } | SessionMode::Group { .. } | SessionMode::PlainText => None,
         }
     }
 
@@ -717,6 +740,7 @@ impl<'a> ReservedSession<'a> {
         dec_key: Option<CanonAeadKeyRef<'_>>,
         enc_key: Option<CanonAeadKeyRef<'_>>,
         att_challenge: Option<AttChallengeRef<'_>>,
+        shared_secret: Option<CanonPkcSharedSecretRef<'_>>,
     ) -> Result<(), Error> {
         self.matter.with_state(|state| {
             self.update_with_state(
@@ -730,6 +754,7 @@ impl<'a> ReservedSession<'a> {
                 dec_key,
                 enc_key,
                 att_challenge,
+                shared_secret,
             )
         })
     }
@@ -747,6 +772,7 @@ impl<'a> ReservedSession<'a> {
         dec_key: Option<CanonAeadKeyRef<'_>>,
         enc_key: Option<CanonAeadKeyRef<'_>>,
         att_challenge: Option<AttChallengeRef<'_>>,
+        shared_secret: Option<CanonPkcSharedSecretRef<'_>>,
     ) -> Result<(), Error> {
         let session = state.sessions.get(self.id).ok_or(ErrorCode::NoSession)?;
 
@@ -767,6 +793,10 @@ impl<'a> ReservedSession<'a> {
 
         if let Some(att_challenge) = att_challenge {
             session.att_challenge.load(att_challenge);
+        }
+
+        if let Some(shared_secret) = shared_secret {
+            session.shared_secret.load(shared_secret);
         }
 
         Ok(())

--- a/rs-matter/tests/case_resumption.rs
+++ b/rs-matter/tests/case_resumption.rs
@@ -1,0 +1,359 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! End-to-end test for CASE session resumption.
+//!
+//! Establishes two CASE sessions back-to-back between two in-process
+//! `Matter` instances that share a fabric, and verifies the second
+//! handshake takes the resumption path rather than a fresh full
+//! handshake.
+//!
+//! The distinguishing signal is the cached `SharedSecret`:
+//! - Full handshake mints a fresh ECDH `SharedSecret` and replaces the
+//!   cache entry with it.
+//! - Successful resumption reuses the previous `SharedSecret` and
+//!   only rotates the `ResumptionID`.
+//!
+//! So after handshake #2, if the `SharedSecret` in the cache is
+//! unchanged from #1 (and the `ResumptionID` did change), we know
+//! resumption happened on both sides.
+
+#![cfg(all(feature = "std", feature = "async-io"))]
+
+use core::num::NonZeroU8;
+use core::pin::pin;
+
+use embassy_futures::select::{select, Either};
+use embassy_time::{Duration, Timer};
+
+use log::info;
+
+use rs_matter::cert::gen::VALID_FOREVER;
+use rs_matter::cert::MAX_CERT_TLV_AND_ASN1_LEN;
+use rs_matter::crypto::{
+    test_only_crypto, CanonAeadKey, CanonAeadKeyRef, CanonPkcSecretKey, Crypto, RngCore, SecretKey,
+    SigningSecretKey, AEAD_CANON_KEY_LEN,
+};
+use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
+use rs_matter::error::Error;
+use rs_matter::onboard::cac::RcacGenerator;
+use rs_matter::onboard::noc::NocGenerator;
+use rs_matter::respond::Responder;
+use rs_matter::sc::case::CaseInitiator;
+use rs_matter::sc::SecureChannel;
+use rs_matter::transport::exchange::Exchange;
+use rs_matter::transport::network::{Address, NoNetwork};
+
+use rs_matter::utils::select::Coalesce;
+use rs_matter::Matter;
+
+use crate::common::{create_localhost_socket_pair, init_env_logger, run_device_controller};
+
+#[allow(dead_code)]
+mod common;
+
+const TEST_FABRIC_ID: u64 = 1;
+const CONTROLLER_NODE_ID: u64 = 100;
+const DEVICE_NODE_ID: u64 = 200;
+
+/// Copy of a resumption record's identifying material, extracted from
+/// the cache so we can compare pre- and post-handshake without holding
+/// a borrow into `MatterState`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CacheSnapshot {
+    shared_secret: [u8; 32],
+    resumption_id: [u8; 16],
+}
+
+/// Pull the resumption record for `(fab_idx, peer_nodeid)` from
+/// `matter`'s in-memory cache, if any. Returns `None` when no matching
+/// record exists.
+fn snapshot(matter: &Matter<'_>, fab_idx: NonZeroU8, peer_nodeid: u64) -> Option<CacheSnapshot> {
+    matter.with_state(|state| {
+        state
+            .resumption
+            .find_by_peer(fab_idx, peer_nodeid)
+            .map(|rec| CacheSnapshot {
+                shared_secret: *rec.shared_secret.reference().access(),
+                resumption_id: *rec.resumption_id.reference().access(),
+            })
+    })
+}
+
+/// Two back-to-back CASE handshakes between two in-process Matter
+/// instances that share a fabric. Handshake #2 must take the
+/// resumption path.
+///
+/// See the module-level doc comment for the distinguishing-signal
+/// rationale (`SharedSecret` unchanged, `ResumptionID` rotated).
+#[test]
+fn test_case_resumption_round_trip() {
+    init_env_logger();
+
+    futures_lite::future::block_on(async {
+        let crypto = test_only_crypto();
+
+        // ---- 1. Generate shared fabric material: RCAC + IPK + NOCs ----
+        //
+        // Same recipe as `tests/case.rs` — signing one RCAC and both
+        // NOCs against it so controller and device end up on the same
+        // fabric.
+
+        let mut rcac_buf = [0u8; MAX_CERT_TLV_AND_ASN1_LEN];
+        let mut rcac_gen = RcacGenerator::new(&mut rcac_buf);
+        let (rcac_privkey, rcac) = rcac_gen
+            .generate(&crypto, TEST_FABRIC_ID, VALID_FOREVER)
+            .unwrap();
+
+        let mut noc_buf = [0u8; MAX_CERT_TLV_AND_ASN1_LEN];
+        let mut noc_generator =
+            NocGenerator::create(rcac_privkey.reference(), rcac, &[], &mut noc_buf).unwrap();
+
+        // Shared fabric IPK (16 random bytes).
+        let mut ipk = CanonAeadKey::new();
+        let mut ipk_bytes = [0u8; AEAD_CANON_KEY_LEN];
+        crypto.rand().unwrap().fill_bytes(&mut ipk_bytes);
+        ipk.load_from_array(&ipk_bytes);
+        let ipk_ref: CanonAeadKeyRef<'_> = ipk.reference();
+
+        // Controller signing keypair + CSR.
+        let controller_secret_key = crypto.generate_secret_key().unwrap();
+        let mut controller_csr_buf = [0u8; 256];
+        let controller_csr = controller_secret_key.csr(&mut controller_csr_buf).unwrap();
+        let mut controller_secret_key_canon = CanonPkcSecretKey::new();
+        controller_secret_key
+            .write_canon(&mut controller_secret_key_canon)
+            .unwrap();
+
+        // Device signing keypair + CSR.
+        let device_secret_key = crypto.generate_secret_key().unwrap();
+        let mut device_csr_buf = [0u8; 256];
+        let device_csr = device_secret_key.csr(&mut device_csr_buf).unwrap();
+        let mut device_secret_key_canon = CanonPkcSecretKey::new();
+        device_secret_key
+            .write_canon(&mut device_secret_key_canon)
+            .unwrap();
+
+        // ---- 2. Set up two Matter instances ----
+
+        let device_matter = Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, 0);
+        let controller_matter = Matter::new(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, 0);
+
+        // ---- 3. Install the same fabric in both fabric tables ----
+        //
+        // The NOC slice returned by `noc_generator.generate` borrows
+        // `noc_buf`, so it must be consumed before the next
+        // `generate` call overwrites the buffer.
+
+        let controller_noc = noc_generator
+            .generate(
+                &crypto,
+                controller_csr,
+                CONTROLLER_NODE_ID,
+                &[],
+                VALID_FOREVER,
+            )
+            .unwrap();
+
+        let controller_fab_idx = controller_matter.with_state(|state| {
+            state
+                .fabrics
+                .add(
+                    &crypto,
+                    controller_secret_key_canon.reference(),
+                    rcac,
+                    controller_noc,
+                    &[], // no ICAC
+                    Some(ipk_ref),
+                    0xFFF1,
+                    CONTROLLER_NODE_ID,
+                )
+                .unwrap()
+                .fab_idx()
+        });
+
+        let device_noc = noc_generator
+            .generate(&crypto, device_csr, DEVICE_NODE_ID, &[], VALID_FOREVER)
+            .unwrap();
+
+        let device_fab_idx = device_matter.with_state(|state| {
+            state
+                .fabrics
+                .add(
+                    &crypto,
+                    device_secret_key_canon.reference(),
+                    rcac,
+                    device_noc,
+                    &[], // no ICAC
+                    Some(ipk_ref),
+                    0xFFF1,
+                    CONTROLLER_NODE_ID,
+                )
+                .unwrap()
+                .fab_idx()
+        });
+
+        // ---- 4. Bind UDP sockets ----
+
+        let (device_socket, controller_socket) = create_localhost_socket_pair();
+        let peer_addr = Address::Udp(device_socket.get_ref().local_addr().unwrap());
+
+        // ---- 5. Device side: transport + SecureChannel responder ----
+
+        let sc = SecureChannel::new(&crypto, &());
+        let responder = Responder::new("device", sc, &device_matter, 0);
+
+        let device_fut = async {
+            select(
+                device_matter.run(&crypto, &device_socket, &device_socket, NoNetwork),
+                responder.run::<4>(),
+            )
+            .coalesce()
+            .await
+        };
+
+        // ---- 6. Controller side: transport + two CASE handshakes ----
+
+        let controller_fut = async {
+            let mut transport = pin!(controller_matter.run(
+                &crypto,
+                &controller_socket,
+                &controller_socket,
+                NoNetwork,
+            ));
+
+            let mut test = pin!(async {
+                // ---- Handshake #1 — full CASE ----
+                info!("--- First CASE handshake (full) ---");
+                run_case_handshake(
+                    &controller_matter,
+                    &crypto,
+                    peer_addr,
+                    controller_fab_idx,
+                    DEVICE_NODE_ID,
+                )
+                .await?;
+
+                // Both sides must have cached a record.
+                let ctrl_after1 = snapshot(&controller_matter, controller_fab_idx, DEVICE_NODE_ID)
+                    .expect("controller cache empty after handshake #1");
+                let dev_after1 = snapshot(&device_matter, device_fab_idx, CONTROLLER_NODE_ID)
+                    .expect("device cache empty after handshake #1");
+
+                // Both sides must agree on the same (SharedSecret, ResumptionID).
+                assert_eq!(
+                    ctrl_after1, dev_after1,
+                    "controller and device disagree on cache contents after handshake #1"
+                );
+
+                // ---- Handshake #2 — must resume ----
+                info!("--- Second CASE handshake (resumption expected) ---");
+                run_case_handshake(
+                    &controller_matter,
+                    &crypto,
+                    peer_addr,
+                    controller_fab_idx,
+                    DEVICE_NODE_ID,
+                )
+                .await?;
+
+                let ctrl_after2 = snapshot(&controller_matter, controller_fab_idx, DEVICE_NODE_ID)
+                    .expect("controller cache empty after handshake #2");
+                let dev_after2 = snapshot(&device_matter, device_fab_idx, CONTROLLER_NODE_ID)
+                    .expect("device cache empty after handshake #2");
+
+                // Distinguishing signal: SharedSecret is unchanged.
+                // If handshake #2 had done a full CASE, this would have
+                // rotated to a fresh ECDH result and the assertion
+                // would fail.
+                assert_eq!(
+                    ctrl_after2.shared_secret, ctrl_after1.shared_secret,
+                    "SharedSecret rotated on controller side — handshake #2 did NOT resume"
+                );
+                assert_eq!(
+                    dev_after2.shared_secret, dev_after1.shared_secret,
+                    "SharedSecret rotated on device side — handshake #2 did NOT resume"
+                );
+
+                // The `ResumptionID` must have rotated (responder mints
+                // a fresh one in `Sigma2_Resume`).
+                assert_ne!(
+                    ctrl_after2.resumption_id, ctrl_after1.resumption_id,
+                    "ResumptionID did not rotate on controller side"
+                );
+                assert_ne!(
+                    dev_after2.resumption_id, dev_after1.resumption_id,
+                    "ResumptionID did not rotate on device side"
+                );
+
+                // Sides must still agree.
+                assert_eq!(
+                    ctrl_after2, dev_after2,
+                    "controller and device disagree on cache contents after handshake #2"
+                );
+
+                info!("CASE resumption verified end-to-end");
+                Ok::<_, Error>(())
+            });
+
+            match select(&mut transport, &mut test).await {
+                Either::First(transport_result) => {
+                    panic!("Controller transport exited prematurely: {transport_result:?}");
+                }
+                Either::Second(test_result) => {
+                    // Give transport a moment to flush final messages
+                    let mut flush = pin!(Timer::after(Duration::from_millis(300)));
+                    if let Either::First(transport_result) =
+                        select(&mut transport, &mut flush).await
+                    {
+                        panic!("Controller transport error during flush: {transport_result:?}");
+                    }
+                    test_result
+                }
+            }
+        };
+
+        // ---- 7. Run device and controller concurrently ----
+
+        run_device_controller(device_fut, controller_fut)
+            .await
+            .unwrap();
+    });
+}
+
+async fn run_case_handshake<C: Crypto>(
+    matter: &Matter<'_>,
+    crypto: &C,
+    peer_addr: Address,
+    fab_idx: NonZeroU8,
+    peer_node_id: u64,
+) -> Result<(), Error> {
+    let exchange = Exchange::initiate_plaintext(matter, crypto, peer_addr).await?;
+
+    let mut case_fut = pin!(CaseInitiator::perform(
+        exchange,
+        crypto,
+        fab_idx,
+        peer_node_id,
+    ));
+    let mut timeout = pin!(Timer::after(Duration::from_secs(30)));
+
+    match select(&mut case_fut, &mut timeout).await {
+        Either::First(result) => result,
+        Either::Second(_) => panic!("CASE handshake timed out after 30 seconds"),
+    }
+}

--- a/rs-matter/tests/common/e2e.rs
+++ b/rs-matter/tests/common/e2e.rs
@@ -292,6 +292,7 @@ impl<C: Crypto> E2eRunner<C> {
             None,
             None,
             None,
+            None,
         )?;
 
         session.complete();


### PR DESCRIPTION
Addresses #33 and partly #498

I must say, I really like the end design, in that:
- The set of `ResumableSession`s is _completely independent_ from the set of active `Session`s. Just a lazy by-product of establishing CASE sessions with peers. To the extent that I wonder if I should rename `ResumableSession` to `CaseResumption`
- Cache of resumable sessions never has to be invalidated (putting aside fabric drop or fabric noc key renegotiation!)
- The cache of resumable sessions is just a "speed accelerator" when the node wants to establish a new CASE `Session` to another node, that's all. It can be as big or as small as we want, affecting only CASE session establishment performance
