### PR TITLE
Persistent subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 * Persistent subscriptions now supported
+  * Subscriptions can be persisted and resumed across a reboot (opt-in via `set_persist_subscriptions`, off by default)
   * Fix: A subscription is no longer pinned to its establishing session which was incorrect
+  * Fix: A not-yet-primed subscription with a `MinIntervalFloor` of 0 is now reported immediately instead of never
 * (Breaking) ICD support: Check-In Protocol, ICD cluster handler, mDNS advertisements (#501)
 * Warn on packet retransmission (#500)
   * (Breaking) Rename feature `debug-tlv-payload` to `log-tlv-payload`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Persistent subscriptions
+  * Fix: A subscription is no longer pinned to its establishing session which was incorrect
 * (Breaking) ICD support: Check-In Protocol, ICD cluster handler, mDNS advertisements (#501)
 * Warn on packet retransmission (#500)
   * (Breaking) Rename feature `debug-tlv-payload` to `log-tlv-payload`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-* Persistent subscriptions
+* Persistent subscriptions now supported
   * Fix: A subscription is no longer pinned to its establishing session which was incorrect
 * (Breaking) ICD support: Check-In Protocol, ICD cluster handler, mDNS advertisements (#501)
 * Warn on packet retransmission (#500)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Subscriptions can be persisted and resumed across a reboot (opt-in via `set_persist_subscriptions`, off by default)
   * Fix: A subscription is no longer pinned to its establishing session which was incorrect
   * Fix: A not-yet-primed subscription with a `MinIntervalFloor` of 0 is now reported immediately instead of never
+  * Fix: A failed report no longer advances the subscription's watermark, so the changes/events it was carrying are retried instead of silently dropped
 * (Breaking) ICD support: Check-In Protocol, ICD cluster handler, mDNS advertisements (#501)
 * Warn on packet retransmission (#500)
   * (Breaking) Rename feature `debug-tlv-payload` to `log-tlv-payload`

--- a/examples/src/bin/system_tests.rs
+++ b/examples/src/bin/system_tests.rs
@@ -182,6 +182,10 @@ fn main() -> Result<(), Error> {
     let mut state: EthInteractionModelState =
         EthInteractionModelState::new(EthNetwork::new_default());
 
+    // Opt in to persistent subscriptions so a subscriber keeps its subscription
+    // across a reboot (persistence is off by default).
+    state.set_persist_subscriptions(true);
+
     // Bind the KV access object (the KV scratch buffer lives in `Matter`).
     let kv = matter.kv(store);
 

--- a/examples/src/bin/system_tests.rs
+++ b/examples/src/bin/system_tests.rs
@@ -329,6 +329,12 @@ fn main() -> Result<(), Error> {
         &state,
     );
 
+    // Re-hydrate any persisted subscriptions into the reporter's table, so a
+    // subscriber that had a subscription before this reboot keeps receiving
+    // reports (over a session re-established on demand) instead of having to
+    // notice the loss and re-subscribe.
+    im.resume_subscriptions()?;
+
     // Responder = the default IM + Secure Channel handler chain, plus a BDX
     // protocol handler for the OTA Provider role. BDX is inert without OTA
     // traffic, so this is equivalent to `DefaultResponder` for every non-OTA

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -191,6 +191,17 @@ impl<N, const NS: usize, const NE: usize> InteractionModelState<N, NS, NE> {
         &self.subscriptions
     }
 
+    /// Enable or disable persistence of subscriptions (off by default).
+    ///
+    /// When enabled, accepted subscriptions are persisted to the key-value store
+    /// and resumed (via [`InteractionModel::resume_subscriptions`]) after a reboot,
+    /// so a subscriber keeps its subscription across a device restart instead of
+    /// having to notice the loss and re-subscribe. Persisting is spec-optional and
+    /// costs flash writes, so it is opt-in. Call once at startup.
+    pub fn set_persist_subscriptions(&self, enabled: bool) {
+        self.subscriptions.set_persist(enabled);
+    }
+
     /// The events queue.
     pub const fn events(&self) -> &Events<NE> {
         &self.events

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -129,7 +129,10 @@ impl<N, const NS: usize, const NE: usize> InteractionModelState<N, NS, NE> {
     {
         // We hold `&mut self`, so borrow the pieces directly - no locking.
         let Self {
-            events, networks, ..
+            events,
+            networks,
+            subscriptions,
+            ..
         } = self;
 
         let events = events.inner_mut();
@@ -142,6 +145,9 @@ impl<N, const NS: usize, const NE: usize> InteractionModelState<N, NS, NE> {
             // The network store.
             networks.reset()?;
             store.remove(NETWORKS_KEY, buf)?;
+
+            // Every persisted subscription record.
+            subscriptions.reset_persist(&mut *store, buf)?;
 
             Ok(())
         })
@@ -820,7 +826,6 @@ where
             now,
             fab_idx,
             peer_node_id,
-            exchange.id().session_id(),
             min_int_secs,
             max_int_secs,
             self.state.events.watermark(),
@@ -848,6 +853,11 @@ where
             // runs on `Drop`) and then wake the reporter so it can account for
             // the new subscription's deadline.
             drop(rctx);
+
+            // Persist the (now-committed) table so this subscription can be
+            // resumed across a reboot.
+            self.persist_subscriptions();
+
             self.state.subscriptions.notification.notify();
         }
 
@@ -909,6 +919,53 @@ where
         })
     }
 
+    /// Persist the current subscription table to `kv`, one record per key.
+    ///
+    /// A no-op when the store is a dummy (no scratch buffer). Best-effort: a
+    /// persistence failure is logged but never propagated, so it cannot break
+    /// reporting — persisting subscriptions is spec-optional.
+    fn persist_subscriptions(&self) {
+        let result = self.kv.access(|store, buf| {
+            self.state
+                .subscriptions
+                .persist_all(&self.subscriptions_buffers, store, buf)
+        });
+
+        if let Err(e) = result {
+            warn!("Failed to persist subscriptions: {:?}", e);
+        }
+    }
+
+    /// Re-hydrate the subscription table from `kv` and re-arm the reporter.
+    ///
+    /// Call once at startup, after the fabrics and events state have been
+    /// loaded and before (or right as) [`InteractionModel::run`] begins. Each
+    /// persisted subscription is replayed into the table as a live (already
+    /// primed) subscription; the reporter then reaches the subscriber on demand
+    /// by establishing a session when the next report is due. No session is
+    /// opened proactively here.
+    pub fn resume_subscriptions(&self) -> Result<(), Error> {
+        let now = Instant::now();
+        let watermark = self.state.events.watermark();
+
+        self.kv.access(|store, buf| {
+            self.state.subscriptions.load_persist(
+                self.buffers,
+                &self.subscriptions_buffers,
+                store,
+                buf,
+                now,
+                watermark,
+            )
+        })?;
+
+        // Wake the reporter so it accounts for the resumed subscriptions'
+        // liveness deadlines.
+        self.state.subscriptions.notification.notify();
+
+        Ok(())
+    }
+
     /// Process all valid subscriptions in an endless loop, checking for changes
     /// and reporting them to the peers.
     async fn process_subscriptions(&self, matter: &Matter<'_>) -> Result<(), Error> {
@@ -937,46 +994,58 @@ where
 
             // First remove all expired or no-longer valid subscriptions
 
+            let mut removed_any = false;
             loop {
-                let removed_any =
-                    self.state
-                        .subscriptions
-                        .remove(&self.subscriptions_buffers, |sub| {
-                            if sub.is_expired(now) {
-                                return Some("expired");
+                let removed = self
+                    .state
+                    .subscriptions
+                    .remove(&self.subscriptions_buffers, |sub| {
+                        if sub.is_expired(now) {
+                            return Some("expired");
+                        }
+
+                        matter.with_state(|state| {
+                            if state.fabrics.get(sub.ids().fab_idx).is_none() {
+                                return Some("fabric removed");
                             }
 
-                            matter.with_state(|state| {
-                                if state.fabrics.get(sub.ids().fab_idx).is_none() {
-                                    return Some("fabric removed");
-                                }
+                            // A subscription is NOT dropped merely because the
+                            // session it was accepted on is gone (eviction,
+                            // peer-side re-handshake, unreachable peer, a received
+                            // Close, ...): reports route by `(fabric, node)` and a
+                            // fresh session is established on demand. A session
+                            // ending is a transport event, not a subscription
+                            // teardown. It ends only through its own lifecycle —
+                            // `max_int` liveness timeout (handled above as
+                            // "expired"), or the subscriber answering a report with
+                            // a non-success status (handled in the report loop, which
+                            // then purges the persisted record).
+                            None
+                        })
+                    });
 
-                                // A subscription is NOT dropped merely because the
-                                // session it was accepted on is gone (eviction,
-                                // peer-side re-handshake, unreachable peer, ...):
-                                // reports route by `(fabric, node)` and a fresh
-                                // session is established on demand. It ends only
-                                // through its own lifecycle — `max_int` liveness
-                                // timeout, or the subscriber answering a report
-                                // with a non-success status.
-                                //
-                                // TODO (persistent subscriptions): a session gone
-                                // via a *received Close* is a deliberate teardown;
-                                // once subscriptions are persisted, that case must
-                                // purge the persisted record (distinct from the
-                                // die-and-resume case).
-                                None
-                            })
-                        });
+                removed_any |= removed;
 
-                if !removed_any {
+                if !removed {
                     break;
                 }
+            }
+
+            // Keep the persisted set an exact mirror of the (now-smaller) table:
+            // any dropped subscription's record is removed so it will not be
+            // resumed on the next reboot.
+            if removed_any {
+                self.persist_subscriptions();
             }
 
             // Now report while there are subscriptions which are due for reporting
 
             let event_numbers_watermark = self.state.events.watermark();
+
+            // Track whether any subscription left the table during reporting (the
+            // subscriber answered a report with a non-success status, i.e. a
+            // deliberate unsubscribe), so its persisted record can be purged.
+            let mut dropped_any = false;
 
             loop {
                 let Some(mut rctx) = self.state.subscriptions.report(
@@ -991,7 +1060,10 @@ where
 
                 match result {
                     Ok(true) => rctx.set_keep(),
-                    Ok(false) => (),
+                    // Not kept: the subscriber tore the subscription down (or we
+                    // could not report). Dropping it from the table on `rctx`
+                    // drop means its persisted record must be purged too.
+                    Ok(false) => dropped_any = true,
                     Err(e) => {
                         // Reporting failed — typically because the session to the
                         // subscriber died (peer unreachable, MRP retransmissions
@@ -1022,6 +1094,13 @@ where
                         rctx.set_keep();
                     }
                 }
+            }
+
+            // A subscription that was torn down during reporting is now gone from
+            // the table; re-persist so the on-disk set stays an exact mirror and
+            // the torn-down subscription is not resumed on the next reboot.
+            if dropped_any {
+                self.persist_subscriptions();
             }
 
             // Periodically trim changed-attr entries that have been reported by every

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -1102,7 +1102,11 @@ where
                                 state.sessions.remove(id);
                             }
                         });
-                        rctx.set_keep();
+
+                        // Keep the subscription to retry, but do NOT advance its
+                        // watermarks: the changes/events this report was carrying
+                        // never reached the subscriber and must be re-sent.
+                        rctx.set_keep_retry();
                     }
                 }
             }

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -951,18 +951,20 @@ where
                                     return Some("fabric removed");
                                 }
 
-                                // The session the subscription was accepted on was
-                                // torn down (eviction, explicit close, peer-side
-                                // CASE re-handshake, ...). Per Matter spec
-                                // subscriptions are scoped to the session they
-                                // were established on, and the publisher can no
-                                // longer route reports to the subscriber. Drop
-                                // immediately rather than waiting for `max_int`
-                                // to expire and time-out the send.
-                                if state.sessions.get(sub.session_id()).is_none() {
-                                    return Some("session removed");
-                                }
-
+                                // A subscription is NOT dropped merely because the
+                                // session it was accepted on is gone (eviction,
+                                // peer-side re-handshake, unreachable peer, ...):
+                                // reports route by `(fabric, node)` and a fresh
+                                // session is established on demand. It ends only
+                                // through its own lifecycle — `max_int` liveness
+                                // timeout, or the subscriber answering a report
+                                // with a non-success status.
+                                //
+                                // TODO (persistent subscriptions): a session gone
+                                // via a *received Close* is a deliberate teardown;
+                                // once subscriptions are persisted, that case must
+                                // purge the persisted record (distinct from the
+                                // die-and-resume case).
                                 None
                             })
                         });
@@ -990,11 +992,35 @@ where
                 match result {
                     Ok(true) => rctx.set_keep(),
                     Ok(false) => (),
-                    Err(e) => error!(
-                        "Error processing subscription {:?}: {:?}",
-                        rctx.subscription().ids(),
-                        e
-                    ),
+                    Err(e) => {
+                        // Reporting failed — typically because the session to the
+                        // subscriber died (peer unreachable, MRP retransmissions
+                        // exhausted). Drop that session so the next report to this
+                        // peer establishes a fresh one, and keep the subscription
+                        // so it retries rather than being torn down.
+                        let (fab_idx, peer_node_id) = {
+                            let ids = rctx.subscription().ids();
+                            (ids.fab_idx, ids.peer_node_id)
+                        };
+
+                        error!(
+                            "Error processing subscription (fab {}, node {:x}): {:?}; dropping its session, will retry",
+                            fab_idx.get(),
+                            peer_node_id,
+                            e
+                        );
+
+                        matter.with_state(|state| {
+                            if let Some(id) = state
+                                .sessions
+                                .get_for_node(fab_idx, peer_node_id)
+                                .map(|s| s.id)
+                            {
+                                state.sessions.remove(id);
+                            }
+                        });
+                        rctx.set_keep();
+                    }
                 }
             }
 
@@ -1021,8 +1047,13 @@ where
         matter: &Matter<'_>,
         rctx: &mut ReportContext<'_, '_, B, NS>,
     ) -> Result<bool, Error> {
+        // Route the report by the subscriber's `(fabric, node)` rather than a
+        // pinned session id: reuse the best live session to that peer, or (if
+        // the original one is gone) establish a fresh one. A subscription is
+        // identified by its id, not bound to the session it was accepted on.
+        let ids = rctx.subscription().ids();
         let mut exchange =
-            Exchange::initiate_for_session(matter, rctx.subscription().session_id())?;
+            Exchange::initiate(matter, self.crypto(), ids.fab_idx, ids.peer_node_id).await?;
 
         if let Some(mut tx) = self.buffers.get().await {
             // Always safe as `IMBuffer` is defined to be `MAX_EXCHANGE_RX_BUF_SIZE`, which is bigger than `MAX_EXCHANGE_TX_BUF_SIZE`

--- a/rs-matter/src/im/subscriptions.rs
+++ b/rs-matter/src/im/subscriptions.rs
@@ -1001,6 +1001,14 @@ impl Subscription {
     /// and a point infinitely in the past reads correctly as "always allowed"
     /// for every consumer (the boolean gate below and `next_report_at`).
     fn report_allowed_at(&self) -> Instant {
+        // Not yet primed: always allowed. This must be an explicit check, not a
+        // reliance on `checked_add` saturating — with `min_int_secs == 0` the add
+        // is `Instant::MAX + 0`, which does NOT overflow and would wrongly yield
+        // `Instant::MAX` ("never allowed").
+        if self.reported_at == Instant::MAX {
+            return Instant::MIN;
+        }
+
         self.reported_at
             .checked_add(embassy_time::Duration::from_secs(self.min_int_secs as _))
             .unwrap_or(Instant::MIN)
@@ -1022,6 +1030,12 @@ impl Subscription {
     /// fresh subscription is immediately due for its priming report (see
     /// [`Self::report_allowed_at`] for why `MIN` is the right sentinel).
     fn report_due_at(&self) -> Instant {
+        // Not yet primed: always due (explicit, for the same reason as
+        // `report_allowed_at`).
+        if self.reported_at == Instant::MAX {
+            return Instant::MIN;
+        }
+
         self.reported_at
             .checked_add(embassy_time::Duration::from_secs(
                 (self.max_int_secs - self.max_int_secs / 2) as _,

--- a/rs-matter/src/im/subscriptions.rs
+++ b/rs-matter/src/im/subscriptions.rs
@@ -439,12 +439,12 @@ impl<const N: usize> Subscriptions<N> {
 
     /// Persist the whole subscription table to `kv`, one record per key.
     ///
-    /// Each subscription is written under its own key (`PERSISTENT_SUBSCRIPTIONS_START
-    /// + slot`) so that no single value grows beyond one subscribe request, and any
-    /// keys past the current table length are removed. Rewriting the full range keeps
-    /// the on-disk set an exact mirror of the live table without a per-subscription
-    /// slot allocator; subscriptions change rarely, so the write amplification is
-    /// negligible.
+    /// Each subscription is written under its own key
+    /// (`PERSISTENT_SUBSCRIPTIONS_START + slot`) so that no single value grows
+    /// beyond one subscribe request, and any keys past the current table length
+    /// are removed. Rewriting the full range keeps the on-disk set an exact
+    /// mirror of the live table without a per-subscription slot allocator;
+    /// subscriptions change rarely, so the write amplification is negligible.
     ///
     /// Persistence is best-effort and spec-optional: a subscription whose record does
     /// not fit in `buf` is simply skipped (logged), not treated as an error.
@@ -1587,6 +1587,25 @@ where
     pub fn set_keep(&mut self) {
         self.keep = true;
     }
+
+    /// Keep the subscription in the table after a *failed* connection to the peer, so it retries,
+    /// but WITHOUT advancing its watermarks.
+    ///
+    /// [`Self::set_keep`] is only correct after a delivered report: `report()`
+    /// captured the current change/event watermarks into the context as "what this
+    /// report covers", and [`report_complete`](Subscriptions::report_complete)
+    /// commits them onto the subscription. If the report never reached the
+    /// subscriber, committing those watermarks would mark the still-unsent changes
+    /// and events as seen — they would then never be reported. This restores the
+    /// watermarks to the subscription's last actually-reported values so the
+    /// pending data is re-attempted on the next report.
+    pub fn set_keep_retry(&mut self) {
+        let sub = self.subscription();
+        let (attr, event) = (sub.max_seen_attr_change_id, sub.max_seen_event_number);
+        self.next_max_seen_attr_change_id = attr;
+        self.next_max_seen_event_number = event;
+        self.keep = true;
+    }
 }
 
 impl<'a, 's, B, const N: usize> Drop for ReportContext<'a, 's, B, N>
@@ -2274,6 +2293,82 @@ mod tests {
         // change, so only the new (1, 2, 4) is pending.
         assert!(!rctx.should_report_attr(1, 2, 3));
         assert!(rctx.should_report_attr(1, 2, 4));
+    }
+
+    /// A failed report (`set_failed`) keeps the subscription but must NOT advance
+    /// its watermark, so the changes it was carrying stay pending and are
+    /// re-attempted on the next report. Contrast with `set_keep`, which commits
+    /// the advanced watermark (correct only after a *delivered* report).
+    #[test]
+    fn failed_report_preserves_pending_changes() {
+        let subs: Subscriptions<2> = Subscriptions::new();
+        let pool = TestPool::<3>::new();
+        let subs_bufs: SubscriptionsBuffers<TestPool<3>, 2> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+
+        // Prime the subscription (delivered) so it is a normal, non-priming entry.
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 60);
+            rctx.set_keep();
+        }
+
+        // A change becomes pending.
+        subs.notify_attr_changed(1, 2, 3);
+
+        let later = now + Duration::from_secs(2);
+
+        // First report attempt FAILS: the report was carrying (1, 2, 3) but never
+        // reached the subscriber.
+        {
+            let mut rctx = subs.report(later, 0, &subs_bufs).unwrap();
+            assert!(rctx.should_report_attr(1, 2, 3), "change is pending");
+            rctx.set_keep_retry();
+        }
+
+        // Because the failed report did not advance the watermark, (1, 2, 3) is
+        // STILL pending on the next report — no silent data loss.
+        let later2 = later + Duration::from_secs(2);
+        {
+            let rctx = subs.report(later2, 0, &subs_bufs).unwrap();
+            assert!(
+                rctx.should_report_attr(1, 2, 3),
+                "a failed report must not consume the pending change"
+            );
+        }
+    }
+
+    /// The success counterpart: `set_keep` after a delivered report DOES advance
+    /// the watermark, so the same change is not reported again.
+    #[test]
+    fn delivered_report_consumes_pending_changes() {
+        let subs: Subscriptions<2> = Subscriptions::new();
+        let pool = TestPool::<3>::new();
+        let subs_bufs: SubscriptionsBuffers<TestPool<3>, 2> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 60);
+            rctx.set_keep();
+        }
+
+        subs.notify_attr_changed(1, 2, 3);
+
+        let later = now + Duration::from_secs(2);
+        {
+            let mut rctx = subs.report(later, 0, &subs_bufs).unwrap();
+            assert!(rctx.should_report_attr(1, 2, 3));
+            rctx.set_keep(); // delivered
+        }
+
+        // The change was consumed by the delivered report and the liveness
+        // deadline is not yet reached, so there is nothing left to report.
+        let later2 = later + Duration::from_secs(2);
+        assert!(
+            subs.report(later2, 0, &subs_bufs).is_none(),
+            "a delivered report consumes the pending change"
+        );
     }
 
     // The following tests cover the public API of `Subscriptions` /

--- a/rs-matter/src/im/subscriptions.rs
+++ b/rs-matter/src/im/subscriptions.rs
@@ -19,12 +19,15 @@ use core::num::NonZeroU8;
 
 use embassy_time::Instant;
 
+use crate::error::Error;
 use crate::fabric::MAX_FABRICS;
 use crate::im::{AttrId, ClusterId, EndptId, EventId, EventNumber, IMBuffer, NodeId};
+use crate::persist::{KvBlobStore, PERSISTENT_SUBSCRIPTIONS_START};
+use crate::tlv::{FromTLV, OctetStr, Octets, TLVElement, TLVTag, ToTLV};
 use crate::utils::cell::RefCell;
 use crate::utils::init::{init, Init};
 use crate::utils::storage::pooled::Buffers;
-use crate::utils::storage::Vec;
+use crate::utils::storage::{Vec, WriteBuf};
 use crate::utils::sync::blocking::Mutex;
 use crate::utils::sync::{DynBase, Notification};
 
@@ -180,8 +183,14 @@ impl<const N: usize> Subscriptions<N> {
         self.notification.notify();
     }
 
-    /// Whether an active subscription exists on `fab_idx` whose subscriber node
+    /// Whether a live subscription exists on `fab_idx` whose subscriber node
     /// matches `node_id`.
+    ///
+    /// This is the ICD "is this client subscribed?" predicate that decides
+    /// whether a registered client is nudged with a Check-In. Persisted
+    /// subscriptions are re-hydrated into this same table at startup
+    /// (`resume_subscriptions`), so a resumed subscription counts here too — no
+    /// separate "persisted subscription" lookup is needed.
     pub fn has_subscription_for(&self, fab_idx: NonZeroU8, node_id: NodeId) -> bool {
         self.state.lock(|internal| {
             internal
@@ -236,7 +245,6 @@ impl<const N: usize> Subscriptions<N> {
         now: Instant,
         fabric_idx: NonZeroU8,
         peer_node_id: u64,
-        session_id: u32,
         min_int_secs: u16,
         max_int_secs: u16,
         event_numbers_watermark: EventNumber,
@@ -250,7 +258,6 @@ impl<const N: usize> Subscriptions<N> {
             let (sub, buf) = state.add::<B>(
                 fabric_idx,
                 peer_node_id,
-                session_id,
                 min_int_secs,
                 max_int_secs,
                 buffer,
@@ -406,6 +413,164 @@ impl<const N: usize> Subscriptions<N> {
             .lock(|state| state.borrow_mut().purge_reported_changes())
     }
 
+    /// Persist the whole subscription table to `kv`, one record per key.
+    ///
+    /// Each subscription is written under its own key (`PERSISTENT_SUBSCRIPTIONS_START
+    /// + slot`) so that no single value grows beyond one subscribe request, and any
+    /// keys past the current table length are removed. Rewriting the full range keeps
+    /// the on-disk set an exact mirror of the live table without a per-subscription
+    /// slot allocator; subscriptions change rarely, so the write amplification is
+    /// negligible.
+    ///
+    /// Persistence is best-effort and spec-optional: a subscription whose record does
+    /// not fit in `buf` is simply skipped (logged), not treated as an error.
+    pub(crate) fn persist_all<'a, B, S>(
+        &self,
+        buffers: &SubscriptionsBuffers<'a, B, N>,
+        mut kv: S,
+        buf: &mut [u8],
+    ) -> Result<(), Error>
+    where
+        B: Buffers<IMBuffer> + 'a,
+        S: KvBlobStore,
+    {
+        self.with(buffers, |state, buffers| {
+            for (slot, (sub, rx)) in state
+                .subscriptions
+                .iter()
+                .zip(buffers.iter())
+                .take(N)
+                .enumerate()
+            {
+                let key = PERSISTENT_SUBSCRIPTIONS_START + slot as u16;
+
+                let record = PersistedSubscription {
+                    fab_idx: sub.ids.fab_idx,
+                    peer_node_id: sub.ids.peer_node_id,
+                    min_int_secs: sub.min_int_secs,
+                    max_int_secs: sub.max_int_secs,
+                    subscribe_req: Octets(rx.as_ref()),
+                };
+
+                // Serialize into the front of `buf`, leaving the tail as the store's
+                // scratch (mirrors `Persist::store`). If it does not fit, skip it —
+                // persisting is optional, so a too-large subscription is simply not
+                // resumable across a reboot.
+                let mut wb = WriteBuf::new(buf);
+                if record.to_tlv(&TLVTag::Anonymous, &mut wb).is_err() {
+                    warn!(
+                        "Subscription {:?} too large to persist; skipping",
+                        sub.ids()
+                    );
+                    continue;
+                }
+
+                let len = wb.get_tail();
+                let (data, scratch) = buf.split_at_mut(len);
+                kv.store(key, data, scratch)?;
+            }
+
+            // Drop the tail keys that a now-shorter table no longer occupies.
+            for slot in state.subscriptions.len()..N {
+                let key = PERSISTENT_SUBSCRIPTIONS_START + slot as u16;
+                kv.remove(key, buf)?;
+            }
+
+            Ok(())
+        })
+    }
+
+    /// Re-hydrate the subscription table from `kv`, replaying each persisted record
+    /// through [`Self::add`] exactly as if the subscribe request had just arrived.
+    ///
+    /// The reloaded subscriptions are NOT primed here (no session exists yet at
+    /// boot): they enter the table already "reported once" so the reporter treats
+    /// them as live and either reports on the next change or drives the liveness
+    /// deadline, re-establishing a session on demand. A record that cannot be
+    /// re-added (e.g. no free buffer) is skipped.
+    pub(crate) fn load_persist<'a, 's, B, S>(
+        &'s self,
+        pool: &'a B,
+        buffers: &'s SubscriptionsBuffers<'a, B, N>,
+        mut kv: S,
+        buf: &mut [u8],
+        now: Instant,
+        event_numbers_watermark: EventNumber,
+    ) -> Result<(), Error>
+    where
+        'a: 's,
+        B: Buffers<IMBuffer> + 'a,
+        S: KvBlobStore,
+    {
+        for slot in 0..N {
+            let key = PERSISTENT_SUBSCRIPTIONS_START + slot as u16;
+
+            let Some(data) = kv.load(key, buf)? else {
+                // The range is contiguous: the first empty slot ends the set.
+                break;
+            };
+
+            let record = PersistedSubscription::from_tlv(&TLVElement::new(data))?;
+
+            let Some(mut rx) = pool.get_immediate() else {
+                warn!("No free buffer to resume a persisted subscription; skipping");
+                continue;
+            };
+            rx.clear();
+            if rx.extend_from_slice(record.subscribe_req.0).is_err() {
+                warn!("Persisted subscription too large for an RX buffer; skipping");
+                continue;
+            }
+
+            let added = self.add(
+                now,
+                record.fab_idx,
+                record.peer_node_id,
+                record.min_int_secs,
+                record.max_int_secs,
+                event_numbers_watermark,
+                rx,
+                buffers,
+            );
+
+            match added {
+                Some(mut rctx) => {
+                    // Commit it into the table and keep it. `add` already stamped
+                    // the report context's `reported_at` with `now`, so on commit
+                    // the subscription is a live, already-reported (non-priming)
+                    // entry: the liveness clock runs from `now` and only future
+                    // changes are reported — no priming report is emitted here (no
+                    // session exists yet at boot).
+                    rctx.set_keep();
+                    info!(
+                        "Resumed persisted subscription {:?}",
+                        rctx.subscription().ids()
+                    );
+                }
+                None => {
+                    warn!("Subscription table full while resuming; dropping a persisted record")
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Remove every persisted subscription record from `kv`.
+    ///
+    /// Used on a factory reset, and to clear the range before it is re-hydrated.
+    pub(crate) fn reset_persist<S>(&self, mut kv: S, buf: &mut [u8]) -> Result<(), Error>
+    where
+        S: KvBlobStore,
+    {
+        for slot in 0..N {
+            let key = PERSISTENT_SUBSCRIPTIONS_START + slot as u16;
+            kv.remove(key, buf)?;
+        }
+
+        Ok(())
+    }
+
     /// Complete a report by updating the subscription's watermark and last-reported timestamp,
     /// and re-inserting it into the table if the `keep` flag is set on the context.
     fn report_complete<'a, B>(&self, report: &mut ReportContext<'a, '_, B, N>)
@@ -526,7 +691,6 @@ impl<const N: usize> SubscriptionsInner<N> {
         &mut self,
         fab_idx: NonZeroU8,
         peer_node_id: u64,
-        session_id: u32,
         min_int_secs: u16,
         max_int_secs: u16,
         buffer: B::Buffer<'a>,
@@ -554,7 +718,6 @@ impl<const N: usize> SubscriptionsInner<N> {
                 fab_idx,
                 peer_node_id,
             },
-            session_id,
             min_int_secs,
             max_int_secs,
             reported_at: Instant::MAX,
@@ -715,17 +878,32 @@ pub struct SubscriptionIds {
     pub peer_node_id: NodeId,
 }
 
+/// The on-disk form of a single subscription.
+///
+/// One record is stored per subscription under its own key (see
+/// [`PERSISTENT_SUBSCRIPTIONS_START`]), so the value never grows beyond a single
+/// subscribe request. Everything the reporter needs to resume the subscription
+/// is captured here: the routing `(fab_idx, peer_node_id)`, the negotiated
+/// intervals, and the raw `SubscribeReq` TLV — the same bytes the live
+/// subscription keeps in its RX buffer and re-parses on every report, so no
+/// separate path list is serialized.
+#[derive(Debug, FromTLV, ToTLV)]
+#[tlvargs(lifetime = "'a")]
+struct PersistedSubscription<'a> {
+    fab_idx: NonZeroU8,
+    peer_node_id: NodeId,
+    min_int_secs: u16,
+    max_int_secs: u16,
+    /// The raw `SubscribeReq` TLV that created this subscription (its selected
+    /// attribute/event paths and fabric-filtered flag live inside it).
+    subscribe_req: OctetStr<'a>,
+}
+
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Subscription {
     /// The IDs of the subscription
     ids: SubscriptionIds,
-    /// The ID of the session on which the subscription was accepted. Used by
-    /// the reporter task to route outgoing reports back to the exact session
-    /// the subscriber established, rather than picking any secure session
-    /// matching `(fab_idx, peer_node_id)` (which may not be the one the peer
-    /// is actually listening on, breaking at least HomeKit and chip-tool).
-    session_id: u32,
     /// The minimum interval in seconds. The subscription should not receive reports more frequently than this interval, but may receive them less frequently.
     /// We use u16 instead of embassy::Duration to save some storage
     min_int_secs: u16,
@@ -746,11 +924,6 @@ impl Subscription {
     /// Return the IDs of the subscription.
     pub const fn ids(&self) -> &SubscriptionIds {
         &self.ids
-    }
-
-    /// Return the session ID on which this subscription was accepted.
-    pub const fn session_id(&self) -> u32 {
-        self.session_id
     }
 
     /// Return `true` if the subscription is expired and should be removed, or `false` if it is still active.
@@ -1964,7 +2137,6 @@ mod tests {
                 now,
                 fab(1),
                 10,
-                100,
                 1,
                 60,
                 0,
@@ -1977,7 +2149,6 @@ mod tests {
                 now,
                 fab(1),
                 10,
-                100,
                 1,
                 60,
                 0,
@@ -1994,7 +2165,6 @@ mod tests {
                 now,
                 fab(1),
                 10,
-                100,
                 1,
                 60,
                 0,
@@ -2019,7 +2189,6 @@ mod tests {
                     now,
                     fab(1),
                     10,
-                    100,
                     1,
                     60,
                     0,
@@ -2086,7 +2255,6 @@ mod tests {
             now,
             fab(fab_idx),
             peer_node_id,
-            /* session_id */ 0,
             min_int,
             max_int,
             /* event_numbers_watermark */ 0,
@@ -2479,7 +2647,6 @@ mod tests {
                 now,
                 fab(1),
                 200,
-                0,
                 1,
                 60,
                 0,
@@ -2519,7 +2686,6 @@ mod tests {
                 now,
                 fab(3),
                 302,
-                0,
                 1,
                 60,
                 0,
@@ -2733,5 +2899,218 @@ mod tests {
             assert_eq!(rctx.next_max_seen_event_number(), 42);
             rctx.set_keep();
         }
+    }
+
+    // ---------- persistence ----------
+
+    /// A minimal multi-key in-memory store, enough to test the
+    /// one-record-per-key subscription persist/reload roundtrip.
+    #[derive(Default)]
+    struct MemKv {
+        blobs: std::collections::HashMap<u16, std::vec::Vec<u8>>,
+    }
+
+    impl KvBlobStore for &mut MemKv {
+        fn load<'a>(&mut self, key: u16, buf: &'a mut [u8]) -> Result<Option<&'a [u8]>, Error> {
+            Ok(self.blobs.get(&key).map(|v| {
+                buf[..v.len()].copy_from_slice(v);
+                &buf[..v.len()]
+            }))
+        }
+
+        fn store(&mut self, key: u16, data: &[u8], _buf: &mut [u8]) -> Result<(), Error> {
+            self.blobs.insert(key, data.to_vec());
+            Ok(())
+        }
+
+        fn remove(&mut self, key: u16, _buf: &mut [u8]) -> Result<(), Error> {
+            self.blobs.remove(&key);
+            Ok(())
+        }
+    }
+
+    /// Add a subscription whose RX buffer carries `req` (standing in for a raw
+    /// `SubscribeReq` TLV), and commit it into the table.
+    #[allow(clippy::too_many_arguments)]
+    fn add_sub_with_req<'a, 's, const N: usize, const B: usize>(
+        subs: &'s Subscriptions<N>,
+        subs_bufs: &'s SubscriptionsBuffers<'a, TestPool<B>, N>,
+        pool: &'a TestPool<B>,
+        now: Instant,
+        fab_idx: u8,
+        peer_node_id: u64,
+        min_int: u16,
+        max_int: u16,
+        req: &[u8],
+    ) where
+        'a: 's,
+    {
+        let mut rx = pool.get_immediate().unwrap();
+        rx.clear();
+        rx.extend_from_slice(req).unwrap();
+
+        let mut rctx = subs
+            .add(
+                now,
+                fab(fab_idx),
+                peer_node_id,
+                min_int,
+                max_int,
+                0,
+                rx,
+                subs_bufs,
+            )
+            .unwrap();
+        // Commit it as a live subscription (`add` already stamped `reported_at`
+        // with `now`, so this is a non-priming entry once kept).
+        rctx.set_keep();
+    }
+
+    /// A subscription persisted by one `Subscriptions` instance is faithfully
+    /// re-hydrated — routing IDs, intervals, and the raw request bytes — into a
+    /// fresh instance, exactly as a reboot would.
+    #[test]
+    fn persist_reload_roundtrip() {
+        let mut kv = MemKv::default();
+        let now = Instant::now();
+
+        // --- First "boot": build a table and persist it. ---
+        {
+            let subs: Subscriptions<4> = Subscriptions::new();
+            let pool = TestPool::<5>::new();
+            let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+
+            add_sub_with_req(
+                &subs,
+                &subs_bufs,
+                &pool,
+                now,
+                1,
+                0xAABB,
+                1,
+                60,
+                &[1, 2, 3, 4],
+            );
+            add_sub_with_req(&subs, &subs_bufs, &pool, now, 2, 0xCCDD, 0, 120, &[9, 8, 7]);
+
+            let mut buf = [0u8; 512];
+            subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
+        }
+
+        // Two records written; the rest of the reserved range is empty.
+        assert!(kv.blobs.contains_key(&PERSISTENT_SUBSCRIPTIONS_START));
+        assert!(kv.blobs.contains_key(&(PERSISTENT_SUBSCRIPTIONS_START + 1)));
+        assert!(!kv.blobs.contains_key(&(PERSISTENT_SUBSCRIPTIONS_START + 2)));
+
+        // --- Second "boot": a fresh, empty table reloads from the same store. ---
+        let subs2: Subscriptions<4> = Subscriptions::new();
+        let pool2 = TestPool::<5>::new();
+        let subs_bufs2: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+
+        let mut buf = [0u8; 512];
+        subs2
+            .load_persist(&pool2, &subs_bufs2, &mut kv, &mut buf, now, 0)
+            .unwrap();
+
+        // Both subscriptions are back, with their routing + intervals intact...
+        subs2.state.lock(|s| {
+            let s = s.borrow();
+            assert_eq!(s.subscriptions.len(), 2);
+
+            let a = s
+                .subscriptions
+                .iter()
+                .find(|x| x.ids.peer_node_id == 0xAABB)
+                .expect("first sub resumed");
+            assert_eq!(a.ids.fab_idx, fab(1));
+            assert_eq!(a.min_int_secs, 1);
+            assert_eq!(a.max_int_secs, 60);
+
+            let b = s
+                .subscriptions
+                .iter()
+                .find(|x| x.ids.peer_node_id == 0xCCDD)
+                .expect("second sub resumed");
+            assert_eq!(b.ids.fab_idx, fab(2));
+            assert_eq!(b.min_int_secs, 0);
+            assert_eq!(b.max_int_secs, 120);
+        });
+
+        // ...and the raw request bytes survived (they live in the parallel buffer
+        // pool, indexed alongside the subscriptions).
+        subs_bufs2.with(|bufs| {
+            let mut reqs: std::vec::Vec<std::vec::Vec<u8>> =
+                bufs.iter().map(|b| b[..].to_vec()).collect();
+            reqs.sort();
+            assert_eq!(reqs, std::vec![std::vec![1, 2, 3, 4], std::vec![9, 8, 7]]);
+        });
+
+        // The ICD predicate now sees the resumed subscriptions.
+        assert!(subs2.has_subscription_for(fab(1), 0xAABB));
+        assert!(subs2.has_subscription_for(fab(2), 0xCCDD));
+        assert!(!subs2.has_subscription_for(fab(1), 0x9999));
+    }
+
+    /// Removing a subscription and re-persisting drops exactly its record from
+    /// the store (the table stays an exact mirror of what is on disk).
+    #[test]
+    fn persist_mirrors_removal() {
+        let mut kv = MemKv::default();
+        let now = Instant::now();
+
+        let subs: Subscriptions<4> = Subscriptions::new();
+        let pool = TestPool::<5>::new();
+        let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+
+        add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 100, 1, 60, &[1]);
+        add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 101, 1, 60, &[2]);
+        add_sub_with_req(&subs, &subs_bufs, &pool, now, 2, 102, 1, 60, &[3]);
+
+        let mut buf = [0u8; 512];
+        subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
+        assert_eq!(kv.blobs.len(), 3);
+
+        // Drop the two fab(1) subscriptions and re-persist.
+        subs.remove(&subs_bufs, |sub| {
+            (sub.ids().fab_idx == fab(1)).then_some("fabric 1 removed")
+        });
+        subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
+
+        // Only the single surviving record remains on disk.
+        assert_eq!(kv.blobs.len(), 1);
+
+        // And a fresh reload sees exactly that one.
+        let subs2: Subscriptions<4> = Subscriptions::new();
+        let pool2 = TestPool::<5>::new();
+        let subs_bufs2: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+        subs2
+            .load_persist(&pool2, &subs_bufs2, &mut kv, &mut buf, now, 0)
+            .unwrap();
+        subs2.state.lock(|s| {
+            let s = s.borrow();
+            assert_eq!(s.subscriptions.len(), 1);
+            assert_eq!(s.subscriptions[0].ids.peer_node_id, 102);
+        });
+    }
+
+    /// `reset_persist` wipes the whole reserved range.
+    #[test]
+    fn reset_persist_clears_all_records() {
+        let mut kv = MemKv::default();
+        let now = Instant::now();
+
+        let subs: Subscriptions<4> = Subscriptions::new();
+        let pool = TestPool::<5>::new();
+        let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+
+        add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 100, 1, 60, &[1]);
+        add_sub_with_req(&subs, &subs_bufs, &pool, now, 2, 101, 1, 60, &[2]);
+
+        let mut buf = [0u8; 512];
+        subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
+        assert_eq!(kv.blobs.len(), 2);
+
+        subs.reset_persist(&mut kv, &mut buf).unwrap();
+        assert!(kv.blobs.is_empty());
     }
 }

--- a/rs-matter/src/im/subscriptions.rs
+++ b/rs-matter/src/im/subscriptions.rs
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+use core::cell::Cell;
 use core::num::NonZeroU8;
 
 use embassy_time::Instant;
@@ -105,6 +106,12 @@ type SubscriptionsBuffersInner<'a, B, const N: usize> =
 /// Additional subscriptions are rejected by the data model with a "resource exhausted" IM status message.
 pub struct Subscriptions<const N: usize = DEFAULT_MAX_SUBSCRIPTIONS> {
     state: Mutex<RefCell<SubscriptionsInner<N>>>,
+    /// Whether accepted subscriptions are persisted to (and resumed from) the
+    /// key-value store. Off by default (opt-in): persisting subscriptions is
+    /// spec-optional and adds flash writes, so the application enables it only
+    /// when it wants subscriptions to survive a reboot (e.g. a long-idle ICD).
+    /// Set once at startup via [`Subscriptions::set_persist`].
+    persist: Mutex<Cell<bool>>,
     pub(crate) notification: Notification,
 }
 
@@ -114,6 +121,7 @@ impl<const N: usize> Subscriptions<N> {
     pub const fn new() -> Self {
         Self {
             state: Mutex::new(RefCell::new(SubscriptionsInner::new())),
+            persist: Mutex::new(Cell::new(false)),
             notification: Notification::new(),
         }
     }
@@ -122,8 +130,24 @@ impl<const N: usize> Subscriptions<N> {
     pub fn init() -> impl Init<Self> {
         init!(Self {
             state <- Mutex::init(RefCell::init(SubscriptionsInner::init())),
+            persist: Mutex::new(Cell::new(false)),
             notification: Notification::new(),
         })
+    }
+
+    /// Enable or disable persistence of subscriptions (off by default).
+    ///
+    /// When disabled, [`Self::persist_all`], [`Self::load_persist`] and
+    /// [`Self::reset_persist`] are no-ops, so accepted subscriptions live only in
+    /// memory and do not survive a reboot. Call once at startup, before the data
+    /// model starts accepting traffic.
+    pub fn set_persist(&self, enabled: bool) {
+        self.persist.lock(|p| p.set(enabled));
+    }
+
+    /// Whether subscription persistence is currently enabled.
+    pub fn persist_enabled(&self) -> bool {
+        self.persist.lock(|p| p.get())
     }
 
     /// Notify the instance that the data of a specific attribute has changed and that it should re-evaluate the subscriptions
@@ -434,6 +458,10 @@ impl<const N: usize> Subscriptions<N> {
         B: Buffers<IMBuffer> + 'a,
         S: KvBlobStore,
     {
+        if !self.persist_enabled() {
+            return Ok(());
+        }
+
         self.with(buffers, |state, buffers| {
             for (slot, (sub, rx)) in state
                 .subscriptions
@@ -483,11 +511,11 @@ impl<const N: usize> Subscriptions<N> {
     /// Re-hydrate the subscription table from `kv`, replaying each persisted record
     /// through [`Self::add`] exactly as if the subscribe request had just arrived.
     ///
-    /// The reloaded subscriptions are NOT primed here (no session exists yet at
-    /// boot): they enter the table already "reported once" so the reporter treats
-    /// them as live and either reports on the next change or drives the liveness
-    /// deadline, re-establishing a session on demand. A record that cannot be
-    /// re-added (e.g. no free buffer) is skipped.
+    /// Each reloaded subscription enters the table un-primed, so the reporter sends
+    /// it a prompt priming report (establishing a session on demand) rather than
+    /// waiting toward its max-interval deadline — see the priming note in the body
+    /// for why that timing matters. A record that cannot be re-added (e.g. no free
+    /// buffer) is skipped. A no-op when persistence is disabled.
     pub(crate) fn load_persist<'a, 's, B, S>(
         &'s self,
         pool: &'a B,
@@ -502,6 +530,10 @@ impl<const N: usize> Subscriptions<N> {
         B: Buffers<IMBuffer> + 'a,
         S: KvBlobStore,
     {
+        if !self.persist_enabled() {
+            return Ok(());
+        }
+
         for slot in 0..N {
             let key = PERSISTENT_SUBSCRIPTIONS_START + slot as u16;
 
@@ -2987,6 +3019,7 @@ mod tests {
         // --- First "boot": build a table and persist it. ---
         {
             let subs: Subscriptions<4> = Subscriptions::new();
+            subs.set_persist(true);
             let pool = TestPool::<5>::new();
             let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
 
@@ -3014,6 +3047,7 @@ mod tests {
 
         // --- Second "boot": a fresh, empty table reloads from the same store. ---
         let subs2: Subscriptions<4> = Subscriptions::new();
+        subs2.set_persist(true);
         let pool2 = TestPool::<5>::new();
         let subs_bufs2: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
 
@@ -3082,6 +3116,7 @@ mod tests {
         let now = Instant::now();
 
         let subs: Subscriptions<4> = Subscriptions::new();
+        subs.set_persist(true);
         let pool = TestPool::<5>::new();
         let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
 
@@ -3104,6 +3139,7 @@ mod tests {
 
         // And a fresh reload sees exactly that one.
         let subs2: Subscriptions<4> = Subscriptions::new();
+        subs2.set_persist(true);
         let pool2 = TestPool::<5>::new();
         let subs_bufs2: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
         subs2
@@ -3123,6 +3159,7 @@ mod tests {
         let now = Instant::now();
 
         let subs: Subscriptions<4> = Subscriptions::new();
+        subs.set_persist(true);
         let pool = TestPool::<5>::new();
         let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
 
@@ -3135,5 +3172,40 @@ mod tests {
 
         subs.reset_persist(&mut kv, &mut buf).unwrap();
         assert!(kv.blobs.is_empty());
+    }
+
+    /// With persistence disabled (the default), `persist_all` and `load_persist`
+    /// are no-ops: nothing is written and nothing is resumed.
+    #[test]
+    fn persistence_off_by_default_is_a_noop() {
+        let mut kv = MemKv::default();
+        let now = Instant::now();
+
+        let subs: Subscriptions<4> = Subscriptions::new();
+        assert!(!subs.persist_enabled(), "persistence must default to off");
+
+        let pool = TestPool::<5>::new();
+        let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+
+        add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 100, 1, 60, &[1]);
+
+        // persist_all writes nothing while disabled.
+        let mut buf = [0u8; 512];
+        subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
+        assert!(kv.blobs.is_empty());
+
+        // Even with a record planted directly in the store, a disabled instance
+        // resumes nothing.
+        kv.blobs
+            .insert(PERSISTENT_SUBSCRIPTIONS_START, std::vec![0; 8]);
+        let subs2: Subscriptions<4> = Subscriptions::new();
+        let pool2 = TestPool::<5>::new();
+        let subs_bufs2: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+        subs2
+            .load_persist(&pool2, &subs_bufs2, &mut kv, &mut buf, now, 0)
+            .unwrap();
+        subs2
+            .state
+            .lock(|s| assert_eq!(s.borrow().subscriptions.len(), 0));
     }
 }

--- a/rs-matter/src/im/subscriptions.rs
+++ b/rs-matter/src/im/subscriptions.rs
@@ -535,12 +535,22 @@ impl<const N: usize> Subscriptions<N> {
 
             match added {
                 Some(mut rctx) => {
-                    // Commit it into the table and keep it. `add` already stamped
-                    // the report context's `reported_at` with `now`, so on commit
-                    // the subscription is a live, already-reported (non-priming)
-                    // entry: the liveness clock runs from `now` and only future
-                    // changes are reported — no priming report is emitted here (no
-                    // session exists yet at boot).
+                    // Commit it into the table as an un-primed subscription so the
+                    // reporter sends a full priming report to the subscriber right
+                    // away (establishing a session on demand), rather than staying
+                    // silent until the max-interval liveness point.
+                    //
+                    // This is essential, not cosmetic: the *subscriber* measures its
+                    // own liveness timeout from the last report IT received, not from
+                    // our reboot. If we waited toward our own max-interval deadline,
+                    // the subscriber — whose clock has been running the whole time we
+                    // were down — could already have torn the subscription down. A
+                    // prompt priming report resets the subscriber's liveness clock and
+                    // re-syncs the state it missed while we were away.
+                    //
+                    // Leaving `reported_at` at the `Instant::MAX` priming sentinel
+                    // (rather than stamping it with `now`) is what marks it un-primed.
+                    rctx.next_reported_at = Instant::MAX;
                     rctx.set_keep();
                     info!(
                         "Resumed persisted subscription {:?}",
@@ -3034,6 +3044,19 @@ mod tests {
             assert_eq!(b.ids.fab_idx, fab(2));
             assert_eq!(b.min_int_secs, 0);
             assert_eq!(b.max_int_secs, 120);
+
+            // Resumed subscriptions must be un-primed so the reporter sends a
+            // prompt priming report (resetting the subscriber's own liveness
+            // clock before it can time the subscription out), NOT wait toward
+            // our max-interval deadline.
+            for sub in s.subscriptions.iter() {
+                assert!(
+                    sub.is_report_due(now),
+                    "resumed sub {:?} should be immediately report-due (primed)",
+                    sub.ids()
+                );
+                assert!(sub.is_report_due(now + Duration::from_secs(1)));
+            }
         });
 
         // ...and the raw request bytes survived (they live in the parallel buffer

--- a/rs-matter/src/persist.rs
+++ b/rs-matter/src/persist.rs
@@ -127,6 +127,16 @@ pub const ICD_CHECK_IN_COUNTER_KEY: u16 = ICD_REGISTERED_CLIENTS_KEY + 1;
 /// in-memory cache diverges from what was last written.
 pub const CASE_RESUMPTION_KEY: u16 = ICD_CHECK_IN_COUNTER_KEY + 1;
 
+/// The first key of the range reserved for persisted subscriptions.
+///
+/// Each persisted subscription occupies its own key (`PERSISTENT_SUBSCRIPTIONS_START
+/// + slot`), so that a single record never grows the value beyond one subscribe
+/// request (already bounded to one RX packet, comfortably under the ~4 KiB
+/// per-value cap that some MCU key-value backends impose). The range runs up to
+/// (but not including) [`VENDOR_KEYS_START`], which leaves room for far more slots
+/// than any practical `Subscriptions<N>` table.
+pub const PERSISTENT_SUBSCRIPTIONS_START: u16 = CASE_RESUMPTION_KEY + 1;
+
 /// A trait representing a key-value BLOB storage.
 ///
 /// NOTE: For now, the trait is deliberately modeled as non-async, so that it can be used from

--- a/rs-matter/src/persist.rs
+++ b/rs-matter/src/persist.rs
@@ -129,12 +129,12 @@ pub const CASE_RESUMPTION_KEY: u16 = ICD_CHECK_IN_COUNTER_KEY + 1;
 
 /// The first key of the range reserved for persisted subscriptions.
 ///
-/// Each persisted subscription occupies its own key (`PERSISTENT_SUBSCRIPTIONS_START
-/// + slot`), so that a single record never grows the value beyond one subscribe
-/// request (already bounded to one RX packet, comfortably under the ~4 KiB
-/// per-value cap that some MCU key-value backends impose). The range runs up to
-/// (but not including) [`VENDOR_KEYS_START`], which leaves room for far more slots
-/// than any practical `Subscriptions<N>` table.
+/// Each persisted subscription occupies its own key
+/// (`PERSISTENT_SUBSCRIPTIONS_START + slot`), so that a single record never grows
+/// the value beyond one subscribe request (already bounded to one RX packet,
+/// comfortably under the ~4 KiB per-value cap that some MCU key-value backends
+/// impose). The range runs up to (but not including) [`VENDOR_KEYS_START`], which
+/// leaves room for far more slots than any practical `Subscriptions<N>` table.
 pub const PERSISTENT_SUBSCRIPTIONS_START: u16 = CASE_RESUMPTION_KEY + 1;
 
 /// A trait representing a key-value BLOB storage.

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -1433,12 +1433,17 @@ impl Sessions {
         // limits) over UDP when both are available for the same peer. This
         // is required e.g. for the WebRTC Transport Provider's outbound
         // `Answer(sdp)` invoke whose payload can easily exceed a UDP MTU.
+        //
+        // Among sessions of the same transport, prefer the most recently used
+        // one: when several CASE sessions to the same peer exist, the freshest
+        // is the one the peer is actually communicating on, so reports and other
+        // outbound traffic reach the session it is listening on.
         let idx = self
             .sessions
             .iter()
             .enumerate()
             .filter(|(_, s)| !s.expired && s.is_for_node(fabric_idx, peer_node_id))
-            .max_by_key(|(_, s)| i32::from(s.peer_addr.is_tcp()))
+            .max_by_key(|(_, s)| (s.peer_addr.is_tcp(), s.last_use))
             .map(|(i, _)| i)?;
 
         let session = &mut self.sessions[idx];

--- a/rs-matter/tests/common/e2e.rs
+++ b/rs-matter/tests/common/e2e.rs
@@ -29,7 +29,7 @@ use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::{DataModel, Privilege};
 use rs_matter::error::Error;
 use rs_matter::im::{InteractionModel, InteractionModelState};
-use rs_matter::persist::DummyKvBlobStore;
+use rs_matter::persist::{DummyKvBlobStore, KvBlobStore};
 use rs_matter::respond::{ExchangeHandler, Responder};
 use rs_matter::transport::exchange::Exchange;
 use rs_matter::transport::exchange::MatterBuffers;
@@ -164,6 +164,30 @@ impl<C: Crypto> E2eRunner<C> {
     where
         H: DataModel,
     {
+        self.run_with(handler, &self.state, DummyKvBlobStore, false)
+            .await
+    }
+
+    /// Like [`run`](Self::run), but drives the remote (tested) data model over
+    /// an explicit [`InteractionModelState`] and key-value store, and optionally
+    /// resumes persisted subscriptions before serving traffic.
+    ///
+    /// This is what makes a reboot testable: run once to establish + persist a
+    /// subscription (into a retained `kv`), then run again with a *fresh* state
+    /// and `resume = true` over the *same* `kv` to re-hydrate it — the moral
+    /// equivalent of the device restarting with its storage intact.
+    pub async fn run_with<H, S, K, const NS: usize, const NE: usize>(
+        &self,
+        handler: H,
+        state: &InteractionModelState<S, NS, NE>,
+        kv_store: K,
+        resume: bool,
+    ) -> Result<(), Error>
+    where
+        H: DataModel,
+        S: rs_matter::dm::clusters::net_comm::Networks,
+        K: KvBlobStore,
+    {
         self.init()?;
 
         let mut buf1 = [heapless::Vec::new(); 1];
@@ -177,7 +201,7 @@ impl<C: Crypto> E2eRunner<C> {
 
         let matter_client = &self.matter_client;
 
-        let kv = self.matter.kv(DummyKvBlobStore);
+        let kv = self.matter.kv(kv_store);
 
         let dm = InteractionModel::new(
             &self.matter,
@@ -185,8 +209,12 @@ impl<C: Crypto> E2eRunner<C> {
             &self.buffers,
             handler,
             &kv,
-            &self.state,
+            state,
         );
+
+        if resume {
+            dm.resume_subscriptions()?;
+        }
 
         let responder = Responder::new_default(&dm);
 

--- a/rs-matter/tests/common/mod.rs
+++ b/rs-matter/tests/common/mod.rs
@@ -22,10 +22,51 @@ pub mod mdns;
 use core::future::Future;
 use core::pin::pin;
 
+use std::collections::HashMap;
+
 use embassy_futures::select::{select, Either};
 use embassy_time::{Duration, Timer};
 
 use rs_matter::error::Error;
+use rs_matter::persist::KvBlobStore;
+
+/// A simple in-memory multi-key [`KvBlobStore`] for tests.
+///
+/// Unlike [`rs_matter::persist::DummyKvBlobStore`] it actually retains what it
+/// stores, so a value written by one data-model incarnation can be read back by
+/// a later one — the moral equivalent of on-disk state surviving a reboot.
+#[derive(Default, Clone)]
+#[allow(unused)]
+pub struct MemKvBlobStore {
+    blobs: std::rc::Rc<std::cell::RefCell<HashMap<u16, std::vec::Vec<u8>>>>,
+}
+
+#[allow(unused)]
+impl MemKvBlobStore {
+    /// Whether a value is stored under `key`.
+    pub fn contains_key(&self, key: u16) -> bool {
+        self.blobs.borrow().contains_key(&key)
+    }
+}
+
+impl KvBlobStore for MemKvBlobStore {
+    fn load<'a>(&mut self, key: u16, buf: &'a mut [u8]) -> Result<Option<&'a [u8]>, Error> {
+        Ok(self.blobs.borrow().get(&key).map(|v| {
+            buf[..v.len()].copy_from_slice(v);
+            &buf[..v.len()]
+        }))
+    }
+
+    fn store(&mut self, key: u16, data: &[u8], _buf: &mut [u8]) -> Result<(), Error> {
+        self.blobs.borrow_mut().insert(key, data.to_vec());
+        Ok(())
+    }
+
+    fn remove(&mut self, key: u16, _buf: &mut [u8]) -> Result<(), Error> {
+        self.blobs.borrow_mut().remove(&key);
+        Ok(())
+    }
+}
 
 /// Drives a device future and a controller future concurrently.
 ///

--- a/rs-matter/tests/im/mod.rs
+++ b/rs-matter/tests/im/mod.rs
@@ -19,3 +19,4 @@ mod client_invokes;
 mod client_reads;
 mod client_subscribes;
 mod client_writes;
+mod subscription_reboot;

--- a/rs-matter/tests/im/subscription_reboot.rs
+++ b/rs-matter/tests/im/subscription_reboot.rs
@@ -1,0 +1,158 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! End-to-end proof of persistent subscriptions across a (simulated) reboot.
+//!
+//! A client subscribes to an attribute over CASE; the server persists the
+//! subscription to a retained key-value store. The server is then torn down and
+//! brought back up with a *fresh* subscription table but the *same* store — the
+//! moral equivalent of the device rebooting with its flash intact. On the second
+//! boot the server resumes the persisted subscription and, because a resumed
+//! subscription is re-primed, promptly drives a `ReportData` back to the client
+//! without the client having to re-subscribe.
+
+use embassy_futures::block_on;
+use embassy_futures::select::{select, Either};
+
+use rs_matter::im::client::{ImClient, SubscribeOutcome, TxOutcome};
+use rs_matter::im::{
+    AttrPath, GenericPath, IMStatusCode, InteractionModelState, OpCode, StatusResp,
+};
+use rs_matter::persist::PERSISTENT_SUBSCRIPTIONS_START;
+use rs_matter::transport::exchange::Exchange;
+use rs_matter::utils::select::Coalesce;
+
+use crate::common::e2e::im::echo_cluster;
+use crate::common::e2e::{new_default_runner, E2E_EVENTS_BUF_SIZE};
+use crate::common::{init_env_logger, MemKvBlobStore};
+
+use rs_matter::dm::clusters::net_comm::DummyNetworks;
+
+/// Subscribe → persist → reboot the server (fresh table, same store) → resume →
+/// the resumed subscription reports back to the still-connected client.
+#[test]
+fn test_subscription_survives_reboot() {
+    init_env_logger();
+
+    let im = new_default_runner();
+    im.add_default_acl();
+
+    // A retained store, shared (via a cheap `Rc` clone) across both boots so that
+    // what the first boot persists is what the second boot reads back.
+    let kv = MemKvBlobStore::default();
+
+    // Persistence is opt-in; enable it on the (first-boot) state.
+    im.state.set_persist_subscriptions(true);
+
+    let path = AttrPath::from_gp(&GenericPath::new(
+        Some(0),
+        Some(echo_cluster::ID),
+        Some(echo_cluster::AttributesDiscriminants::Att1 as u32),
+    ));
+    let paths = [path];
+
+    // ---- Boot 1: subscribe and let the server persist the subscription. ----
+    block_on(
+        select(
+            im.run_with(im.handler(), &im.state, kv.clone(), false),
+            async {
+                let exchange = im.initiate_exchange().await?;
+                let mut sender = exchange.subscribe_sender().await?;
+
+                let mut chunk = loop {
+                    match sender.tx().await? {
+                        TxOutcome::BuildRequest(builder) => {
+                            sender = builder
+                                .keep_subs(true)?
+                                .min_int_floor(0)?
+                                .max_int_ceil(60)?
+                                .attr_requests_from(&paths)?
+                                .fabric_filtered(false)?
+                                .end()?;
+                        }
+                        TxOutcome::GotResponse(c) => break c,
+                    }
+                };
+
+                let established = loop {
+                    let _ = chunk.response()?;
+                    match chunk.complete().await? {
+                        SubscribeOutcome::NextChunk(next) => chunk = next,
+                        SubscribeOutcome::Established(est) => break est,
+                    }
+                };
+
+                assert_ne!(established.subscription_id, 0);
+
+                // The client is `Established` the moment it receives the
+                // `SubscribeResponse`, but the server persists the subscription
+                // slightly *after* sending that response. Give the server task a
+                // moment to run to completion before we tear boot 1 down.
+                embassy_time::Timer::after(embassy_time::Duration::from_millis(200)).await;
+
+                Ok(())
+            },
+        )
+        .coalesce(),
+    )
+    .unwrap();
+
+    // The subscription must now be on disk.
+    assert!(
+        kv.contains_key(PERSISTENT_SUBSCRIPTIONS_START),
+        "boot 1 should have persisted the subscription"
+    );
+
+    // ---- Boot 2: a fresh subscription table, the same store. ----
+    let state2: InteractionModelState<DummyNetworks, 3, E2E_EVENTS_BUF_SIZE> =
+        InteractionModelState::new(DummyNetworks);
+    state2.set_persist_subscriptions(true);
+
+    // The resumed subscription is primed, so the server initiates a `ReportData`
+    // to the client on its own. We accept that server-initiated exchange and
+    // verify it is indeed a report — proof that the subscription survived the
+    // reboot and delivered without the client re-subscribing.
+    let got_report = block_on(async {
+        let server = im.run_with(im.handler(), &state2, kv.clone(), true);
+        let client = async {
+            // The resumed subscription's report arrives on a server-initiated
+            // exchange. Accept it, note the opcode, and answer with a
+            // `StatusResponse(Success)` so the server sees the report delivered.
+            let mut exchange = Exchange::accept(im.matter_client()).await?;
+            exchange.recv_fetch().await?;
+            let opcode = exchange.rx()?.meta().proto_opcode;
+            exchange
+                .send_with(|_, wb| {
+                    StatusResp::write(wb, IMStatusCode::Success)?;
+                    Ok(Some(OpCode::StatusResponse.into()))
+                })
+                .await?;
+            Ok::<_, rs_matter::error::Error>(opcode)
+        };
+
+        match select(server, client).await {
+            Either::First(r) => panic!("server exited before delivering a report: {r:?}"),
+            Either::Second(result) => result.unwrap(),
+        }
+    });
+
+    assert_eq!(
+        got_report,
+        OpCode::ReportData as u8,
+        "the resumed subscription should have delivered a ReportData after reboot"
+    );
+}


### PR DESCRIPTION
Subject says it all.

The last open item in #498

Currently protected with a runtime flag (and off by default).

In future, this one, and perhaps Groups support, CASE Resumption (and hopefully a few others) will be hidden under feature flags so as to conserve flash usage (these can't be automatically removed by the linker when not used as they are inter-mixed with mandatory, always-used functionality).