### PR TITLE
Put several functionalities behind feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Test
         if: matrix.features == 'os'
-        run: cd rs-matter; cargo test --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},async-io,log,groups,max-group-keys-per-fabric-2,max-groups-per-fabric-4
+        run: cd rs-matter; cargo test --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},async-io,log,groups,case-resumption,max-group-keys-per-fabric-2,max-groups-per-fabric-4
 
       - name: Examples
         if: matrix.features == 'os' && matrix.crypto-backend == 'rustcrypto'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Test
         if: matrix.features == 'os'
-        run: cd rs-matter; cargo test --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},async-io,log,max-group-keys-per-fabric-2,max-groups-per-fabric-4
+        run: cd rs-matter; cargo test --no-default-features --features ${{matrix.crypto-backend}},${{matrix.features}},async-io,log,groups,max-group-keys-per-fabric-2,max-groups-per-fabric-4
 
       - name: Examples
         if: matrix.features == 'os' && matrix.crypto-backend == 'rustcrypto'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Multicast groups support is now under a `groups` opt-in feature to save flash size
+* CASE session resumption support - under a `case-resumption` Cargo feature
 * Persistent subscriptions now supported
-  * Subscriptions can be persisted and resumed across a reboot (opt-in via the `persistent-subscriptions` Cargo feature, off by default)
+  * Subscriptions can be persisted and resumed across a reboot (opt-in via a new `persistent-subscriptions` Cargo feature, off by default)
   * New `case-responder-only` Cargo feature (off by default): `Exchange::initiate` never establishes a new CASE session (it only reuses an existing one, else fails), letting the linker drop the CASE initiator and mDNS resolver from a pure accessory that only reports over sessions its peers established
   * Fix: A subscription is no longer pinned to its establishing session which was incorrect
   * Fix: A not-yet-primed subscription with a `MinIntervalFloor` of 0 is now reported immediately instead of never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 * Persistent subscriptions now supported
-  * Subscriptions can be persisted and resumed across a reboot (opt-in via `set_persist_subscriptions`, off by default)
+  * Subscriptions can be persisted and resumed across a reboot (opt-in via the `persistent-subscriptions` Cargo feature, off by default)
+  * New `sticky-primed-session` Cargo feature (off by default): reports a subscription only over an already-established session, restoring the pre-persistence behavior and letting the linker drop the CASE initiator and mDNS resolver from a pure accessory
   * Fix: A subscription is no longer pinned to its establishing session which was incorrect
   * Fix: A not-yet-primed subscription with a `MinIntervalFloor` of 0 is now reported immediately instead of never
   * Fix: A failed report no longer advances the subscription's watermark, so the changes/events it was carrying are retried instead of silently dropped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 * Persistent subscriptions now supported
   * Subscriptions can be persisted and resumed across a reboot (opt-in via the `persistent-subscriptions` Cargo feature, off by default)
-  * New `sticky-primed-session` Cargo feature (off by default): reports a subscription only over an already-established session, restoring the pre-persistence behavior and letting the linker drop the CASE initiator and mDNS resolver from a pure accessory
+  * New `case-responder-only` Cargo feature (off by default): `Exchange::initiate` never establishes a new CASE session (it only reuses an existing one, else fails), letting the linker drop the CASE initiator and mDNS resolver from a pure accessory that only reports over sessions its peers established
   * Fix: A subscription is no longer pinned to its establishing session which was incorrect
   * Fix: A not-yet-primed subscription with a `MinIntervalFloor` of 0 is now reported immediately instead of never
   * Fix: A failed report no longer advances the subscription's watermark, so the changes/events it was carrying are retried instead of silently dropped

--- a/bloat-check/Cargo.toml
+++ b/bloat-check/Cargo.toml
@@ -39,7 +39,7 @@ embassy-futures = "0.1"
 static_cell = "1"
 critical-section = "1"
 embassy-executor = { version = "0.10", features = ["executor-thread"] }
-rs-matter = { path = "../rs-matter", default-features = false, features = ["rustcrypto"] }
+rs-matter = { path = "../rs-matter", default-features = false, features = ["rustcrypto", "case-responder-only"] }
 
 [target.'cfg(not(target_os = "none"))'.dependencies]
 log = { version = "0.4", features = ["max_level_info"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -93,7 +93,7 @@ async-io = "2"
 async-compat = "0.2"
 blocking = "1"
 futures-lite = "2"
-rs-matter = { path = "../rs-matter", features = ["async-io", "max-groups-per-fabric-12", "max-group-keys-per-fabric-2", "max-group-endpoints-per-fabric-3", "max-sessions-32"] }
+rs-matter = { path = "../rs-matter", features = ["async-io", "groups", "max-groups-per-fabric-12", "max-group-keys-per-fabric-2", "max-group-endpoints-per-fabric-3", "max-sessions-32"] }
 rand = { version = "0.8", features = ["std", "std_rng"] }
 async-signal = "0.2"
 socket2 = "0.5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -93,7 +93,7 @@ async-io = "2"
 async-compat = "0.2"
 blocking = "1"
 futures-lite = "2"
-rs-matter = { path = "../rs-matter", features = ["async-io", "groups", "max-groups-per-fabric-12", "max-group-keys-per-fabric-2", "max-group-endpoints-per-fabric-3", "max-sessions-32"] }
+rs-matter = { path = "../rs-matter", features = ["async-io", "groups", "persistent-subscriptions", "max-groups-per-fabric-12", "max-group-keys-per-fabric-2", "max-group-endpoints-per-fabric-3", "max-sessions-32"] }
 rand = { version = "0.8", features = ["std", "std_rng"] }
 async-signal = "0.2"
 socket2 = "0.5"

--- a/examples/src/bin/system_tests.rs
+++ b/examples/src/bin/system_tests.rs
@@ -179,12 +179,10 @@ fn main() -> Result<(), Error> {
     let buffers = BUFFERS.uninit().init_with(MatterBuffers::init());
 
     // Create the data model state (subscriptions, events, network store).
+    // Persistent subscriptions are compiled in via the `persistent-subscriptions`
+    // feature, so a subscriber keeps its subscription across a reboot.
     let mut state: EthInteractionModelState =
         EthInteractionModelState::new(EthNetwork::new_default());
-
-    // Opt in to persistent subscriptions so a subscriber keeps its subscription
-    // across a reboot (persistence is off by default).
-    state.set_persist_subscriptions(true);
 
     // Bind the KV access object (the KV scratch buffer lives in `Matter`).
     let kv = matter.kv(store);

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -16,29 +16,20 @@ default = ["os", "rustcrypto", "log"]
 
 # Sizing
 
-# Number of fabrics
+# Number of fabrics.
 max-fabrics-32 = []
 max-fabrics-16 = []
 max-fabrics-8 = []
 max-fabrics-7 = []
 max-fabrics-6 = []
+# Default number of fabrics (Matter requires a minimum of 5 fabrics).
 max-fabrics-5 = []
 max-fabrics-4 = []
-max-fabrics-3 = [] # default
+max-fabrics-3 = []
 max-fabrics-2 = []
 max-fabrics-1 = []
 
-# Size (in bytes) of the key-value persistence scratch buffer owned by `Matter`
-kv-blob-store-65536 = []
-kv-blob-store-32768 = []
-kv-blob-store-16384 = []
-kv-blob-store-8192 = []
-# Default key-value persistence scratch buffer size
-kv-blob-store-4096 = []
-kv-blob-store-2048 = []
-kv-blob-store-1024 = []
-
-# Number of groups per fabrics
+# Number of groups per fabrics.
 max-groups-per-fabric-32 = []
 max-groups-per-fabric-16 = []
 max-groups-per-fabric-12 = []
@@ -46,51 +37,51 @@ max-groups-per-fabric-8 = []
 max-groups-per-fabric-7 = []
 max-groups-per-fabric-6 = []
 max-groups-per-fabric-5 = []
-# Default number of groups per fabric (Matter requires a minimum of 4 group table entries per fabric)
+# Default number of groups per fabric (Matter requires a minimum of 4 group table entries per fabric).
 max-groups-per-fabric-4 = []
 
-# Number of group keys per fabric
+# Number of group keys per fabric.
 max-group-keys-per-fabric-5 = []
 max-group-keys-per-fabric-4 = []
-# Default number of group keys per fabric (Matter requires a minimum of 3 group keys per fabric)
+# Default number of group keys per fabric (Matter requires a minimum of 1 group keys per fabric).
 max-group-keys-per-fabric-3 = []
 max-group-keys-per-fabric-2 = []
 
-# Number of endpoints that can be members of a group (per fabric)
+# Number of endpoints that can be members of a group (per fabric).
 max-group-endpoints-per-fabric-5 = []
 max-group-endpoints-per-fabric-4 = []
-# Default number of endpoints that can be members of a group (per fabric)
+# Default number of endpoints that can be members of a group (per fabric).
 max-group-endpoints-per-fabric-3 = []
 max-group-endpoints-per-fabric-2 = []
 max-group-endpoints-per-fabric-1 = []
 
-# Number of ACL entries per fabric
+# Number of ACL entries per fabric.
 max-acls-per-fabric-32 = []
 max-acls-per-fabric-16 = []
 max-acls-per-fabric-8 = []
 max-acls-per-fabric-7 = []
 max-acls-per-fabric-6 = []
 max-acls-per-fabric-5 = []
-# Default number of ACL entries per fabric (Matter requires a minimum of 4 ACL entries per fabric)
+# Default number of ACL entries per fabric (Matter requires a minimum of 3 ACL entries per fabric).
 max-acls-per-fabric-4 = []
 max-acls-per-fabric-3 = []
 max-acls-per-fabric-2 = []
 max-acls-per-fabric-1 = []
 
-# Number of subjects per ACL entry
+# Number of subjects per ACL entry.
 max-subjects-per-acl-32 = []
 max-subjects-per-acl-16 = []
 max-subjects-per-acl-8 = []
 max-subjects-per-acl-7 = []
 max-subjects-per-acl-6 = []
 max-subjects-per-acl-5 = []
-# Default number of subjects per ACL entry (Matter requires a minimum of 4 subjects per ACL entry)
+# Default number of subjects per ACL entry (Matter requires a minimum of 4 subjects per ACL entry).
 max-subjects-per-acl-4 = []
 max-subjects-per-acl-3 = []
 max-subjects-per-acl-2 = []
 max-subjects-per-acl-1 = []
 
-# Number of targets per ACL entry
+# Number of targets per ACL entry.
 max-targets-per-acl-32 = []
 max-targets-per-acl-16 = []
 max-targets-per-acl-8 = []
@@ -98,15 +89,15 @@ max-targets-per-acl-7 = []
 max-targets-per-acl-6 = []
 max-targets-per-acl-5 = []
 max-targets-per-acl-4 = []
-# Default number of targets per ACL entry (Matter requires a minimum of 3 targets per ACL entry)
+# Default number of targets per ACL entry (Matter requires a minimum of 3 targets per ACL entry).
 max-targets-per-acl-3 = []
 max-targets-per-acl-2 = []
 max-targets-per-acl-1 = []
 
-# Number of sessions
+# Number of sessions.
 max-sessions-64 = []
 max-sessions-32 = []
-# Default number of sessions (Matter requires a minimum of 3 sessions per fabric)
+# Default number of sessions (Matter requires a minimum of 3 sessions per fabric).
 max-sessions-16 = []
 max-sessions-8 = []
 max-sessions-7 = []
@@ -115,75 +106,88 @@ max-sessions-5 = []
 max-sessions-4 = []
 max-sessions-3 = []
 
-# Number of exchanges per session
+# Number of exchanges per session.
 max-exchanges-per-session-16 = []
 max-exchanges-per-session-8 = []
 max-exchanges-per-session-7 = []
 max-exchanges-per-session-6 = []
-# Default number of exchanges per session (Matter requires a minimum of 5 exchanges per session)
+# Default number of exchanges per session (Matter requires a minimum of 5 exchanges per session).
 max-exchanges-per-session-5 = []
 max-exchanges-per-session-4 = []
 max-exchanges-per-session-3 = []
 
-# Number of BTP sessions
+# Number of BTP sessions.
 max-btp-sessions-8 = []
 max-btp-sessions-4 = []
 max-btp-sessions-2 = []
-# Default number of BTP sessions (Matter accessories typically need just 1 BTP session)
+# Default number of BTP sessions (Matter accessories typically need just 1 BTP session).
 max-btp-sessions-1 = []
+
+# Size (in bytes) of the key-value persistence scratch buffer owned by `Matter`.
+kv-blob-store-65536 = []
+kv-blob-store-32768 = []
+kv-blob-store-16384 = []
+kv-blob-store-8192 = []
+# Default key-value persistence scratch buffer size.
+kv-blob-store-4096 = []
+kv-blob-store-2048 = []
+kv-blob-store-1024 = []
 
 # General
 
-# mDNS support for MacOSX
+# mDNS support for MacOSX.
 astro-dnssd = ["os", "dep:astro-dnssd"]
-# mDNS support for Linux and Windows (via Avahi or Bonjour)
-# Prefer the Avahi and Resolved mDNS implementations over Zeroconf for production deployments, via `zbus`
+# mDNS support for Linux and Windows (via Avahi or Bonjour).
+# Prefer the Avahi and Resolved mDNS implementations over Zeroconf for production deployments, via `zbus`.
 zeroconf = ["os", "dep:zeroconf"]
-# Enable the zBus proxies for a range of Linux dBus services used by `rs-matter` (off by default due to slow compilation)
+# Enable the zBus proxies for a range of Linux dBus services used by `rs-matter` (off by default due to slow compilation).
 zbus = ["dep:zbus", "dep:serde", "os", "futures-lite", "libc", "uuid", "async-channel"]
-# BLE suppport for Linux (via BlueZ)
-# Prefer the BlueZ implementation over Bluer for production deployments, via `zbus`
+# BLE suppport for Linux (via BlueZ).
+# Prefer the BlueZ implementation over Bluer for production deployments, via `zbus`.
 bluer = ["dep:bluer", "os"]
-# Umbrella set of features for typical OS-based non-baremetal deployments
+# Umbrella set of features for typical OS-based non-baremetal deployments.
 os = ["std", "backtrace", "async-io", "critical-section/std", "embassy-sync/std", "embassy-time/std", "dep:if-addrs"]
-# Minimal set of features for targets with support for Rust STD (narrower than `os` above)
+# Minimal set of features for targets with support for Rust STD (narrower than `os` above).
 std = ["alloc", "rand"]
-# Enable backtrace capturing (useful for debugging)
+# Enable backtrace capturing (useful for debugging).
 backtrace = []
-# Enable the alloc feature for targets that support it
-# In general, `rs-matter` does not use heap, so this feature enables only a few convenience features
+# Enable the alloc feature for targets that support it.
+# In general, `rs-matter` does not use heap, so this feature enables only a few convenience features.
 alloc = ["defmt?/alloc"]
-# Crypto backend: Rust Crypto
+# Crypto backend: Rust Crypto.
 rustcrypto = ["alloc", "digest", "cipher", "ccm", "elliptic-curve", "primeorder", "ecdsa", "sec1", "signature", "hmac", "hkdf", "pbkdf2", "crypto-bigint", "sha1", "sha2", "aes", "p256", "x509-cert"]
-# Crypto backend: OpenSSL (not usable for baremetal targets, only for OS targets with OpenSSL installed)
+# Crypto backend: OpenSSL (not usable for baremetal targets, only for OS targets with OpenSSL installed).
 openssl = ["alloc", "dep:openssl", "foreign-types", "hmac", "sha2"]
-# Crypto backend: mbedTLS
+# Crypto backend: mbedTLS.
 mbedtls = ["alloc", "dep:mbedtls-rs-sys"]
 # Build `rs-matter` with support for work-stealing executors, like the default Tokio executor.
 # This is a WIP feature and not yet fully supported.
 sync-mutex = []
-# Enable a small OTA DCL client
-# TODO: We likely don't need this hidden behind a feature
+# Enable a small OTA DCL client.
+# TODO: We likely don't need this hidden behind a feature.
 ota-dcl = ["dep:serde", "dep:serde-json-core", "heapless/serde"]
-# Enable support for `defmt` logging (for embedded targets)
+# Enable support for `defmt` logging (for embedded targets).
 defmt = ["dep:defmt", "heapless/defmt", "embassy-time/defmt", "mbedtls-rs-sys?/defmt"]
-# Enable support for `log` logging (for embedded and OS targets)
+# Enable support for `log` logging (for embedded and OS targets).
 log = ["dep:log", "embassy-time/log"]
-# Enable `debug`-level logging of TLV payloads. This is very verbose and should only be used for debugging.
+# Enable `debug`-level logging of TLV payloads.
+# This is very verbose and should only be used for debugging.
 log-tlv-payload = []
 # Promote MRP-diagnostic logs from `debug` to `warn` so they are visible under a typical `info`-level filter.
 log-mrp = []
-# Typically enabled when TCP is used
+# Typically enabled when TCP is used.
 # When enabled, this feature extends the Transport layer packet buffers, as well as the ones
-# served by `MatterBuffers` to 1MB (from 1500 B)
+# served by `MatterBuffers` to 1MB (from 1500 B).
 large-buffers = [] 
-# Multicast groups support
+# Multicast groups support.
 groups = []
-# Persist accepted subscriptions and resume them across a reboot
+# Persist accepted subscriptions and resume them across a reboot.
 persistent-subscriptions = []
-# CASE session resumption (Sigma2-Resume fast-path + its persisted cache). When off, CASE always runs the full Sigma1/2/3 handshake, which is spec-compliant (resumption is optional) and drops the resume crypto + cache from the build
+# CASE session resumption (Sigma2-Resume fast-path + its persisted cache).
+# When off, CASE always runs the full Sigma1/2/3 handshake, which is spec-compliant (resumption is optional) and drops the resume crypto + cache from the build.
 case-resumption = []
-# Never initiate a new CASE session: `Exchange::initiate` only reuses an existing session (else fails), so the linker drops the CASE initiator + mDNS resolver. Suits a pure accessory that only reports over sessions its peers established
+# Never initiate a new CASE session: `Exchange::initiate` only reuses an existing session (else fails), so the linker drops the CASE initiator + mDNS resolver.
+# Suits a pure accessory that only reports over sessions its peers established.
 case-responder-only = []
 
 [dependencies]

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -141,6 +141,7 @@ log = ["dep:log", "embassy-time/log"]
 log-tlv-payload = [] # Enable `debug`-level logging of TLV payloads. This is very verbose and should only be used for debugging.
 log-mrp = [] # Promote MRP-diagnostic logs from `debug` to `warn` so they are visible under a typical `info`-level filter.
 large-buffers = [] # TCP support
+groups = [] # Multicast groups support
 
 [dependencies]
 rs-matter-macros = { path = "../rs-matter-macros", version = "0.2.0" }

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -143,7 +143,7 @@ log-mrp = [] # Promote MRP-diagnostic logs from `debug` to `warn` so they are vi
 large-buffers = [] # TCP support
 groups = [] # Multicast groups support
 persistent-subscriptions = [] # Persist accepted subscriptions and resume them across a reboot
-sticky-primed-session = [] # Report subscriptions only over their priming session (drops the CASE initiator + mDNS resolver from the reporter)
+case-responder-only = [] # Never initiate a new CASE session: `Exchange::initiate` only reuses an existing session (else fails), so the linker drops the CASE initiator + mDNS resolver. Suits a pure accessory that only reports over sessions its peers established.
 
 [dependencies]
 rs-matter-macros = { path = "../rs-matter-macros", version = "0.2.0" }

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -45,18 +45,18 @@ max-groups-per-fabric-8 = []
 max-groups-per-fabric-7 = []
 max-groups-per-fabric-6 = []
 max-groups-per-fabric-5 = []
-max-groups-per-fabric-4 = []
+max-groups-per-fabric-4 = [] # default
 
 # Number of group keys per fabric
 max-group-keys-per-fabric-5 = []
 max-group-keys-per-fabric-4 = []
-max-group-keys-per-fabric-3 = []
+max-group-keys-per-fabric-3 = [] # default
 max-group-keys-per-fabric-2 = []
 
 # Number of endpoints that can be members of a group (per fabric)
 max-group-endpoints-per-fabric-5 = []
 max-group-endpoints-per-fabric-4 = []
-max-group-endpoints-per-fabric-3 = []
+max-group-endpoints-per-fabric-3 = [] # default
 max-group-endpoints-per-fabric-2 = []
 max-group-endpoints-per-fabric-1 = []
 

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -142,6 +142,8 @@ log-tlv-payload = [] # Enable `debug`-level logging of TLV payloads. This is ver
 log-mrp = [] # Promote MRP-diagnostic logs from `debug` to `warn` so they are visible under a typical `info`-level filter.
 large-buffers = [] # TCP support
 groups = [] # Multicast groups support
+persistent-subscriptions = [] # Persist accepted subscriptions and resume them across a reboot
+sticky-primed-session = [] # Report subscriptions only over their priming session (drops the CASE initiator + mDNS resolver from the reporter)
 
 [dependencies]
 rs-matter-macros = { path = "../rs-matter-macros", version = "0.2.0" }

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -33,7 +33,8 @@ kv-blob-store-65536 = []
 kv-blob-store-32768 = []
 kv-blob-store-16384 = []
 kv-blob-store-8192 = []
-kv-blob-store-4096 = [] # default
+# Default key-value persistence scratch buffer size
+kv-blob-store-4096 = []
 kv-blob-store-2048 = []
 kv-blob-store-1024 = []
 
@@ -45,18 +46,21 @@ max-groups-per-fabric-8 = []
 max-groups-per-fabric-7 = []
 max-groups-per-fabric-6 = []
 max-groups-per-fabric-5 = []
-max-groups-per-fabric-4 = [] # default
+# Default number of groups per fabric (Matter requires a minimum of 4 group table entries per fabric)
+max-groups-per-fabric-4 = []
 
 # Number of group keys per fabric
 max-group-keys-per-fabric-5 = []
 max-group-keys-per-fabric-4 = []
-max-group-keys-per-fabric-3 = [] # default
+# Default number of group keys per fabric (Matter requires a minimum of 3 group keys per fabric)
+max-group-keys-per-fabric-3 = []
 max-group-keys-per-fabric-2 = []
 
 # Number of endpoints that can be members of a group (per fabric)
 max-group-endpoints-per-fabric-5 = []
 max-group-endpoints-per-fabric-4 = []
-max-group-endpoints-per-fabric-3 = [] # default
+# Default number of endpoints that can be members of a group (per fabric)
+max-group-endpoints-per-fabric-3 = []
 max-group-endpoints-per-fabric-2 = []
 max-group-endpoints-per-fabric-1 = []
 
@@ -67,7 +71,8 @@ max-acls-per-fabric-8 = []
 max-acls-per-fabric-7 = []
 max-acls-per-fabric-6 = []
 max-acls-per-fabric-5 = []
-max-acls-per-fabric-4 = [] # default
+# Default number of ACL entries per fabric (Matter requires a minimum of 4 ACL entries per fabric)
+max-acls-per-fabric-4 = []
 max-acls-per-fabric-3 = []
 max-acls-per-fabric-2 = []
 max-acls-per-fabric-1 = []
@@ -79,7 +84,8 @@ max-subjects-per-acl-8 = []
 max-subjects-per-acl-7 = []
 max-subjects-per-acl-6 = []
 max-subjects-per-acl-5 = []
-max-subjects-per-acl-4 = [] # default
+# Default number of subjects per ACL entry (Matter requires a minimum of 4 subjects per ACL entry)
+max-subjects-per-acl-4 = []
 max-subjects-per-acl-3 = []
 max-subjects-per-acl-2 = []
 max-subjects-per-acl-1 = []
@@ -92,14 +98,16 @@ max-targets-per-acl-7 = []
 max-targets-per-acl-6 = []
 max-targets-per-acl-5 = []
 max-targets-per-acl-4 = []
-max-targets-per-acl-3 = [] # default
+# Default number of targets per ACL entry (Matter requires a minimum of 3 targets per ACL entry)
+max-targets-per-acl-3 = []
 max-targets-per-acl-2 = []
 max-targets-per-acl-1 = []
 
 # Number of sessions
 max-sessions-64 = []
 max-sessions-32 = []
-max-sessions-16 = [] # default
+# Default number of sessions (Matter requires a minimum of 3 sessions per fabric)
+max-sessions-16 = []
 max-sessions-8 = []
 max-sessions-7 = []
 max-sessions-6 = []
@@ -112,7 +120,8 @@ max-exchanges-per-session-16 = []
 max-exchanges-per-session-8 = []
 max-exchanges-per-session-7 = []
 max-exchanges-per-session-6 = []
-max-exchanges-per-session-5 = [] # default
+# Default number of exchanges per session (Matter requires a minimum of 5 exchanges per session)
+max-exchanges-per-session-5 = []
 max-exchanges-per-session-4 = []
 max-exchanges-per-session-3 = []
 
@@ -120,31 +129,62 @@ max-exchanges-per-session-3 = []
 max-btp-sessions-8 = []
 max-btp-sessions-4 = []
 max-btp-sessions-2 = []
-max-btp-sessions-1 = [] # default
+# Default number of BTP sessions (Matter accessories typically need just 1 BTP session)
+max-btp-sessions-1 = []
 
 # General
+
+# mDNS support for MacOSX
 astro-dnssd = ["os", "dep:astro-dnssd"]
+# mDNS support for Linux and Windows (via Avahi or Bonjour)
+# Prefer the Avahi and Resolved mDNS implementations over Zeroconf for production deployments, via `zbus`
 zeroconf = ["os", "dep:zeroconf"]
+# Enable the zBus proxies for a range of Linux dBus services used by `rs-matter` (off by default due to slow compilation)
 zbus = ["dep:zbus", "dep:serde", "os", "futures-lite", "libc", "uuid", "async-channel"]
+# BLE suppport for Linux (via BlueZ)
+# Prefer the BlueZ implementation over Bluer for production deployments, via `zbus`
 bluer = ["dep:bluer", "os"]
+# Umbrella set of features for typical OS-based non-baremetal deployments
 os = ["std", "backtrace", "async-io", "critical-section/std", "embassy-sync/std", "embassy-time/std", "dep:if-addrs"]
+# Minimal set of features for targets with support for Rust STD (narrower than `os` above)
 std = ["alloc", "rand"]
+# Enable backtrace capturing (useful for debugging)
 backtrace = []
+# Enable the alloc feature for targets that support it
+# In general, `rs-matter` does not use heap, so this feature enables only a few convenience features
 alloc = ["defmt?/alloc"]
-openssl = ["alloc", "dep:openssl", "foreign-types", "hmac", "sha2"]
-mbedtls = ["alloc", "dep:mbedtls-rs-sys"]
-ota-dcl = ["dep:serde", "dep:serde-json-core", "heapless/serde"]
-sync-mutex = []
+# Crypto backend: Rust Crypto
 rustcrypto = ["alloc", "digest", "cipher", "ccm", "elliptic-curve", "primeorder", "ecdsa", "sec1", "signature", "hmac", "hkdf", "pbkdf2", "crypto-bigint", "sha1", "sha2", "aes", "p256", "x509-cert"]
+# Crypto backend: OpenSSL (not usable for baremetal targets, only for OS targets with OpenSSL installed)
+openssl = ["alloc", "dep:openssl", "foreign-types", "hmac", "sha2"]
+# Crypto backend: mbedTLS
+mbedtls = ["alloc", "dep:mbedtls-rs-sys"]
+# Build `rs-matter` with support for work-stealing executors, like the default Tokio executor.
+# This is a WIP feature and not yet fully supported.
+sync-mutex = []
+# Enable a small OTA DCL client
+# TODO: We likely don't need this hidden behind a feature
+ota-dcl = ["dep:serde", "dep:serde-json-core", "heapless/serde"]
+# Enable support for `defmt` logging (for embedded targets)
 defmt = ["dep:defmt", "heapless/defmt", "embassy-time/defmt", "mbedtls-rs-sys?/defmt"]
+# Enable support for `log` logging (for embedded and OS targets)
 log = ["dep:log", "embassy-time/log"]
-log-tlv-payload = [] # Enable `debug`-level logging of TLV payloads. This is very verbose and should only be used for debugging.
-log-mrp = [] # Promote MRP-diagnostic logs from `debug` to `warn` so they are visible under a typical `info`-level filter.
-large-buffers = [] # TCP support
-groups = [] # Multicast groups support
-persistent-subscriptions = [] # Persist accepted subscriptions and resume them across a reboot
-case-resumption = [] # CASE session resumption (Sigma2-Resume fast-path + its persisted cache). When off, CASE always runs the full Sigma1/2/3 handshake, which is spec-compliant (resumption is optional) and drops the resume crypto + cache from the build.
-case-responder-only = [] # Never initiate a new CASE session: `Exchange::initiate` only reuses an existing session (else fails), so the linker drops the CASE initiator + mDNS resolver. Suits a pure accessory that only reports over sessions its peers established.
+# Enable `debug`-level logging of TLV payloads. This is very verbose and should only be used for debugging.
+log-tlv-payload = []
+# Promote MRP-diagnostic logs from `debug` to `warn` so they are visible under a typical `info`-level filter.
+log-mrp = []
+# Typically enabled when TCP is used
+# When enabled, this feature extends the Transport layer packet buffers, as well as the ones
+# served by `MatterBuffers` to 1MB (from 1500 B)
+large-buffers = [] 
+# Multicast groups support
+groups = []
+# Persist accepted subscriptions and resume them across a reboot
+persistent-subscriptions = []
+# CASE session resumption (Sigma2-Resume fast-path + its persisted cache). When off, CASE always runs the full Sigma1/2/3 handshake, which is spec-compliant (resumption is optional) and drops the resume crypto + cache from the build
+case-resumption = []
+# Never initiate a new CASE session: `Exchange::initiate` only reuses an existing session (else fails), so the linker drops the CASE initiator + mDNS resolver. Suits a pure accessory that only reports over sessions its peers established
+case-responder-only = []
 
 [dependencies]
 rs-matter-macros = { path = "../rs-matter-macros", version = "0.2.0" }

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -143,6 +143,7 @@ log-mrp = [] # Promote MRP-diagnostic logs from `debug` to `warn` so they are vi
 large-buffers = [] # TCP support
 groups = [] # Multicast groups support
 persistent-subscriptions = [] # Persist accepted subscriptions and resume them across a reboot
+case-resumption = [] # CASE session resumption (Sigma2-Resume fast-path + its persisted cache). When off, CASE always runs the full Sigma1/2/3 handshake, which is spec-compliant (resumption is optional) and drops the resume crypto + cache from the build.
 case-responder-only = [] # Never initiate a new CASE session: `Exchange::initiate` only reuses an existing session (else fails), so the linker drops the CASE initiator + mDNS resolver. Suits a pure accessory that only reports over sessions its peers established.
 
 [dependencies]

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -409,9 +409,8 @@ impl<'a> Accessor<'a> {
             return true;
         }
 
-        // Group access is only reachable with multicast group support; without
-        // it there are no group sessions, so `auth_mode` is never `Group` and
-        // this point is unreachable.
+        // A group session reaches an endpoint only if that endpoint is a member
+        // of the session's group.
         #[cfg(feature = "groups")]
         {
             let group_id = self.subjects.0[0] as u16;
@@ -432,10 +431,14 @@ impl<'a> Accessor<'a> {
             })
         }
 
+        // Without multicast group support there are no group sessions, so
+        // `auth_mode` above is never `Group` and this point is unreachable. Deny
+        // anyway (fail closed): if a `Group` auth mode ever did reach here, it must
+        // not silently grant access to an endpoint.
         #[cfg(not(feature = "groups"))]
         {
             let _ = endpoint_id;
-            true
+            false
         }
     }
 

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -409,22 +409,34 @@ impl<'a> Accessor<'a> {
             return true;
         }
 
-        let group_id = self.subjects.0[0] as u16;
+        // Group access is only reachable with multicast group support; without
+        // it there are no group sessions, so `auth_mode` is never `Group` and
+        // this point is unreachable.
+        #[cfg(feature = "groups")]
+        {
+            let group_id = self.subjects.0[0] as u16;
 
-        let Some(fab_idx) = core::num::NonZeroU8::new(self.fab_idx) else {
-            return false;
-        };
-
-        self.matter.with_state(|state| {
-            let Some(fabric) = state.fabrics.get(fab_idx) else {
+            let Some(fab_idx) = core::num::NonZeroU8::new(self.fab_idx) else {
                 return false;
             };
 
-            fabric
-                .groups()
-                .get(group_id)
-                .is_some_and(|e| e.endpoints.contains(&endpoint_id))
-        })
+            self.matter.with_state(|state| {
+                let Some(fabric) = state.fabrics.get(fab_idx) else {
+                    return false;
+                };
+
+                fabric
+                    .groups()
+                    .get(group_id)
+                    .is_some_and(|e| e.endpoints.contains(&endpoint_id))
+            })
+        }
+
+        #[cfg(not(feature = "groups"))]
+        {
+            let _ = endpoint_id;
+            true
+        }
     }
 
     /// Return the Operational Node ID of the accessor, if any

--- a/rs-matter/src/dm/clusters.rs
+++ b/rs-matter/src/dm/clusters.rs
@@ -33,6 +33,7 @@ pub mod eth_diag;
 pub mod fixed_label;
 pub mod gen_comm;
 pub mod gen_diag;
+#[cfg(feature = "groups")]
 pub mod groups;
 pub mod grp_key_mgmt;
 pub mod icd_mgmt;

--- a/rs-matter/src/dm/clusters/grp_key_mgmt.rs
+++ b/rs-matter/src/dm/clusters/grp_key_mgmt.rs
@@ -655,8 +655,14 @@ impl ClusterHandler for GrpKeyMgmtHandler {
     fn handle_key_set_remove(
         &self,
         _ctx: impl InvokeContext,
-        _request: KeySetRemoveRequest<'_>,
+        request: KeySetRemoveRequest<'_>,
     ) -> Result<(), Error> {
+        // KeySetRemove of ID 0 (IPK) is not allowed. This is the only key set the
+        // minimal handler knows about; there is nothing else to remove.
+        if request.group_key_set_id()? == 0 {
+            return Err(ErrorCode::InvalidCommand.into());
+        }
+
         Ok(())
     }
 

--- a/rs-matter/src/dm/clusters/grp_key_mgmt.rs
+++ b/rs-matter/src/dm/clusters/grp_key_mgmt.rs
@@ -33,9 +33,7 @@ use crate::fabric::{
 };
 #[cfg(feature = "groups")]
 use crate::group_keys::{GroupEpochKeyEntry, GroupKeySet};
-#[cfg(feature = "groups")]
-use crate::tlv::{Nullable, Octets};
-use crate::tlv::{TLVArray, TLVBuilderParent};
+use crate::tlv::{Nullable, Octets, TLVArray, TLVBuilderParent};
 use crate::with;
 
 pub use crate::dm::clusters::decl::group_key_management::*;
@@ -616,18 +614,42 @@ impl ClusterHandler for GrpKeyMgmtHandler {
     fn handle_key_set_write(
         &self,
         _ctx: impl InvokeContext,
-        _request: KeySetWriteRequest<'_>,
+        request: KeySetWriteRequest<'_>,
     ) -> Result<(), Error> {
+        // Key set 0 (the IPK) is reserved and cannot be written via this cluster
+        // (it is delivered by `AddNOC`); reject it like the full handler. Group
+        // key sets are accepted as a no-op since there is no group storage.
+        if request.group_key_set()?.group_key_set_id()? == 0 {
+            return Err(ErrorCode::InvalidCommand.into());
+        }
         Ok(())
     }
 
     fn handle_key_set_read<P: TLVBuilderParent>(
         &self,
         _ctx: impl InvokeContext,
-        _request: KeySetReadRequest<'_>,
-        _response: KeySetReadResponseBuilder<P>,
+        request: KeySetReadRequest<'_>,
+        response: KeySetReadResponseBuilder<P>,
     ) -> Result<P, Error> {
-        Err(ErrorCode::NotFound.into())
+        // Key set 0 is the IPK: always present once the fabric is added (via
+        // `AddNOC`, independent of multicast group support), reported with its
+        // epoch keys redacted to null. Any other key set is unknown here.
+        if request.group_key_set_id()? == 0 {
+            response
+                .group_key_set()?
+                .group_key_set_id(0)?
+                .group_key_security_policy(GroupKeySecurityPolicyEnum::TrustFirst)?
+                .epoch_key_0(Nullable::<Octets<'_>>::none())?
+                .epoch_start_time_0(Nullable::some(0))?
+                .epoch_key_1(Nullable::<Octets<'_>>::none())?
+                .epoch_start_time_1(Nullable::none())?
+                .epoch_key_2(Nullable::<Octets<'_>>::none())?
+                .epoch_start_time_2(Nullable::none())?
+                .end()?
+                .end()
+        } else {
+            Err(ErrorCode::NotFound.into())
+        }
     }
 
     fn handle_key_set_remove(
@@ -643,6 +665,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         _ctx: impl InvokeContext,
         response: KeySetReadAllIndicesResponseBuilder<P>,
     ) -> Result<P, Error> {
-        response.group_key_set_i_ds()?.end()?.end()
+        // The IPK (key set 0) is always present, even without group support.
+        response.group_key_set_i_ds()?.push(&0u16)?.end()?.end()
     }
 }

--- a/rs-matter/src/dm/clusters/grp_key_mgmt.rs
+++ b/rs-matter/src/dm/clusters/grp_key_mgmt.rs
@@ -17,19 +17,25 @@
 
 //! This module contains the implementation of the Group Key Management cluster and its handler.
 
+#[cfg(feature = "groups")]
 use core::num::NonZeroU8;
 
+#[cfg(feature = "groups")]
 use crate::crypto::AEAD_CANON_KEY_LEN;
 use crate::dm::{
     ArrayAttributeRead, ArrayAttributeWrite, Cluster, Dataver, InvokeContext, ReadContext,
     WriteContext,
 };
 use crate::error::{Error, ErrorCode};
+#[cfg(feature = "groups")]
 use crate::fabric::{
     FabricPersist, GroupKeyMapping, MAX_GROUPS_PER_FABRIC, MAX_GROUP_KEYS_PER_FABRIC,
 };
+#[cfg(feature = "groups")]
 use crate::group_keys::{GroupEpochKeyEntry, GroupKeySet};
-use crate::tlv::{Nullable, Octets, TLVArray, TLVBuilderParent};
+#[cfg(feature = "groups")]
+use crate::tlv::{Nullable, Octets};
+use crate::tlv::{TLVArray, TLVBuilderParent};
 use crate::with;
 
 pub use crate::dm::clusters::decl::group_key_management::*;
@@ -53,6 +59,9 @@ impl GrpKeyMgmtHandler {
     }
 }
 
+/// The full Group Key Management implementation, backing multicast group keys
+/// and the group→keyset map on top of the fabric's group state.
+#[cfg(feature = "groups")]
 impl ClusterHandler for GrpKeyMgmtHandler {
     const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
 
@@ -540,5 +549,100 @@ impl ClusterHandler for GrpKeyMgmtHandler {
 
             ids.end()?.end()
         })
+    }
+}
+
+/// A spec-minimal Group Key Management implementation for builds without the
+/// `groups` feature. The Root Node device type mandates this cluster, so it is
+/// always present, but with no multicast support it stores no group keys or
+/// mappings: reads return empty, group-key writes/removes are accepted as
+/// no-ops, and `KeySetRead` reports not-found. The IPK (key set 0) is delivered
+/// out of band via `AddNOC`, so commissioning and operation are unaffected.
+#[cfg(not(feature = "groups"))]
+impl ClusterHandler for GrpKeyMgmtHandler {
+    const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
+
+    fn dataver(&self) -> u32 {
+        self.dataver.get()
+    }
+
+    fn dataver_changed(&self) {
+        self.dataver.changed();
+    }
+
+    fn group_key_map<P: TLVBuilderParent>(
+        &self,
+        _ctx: impl ReadContext,
+        builder: ArrayAttributeRead<GroupKeyMapStructArrayBuilder<P>, GroupKeyMapStructBuilder<P>>,
+    ) -> Result<P, Error> {
+        match builder {
+            ArrayAttributeRead::ReadAll(builder) => builder.end(),
+            ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
+        }
+    }
+
+    fn group_table<P: TLVBuilderParent>(
+        &self,
+        _ctx: impl ReadContext,
+        builder: ArrayAttributeRead<
+            GroupInfoMapStructArrayBuilder<P>,
+            GroupInfoMapStructBuilder<P>,
+        >,
+    ) -> Result<P, Error> {
+        match builder {
+            ArrayAttributeRead::ReadAll(builder) => builder.end(),
+            ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
+        }
+    }
+
+    fn max_groups_per_fabric(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
+        Ok(1)
+    }
+
+    fn max_group_keys_per_fabric(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
+        Ok(1)
+    }
+
+    fn set_group_key_map(
+        &self,
+        _ctx: impl WriteContext,
+        _value: ArrayAttributeWrite<TLVArray<'_, GroupKeyMapStruct<'_>>, GroupKeyMapStruct<'_>>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn handle_key_set_write(
+        &self,
+        _ctx: impl InvokeContext,
+        _request: KeySetWriteRequest<'_>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn handle_key_set_read<P: TLVBuilderParent>(
+        &self,
+        _ctx: impl InvokeContext,
+        _request: KeySetReadRequest<'_>,
+        _response: KeySetReadResponseBuilder<P>,
+    ) -> Result<P, Error> {
+        Err(ErrorCode::NotFound.into())
+    }
+
+    fn handle_key_set_remove(
+        &self,
+        _ctx: impl InvokeContext,
+        _request: KeySetRemoveRequest<'_>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn handle_key_set_read_all_indices<P: TLVBuilderParent>(
+        &self,
+        _ctx: impl InvokeContext,
+        response: KeySetReadAllIndicesResponseBuilder<P>,
+    ) -> Result<P, Error> {
+        response.group_key_set_i_ds()?.end()?.end()
     }
 }

--- a/rs-matter/src/dm/clusters/net_comm.rs
+++ b/rs-matter/src/dm/clusters/net_comm.rs
@@ -37,7 +37,6 @@ use crate::utils::sync::{DynBase, Notification};
 use crate::with;
 
 pub use crate::dm::clusters::decl::network_commissioning::*;
-pub use crate::dm::clusters::groups;
 
 /// Network type supported by the `NetCtl` implementations
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -700,6 +700,7 @@ impl ClusterHandler for NocHandler {
                 // Drop any CASE session resumption records that were
                 // scoped to this fabric so a subsequent CASE handshake
                 // to any peer that used to belong to it starts fresh.
+                #[cfg(feature = "case-resumption")]
                 state.resumption.remove_for_fabric(fab_idx);
 
                 // Notify that a session was removed
@@ -708,6 +709,7 @@ impl ClusterHandler for NocHandler {
                 // The resumption cache was just mutated — wake the
                 // background persist task so the on-disk copy sheds
                 // the removed fabric's records too.
+                #[cfg(feature = "case-resumption")]
                 ctx.exchange()
                     .matter()
                     .transport()

--- a/rs-matter/src/dm/clusters/scenes.rs
+++ b/rs-matter/src/dm/clusters/scenes.rs
@@ -696,14 +696,26 @@ where
         if group_id == 0 {
             return Ok(true);
         }
-        ctx.exchange().with_state(|state| {
-            let fabric = state.fabrics.fabric(fab_idx)?;
-            Ok(fabric
-                .groups()
-                .get(group_id)
-                .map(|g| g.endpoints.contains(&endpoint_id))
-                .unwrap_or(false))
-        })
+
+        #[cfg(feature = "groups")]
+        {
+            ctx.exchange().with_state(|state| {
+                let fabric = state.fabrics.fabric(fab_idx)?;
+                Ok(fabric
+                    .groups()
+                    .get(group_id)
+                    .map(|g| g.endpoints.contains(&endpoint_id))
+                    .unwrap_or(false))
+            })
+        }
+
+        // Without multicast group support a non-zero group can never be in the
+        // (empty) group table.
+        #[cfg(not(feature = "groups"))]
+        {
+            let _ = (ctx, fab_idx, endpoint_id);
+            Ok(false)
+        }
     }
 
     /// Stamp `(endpoint, group, scene)` as the recalled scene for

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -17,7 +17,6 @@
 
 use core::mem::MaybeUninit;
 use core::num::NonZeroU8;
-use core::str::FromStr;
 
 use cfg_if::cfg_if;
 use heapless::String;
@@ -30,7 +29,7 @@ use crate::crypto::{
 };
 use crate::dm::Privilege;
 use crate::error::{Error, ErrorCode};
-use crate::group_keys::{GroupKeySet, KeySet};
+use crate::group_keys::KeySet;
 use crate::persist::{KvBlobStore, KvBlobStoreAccess, Persist, FABRIC_KEYS_START};
 use crate::tlv::{FromTLV, TLVElement, ToTLV};
 use crate::transport::network::MatterLocalService;
@@ -39,265 +38,288 @@ use crate::utils::storage::Vec;
 
 const COMPRESSED_FABRIC_ID_LEN: usize = 8;
 
-cfg_if! {
-    if #[cfg(feature = "max-group-keys-per-fabric-5")] {
-        /// Max number of group key sets per fabric (excluding IPK at index 0).
-        pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 5;
-    } else if #[cfg(feature = "max-group-keys-per-fabric-4")] {
-        /// Max number of group key sets per fabric (excluding IPK at index 0).
-        pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 4;
-    } else if #[cfg(feature = "max-group-keys-per-fabric-3")] {
-        /// Max number of group key sets per fabric (excluding IPK at index 0).
-        pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 3;
-    } else if #[cfg(feature = "max-group-keys-per-fabric-2")] {
-        /// Max number of group key sets per fabric (excluding IPK at index 0).
-        pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 2;
-    } else {
-        /// Max number of group key sets per fabric (excluding IPK at index 0).
-        pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 0;
-    }
-}
+/// All multicast-group fabric state: the group key sets, the group→keyset
+/// mapping, and the group table. Gated as one inline module so the whole block
+/// (consts, TLV structs and the `Groups` container) is compiled out with a
+/// single `#[cfg]` when the `groups` feature is off, and re-exported so the rest
+/// of `fabric` refers to these items unqualified.
+#[cfg(feature = "groups")]
+mod groups {
+    use core::str::FromStr;
 
-/// Max length of a group name (per Matter spec).
-pub const MAX_GROUP_NAME_LEN: usize = 16;
+    use cfg_if::cfg_if;
 
-cfg_if! {
-    if #[cfg(feature = "max-groups-per-fabric-32")] {
-        /// Max number of group key map entries per fabric.
-        pub const MAX_GROUPS_PER_FABRIC: usize = 32;
-    } else if #[cfg(feature = "max-groups-per-fabric-16")] {
-        /// Max number of group key map entries per fabric.
-        pub const MAX_GROUPS_PER_FABRIC: usize = 16;
-    } else if #[cfg(feature = "max-groups-per-fabric-12")] {
-        /// Max number of group key map entries per fabric.
-        pub const MAX_GROUPS_PER_FABRIC: usize = 12;
-    } else if #[cfg(feature = "max-groups-per-fabric-8")] {
-        /// Max number of group key map entries per fabric.
-        pub const MAX_GROUPS_PER_FABRIC: usize = 9;
-    } else if #[cfg(feature = "max-groups-per-fabric-7")] {
-        /// Max number of group key map entries per fabric.
-        pub const MAX_GROUPS_PER_FABRIC: usize = 7;
-    } else if #[cfg(feature = "max-groups-per-fabric-6")] {
-        /// Max number of group key map entries per fabric.
-        pub const MAX_GROUPS_PER_FABRIC: usize = 6;
-    } else if #[cfg(feature = "max-groups-per-fabric-5")] {
-        /// Max number of group key map entries per fabric.
-        pub const MAX_GROUPS_PER_FABRIC: usize = 5;
-    } else if #[cfg(feature = "max-groups-per-fabric-4")] {
-        /// Max number of group key map entries per fabric.
-        pub const MAX_GROUPS_PER_FABRIC: usize = 4;
-    } else {
-        /// Max number of group key map entries per fabric.
-        pub const MAX_GROUPS_PER_FABRIC: usize = 0;
-    }
-}
+    use heapless::String;
 
-cfg_if! {
-    if #[cfg(feature = "max-group-endpoints-per-fabric-5")] {
-        /// Max number of endpoints per group entry.
-        pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 5;
-    } else if #[cfg(feature = "max-group-endpoints-per-fabric-4")] {
-        /// Max number of endpoints per group entry.
-        pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 4;
-    } else if #[cfg(feature = "max-group-endpoints-per-fabric-3")] {
-        /// Max number of endpoints per group entry.
-        pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 3;
-    } else if #[cfg(feature = "max-group-endpoints-per-fabric-2")] {
-        /// Max number of endpoints per group entry.
-        pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 2;
-    } else if #[cfg(feature = "max-group-endpoints-per-fabric-1")] {
-        /// Max number of endpoints per group entry.
-        pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 1;
-    } else {
-        /// Max number of endpoints per group entry.
-        pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 0;
-    }
-}
+    use crate::error::{Error, ErrorCode};
+    use crate::group_keys::GroupKeySet;
+    use crate::tlv::{FromTLV, ToTLV};
+    use crate::utils::init::{init, Init};
+    use crate::utils::storage::Vec;
 
-/// A group table entry mapping a group ID to its endpoints and name.
-#[derive(Debug, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct GroupEndpointMapping {
-    pub group_id: u16,
-    pub endpoints: Vec<u16, GROUP_ENDPOINTS_PER_FABRIC>,
-    pub group_name: String<MAX_GROUP_NAME_LEN>,
-}
-
-/// A stored group key map entry (maps group ID to key set).
-#[derive(Debug, Clone, Default, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct GroupKeyMapping {
-    pub group_id: u16,
-    pub group_key_set_id: u16,
-}
-
-#[derive(Debug, FromTLV, ToTLV)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Groups {
-    /// Group key sets (excluding IPK which is stored in `ipk`)
-    key_sets: Vec<GroupKeySet, MAX_GROUP_KEYS_PER_FABRIC>,
-    /// Groups keyset mapping
-    key_map: Vec<GroupKeyMapping, MAX_GROUPS_PER_FABRIC>,
-    /// Group table (group ID → endpoints + name)
-    endpoint_mapping: Vec<GroupEndpointMapping, MAX_GROUPS_PER_FABRIC>,
-}
-
-impl Groups {
-    fn init() -> impl Init<Self> {
-        init!(Self {
-            key_sets <- Vec::init(),
-            key_map <- Vec::init(),
-            endpoint_mapping <- Vec::init(),
-        })
-    }
-
-    /// Return an iterator over the group key sets of the fabric
-    pub fn key_set_iter(&self) -> impl Iterator<Item = &GroupKeySet> {
-        self.key_sets.iter()
-    }
-
-    /// Find a group key set by ID
-    pub fn key_set_get(&self, id: u16) -> Option<&GroupKeySet> {
-        self.key_sets.iter().find(|e| e.group_key_set_id == id)
-    }
-
-    /// Add or update a group key set
-    pub fn key_set_add(&mut self, entry: GroupKeySet) -> Result<(), Error> {
-        if let Some(existing) = self
-            .key_sets
-            .iter_mut()
-            .find(|e| e.group_key_set_id == entry.group_key_set_id)
-        {
-            *existing = entry;
+    cfg_if! {
+        if #[cfg(feature = "max-group-keys-per-fabric-5")] {
+            /// Max number of group key sets per fabric (excluding IPK at index 0).
+            pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 5;
+        } else if #[cfg(feature = "max-group-keys-per-fabric-4")] {
+            /// Max number of group key sets per fabric (excluding IPK at index 0).
+            pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 4;
+        } else if #[cfg(feature = "max-group-keys-per-fabric-3")] {
+            /// Max number of group key sets per fabric (excluding IPK at index 0).
+            pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 3;
+        } else if #[cfg(feature = "max-group-keys-per-fabric-2")] {
+            /// Max number of group key sets per fabric (excluding IPK at index 0).
+            pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 2;
         } else {
-            self.key_sets
-                .push(entry)
-                .map_err(|_| ErrorCode::ResourceExhausted)?;
+            /// Max number of group key sets per fabric (excluding IPK at index 0).
+            pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 0;
         }
-        Ok(())
     }
 
-    /// Remove a group key set by ID. Returns true if found and removed.
-    pub fn key_set_remove(&mut self, id: u16) -> Result<(), Error> {
-        let before = self.key_sets.len();
-        self.key_sets.retain(|e| e.group_key_set_id != id);
-        let removed = self.key_sets.len() < before;
+    /// Max length of a group name (per Matter spec).
+    pub const MAX_GROUP_NAME_LEN: usize = 16;
 
-        self.key_map_remove_by_key_set(id);
+    cfg_if! {
+        if #[cfg(feature = "max-groups-per-fabric-32")] {
+            /// Max number of group key map entries per fabric.
+            pub const MAX_GROUPS_PER_FABRIC: usize = 32;
+        } else if #[cfg(feature = "max-groups-per-fabric-16")] {
+            /// Max number of group key map entries per fabric.
+            pub const MAX_GROUPS_PER_FABRIC: usize = 16;
+        } else if #[cfg(feature = "max-groups-per-fabric-12")] {
+            /// Max number of group key map entries per fabric.
+            pub const MAX_GROUPS_PER_FABRIC: usize = 12;
+        } else if #[cfg(feature = "max-groups-per-fabric-8")] {
+            /// Max number of group key map entries per fabric.
+            pub const MAX_GROUPS_PER_FABRIC: usize = 9;
+        } else if #[cfg(feature = "max-groups-per-fabric-7")] {
+            /// Max number of group key map entries per fabric.
+            pub const MAX_GROUPS_PER_FABRIC: usize = 7;
+        } else if #[cfg(feature = "max-groups-per-fabric-6")] {
+            /// Max number of group key map entries per fabric.
+            pub const MAX_GROUPS_PER_FABRIC: usize = 6;
+        } else if #[cfg(feature = "max-groups-per-fabric-5")] {
+            /// Max number of group key map entries per fabric.
+            pub const MAX_GROUPS_PER_FABRIC: usize = 5;
+        } else if #[cfg(feature = "max-groups-per-fabric-4")] {
+            /// Max number of group key map entries per fabric.
+            pub const MAX_GROUPS_PER_FABRIC: usize = 4;
+        } else {
+            /// Max number of group key map entries per fabric.
+            pub const MAX_GROUPS_PER_FABRIC: usize = 0;
+        }
+    }
 
-        // Check if element was actually removed
-        if removed {
+    cfg_if! {
+        if #[cfg(feature = "max-group-endpoints-per-fabric-5")] {
+            /// Max number of endpoints per group entry.
+            pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 5;
+        } else if #[cfg(feature = "max-group-endpoints-per-fabric-4")] {
+            /// Max number of endpoints per group entry.
+            pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 4;
+        } else if #[cfg(feature = "max-group-endpoints-per-fabric-3")] {
+            /// Max number of endpoints per group entry.
+            pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 3;
+        } else if #[cfg(feature = "max-group-endpoints-per-fabric-2")] {
+            /// Max number of endpoints per group entry.
+            pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 2;
+        } else if #[cfg(feature = "max-group-endpoints-per-fabric-1")] {
+            /// Max number of endpoints per group entry.
+            pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 1;
+        } else {
+            /// Max number of endpoints per group entry.
+            pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 0;
+        }
+    }
+
+    /// A group table entry mapping a group ID to its endpoints and name.
+    #[derive(Debug, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub struct GroupEndpointMapping {
+        pub group_id: u16,
+        pub endpoints: Vec<u16, GROUP_ENDPOINTS_PER_FABRIC>,
+        pub group_name: String<MAX_GROUP_NAME_LEN>,
+    }
+
+    /// A stored group key map entry (maps group ID to key set).
+    #[derive(Debug, Clone, Default, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub struct GroupKeyMapping {
+        pub group_id: u16,
+        pub group_key_set_id: u16,
+    }
+
+    #[derive(Debug, FromTLV, ToTLV)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub struct Groups {
+        /// Group key sets (excluding IPK which is stored in `ipk`)
+        key_sets: Vec<GroupKeySet, MAX_GROUP_KEYS_PER_FABRIC>,
+        /// Groups keyset mapping
+        key_map: Vec<GroupKeyMapping, MAX_GROUPS_PER_FABRIC>,
+        /// Group table (group ID → endpoints + name)
+        endpoint_mapping: Vec<GroupEndpointMapping, MAX_GROUPS_PER_FABRIC>,
+    }
+
+    impl Groups {
+        pub(crate) fn init() -> impl Init<Self> {
+            init!(Self {
+                key_sets <- Vec::init(),
+                key_map <- Vec::init(),
+                endpoint_mapping <- Vec::init(),
+            })
+        }
+
+        /// Return an iterator over the group key sets of the fabric
+        pub fn key_set_iter(&self) -> impl Iterator<Item = &GroupKeySet> {
+            self.key_sets.iter()
+        }
+
+        /// Find a group key set by ID
+        pub fn key_set_get(&self, id: u16) -> Option<&GroupKeySet> {
+            self.key_sets.iter().find(|e| e.group_key_set_id == id)
+        }
+
+        /// Add or update a group key set
+        pub fn key_set_add(&mut self, entry: GroupKeySet) -> Result<(), Error> {
+            if let Some(existing) = self
+                .key_sets
+                .iter_mut()
+                .find(|e| e.group_key_set_id == entry.group_key_set_id)
+            {
+                *existing = entry;
+            } else {
+                self.key_sets
+                    .push(entry)
+                    .map_err(|_| ErrorCode::ResourceExhausted)?;
+            }
             Ok(())
-        } else {
-            Err(Error::new(ErrorCode::NotFound))
         }
-    }
 
-    pub fn key_map_add(&mut self, entry: GroupKeyMapping) -> Result<(), Error> {
-        self.key_map.push(entry).map_err(|_| ErrorCode::Failure)?;
+        /// Remove a group key set by ID. Returns true if found and removed.
+        pub fn key_set_remove(&mut self, id: u16) -> Result<(), Error> {
+            let before = self.key_sets.len();
+            self.key_sets.retain(|e| e.group_key_set_id != id);
+            let removed = self.key_sets.len() < before;
 
-        Ok(())
-    }
+            self.key_map_remove_by_key_set(id);
 
-    /// Return an iterator over the group key map entries of the fabric
-    pub fn key_map_iter(&self) -> impl Iterator<Item = &GroupKeyMapping> {
-        self.key_map.iter()
-    }
-
-    /// Replace all group key map entries
-    pub fn key_map_replace(
-        &mut self,
-        entries: impl Iterator<Item = GroupKeyMapping>,
-    ) -> Result<(), Error> {
-        self.key_map.clear();
-        for entry in entries {
-            self.key_map
-                .push(entry)
-                .map_err(|_| ErrorCode::ResourceExhausted)?;
+            // Check if element was actually removed
+            if removed {
+                Ok(())
+            } else {
+                Err(Error::new(ErrorCode::NotFound))
+            }
         }
-        Ok(())
-    }
 
-    /// Remove group key map entries that reference a specific key set ID
-    pub fn key_map_remove_by_key_set(&mut self, key_set_id: u16) {
-        self.key_map.retain(|e| e.group_key_set_id != key_set_id);
-    }
+        pub fn key_map_add(&mut self, entry: GroupKeyMapping) -> Result<(), Error> {
+            self.key_map.push(entry).map_err(|_| ErrorCode::Failure)?;
 
-    /// Return an iterator over the group table entries
-    pub fn iter(&self) -> impl Iterator<Item = &GroupEndpointMapping> {
-        self.endpoint_mapping.iter()
-    }
+            Ok(())
+        }
 
-    /// Look up a group by ID
-    pub fn get(&self, group_id: u16) -> Option<&GroupEndpointMapping> {
-        self.endpoint_mapping
-            .iter()
-            .find(|e| e.group_id == group_id)
-    }
+        /// Return an iterator over the group key map entries of the fabric
+        pub fn key_map_iter(&self) -> impl Iterator<Item = &GroupKeyMapping> {
+            self.key_map.iter()
+        }
 
-    /// Add an endpoint to a group.
-    /// Returns true if the endpoint was already a member (name still updated per spec).
-    pub fn add(
-        &mut self,
-        endpoint_id: u16,
-        group_id: u16,
-        group_name: &str,
-    ) -> Result<bool, Error> {
-        let entry = if let Some(entry) = self
-            .endpoint_mapping
-            .iter_mut()
-            .find(|e| e.group_id == group_id)
-        {
-            entry
-        } else {
+        /// Replace all group key map entries
+        pub fn key_map_replace(
+            &mut self,
+            entries: impl Iterator<Item = GroupKeyMapping>,
+        ) -> Result<(), Error> {
+            self.key_map.clear();
+            for entry in entries {
+                self.key_map
+                    .push(entry)
+                    .map_err(|_| ErrorCode::ResourceExhausted)?;
+            }
+            Ok(())
+        }
+
+        /// Remove group key map entries that reference a specific key set ID
+        pub fn key_map_remove_by_key_set(&mut self, key_set_id: u16) {
+            self.key_map.retain(|e| e.group_key_set_id != key_set_id);
+        }
+
+        /// Return an iterator over the group table entries
+        pub fn iter(&self) -> impl Iterator<Item = &GroupEndpointMapping> {
+            self.endpoint_mapping.iter()
+        }
+
+        /// Look up a group by ID
+        pub fn get(&self, group_id: u16) -> Option<&GroupEndpointMapping> {
             self.endpoint_mapping
-                .push(GroupEndpointMapping {
-                    group_id,
-                    endpoints: Vec::new(),
-                    group_name: unwrap!(String::from_str(group_name)),
-                })
+                .iter()
+                .find(|e| e.group_id == group_id)
+        }
+
+        /// Add an endpoint to a group.
+        /// Returns true if the endpoint was already a member (name still updated per spec).
+        pub fn add(
+            &mut self,
+            endpoint_id: u16,
+            group_id: u16,
+            group_name: &str,
+        ) -> Result<bool, Error> {
+            let entry = if let Some(entry) = self
+                .endpoint_mapping
+                .iter_mut()
+                .find(|e| e.group_id == group_id)
+            {
+                entry
+            } else {
+                self.endpoint_mapping
+                    .push(GroupEndpointMapping {
+                        group_id,
+                        endpoints: Vec::new(),
+                        group_name: unwrap!(String::from_str(group_name)),
+                    })
+                    .map_err(|_| ErrorCode::ResourceExhausted)?;
+                unwrap!(self.endpoint_mapping.last_mut())
+            };
+
+            // Update group name
+            entry.group_name.clear();
+            unwrap!(entry.group_name.push_str(group_name));
+
+            if entry.endpoints.contains(&endpoint_id) {
+                return Ok(true);
+            }
+
+            entry
+                .endpoints
+                .push(endpoint_id)
                 .map_err(|_| ErrorCode::ResourceExhausted)?;
-            unwrap!(self.endpoint_mapping.last_mut())
-        };
 
-        // Update group name
-        entry.group_name.clear();
-        unwrap!(entry.group_name.push_str(group_name));
-
-        if entry.endpoints.contains(&endpoint_id) {
-            return Ok(true);
+            Ok(false)
         }
 
-        entry
-            .endpoints
-            .push(endpoint_id)
-            .map_err(|_| ErrorCode::ResourceExhausted)?;
+        /// Remove an endpoint from a group, or from all groups if `group_id` is `None`.
+        /// Returns true if the endpoint was removed from at least one group.
+        pub fn remove(&mut self, endpoint_id: u16, group_id: Option<u16>) -> bool {
+            let mut removed = false;
 
-        Ok(false)
-    }
-
-    /// Remove an endpoint from a group, or from all groups if `group_id` is `None`.
-    /// Returns true if the endpoint was removed from at least one group.
-    pub fn remove(&mut self, endpoint_id: u16, group_id: Option<u16>) -> bool {
-        let mut removed = false;
-
-        for entry in self.endpoint_mapping.iter_mut() {
-            if group_id.is_some_and(|id| id != entry.group_id) {
-                continue;
+            for entry in self.endpoint_mapping.iter_mut() {
+                if group_id.is_some_and(|id| id != entry.group_id) {
+                    continue;
+                }
+                let before = entry.endpoints.len();
+                entry.endpoints.retain(|&ep| ep != endpoint_id);
+                if entry.endpoints.len() < before {
+                    removed = true;
+                }
             }
-            let before = entry.endpoints.len();
-            entry.endpoints.retain(|&ep| ep != endpoint_id);
-            if entry.endpoints.len() < before {
-                removed = true;
-            }
+
+            // Remove entries with no endpoints left
+            self.endpoint_mapping.retain(|e| !e.endpoints.is_empty());
+
+            removed
         }
-
-        // Remove entries with no endpoints left
-        self.endpoint_mapping.retain(|e| !e.endpoints.is_empty());
-
-        removed
     }
 }
+
+#[cfg(feature = "groups")]
+pub use groups::*;
 
 /// Fabric type
 #[derive(Debug, ToTLV, FromTLV)]
@@ -342,13 +364,19 @@ pub struct Fabric {
     label: String<32>,
     /// Access Control List
     acl: Vec<AclEntry, { acl::MAX_ACL_ENTRIES_PER_FABRIC }>,
-    /// Fabric group information
-    groups: Groups,
     /// VID Verification Statement (Matter Core spec).
     /// Either empty (not set) or exactly `VID_VERIFICATION_STATEMENT_LEN`
     /// bytes long; the cluster XML enforces both bounds at the schema
     /// level (`length="85" minLength="85"`).
     vid_verification_statement: Vec<u8, VID_VERIFICATION_STATEMENT_LEN>,
+    /// Fabric group information.
+    ///
+    /// Kept as the last field so that gating it out under `not(feature =
+    /// "groups")` does not shift the derived TLV tag of any earlier field
+    /// (tags are positional), preserving on-disk fabric compatibility across
+    /// builds with and without the `groups` feature.
+    #[cfg(feature = "groups")]
+    groups: Groups,
 }
 
 /// Exact length of a non-empty VID Verification Statement.
@@ -366,7 +394,11 @@ impl Fabric {
     /// The Fabric must be updated with the correct values before it can be
     /// used, via `Fabric::update`.
     fn init(fab_idx: NonZeroU8) -> impl Init<Self> {
-        init!(Self {
+        // NOTE: the `init!` macro does not accept `#[cfg]` on its field entries,
+        // so the `groups` field (present only under the `groups` feature) forces
+        // two variants of the initializer that differ solely by that last field.
+        #[cfg(feature = "groups")]
+        let r = init!(Self {
             fab_idx,
             node_id: 0,
             fabric_id: 0,
@@ -380,9 +412,27 @@ impl Fabric {
             ipk <- KeySet::init(),
             label: String::new(),
             acl <- Vec::init(),
-            groups <- Groups::init(),
             vid_verification_statement <- Vec::init(),
-        })
+            groups <- Groups::init(),
+        });
+        #[cfg(not(feature = "groups"))]
+        let r = init!(Self {
+            fab_idx,
+            node_id: 0,
+            fabric_id: 0,
+            vendor_id: 0,
+            compressed_fabric_id: 0,
+            secret_key <- CanonPkcSecretKey::init(),
+            root_ca <- Vec::init(),
+            icac_or_vvsc <- Vec::init(),
+            vvsc_set: false,
+            noc <- Vec::init(),
+            ipk <- KeySet::init(),
+            label: String::new(),
+            acl <- Vec::init(),
+            vid_verification_statement <- Vec::init(),
+        });
+        r
     }
 
     /// Update the fabric with the provided data so that it can operate.
@@ -596,11 +646,13 @@ impl Fabric {
     }
 
     /// Return the fabric's groups
+    #[cfg(feature = "groups")]
     pub fn groups(&self) -> &Groups {
         &self.groups
     }
 
     /// Return a mutable reference to the fabric's groups
+    #[cfg(feature = "groups")]
     pub fn groups_mut(&mut self) -> &mut Groups {
         &mut self.groups
     }

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -72,9 +72,9 @@ mod groups {
         } else if #[cfg(feature = "max-group-keys-per-fabric-2")] {
             /// Max number of group key sets per fabric (excluding IPK at index 0).
             pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 2;
-        } else {
+        } else { // Matter requires a minimum of 3 group key sets per fabric
             /// Max number of group key sets per fabric (excluding IPK at index 0).
-            pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 0;
+            pub const MAX_GROUP_KEYS_PER_FABRIC: usize = 3;
         }
     }
 
@@ -106,9 +106,9 @@ mod groups {
         } else if #[cfg(feature = "max-groups-per-fabric-4")] {
             /// Max number of group key map entries per fabric.
             pub const MAX_GROUPS_PER_FABRIC: usize = 4;
-        } else {
+        } else { // Matter requires a minimum of 4 group table entries per fabric
             /// Max number of group key map entries per fabric.
-            pub const MAX_GROUPS_PER_FABRIC: usize = 0;
+            pub const MAX_GROUPS_PER_FABRIC: usize = 4;
         }
     }
 
@@ -128,9 +128,9 @@ mod groups {
         } else if #[cfg(feature = "max-group-endpoints-per-fabric-1")] {
             /// Max number of endpoints per group entry.
             pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 1;
-        } else {
+        } else { // Default: 3 endpoints per group entry
             /// Max number of endpoints per group entry.
-            pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 0;
+            pub const GROUP_ENDPOINTS_PER_FABRIC: usize = 3;
         }
     }
 

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -386,21 +386,16 @@ pub struct Fabric {
     label: String<32>,
     /// Access Control List
     acl: Vec<AclEntry, { acl::MAX_ACL_ENTRIES_PER_FABRIC }>,
+    /// Fabric group information.
+    #[cfg(feature = "groups")]
+    #[tagval(13)]
+    groups: Skippable<Groups>,
     /// VID Verification Statement (Matter Core spec).
     /// Either empty (not set) or exactly `VID_VERIFICATION_STATEMENT_LEN`
     /// bytes long; the cluster XML enforces both bounds at the schema
     /// level (`length="85" minLength="85"`).
+    #[tagval(14)]
     vid_verification_statement: Vec<u8, VID_VERIFICATION_STATEMENT_LEN>,
-    /// Fabric group information.
-    ///
-    /// Two properties keep this compatible with fabrics persisted by other
-    /// builds:
-    /// - It is the LAST field, so gating it out under `not(feature = "groups")`
-    ///   does not shift the derived (positional) TLV tag of any earlier field.
-    /// - It is `Skippable`, so a fabric persisted by a `groups`-off build (whose
-    ///   TLV has no `groups` tag at all) still deserializes here.
-    #[cfg(feature = "groups")]
-    groups: Skippable<Groups>,
 }
 
 /// Exact length of a non-empty VID Verification Statement.
@@ -1261,14 +1256,60 @@ mod tests {
     };
     use crate::utils::init::InitMaybeUninit;
 
-    use super::Fabrics;
+    use core::num::NonZeroU8;
 
-    // NOTE: the upgrade-compatibility property that lets a `Fabric` persisted by
-    // a `groups`-off build (whose TLV lacks the trailing `groups` tag) still
-    // deserialize in a `groups`-on build comes from `groups` being the last field
-    // and typed `Skippable<Groups>`. The `Skippable` mechanism — including the
-    // "missing trailing struct field reads back as default" case that mirrors
-    // this exactly — is unit-tested in `crate::tlv::traits::skippable`.
+    use super::{Fabric, Fabrics};
+
+    /// Lock the on-disk TLV tag layout of the fields whose position is sensitive
+    /// to the `groups` feature. A released `rs-matter` persists `groups` at
+    /// context tag 13 and `vid_verification_statement` at 14; gating `groups` in
+    /// or out must not move either. Serializing an (empty) `Fabric` and checking
+    /// the raw tags catches any future reorder that would silently corrupt
+    /// existing persisted fabrics.
+    #[test]
+    fn fabric_tlv_tag_layout_is_stable() {
+        use crate::tlv::{TLVElement, TLVTag, ToTLV};
+        use crate::utils::init::InitMaybeUninit;
+        use crate::utils::storage::WriteBuf;
+
+        let mut fabric = core::mem::MaybeUninit::<Fabric>::uninit();
+        let fabric = fabric.init_with(Fabric::init(unwrap!(NonZeroU8::new(1))));
+
+        let mut buf = [0u8; 512];
+        let mut wb = WriteBuf::new(&mut buf);
+        fabric.to_tlv(&TLVTag::Anonymous, &mut wb).unwrap();
+        let len = wb.get_tail();
+
+        let root = TLVElement::new(&buf[..len]).structure().unwrap();
+
+        // `find_ctx` returns an EMPTY element (not an error) when the tag is
+        // absent, so presence is `!is_empty()` and absence is `is_empty()`.
+
+        // `acl` (the last always-present field before the sensitive pair) is at 12.
+        assert!(
+            !root.find_ctx(12).unwrap().is_empty(),
+            "acl must stay at TLV tag 12"
+        );
+
+        // `vid_verification_statement` must always be at context tag 14.
+        assert!(
+            !root.find_ctx(14).unwrap().is_empty(),
+            "vid_verification_statement must stay at TLV tag 14"
+        );
+
+        // With `groups` compiled in it must be at tag 13; compiled out, tag 13 is
+        // simply absent (and a reader defaults it).
+        #[cfg(feature = "groups")]
+        assert!(
+            !root.find_ctx(13).unwrap().is_empty(),
+            "groups must be at TLV tag 13 when compiled in"
+        );
+        #[cfg(not(feature = "groups"))]
+        assert!(
+            root.find_ctx(13).unwrap().is_empty(),
+            "no field should occupy tag 13 when groups is compiled out"
+        );
+    }
 
     /// Verify that `compute_dest_id` and `is_dest_id` agree: the hash output by
     /// `compute_dest_id` must be accepted by `is_dest_id` on the same fabric with

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -31,6 +31,8 @@ use crate::dm::Privilege;
 use crate::error::{Error, ErrorCode};
 use crate::group_keys::KeySet;
 use crate::persist::{KvBlobStore, KvBlobStoreAccess, Persist, FABRIC_KEYS_START};
+#[cfg(feature = "groups")]
+use crate::tlv::Skippable;
 use crate::tlv::{FromTLV, TLVElement, ToTLV};
 use crate::transport::network::MatterLocalService;
 use crate::utils::init::{init, Init, InitMaybeUninit, IntoFallibleInit};
@@ -54,7 +56,7 @@ mod groups {
     use crate::error::{Error, ErrorCode};
     use crate::group_keys::GroupKeySet;
     use crate::tlv::{FromTLV, ToTLV};
-    use crate::utils::init::{init, Init};
+    use crate::utils::init::{init, Init, InitDefault};
     use crate::utils::storage::Vec;
 
     cfg_if! {
@@ -161,6 +163,14 @@ mod groups {
     }
 
     impl Groups {
+        pub(crate) const fn new() -> Self {
+            Self {
+                key_sets: Vec::new(),
+                key_map: Vec::new(),
+                endpoint_mapping: Vec::new(),
+            }
+        }
+
         pub(crate) fn init() -> impl Init<Self> {
             init!(Self {
                 key_sets <- Vec::init(),
@@ -316,6 +326,18 @@ mod groups {
             removed
         }
     }
+
+    impl Default for Groups {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl InitDefault for Groups {
+        fn init_default() -> impl Init<Self> {
+            Self::init()
+        }
+    }
 }
 
 #[cfg(feature = "groups")]
@@ -371,12 +393,14 @@ pub struct Fabric {
     vid_verification_statement: Vec<u8, VID_VERIFICATION_STATEMENT_LEN>,
     /// Fabric group information.
     ///
-    /// Kept as the last field so that gating it out under `not(feature =
-    /// "groups")` does not shift the derived TLV tag of any earlier field
-    /// (tags are positional), preserving on-disk fabric compatibility across
-    /// builds with and without the `groups` feature.
+    /// Two properties keep this compatible with fabrics persisted by other
+    /// builds:
+    /// - It is the LAST field, so gating it out under `not(feature = "groups")`
+    ///   does not shift the derived (positional) TLV tag of any earlier field.
+    /// - It is `Skippable`, so a fabric persisted by a `groups`-off build (whose
+    ///   TLV has no `groups` tag at all) still deserializes here.
     #[cfg(feature = "groups")]
-    groups: Groups,
+    groups: Skippable<Groups>,
 }
 
 /// Exact length of a non-empty VID Verification Statement.
@@ -413,8 +437,9 @@ impl Fabric {
             label: String::new(),
             acl <- Vec::init(),
             vid_verification_statement <- Vec::init(),
-            groups <- Groups::init(),
+            groups <- Skippable::init_default(),
         });
+
         #[cfg(not(feature = "groups"))]
         let r = init!(Self {
             fab_idx,
@@ -645,16 +670,18 @@ impl Fabric {
         &self.ipk
     }
 
-    /// Return the fabric's groups
+    /// Return the fabric's groups, or an empty group state if this fabric was
+    /// persisted before the `groups` field existed (see [`Fabric::groups`]).
     #[cfg(feature = "groups")]
     pub fn groups(&self) -> &Groups {
-        &self.groups
+        self.groups.value()
     }
 
-    /// Return a mutable reference to the fabric's groups
+    /// Return a mutable reference to the fabric's groups, materializing empty
+    /// group state on first access if it was absent.
     #[cfg(feature = "groups")]
     pub fn groups_mut(&mut self) -> &mut Groups {
-        &mut self.groups
+        self.groups.value_mut()
     }
 
     /// Return the fabric's VVSC bytes (Matter Core spec).
@@ -1235,6 +1262,13 @@ mod tests {
     use crate::utils::init::InitMaybeUninit;
 
     use super::Fabrics;
+
+    // NOTE: the upgrade-compatibility property that lets a `Fabric` persisted by
+    // a `groups`-off build (whose TLV lacks the trailing `groups` tag) still
+    // deserialize in a `groups`-on build comes from `groups` being the last field
+    // and typed `Skippable<Groups>`. The `Skippable` mechanism — including the
+    // "missing trailing struct field reads back as default" case that mirrors
+    // this exactly — is unit-tested in `crate::tlv::traits::skippable`.
 
     /// Verify that `compute_dest_id` and `is_dest_id` agree: the hash output by
     /// `compute_dest_id` must be accepted by `is_dest_id` on the same fabric with

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -282,7 +282,8 @@ mod groups {
                     .push(GroupEndpointMapping {
                         group_id,
                         endpoints: Vec::new(),
-                        group_name: unwrap!(String::from_str(group_name)),
+                        group_name: String::from_str(group_name)
+                            .map_err(|_| ErrorCode::ConstraintError)?,
                     })
                     .map_err(|_| ErrorCode::ResourceExhausted)?;
                 unwrap!(self.endpoint_mapping.last_mut())
@@ -290,7 +291,10 @@ mod groups {
 
             // Update group name
             entry.group_name.clear();
-            unwrap!(entry.group_name.push_str(group_name));
+            entry
+                .group_name
+                .push_str(group_name)
+                .map_err(|_| ErrorCode::ConstraintError)?;
 
             if entry.endpoints.contains(&endpoint_id) {
                 return Ok(true);

--- a/rs-matter/src/group_keys.rs
+++ b/rs-matter/src/group_keys.rs
@@ -19,11 +19,14 @@ use crate::crypto::{self, CanonAeadKey, CanonAeadKeyRef, Crypto, Kdf};
 use crate::error::{Error, ErrorCode};
 use crate::tlv::{FromTLV, ToTLV};
 use crate::utils::init::{init, Init};
+#[cfg(feature = "groups")]
 use crate::utils::storage::Vec;
 
+#[cfg(feature = "groups")]
 pub const GROUP_MAX_EPOCH_KEYS: usize = 3;
 
 /// A stored group key set entry.
+#[cfg(feature = "groups")]
 #[derive(Debug, Clone, Default, FromTLV, ToTLV)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GroupEpochKeyEntry {
@@ -32,6 +35,7 @@ pub struct GroupEpochKeyEntry {
 }
 
 /// A stored group key set entry.
+#[cfg(feature = "groups")]
 #[derive(Debug, Clone, Default, FromTLV, ToTLV)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GroupKeySet {

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -1090,9 +1090,37 @@ where
                     // drop means its persisted record must be purged too.
                     Ok(false) => dropped_any = true,
                     Err(e) => {
-                        if self.handle_subscription_report_error(matter, &mut rctx, e) {
-                            dropped_any = true;
-                        }
+                        // Reporting failed — typically because the session to the
+                        // subscriber died (peer unreachable, MRP retransmissions
+                        // exhausted). Drop that session so the next report to this
+                        // peer establishes a fresh one, and keep the subscription
+                        // so it retries rather than being torn down.
+                        let (fab_idx, peer_node_id) = {
+                            let ids = rctx.subscription().ids();
+                            (ids.fab_idx, ids.peer_node_id)
+                        };
+
+                        warn!(
+                            "Error processing subscription (fab {}, node {:x}): {:?}; dropping its session, will retry",
+                            fab_idx.get(),
+                            peer_node_id,
+                            e
+                        );
+
+                        matter.with_state(|state| {
+                            if let Some(id) = state
+                                .sessions
+                                .get_for_node(fab_idx, peer_node_id)
+                                .map(|s| s.id)
+                            {
+                                state.sessions.remove(id);
+                            }
+                        });
+
+                        // Keep the subscription to retry, but do NOT advance its
+                        // watermarks: the changes/events this report was carrying
+                        // never reached the subscriber and must be re-sent.
+                        rctx.set_keep_retry();
                     }
                 }
             }
@@ -1110,131 +1138,19 @@ where
         }
     }
 
-    /// Handle a failed subscription report. Returns `true` if the subscription was
-    /// dropped from the table (so the caller re-persists to purge its record).
-    ///
-    /// Without `sticky-primed-session` a subscription outlives the session it was
-    /// accepted on: a failed report usually means that session died, so we drop it
-    /// (forcing a fresh one on the next attempt) and keep the subscription, backing
-    /// it off and only letting it expire at its `max_int` liveness deadline.
-    #[cfg(not(feature = "sticky-primed-session"))]
-    fn handle_subscription_report_error(
-        &self,
-        matter: &Matter<'_>,
-        rctx: &mut ReportContext<'_, '_, B, NS>,
-        e: Error,
-    ) -> bool {
-        let (fab_idx, peer_node_id) = {
-            let ids = rctx.subscription().ids();
-            (ids.fab_idx, ids.peer_node_id)
-        };
-
-        error!(
-            "Error processing subscription (fab {}, node {:x}): {:?}; dropping its session, will retry",
-            fab_idx.get(),
-            peer_node_id,
-            e
-        );
-
-        matter.with_state(|state| {
-            if let Some(id) = state
-                .sessions
-                .get_for_node(fab_idx, peer_node_id)
-                .map(|s| s.id)
-            {
-                state.sessions.remove(id);
-            }
-        });
-
-        // Keep the subscription to retry, but do NOT advance its watermarks: the
-        // changes/events this report was carrying never reached the subscriber and
-        // must be re-sent.
-        rctx.set_keep_retry();
-
-        false
-    }
-
-    /// The `sticky-primed-session` variant: restore the pre-persistence behavior.
-    ///
-    /// A sticky subscription reports only over an already-established session and
-    /// never creates a new one, so a report failure it cannot recover from — the
-    /// session is gone and will not be re-established here. Retrying is pointless,
-    /// so the subscription is simply dropped (its `rctx` is left without
-    /// `set_keep`), exactly as the reporter did before subscriptions could outlive
-    /// their session.
-    #[cfg(feature = "sticky-primed-session")]
-    fn handle_subscription_report_error(
-        &self,
-        _matter: &Matter<'_>,
-        rctx: &mut ReportContext<'_, '_, B, NS>,
-        e: Error,
-    ) -> bool {
-        error!(
-            "Error processing subscription {:?}: {:?}; dropping it",
-            rctx.subscription().ids(),
-            e
-        );
-
-        // Leave `rctx` without `set_keep`: it drops out of the table on drop.
-        true
-    }
-
-    /// Open the exchange over which a subscription report is delivered to its
-    /// subscriber, routed by the subscriber's `(fabric, node)`.
-    ///
-    /// Without the `sticky-primed-session` feature this reuses the best live
-    /// session to the peer or, if none exists, establishes a fresh one via CASE
-    /// (resolving the operational address over mDNS). This is the spec-correct
-    /// behavior: a subscription is identified by its id, not bound to the session
-    /// it was accepted on, so it keeps reporting even after that session is gone.
-    #[cfg(not(feature = "sticky-primed-session"))]
-    async fn initiate_report_exchange<'m>(
-        &self,
-        matter: &'m Matter<'m>,
-        fabric_idx: NonZeroU8,
-        peer_node_id: NodeId,
-    ) -> Result<Exchange<'m>, Error> {
-        Exchange::initiate(matter, self.crypto(), fabric_idx, peer_node_id).await
-    }
-
-    /// The `sticky-primed-session` variant: report **only** over a session that
-    /// already exists to the peer, and never establish a new one.
-    ///
-    /// This trades spec-completeness for code size: because it never calls into
-    /// CASE or mDNS, the linker drops the whole CASE-initiator and mDNS-resolver
-    /// machinery from an accessory that only ever reports over its priming
-    /// session. If no live session to the peer remains, this errors — the
-    /// reporter then backs the subscription off and eventually lets it expire,
-    /// exactly as it would for any other failed report.
-    #[cfg(feature = "sticky-primed-session")]
-    async fn initiate_report_exchange<'m>(
-        &self,
-        matter: &'m Matter<'m>,
-        fabric_idx: NonZeroU8,
-        peer_node_id: NodeId,
-    ) -> Result<Exchange<'m>, Error> {
-        let session_id = matter
-            .with_state(|state| {
-                state
-                    .sessions
-                    .get_for_node(fabric_idx, peer_node_id)
-                    .map(|s| s.id)
-            })
-            .ok_or(ErrorCode::NoSession)?;
-
-        Exchange::initiate_for_session(matter, session_id)
-    }
-
     /// Process one valid subscription, reporting the data to the peer.
     async fn process_subscription(
         &self,
         matter: &Matter<'_>,
         rctx: &mut ReportContext<'_, '_, B, NS>,
     ) -> Result<bool, Error> {
+        // Route the report by the subscriber's `(fabric, node)`: reuse the best
+        // live session to that peer, or (with the `case-responder-only` feature
+        // off) establish a fresh one on demand. A subscription is identified by
+        // its id, not bound to the session it was accepted on.
         let ids = rctx.subscription().ids();
-        let mut exchange = self
-            .initiate_report_exchange(matter, ids.fab_idx, ids.peer_node_id)
-            .await?;
+        let mut exchange =
+            Exchange::initiate(matter, self.crypto(), ids.fab_idx, ids.peer_node_id).await?;
 
         if let Some(mut tx) = self.buffers.get().await {
             // Always safe as `IMBuffer` is defined to be `MAX_EXCHANGE_RX_BUF_SIZE`, which is bigger than `MAX_EXCHANGE_TX_BUF_SIZE`

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -147,7 +147,10 @@ impl<N, const NS: usize, const NE: usize> InteractionModelState<N, NS, NE> {
             store.remove(NETWORKS_KEY, buf)?;
 
             // Every persisted subscription record.
+            #[cfg(feature = "persistent-subscriptions")]
             subscriptions.reset_persist(&mut *store, buf)?;
+            #[cfg(not(feature = "persistent-subscriptions"))]
+            let _ = &subscriptions;
 
             Ok(())
         })
@@ -189,17 +192,6 @@ impl<N, const NS: usize, const NE: usize> InteractionModelState<N, NS, NE> {
     /// The subscriptions table.
     pub const fn subscriptions(&self) -> &Subscriptions<NS> {
         &self.subscriptions
-    }
-
-    /// Enable or disable persistence of subscriptions (off by default).
-    ///
-    /// When enabled, accepted subscriptions are persisted to the key-value store
-    /// and resumed (via [`InteractionModel::resume_subscriptions`]) after a reboot,
-    /// so a subscriber keeps its subscription across a device restart instead of
-    /// having to notice the loss and re-subscribe. Persisting is spec-optional and
-    /// costs flash writes, so it is opt-in. Call once at startup.
-    pub fn set_persist_subscriptions(&self, enabled: bool) {
-        self.subscriptions.set_persist(enabled);
     }
 
     /// The events queue.
@@ -935,6 +927,11 @@ where
     /// A no-op when the store is a dummy (no scratch buffer). Best-effort: a
     /// persistence failure is logged but never propagated, so it cannot break
     /// reporting — persisting subscriptions is spec-optional.
+    ///
+    /// Compiled to a no-op unless the `persistent-subscriptions` feature is
+    /// enabled, so the whole persistence path (TLV serialization, the key-value
+    /// store writes) is dropped from a device that does not want it.
+    #[cfg(feature = "persistent-subscriptions")]
     fn persist_subscriptions(&self) {
         let result = self.kv.access(|store, buf| {
             self.state
@@ -947,6 +944,10 @@ where
         }
     }
 
+    #[cfg(not(feature = "persistent-subscriptions"))]
+    #[inline(always)]
+    fn persist_subscriptions(&self) {}
+
     /// Re-hydrate the subscription table from `kv` and re-arm the reporter.
     ///
     /// Call once at startup, after the fabrics and events state have been
@@ -955,6 +956,11 @@ where
     /// primed) subscription; the reporter then reaches the subscriber on demand
     /// by establishing a session when the next report is due. No session is
     /// opened proactively here.
+    ///
+    /// Compiled to a no-op (returning `Ok`) unless the `persistent-subscriptions`
+    /// feature is enabled, so it is always safe to call from the startup path
+    /// regardless of whether persistence is compiled in.
+    #[cfg(feature = "persistent-subscriptions")]
     pub fn resume_subscriptions(&self) -> Result<(), Error> {
         let now = Instant::now();
         let watermark = self.state.events.watermark();
@@ -974,6 +980,14 @@ where
         // liveness deadlines.
         self.state.subscriptions.notification.notify();
 
+        Ok(())
+    }
+
+    /// See the `persistent-subscriptions` variant above; a no-op when that
+    /// feature is off.
+    #[cfg(not(feature = "persistent-subscriptions"))]
+    #[inline(always)]
+    pub fn resume_subscriptions(&self) -> Result<(), Error> {
         Ok(())
     }
 
@@ -1076,37 +1090,9 @@ where
                     // drop means its persisted record must be purged too.
                     Ok(false) => dropped_any = true,
                     Err(e) => {
-                        // Reporting failed — typically because the session to the
-                        // subscriber died (peer unreachable, MRP retransmissions
-                        // exhausted). Drop that session so the next report to this
-                        // peer establishes a fresh one, and keep the subscription
-                        // so it retries rather than being torn down.
-                        let (fab_idx, peer_node_id) = {
-                            let ids = rctx.subscription().ids();
-                            (ids.fab_idx, ids.peer_node_id)
-                        };
-
-                        error!(
-                            "Error processing subscription (fab {}, node {:x}): {:?}; dropping its session, will retry",
-                            fab_idx.get(),
-                            peer_node_id,
-                            e
-                        );
-
-                        matter.with_state(|state| {
-                            if let Some(id) = state
-                                .sessions
-                                .get_for_node(fab_idx, peer_node_id)
-                                .map(|s| s.id)
-                            {
-                                state.sessions.remove(id);
-                            }
-                        });
-
-                        // Keep the subscription to retry, but do NOT advance its
-                        // watermarks: the changes/events this report was carrying
-                        // never reached the subscriber and must be re-sent.
-                        rctx.set_keep_retry();
+                        if self.handle_subscription_report_error(matter, &mut rctx, e) {
+                            dropped_any = true;
+                        }
                     }
                 }
             }
@@ -1124,30 +1110,131 @@ where
         }
     }
 
-    /// Process one valid subscription, reporting the data to the peer.
+    /// Handle a failed subscription report. Returns `true` if the subscription was
+    /// dropped from the table (so the caller re-persists to purge its record).
     ///
-    /// Arguments:
-    /// - `matter` - a reference to the `Matter` instance
-    /// - `fabric_idx` - the fabric index of the peer
-    /// - `peer_node_id` - the node ID of the peer
-    /// - `session_id` - the session ID of the peer, if any
-    /// - `sub` - the received and saved data for the subscription, when the subscription was primed
-    /// - `min_event_number` - the subscription's current event watermark; updated
-    ///   in place as events are emitted so the caller can persist it
-    /// - `ctx` - the report context for this subscription
-    #[allow(clippy::too_many_arguments)]
+    /// Without `sticky-primed-session` a subscription outlives the session it was
+    /// accepted on: a failed report usually means that session died, so we drop it
+    /// (forcing a fresh one on the next attempt) and keep the subscription, backing
+    /// it off and only letting it expire at its `max_int` liveness deadline.
+    #[cfg(not(feature = "sticky-primed-session"))]
+    fn handle_subscription_report_error(
+        &self,
+        matter: &Matter<'_>,
+        rctx: &mut ReportContext<'_, '_, B, NS>,
+        e: Error,
+    ) -> bool {
+        let (fab_idx, peer_node_id) = {
+            let ids = rctx.subscription().ids();
+            (ids.fab_idx, ids.peer_node_id)
+        };
+
+        error!(
+            "Error processing subscription (fab {}, node {:x}): {:?}; dropping its session, will retry",
+            fab_idx.get(),
+            peer_node_id,
+            e
+        );
+
+        matter.with_state(|state| {
+            if let Some(id) = state
+                .sessions
+                .get_for_node(fab_idx, peer_node_id)
+                .map(|s| s.id)
+            {
+                state.sessions.remove(id);
+            }
+        });
+
+        // Keep the subscription to retry, but do NOT advance its watermarks: the
+        // changes/events this report was carrying never reached the subscriber and
+        // must be re-sent.
+        rctx.set_keep_retry();
+
+        false
+    }
+
+    /// The `sticky-primed-session` variant: restore the pre-persistence behavior.
+    ///
+    /// A sticky subscription reports only over an already-established session and
+    /// never creates a new one, so a report failure it cannot recover from — the
+    /// session is gone and will not be re-established here. Retrying is pointless,
+    /// so the subscription is simply dropped (its `rctx` is left without
+    /// `set_keep`), exactly as the reporter did before subscriptions could outlive
+    /// their session.
+    #[cfg(feature = "sticky-primed-session")]
+    fn handle_subscription_report_error(
+        &self,
+        _matter: &Matter<'_>,
+        rctx: &mut ReportContext<'_, '_, B, NS>,
+        e: Error,
+    ) -> bool {
+        error!(
+            "Error processing subscription {:?}: {:?}; dropping it",
+            rctx.subscription().ids(),
+            e
+        );
+
+        // Leave `rctx` without `set_keep`: it drops out of the table on drop.
+        true
+    }
+
+    /// Open the exchange over which a subscription report is delivered to its
+    /// subscriber, routed by the subscriber's `(fabric, node)`.
+    ///
+    /// Without the `sticky-primed-session` feature this reuses the best live
+    /// session to the peer or, if none exists, establishes a fresh one via CASE
+    /// (resolving the operational address over mDNS). This is the spec-correct
+    /// behavior: a subscription is identified by its id, not bound to the session
+    /// it was accepted on, so it keeps reporting even after that session is gone.
+    #[cfg(not(feature = "sticky-primed-session"))]
+    async fn initiate_report_exchange<'m>(
+        &self,
+        matter: &'m Matter<'m>,
+        fabric_idx: NonZeroU8,
+        peer_node_id: NodeId,
+    ) -> Result<Exchange<'m>, Error> {
+        Exchange::initiate(matter, self.crypto(), fabric_idx, peer_node_id).await
+    }
+
+    /// The `sticky-primed-session` variant: report **only** over a session that
+    /// already exists to the peer, and never establish a new one.
+    ///
+    /// This trades spec-completeness for code size: because it never calls into
+    /// CASE or mDNS, the linker drops the whole CASE-initiator and mDNS-resolver
+    /// machinery from an accessory that only ever reports over its priming
+    /// session. If no live session to the peer remains, this errors — the
+    /// reporter then backs the subscription off and eventually lets it expire,
+    /// exactly as it would for any other failed report.
+    #[cfg(feature = "sticky-primed-session")]
+    async fn initiate_report_exchange<'m>(
+        &self,
+        matter: &'m Matter<'m>,
+        fabric_idx: NonZeroU8,
+        peer_node_id: NodeId,
+    ) -> Result<Exchange<'m>, Error> {
+        let session_id = matter
+            .with_state(|state| {
+                state
+                    .sessions
+                    .get_for_node(fabric_idx, peer_node_id)
+                    .map(|s| s.id)
+            })
+            .ok_or(ErrorCode::NoSession)?;
+
+        Exchange::initiate_for_session(matter, session_id)
+    }
+
+    /// Process one valid subscription, reporting the data to the peer.
     async fn process_subscription(
         &self,
         matter: &Matter<'_>,
         rctx: &mut ReportContext<'_, '_, B, NS>,
     ) -> Result<bool, Error> {
-        // Route the report by the subscriber's `(fabric, node)` rather than a
-        // pinned session id: reuse the best live session to that peer, or (if
-        // the original one is gone) establish a fresh one. A subscription is
-        // identified by its id, not bound to the session it was accepted on.
         let ids = rctx.subscription().ids();
-        let mut exchange =
-            Exchange::initiate(matter, self.crypto(), ids.fab_idx, ids.peer_node_id).await?;
+        let mut exchange = self
+            .initiate_report_exchange(matter, ids.fab_idx, ids.peer_node_id)
+            .await?;
 
         if let Some(mut tx) = self.buffers.get().await {
             // Always safe as `IMBuffer` is defined to be `MAX_EXCHANGE_RX_BUF_SIZE`, which is bigger than `MAX_EXCHANGE_TX_BUF_SIZE`

--- a/rs-matter/src/im/subscriptions.rs
+++ b/rs-matter/src/im/subscriptions.rs
@@ -15,20 +15,24 @@
  *    limitations under the License.
  */
 
-use core::cell::Cell;
 use core::num::NonZeroU8;
 
 use embassy_time::Instant;
 
+#[cfg(feature = "persistent-subscriptions")]
 use crate::error::Error;
 use crate::fabric::MAX_FABRICS;
 use crate::im::{AttrId, ClusterId, EndptId, EventId, EventNumber, IMBuffer, NodeId};
+#[cfg(feature = "persistent-subscriptions")]
 use crate::persist::{KvBlobStore, PERSISTENT_SUBSCRIPTIONS_START};
+#[cfg(feature = "persistent-subscriptions")]
 use crate::tlv::{FromTLV, OctetStr, Octets, TLVElement, TLVTag, ToTLV};
 use crate::utils::cell::RefCell;
 use crate::utils::init::{init, Init};
 use crate::utils::storage::pooled::Buffers;
-use crate::utils::storage::{Vec, WriteBuf};
+use crate::utils::storage::Vec;
+#[cfg(feature = "persistent-subscriptions")]
+use crate::utils::storage::WriteBuf;
 use crate::utils::sync::blocking::Mutex;
 use crate::utils::sync::{DynBase, Notification};
 
@@ -106,12 +110,6 @@ type SubscriptionsBuffersInner<'a, B, const N: usize> =
 /// Additional subscriptions are rejected by the data model with a "resource exhausted" IM status message.
 pub struct Subscriptions<const N: usize = DEFAULT_MAX_SUBSCRIPTIONS> {
     state: Mutex<RefCell<SubscriptionsInner<N>>>,
-    /// Whether accepted subscriptions are persisted to (and resumed from) the
-    /// key-value store. Off by default (opt-in): persisting subscriptions is
-    /// spec-optional and adds flash writes, so the application enables it only
-    /// when it wants subscriptions to survive a reboot (e.g. a long-idle ICD).
-    /// Set once at startup via [`Subscriptions::set_persist`].
-    persist: Mutex<Cell<bool>>,
     pub(crate) notification: Notification,
 }
 
@@ -121,7 +119,6 @@ impl<const N: usize> Subscriptions<N> {
     pub const fn new() -> Self {
         Self {
             state: Mutex::new(RefCell::new(SubscriptionsInner::new())),
-            persist: Mutex::new(Cell::new(false)),
             notification: Notification::new(),
         }
     }
@@ -130,24 +127,17 @@ impl<const N: usize> Subscriptions<N> {
     pub fn init() -> impl Init<Self> {
         init!(Self {
             state <- Mutex::init(RefCell::init(SubscriptionsInner::init())),
-            persist: Mutex::new(Cell::new(false)),
             notification: Notification::new(),
         })
     }
 
-    /// Enable or disable persistence of subscriptions (off by default).
+    /// Whether subscription persistence is compiled in.
     ///
-    /// When disabled, [`Self::persist_all`], [`Self::load_persist`] and
-    /// [`Self::reset_persist`] are no-ops, so accepted subscriptions live only in
-    /// memory and do not survive a reboot. Call once at startup, before the data
-    /// model starts accepting traffic.
-    pub fn set_persist(&self, enabled: bool) {
-        self.persist.lock(|p| p.set(enabled));
-    }
-
-    /// Whether subscription persistence is currently enabled.
-    pub fn persist_enabled(&self) -> bool {
-        self.persist.lock(|p| p.get())
+    /// `true` only when the `persistent-subscriptions` feature is enabled; when it
+    /// is off, the persist/resume machinery is compiled out entirely and this is a
+    /// `const false` that lets the linker drop the callers.
+    pub const fn persist_enabled(&self) -> bool {
+        cfg!(feature = "persistent-subscriptions")
     }
 
     /// Notify the instance that the data of a specific attribute has changed and that it should re-evaluate the subscriptions
@@ -303,6 +293,8 @@ impl<const N: usize> Subscriptions<N> {
             next_max_seen_attr_change_id,
             next_max_seen_event_number: event_numbers_watermark,
             next_reported_at: now,
+            next_retry_at: Instant::MIN,
+            next_fail_count: 0,
             keep: false,
         })
     }
@@ -409,6 +401,8 @@ impl<const N: usize> Subscriptions<N> {
             next_max_seen_attr_change_id,
             next_max_seen_event_number: event_numbers_watermark,
             next_reported_at: now,
+            next_retry_at: Instant::MIN,
+            next_fail_count: 0,
             keep: false,
         })
     }
@@ -437,6 +431,46 @@ impl<const N: usize> Subscriptions<N> {
             .lock(|state| state.borrow_mut().purge_reported_changes())
     }
 
+    /// Complete a report by updating the subscription's watermark and last-reported timestamp,
+    /// and re-inserting it into the table if the `keep` flag is set on the context.
+    fn report_complete<'a, B>(&self, report: &mut ReportContext<'a, '_, B, N>)
+    where
+        B: Buffers<IMBuffer> + 'a,
+    {
+        let mut sub = unwrap!(report.subscription.take());
+        let buf = unwrap!(report.subscription_buffer.take());
+
+        sub.max_seen_attr_change_id = report.next_max_seen_attr_change_id;
+        sub.max_seen_event_number = report.next_max_seen_event_number;
+        sub.reported_at = report.next_reported_at;
+        sub.retry_at = report.next_retry_at;
+        sub.fail_count = report.next_fail_count;
+
+        let keep = report.keep;
+
+        self.with(report.subscriptions_buffers, |state, buffers| {
+            state.report_complete::<B>(sub, buf, buffers, keep)
+        })
+    }
+
+    fn with<'a, B, F, R>(&self, buffers: &SubscriptionsBuffers<'a, B, N>, f: F) -> R
+    where
+        B: Buffers<IMBuffer> + 'a,
+        F: FnOnce(&mut SubscriptionsInner<N>, &mut SubscriptionsBuffersInner<'a, B, N>) -> R,
+    {
+        self.state.lock(|state| {
+            let mut state = state.borrow_mut();
+            buffers.with(|buffers| f(&mut state, buffers))
+        })
+    }
+}
+
+/// Subscription persistence: the whole table is mirrored to (and resumed from)
+/// the key-value store, one record per subscription. Gated as a unit so that a
+/// device that does not want persistence drops it — and the TLV serialization
+/// and key-value store traffic it pulls in — entirely.
+#[cfg(feature = "persistent-subscriptions")]
+impl<const N: usize> Subscriptions<N> {
     /// Persist the whole subscription table to `kv`, one record per key.
     ///
     /// Each subscription is written under its own key
@@ -458,10 +492,6 @@ impl<const N: usize> Subscriptions<N> {
         B: Buffers<IMBuffer> + 'a,
         S: KvBlobStore,
     {
-        if !self.persist_enabled() {
-            return Ok(());
-        }
-
         self.with(buffers, |state, buffers| {
             for (slot, (sub, rx)) in state
                 .subscriptions
@@ -515,7 +545,7 @@ impl<const N: usize> Subscriptions<N> {
     /// it a prompt priming report (establishing a session on demand) rather than
     /// waiting toward its max-interval deadline — see the priming note in the body
     /// for why that timing matters. A record that cannot be re-added (e.g. no free
-    /// buffer) is skipped. A no-op when persistence is disabled.
+    /// buffer) is skipped.
     pub(crate) fn load_persist<'a, 's, B, S>(
         &'s self,
         pool: &'a B,
@@ -530,10 +560,6 @@ impl<const N: usize> Subscriptions<N> {
         B: Buffers<IMBuffer> + 'a,
         S: KvBlobStore,
     {
-        if !self.persist_enabled() {
-            return Ok(());
-        }
-
         for slot in 0..N {
             let key = PERSISTENT_SUBSCRIPTIONS_START + slot as u16;
 
@@ -611,37 +637,6 @@ impl<const N: usize> Subscriptions<N> {
         }
 
         Ok(())
-    }
-
-    /// Complete a report by updating the subscription's watermark and last-reported timestamp,
-    /// and re-inserting it into the table if the `keep` flag is set on the context.
-    fn report_complete<'a, B>(&self, report: &mut ReportContext<'a, '_, B, N>)
-    where
-        B: Buffers<IMBuffer> + 'a,
-    {
-        let mut sub = unwrap!(report.subscription.take());
-        let buf = unwrap!(report.subscription_buffer.take());
-
-        sub.max_seen_attr_change_id = report.next_max_seen_attr_change_id;
-        sub.max_seen_event_number = report.next_max_seen_event_number;
-        sub.reported_at = report.next_reported_at;
-
-        let keep = report.keep;
-
-        self.with(report.subscriptions_buffers, |state, buffers| {
-            state.report_complete::<B>(sub, buf, buffers, keep)
-        })
-    }
-
-    fn with<'a, B, F, R>(&self, buffers: &SubscriptionsBuffers<'a, B, N>, f: F) -> R
-    where
-        B: Buffers<IMBuffer> + 'a,
-        F: FnOnce(&mut SubscriptionsInner<N>, &mut SubscriptionsBuffersInner<'a, B, N>) -> R,
-    {
-        self.state.lock(|state| {
-            let mut state = state.borrow_mut();
-            buffers.with(|buffers| f(&mut state, buffers))
-        })
     }
 }
 
@@ -763,6 +758,8 @@ impl<const N: usize> SubscriptionsInner<N> {
             min_int_secs,
             max_int_secs,
             reported_at: Instant::MAX,
+            retry_at: Instant::MIN,
+            fail_count: 0,
             max_seen_attr_change_id,
             // Start at 0 so the priming report delivers every event that was
             // already in the event buffer at subscribe time. The reader will
@@ -929,6 +926,7 @@ pub struct SubscriptionIds {
 /// intervals, and the raw `SubscribeReq` TLV — the same bytes the live
 /// subscription keeps in its RX buffer and re-parses on every report, so no
 /// separate path list is serialized.
+#[cfg(feature = "persistent-subscriptions")]
 #[derive(Debug, FromTLV, ToTLV)]
 #[tlvargs(lifetime = "'a")]
 struct PersistedSubscription<'a> {
@@ -952,9 +950,17 @@ pub struct Subscription {
     /// The maximum interval in seconds. The subscription should receive reports at least this frequently, even if there are no changes to report (i.e. it is a liveness deadline).
     /// We use u16 instead of embassy::Duration to save some storage
     max_int_secs: u16,
-    /// The timestamp of the last report sent to this subscription. Used to decide when the next report is due based on the min/max intervals.
-    /// Set to `Instant::MAX` when the subscription is created to indicate that no report has been sent yet, so the first report is due immediately. After the first report, it is updated to the actual timestamp of the last report.
+    /// The timestamp of the last SUCCESSFUL report sent to this subscription. Used to decide when the next report is due based on the min/max intervals — and, crucially, when to give up: `is_expired` measures `max_int` from here, so a run of *failed* reports (which do NOT advance it) eventually expires the subscription rather than retrying forever.
+    /// Set to `Instant::MAX` when the subscription is created to indicate that no report has been sent yet, so the first report is due immediately. After the first successful report, it is updated to the actual timestamp of that report.
     reported_at: Instant,
+    /// Earliest instant at which a report may be attempted again after a *failed*
+    /// send (see [`ReportContext::set_keep_retry`]). `Instant::MIN` means no retry
+    /// is pending (normal operation). Gates the report-timing helpers so a peer we
+    /// cannot reach is retried with a growing back-off instead of in a tight loop.
+    retry_at: Instant,
+    /// Number of consecutive failed report attempts, driving the retry back-off.
+    /// Reset to `0` on any successful report.
+    fail_count: u8,
     /// The largest attribute change ID from the [`ChangedAttributes`] table this subscription
     /// has already reported on. Entries with a larger change ID represent pending changes the subscription still needs to emit.
     max_seen_attr_change_id: u64,
@@ -974,6 +980,24 @@ impl Subscription {
             .checked_add(embassy_time::Duration::from_secs(self.max_int_secs as _))
             .map(|expiry| expiry <= now)
             .unwrap_or(false)
+    }
+
+    /// The back-off (in seconds) to wait before the `fail_count`-th consecutive
+    /// retry of a failed report.
+    ///
+    /// Exponential — `BASE * 2^(fail_count - 1)` — capped at `max_int`: it never
+    /// helps to wait longer than the point at which [`Self::is_expired`] gives up
+    /// on the subscription. The cap also means the subscription is guaranteed to
+    /// expire (from the pinned `reported_at`) rather than back off indefinitely.
+    fn retry_backoff_secs(fail_count: u8, max_int_secs: u16) -> u16 {
+        /// First retry delay. Small enough to recover quickly from a transient
+        /// blip, large enough not to hammer an unreachable peer.
+        const BASE_SECS: u16 = 2;
+
+        let shift = fail_count.saturating_sub(1).min(15);
+        let delay = (BASE_SECS as u32) << shift;
+
+        delay.min(max_int_secs.max(BASE_SECS) as u32) as u16
     }
 
     /// Return `true` if the subscription is due for a report based on the given parameters, or `false` if it is not.
@@ -1001,17 +1025,22 @@ impl Subscription {
     /// and a point infinitely in the past reads correctly as "always allowed"
     /// for every consumer (the boolean gate below and `next_report_at`).
     fn report_allowed_at(&self) -> Instant {
-        // Not yet primed: always allowed. This must be an explicit check, not a
-        // reliance on `checked_add` saturating — with `min_int_secs == 0` the add
-        // is `Instant::MAX + 0`, which does NOT overflow and would wrongly yield
-        // `Instant::MAX` ("never allowed").
-        if self.reported_at == Instant::MAX {
-            return Instant::MIN;
-        }
+        // A pending retry after a failed send is a hard floor on the next
+        // attempt, even for a not-yet-primed subscription — otherwise a peer we
+        // cannot reach would be retried in a tight loop.
+        let min_int_gate = if self.reported_at == Instant::MAX {
+            // Not yet primed: always allowed. This must be an explicit check, not
+            // a reliance on `checked_add` saturating — with `min_int_secs == 0`
+            // the add is `Instant::MAX + 0`, which does NOT overflow and would
+            // wrongly yield `Instant::MAX` ("never allowed").
+            Instant::MIN
+        } else {
+            self.reported_at
+                .checked_add(embassy_time::Duration::from_secs(self.min_int_secs as _))
+                .unwrap_or(Instant::MIN)
+        };
 
-        self.reported_at
-            .checked_add(embassy_time::Duration::from_secs(self.min_int_secs as _))
-            .unwrap_or(Instant::MIN)
+        min_int_gate.max(self.retry_at)
     }
 
     /// Return `true` if the subscription is allowed to report based on the min interval, or `false` if it is still in the quiet period since the last report.
@@ -1515,6 +1544,13 @@ where
     /// This is captured here because the subscription's own `next_reported_at`
     /// is not updated until the report completes as it is until then still used.
     next_reported_at: Instant,
+    /// The next retry-gate to commit onto the subscription on completion.
+    /// `Instant::MIN` (the default) clears any pending retry; a failed send
+    /// ([`Self::set_keep_retry`]) sets it to a backed-off future instant.
+    next_retry_at: Instant,
+    /// The next consecutive-failure count to commit. `0` (the default) clears the
+    /// back-off; a failed send sets it to one more than the subscription's.
+    next_fail_count: u8,
     /// Whether the subscription should be kept in the table after the report completes.
     /// Set by the report handler if the other peer acknowledges the data reported by the subscription.
     keep: bool,
@@ -1588,22 +1624,56 @@ where
         self.keep = true;
     }
 
-    /// Keep the subscription in the table after a *failed* connection to the peer, so it retries,
-    /// but WITHOUT advancing its watermarks.
+    /// Keep the subscription in the table after a *failed* send to the peer, so it
+    /// retries — with a back-off, and without advancing its watermarks or its
+    /// last-success timestamp.
     ///
-    /// [`Self::set_keep`] is only correct after a delivered report: `report()`
-    /// captured the current change/event watermarks into the context as "what this
-    /// report covers", and [`report_complete`](Subscriptions::report_complete)
-    /// commits them onto the subscription. If the report never reached the
-    /// subscriber, committing those watermarks would mark the still-unsent changes
-    /// and events as seen — they would then never be reported. This restores the
-    /// watermarks to the subscription's last actually-reported values so the
-    /// pending data is re-attempted on the next report.
+    /// Three things happen, each of which matters:
+    /// - **Watermarks are preserved.** [`Self::set_keep`] is only correct after a
+    ///   delivered report: `report()` captured the current change/event watermarks
+    ///   as "what this report covers", and committing them would mark the
+    ///   still-unsent changes/events as seen — they would then never be reported.
+    ///   We restore the last actually-reported values so the pending data is
+    ///   re-attempted.
+    /// - **`reported_at` is preserved** (not advanced to now). `is_expired`
+    ///   measures `max_int` from `reported_at`, so keeping it pinned to the last
+    ///   *successful* report means a run of failures eventually expires the
+    ///   subscription instead of retrying it forever.
+    /// - **A back-off is scheduled.** `retry_at` is pushed to a growing (capped)
+    ///   delay from now, so an unreachable peer is retried with exponential
+    ///   back-off rather than in a tight loop that would flood the network.
     pub fn set_keep_retry(&mut self) {
+        // Snapshot the values we need off the (borrowed) subscription first, so
+        // the writes below don't conflict with the borrow.
         let sub = self.subscription();
-        let (attr, event) = (sub.max_seen_attr_change_id, sub.max_seen_event_number);
-        self.next_max_seen_attr_change_id = attr;
-        self.next_max_seen_event_number = event;
+        let (last_attr, last_event, last_reported_at, max_int_secs, fail_count) = (
+            sub.max_seen_attr_change_id,
+            sub.max_seen_event_number,
+            sub.reported_at,
+            sub.max_int_secs,
+            sub.fail_count.saturating_add(1),
+        );
+
+        // The report context's "now" — the instant of *this* (failed) attempt —
+        // was captured into `next_reported_at` at construction. Read it before we
+        // overwrite that field with the preserved last-success timestamp below.
+        let now = self.next_reported_at;
+
+        // Preserve watermarks + last-success timestamp (so pending data is
+        // re-attempted and `is_expired` still measures from the last success).
+        self.next_max_seen_attr_change_id = last_attr;
+        self.next_max_seen_event_number = last_event;
+        self.next_reported_at = last_reported_at;
+
+        // Grow the back-off from now. The delay is capped at the subscription's
+        // max interval: it never makes sense to wait longer than the point at
+        // which `is_expired` gives up on the subscription anyway.
+        self.next_fail_count = fail_count;
+        let backoff_secs = Subscription::retry_backoff_secs(fail_count, max_int_secs);
+        self.next_retry_at = now
+            .checked_add(embassy_time::Duration::from_secs(backoff_secs as _))
+            .unwrap_or(Instant::MAX);
+
         self.keep = true;
     }
 }
@@ -2371,6 +2441,195 @@ mod tests {
         );
     }
 
+    /// A failed report must not busy-loop: even with a change pending and
+    /// `min_int` elapsed, the subscription is held back until its back-off
+    /// (`retry_at`) elapses, and the reporter's wake deadline reflects that.
+    #[test]
+    fn failed_report_backs_off_instead_of_busy_looping() {
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new();
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+
+        // Prime (delivered), then make a change pending, all with min_int = 1s.
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 600);
+            rctx.set_keep();
+        }
+        subs.notify_attr_changed(1, 2, 3);
+
+        // min_int has elapsed and the change is pending — the report is due, but
+        // it FAILS.
+        let t1 = now + Duration::from_secs(2);
+        {
+            let mut rctx = subs.report(t1, 0, &subs_bufs).unwrap();
+            rctx.set_keep_retry();
+        }
+
+        // Immediately after the failure the subscription is NOT reportable again,
+        // even though the change is still pending and min_int is long past: the
+        // back-off gates it. This is the anti-busy-loop guarantee.
+        assert!(
+            subs.report(t1, 0, &subs_bufs).is_none(),
+            "a failed report must not be retried in the same instant"
+        );
+        // Still gated a moment later (BASE back-off is 2s).
+        assert!(subs
+            .report(t1 + Duration::from_millis(500), 0, &subs_bufs)
+            .is_none());
+
+        // The reporter's wake deadline is pushed to the back-off point, so the
+        // loop sleeps rather than spinning.
+        assert_eq!(
+            subs.next_report_at(0, &subs_bufs),
+            t1 + Duration::from_secs(2),
+            "wake is scheduled at the back-off point, not immediately"
+        );
+
+        // Once the back-off elapses the pending change is retried.
+        let t2 = t1 + Duration::from_secs(2);
+        {
+            let rctx = subs.report(t2, 0, &subs_bufs).unwrap();
+            assert!(
+                rctx.should_report_attr(1, 2, 3),
+                "pending change is retried"
+            );
+        }
+    }
+
+    /// The back-off grows with consecutive failures (exponential from BASE),
+    /// observable through the reporter's wake deadline.
+    #[test]
+    fn repeated_failures_grow_the_backoff() {
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new();
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+        // Large max_int so the cap never clips the small back-offs under test.
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 600);
+            rctx.set_keep();
+        }
+        subs.notify_attr_changed(1, 2, 3);
+
+        // BASE = 2s, doubling each consecutive failure: 2s, 4s, 8s.
+        let mut t = now + Duration::from_secs(2);
+        for expected_backoff in [2u64, 4, 8] {
+            let mut rctx = subs.report(t, 0, &subs_bufs).unwrap();
+            rctx.set_keep_retry();
+            drop(rctx);
+
+            assert_eq!(
+                subs.next_report_at(0, &subs_bufs),
+                t + Duration::from_secs(expected_backoff),
+                "back-off after this failure",
+            );
+
+            // Advance exactly to the back-off point for the next failed attempt.
+            t += Duration::from_secs(expected_backoff);
+        }
+    }
+
+    /// The back-off never exceeds `max_int`: it makes no sense to wait past the
+    /// point at which the subscription expires anyway.
+    #[test]
+    fn backoff_is_capped_at_max_int() {
+        // With max_int = 5s, even a high fail count is clamped to 5s.
+        assert_eq!(Subscription::retry_backoff_secs(1, 5), 2);
+        assert_eq!(Subscription::retry_backoff_secs(3, 5), 5); // 8 -> capped to 5
+        assert_eq!(Subscription::retry_backoff_secs(20, 5), 5); // huge -> capped
+                                                                // With a generous max_int the exponential shows through, then saturates.
+        assert_eq!(Subscription::retry_backoff_secs(1, 600), 2);
+        assert_eq!(Subscription::retry_backoff_secs(4, 600), 16);
+        assert_eq!(Subscription::retry_backoff_secs(100, 600), 600);
+    }
+
+    /// `is_expired` measures `max_int` from the last *successful* report, not
+    /// from the last attempt: a run of failures does NOT keep the subscription
+    /// alive forever — it expires `max_int` after the last success.
+    #[test]
+    fn failures_do_not_postpone_expiry() {
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new();
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let base = Instant::now();
+        // max_int = 10s.
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, base, 1, 10, 1, 10);
+            rctx.set_keep(); // last SUCCESS is at `base`
+        }
+        subs.notify_attr_changed(1, 2, 3);
+
+        // A failed report at base+2s must NOT move the expiry deadline.
+        {
+            let mut rctx = subs
+                .report(base + Duration::from_secs(2), 0, &subs_bufs)
+                .unwrap();
+            rctx.set_keep_retry();
+        }
+
+        // Just short of max_int-since-success: still alive.
+        let before = base + Duration::from_secs(9);
+        assert!(!subs.remove(&subs_bufs, |sub| sub
+            .is_expired(before)
+            .then_some("expired")));
+
+        // At max_int-since-success (measured from `base`, not from the failed
+        // attempt at base+2s): expired.
+        let after = base + Duration::from_secs(10);
+        assert!(
+            subs.remove(&subs_bufs, |sub| sub.is_expired(after).then_some("expired")),
+            "expiry is measured from the last success, not the last attempt"
+        );
+    }
+
+    /// A delivered report after a run of failures clears the back-off: the next
+    /// wake returns to the normal liveness schedule rather than a back-off floor.
+    #[test]
+    fn success_clears_the_backoff() {
+        let subs: Subscriptions<1> = Subscriptions::new();
+        let pool = TestPool::<2>::new();
+        let subs_bufs: SubscriptionsBuffers<TestPool<2>, 1> = SubscriptionsBuffers::new();
+
+        let now = Instant::now();
+        {
+            let mut rctx = add_sub(&subs, &subs_bufs, &pool, now, 1, 10, 1, 60);
+            rctx.set_keep();
+        }
+        subs.notify_attr_changed(1, 2, 3);
+
+        // Two failures build up a back-off.
+        let t1 = now + Duration::from_secs(2);
+        {
+            let mut rctx = subs.report(t1, 0, &subs_bufs).unwrap();
+            rctx.set_keep_retry();
+        }
+        let t2 = t1 + Duration::from_secs(2);
+        {
+            let mut rctx = subs.report(t2, 0, &subs_bufs).unwrap();
+            rctx.set_keep_retry();
+        }
+
+        // Now a delivered report at t3.
+        let t3 = t2 + Duration::from_secs(4);
+        {
+            let mut rctx = subs.report(t3, 0, &subs_bufs).unwrap();
+            assert!(rctx.should_report_attr(1, 2, 3));
+            rctx.set_keep(); // delivered — resets fail_count and retry_at
+        }
+
+        // The back-off is gone: the next wake is the plain liveness point
+        // (reported_at + max_int - max_int/2 = t3 + 30s), with no retry floor.
+        assert_eq!(
+            subs.next_report_at(0, &subs_bufs),
+            t3 + Duration::from_secs(30),
+            "a delivered report clears the back-off"
+        );
+    }
+
     // The following tests cover the public API of `Subscriptions` /
     // `SubscriptionsBuffers` / `ReportContext` post-refactor. A few of the
     // pre-refactor tests had no meaningful successor and were deleted:
@@ -3054,267 +3313,234 @@ mod tests {
 
     // ---------- persistence ----------
 
-    /// A minimal multi-key in-memory store, enough to test the
-    /// one-record-per-key subscription persist/reload roundtrip.
-    #[derive(Default)]
-    struct MemKv {
-        blobs: std::collections::HashMap<u16, std::vec::Vec<u8>>,
-    }
+    // Gated as a unit: the persist/resume machinery under test only exists when
+    // the `persistent-subscriptions` feature is enabled.
+    #[cfg(feature = "persistent-subscriptions")]
+    mod persistence {
+        use super::*;
 
-    impl KvBlobStore for &mut MemKv {
-        fn load<'a>(&mut self, key: u16, buf: &'a mut [u8]) -> Result<Option<&'a [u8]>, Error> {
-            Ok(self.blobs.get(&key).map(|v| {
-                buf[..v.len()].copy_from_slice(v);
-                &buf[..v.len()]
-            }))
+        /// A minimal multi-key in-memory store, enough to test the
+        /// one-record-per-key subscription persist/reload roundtrip.
+        #[derive(Default)]
+        struct MemKv {
+            blobs: std::collections::HashMap<u16, std::vec::Vec<u8>>,
         }
 
-        fn store(&mut self, key: u16, data: &[u8], _buf: &mut [u8]) -> Result<(), Error> {
-            self.blobs.insert(key, data.to_vec());
-            Ok(())
+        impl KvBlobStore for &mut MemKv {
+            fn load<'a>(&mut self, key: u16, buf: &'a mut [u8]) -> Result<Option<&'a [u8]>, Error> {
+                Ok(self.blobs.get(&key).map(|v| {
+                    buf[..v.len()].copy_from_slice(v);
+                    &buf[..v.len()]
+                }))
+            }
+
+            fn store(&mut self, key: u16, data: &[u8], _buf: &mut [u8]) -> Result<(), Error> {
+                self.blobs.insert(key, data.to_vec());
+                Ok(())
+            }
+
+            fn remove(&mut self, key: u16, _buf: &mut [u8]) -> Result<(), Error> {
+                self.blobs.remove(&key);
+                Ok(())
+            }
         }
 
-        fn remove(&mut self, key: u16, _buf: &mut [u8]) -> Result<(), Error> {
-            self.blobs.remove(&key);
-            Ok(())
-        }
-    }
-
-    /// Add a subscription whose RX buffer carries `req` (standing in for a raw
-    /// `SubscribeReq` TLV), and commit it into the table.
-    #[allow(clippy::too_many_arguments)]
-    fn add_sub_with_req<'a, 's, const N: usize, const B: usize>(
-        subs: &'s Subscriptions<N>,
-        subs_bufs: &'s SubscriptionsBuffers<'a, TestPool<B>, N>,
-        pool: &'a TestPool<B>,
-        now: Instant,
-        fab_idx: u8,
-        peer_node_id: u64,
-        min_int: u16,
-        max_int: u16,
-        req: &[u8],
-    ) where
-        'a: 's,
-    {
-        let mut rx = pool.get_immediate().unwrap();
-        rx.clear();
-        rx.extend_from_slice(req).unwrap();
-
-        let mut rctx = subs
-            .add(
-                now,
-                fab(fab_idx),
-                peer_node_id,
-                min_int,
-                max_int,
-                0,
-                rx,
-                subs_bufs,
-            )
-            .unwrap();
-        // Commit it as a live subscription (`add` already stamped `reported_at`
-        // with `now`, so this is a non-priming entry once kept).
-        rctx.set_keep();
-    }
-
-    /// A subscription persisted by one `Subscriptions` instance is faithfully
-    /// re-hydrated — routing IDs, intervals, and the raw request bytes — into a
-    /// fresh instance, exactly as a reboot would.
-    #[test]
-    fn persist_reload_roundtrip() {
-        let mut kv = MemKv::default();
-        let now = Instant::now();
-
-        // --- First "boot": build a table and persist it. ---
+        /// Add a subscription whose RX buffer carries `req` (standing in for a raw
+        /// `SubscribeReq` TLV), and commit it into the table.
+        #[allow(clippy::too_many_arguments)]
+        fn add_sub_with_req<'a, 's, const N: usize, const B: usize>(
+            subs: &'s Subscriptions<N>,
+            subs_bufs: &'s SubscriptionsBuffers<'a, TestPool<B>, N>,
+            pool: &'a TestPool<B>,
+            now: Instant,
+            fab_idx: u8,
+            peer_node_id: u64,
+            min_int: u16,
+            max_int: u16,
+            req: &[u8],
+        ) where
+            'a: 's,
         {
+            let mut rx = pool.get_immediate().unwrap();
+            rx.clear();
+            rx.extend_from_slice(req).unwrap();
+
+            let mut rctx = subs
+                .add(
+                    now,
+                    fab(fab_idx),
+                    peer_node_id,
+                    min_int,
+                    max_int,
+                    0,
+                    rx,
+                    subs_bufs,
+                )
+                .unwrap();
+            // Commit it as a live subscription (`add` already stamped `reported_at`
+            // with `now`, so this is a non-priming entry once kept).
+            rctx.set_keep();
+        }
+
+        /// A subscription persisted by one `Subscriptions` instance is faithfully
+        /// re-hydrated — routing IDs, intervals, and the raw request bytes — into a
+        /// fresh instance, exactly as a reboot would.
+        #[test]
+        fn persist_reload_roundtrip() {
+            let mut kv = MemKv::default();
+            let now = Instant::now();
+
+            // --- First "boot": build a table and persist it. ---
+            {
+                let subs: Subscriptions<4> = Subscriptions::new();
+                let pool = TestPool::<5>::new();
+                let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+
+                add_sub_with_req(
+                    &subs,
+                    &subs_bufs,
+                    &pool,
+                    now,
+                    1,
+                    0xAABB,
+                    1,
+                    60,
+                    &[1, 2, 3, 4],
+                );
+                add_sub_with_req(&subs, &subs_bufs, &pool, now, 2, 0xCCDD, 0, 120, &[9, 8, 7]);
+
+                let mut buf = [0u8; 512];
+                subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
+            }
+
+            // Two records written; the rest of the reserved range is empty.
+            assert!(kv.blobs.contains_key(&PERSISTENT_SUBSCRIPTIONS_START));
+            assert!(kv.blobs.contains_key(&(PERSISTENT_SUBSCRIPTIONS_START + 1)));
+            assert!(!kv.blobs.contains_key(&(PERSISTENT_SUBSCRIPTIONS_START + 2)));
+
+            // --- Second "boot": a fresh, empty table reloads from the same store. ---
+            let subs2: Subscriptions<4> = Subscriptions::new();
+            let pool2 = TestPool::<5>::new();
+            let subs_bufs2: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+
+            let mut buf = [0u8; 512];
+            subs2
+                .load_persist(&pool2, &subs_bufs2, &mut kv, &mut buf, now, 0)
+                .unwrap();
+
+            // Both subscriptions are back, with their routing + intervals intact...
+            subs2.state.lock(|s| {
+                let s = s.borrow();
+                assert_eq!(s.subscriptions.len(), 2);
+
+                let a = s
+                    .subscriptions
+                    .iter()
+                    .find(|x| x.ids.peer_node_id == 0xAABB)
+                    .expect("first sub resumed");
+                assert_eq!(a.ids.fab_idx, fab(1));
+                assert_eq!(a.min_int_secs, 1);
+                assert_eq!(a.max_int_secs, 60);
+
+                let b = s
+                    .subscriptions
+                    .iter()
+                    .find(|x| x.ids.peer_node_id == 0xCCDD)
+                    .expect("second sub resumed");
+                assert_eq!(b.ids.fab_idx, fab(2));
+                assert_eq!(b.min_int_secs, 0);
+                assert_eq!(b.max_int_secs, 120);
+
+                // Resumed subscriptions must be un-primed so the reporter sends a
+                // prompt priming report (resetting the subscriber's own liveness
+                // clock before it can time the subscription out), NOT wait toward
+                // our max-interval deadline.
+                for sub in s.subscriptions.iter() {
+                    assert!(
+                        sub.is_report_due(now),
+                        "resumed sub {:?} should be immediately report-due (primed)",
+                        sub.ids()
+                    );
+                    assert!(sub.is_report_due(now + Duration::from_secs(1)));
+                }
+            });
+
+            // ...and the raw request bytes survived (they live in the parallel buffer
+            // pool, indexed alongside the subscriptions).
+            subs_bufs2.with(|bufs| {
+                let mut reqs: std::vec::Vec<std::vec::Vec<u8>> =
+                    bufs.iter().map(|b| b[..].to_vec()).collect();
+                reqs.sort();
+                assert_eq!(reqs, std::vec![std::vec![1, 2, 3, 4], std::vec![9, 8, 7]]);
+            });
+
+            // The ICD predicate now sees the resumed subscriptions.
+            assert!(subs2.has_subscription_for(fab(1), 0xAABB));
+            assert!(subs2.has_subscription_for(fab(2), 0xCCDD));
+            assert!(!subs2.has_subscription_for(fab(1), 0x9999));
+        }
+
+        /// Removing a subscription and re-persisting drops exactly its record from
+        /// the store (the table stays an exact mirror of what is on disk).
+        #[test]
+        fn persist_mirrors_removal() {
+            let mut kv = MemKv::default();
+            let now = Instant::now();
+
             let subs: Subscriptions<4> = Subscriptions::new();
-            subs.set_persist(true);
             let pool = TestPool::<5>::new();
             let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
 
-            add_sub_with_req(
-                &subs,
-                &subs_bufs,
-                &pool,
-                now,
-                1,
-                0xAABB,
-                1,
-                60,
-                &[1, 2, 3, 4],
-            );
-            add_sub_with_req(&subs, &subs_bufs, &pool, now, 2, 0xCCDD, 0, 120, &[9, 8, 7]);
+            add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 100, 1, 60, &[1]);
+            add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 101, 1, 60, &[2]);
+            add_sub_with_req(&subs, &subs_bufs, &pool, now, 2, 102, 1, 60, &[3]);
 
             let mut buf = [0u8; 512];
             subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
+            assert_eq!(kv.blobs.len(), 3);
+
+            // Drop the two fab(1) subscriptions and re-persist.
+            subs.remove(&subs_bufs, |sub| {
+                (sub.ids().fab_idx == fab(1)).then_some("fabric 1 removed")
+            });
+            subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
+
+            // Only the single surviving record remains on disk.
+            assert_eq!(kv.blobs.len(), 1);
+
+            // And a fresh reload sees exactly that one.
+            let subs2: Subscriptions<4> = Subscriptions::new();
+            let pool2 = TestPool::<5>::new();
+            let subs_bufs2: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+            subs2
+                .load_persist(&pool2, &subs_bufs2, &mut kv, &mut buf, now, 0)
+                .unwrap();
+            subs2.state.lock(|s| {
+                let s = s.borrow();
+                assert_eq!(s.subscriptions.len(), 1);
+                assert_eq!(s.subscriptions[0].ids.peer_node_id, 102);
+            });
         }
 
-        // Two records written; the rest of the reserved range is empty.
-        assert!(kv.blobs.contains_key(&PERSISTENT_SUBSCRIPTIONS_START));
-        assert!(kv.blobs.contains_key(&(PERSISTENT_SUBSCRIPTIONS_START + 1)));
-        assert!(!kv.blobs.contains_key(&(PERSISTENT_SUBSCRIPTIONS_START + 2)));
+        /// `reset_persist` wipes the whole reserved range.
+        #[test]
+        fn reset_persist_clears_all_records() {
+            let mut kv = MemKv::default();
+            let now = Instant::now();
 
-        // --- Second "boot": a fresh, empty table reloads from the same store. ---
-        let subs2: Subscriptions<4> = Subscriptions::new();
-        subs2.set_persist(true);
-        let pool2 = TestPool::<5>::new();
-        let subs_bufs2: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
+            let subs: Subscriptions<4> = Subscriptions::new();
+            let pool = TestPool::<5>::new();
+            let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
 
-        let mut buf = [0u8; 512];
-        subs2
-            .load_persist(&pool2, &subs_bufs2, &mut kv, &mut buf, now, 0)
-            .unwrap();
+            add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 100, 1, 60, &[1]);
+            add_sub_with_req(&subs, &subs_bufs, &pool, now, 2, 101, 1, 60, &[2]);
 
-        // Both subscriptions are back, with their routing + intervals intact...
-        subs2.state.lock(|s| {
-            let s = s.borrow();
-            assert_eq!(s.subscriptions.len(), 2);
+            let mut buf = [0u8; 512];
+            subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
+            assert_eq!(kv.blobs.len(), 2);
 
-            let a = s
-                .subscriptions
-                .iter()
-                .find(|x| x.ids.peer_node_id == 0xAABB)
-                .expect("first sub resumed");
-            assert_eq!(a.ids.fab_idx, fab(1));
-            assert_eq!(a.min_int_secs, 1);
-            assert_eq!(a.max_int_secs, 60);
-
-            let b = s
-                .subscriptions
-                .iter()
-                .find(|x| x.ids.peer_node_id == 0xCCDD)
-                .expect("second sub resumed");
-            assert_eq!(b.ids.fab_idx, fab(2));
-            assert_eq!(b.min_int_secs, 0);
-            assert_eq!(b.max_int_secs, 120);
-
-            // Resumed subscriptions must be un-primed so the reporter sends a
-            // prompt priming report (resetting the subscriber's own liveness
-            // clock before it can time the subscription out), NOT wait toward
-            // our max-interval deadline.
-            for sub in s.subscriptions.iter() {
-                assert!(
-                    sub.is_report_due(now),
-                    "resumed sub {:?} should be immediately report-due (primed)",
-                    sub.ids()
-                );
-                assert!(sub.is_report_due(now + Duration::from_secs(1)));
-            }
-        });
-
-        // ...and the raw request bytes survived (they live in the parallel buffer
-        // pool, indexed alongside the subscriptions).
-        subs_bufs2.with(|bufs| {
-            let mut reqs: std::vec::Vec<std::vec::Vec<u8>> =
-                bufs.iter().map(|b| b[..].to_vec()).collect();
-            reqs.sort();
-            assert_eq!(reqs, std::vec![std::vec![1, 2, 3, 4], std::vec![9, 8, 7]]);
-        });
-
-        // The ICD predicate now sees the resumed subscriptions.
-        assert!(subs2.has_subscription_for(fab(1), 0xAABB));
-        assert!(subs2.has_subscription_for(fab(2), 0xCCDD));
-        assert!(!subs2.has_subscription_for(fab(1), 0x9999));
-    }
-
-    /// Removing a subscription and re-persisting drops exactly its record from
-    /// the store (the table stays an exact mirror of what is on disk).
-    #[test]
-    fn persist_mirrors_removal() {
-        let mut kv = MemKv::default();
-        let now = Instant::now();
-
-        let subs: Subscriptions<4> = Subscriptions::new();
-        subs.set_persist(true);
-        let pool = TestPool::<5>::new();
-        let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
-
-        add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 100, 1, 60, &[1]);
-        add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 101, 1, 60, &[2]);
-        add_sub_with_req(&subs, &subs_bufs, &pool, now, 2, 102, 1, 60, &[3]);
-
-        let mut buf = [0u8; 512];
-        subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
-        assert_eq!(kv.blobs.len(), 3);
-
-        // Drop the two fab(1) subscriptions and re-persist.
-        subs.remove(&subs_bufs, |sub| {
-            (sub.ids().fab_idx == fab(1)).then_some("fabric 1 removed")
-        });
-        subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
-
-        // Only the single surviving record remains on disk.
-        assert_eq!(kv.blobs.len(), 1);
-
-        // And a fresh reload sees exactly that one.
-        let subs2: Subscriptions<4> = Subscriptions::new();
-        subs2.set_persist(true);
-        let pool2 = TestPool::<5>::new();
-        let subs_bufs2: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
-        subs2
-            .load_persist(&pool2, &subs_bufs2, &mut kv, &mut buf, now, 0)
-            .unwrap();
-        subs2.state.lock(|s| {
-            let s = s.borrow();
-            assert_eq!(s.subscriptions.len(), 1);
-            assert_eq!(s.subscriptions[0].ids.peer_node_id, 102);
-        });
-    }
-
-    /// `reset_persist` wipes the whole reserved range.
-    #[test]
-    fn reset_persist_clears_all_records() {
-        let mut kv = MemKv::default();
-        let now = Instant::now();
-
-        let subs: Subscriptions<4> = Subscriptions::new();
-        subs.set_persist(true);
-        let pool = TestPool::<5>::new();
-        let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
-
-        add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 100, 1, 60, &[1]);
-        add_sub_with_req(&subs, &subs_bufs, &pool, now, 2, 101, 1, 60, &[2]);
-
-        let mut buf = [0u8; 512];
-        subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
-        assert_eq!(kv.blobs.len(), 2);
-
-        subs.reset_persist(&mut kv, &mut buf).unwrap();
-        assert!(kv.blobs.is_empty());
-    }
-
-    /// With persistence disabled (the default), `persist_all` and `load_persist`
-    /// are no-ops: nothing is written and nothing is resumed.
-    #[test]
-    fn persistence_off_by_default_is_a_noop() {
-        let mut kv = MemKv::default();
-        let now = Instant::now();
-
-        let subs: Subscriptions<4> = Subscriptions::new();
-        assert!(!subs.persist_enabled(), "persistence must default to off");
-
-        let pool = TestPool::<5>::new();
-        let subs_bufs: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
-
-        add_sub_with_req(&subs, &subs_bufs, &pool, now, 1, 100, 1, 60, &[1]);
-
-        // persist_all writes nothing while disabled.
-        let mut buf = [0u8; 512];
-        subs.persist_all(&subs_bufs, &mut kv, &mut buf).unwrap();
-        assert!(kv.blobs.is_empty());
-
-        // Even with a record planted directly in the store, a disabled instance
-        // resumes nothing.
-        kv.blobs
-            .insert(PERSISTENT_SUBSCRIPTIONS_START, std::vec![0; 8]);
-        let subs2: Subscriptions<4> = Subscriptions::new();
-        let pool2 = TestPool::<5>::new();
-        let subs_bufs2: SubscriptionsBuffers<TestPool<5>, 4> = SubscriptionsBuffers::new();
-        subs2
-            .load_persist(&pool2, &subs_bufs2, &mut kv, &mut buf, now, 0)
-            .unwrap();
-        subs2
-            .state
-            .lock(|s| assert_eq!(s.borrow().subscriptions.len(), 0));
+            subs.reset_persist(&mut kv, &mut buf).unwrap();
+            assert!(kv.blobs.is_empty());
+        }
     }
 }

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -46,6 +46,7 @@ use crate::pairing::qr::{
 };
 use crate::pairing::DiscoveryCapabilities;
 use crate::persist::{KvBlobStore, KvBlobStoreAccess, Persist, BASIC_INFO_KEY};
+#[cfg(feature = "case-resumption")]
 use crate::sc::case::ResumableSessions;
 use crate::sc::pase::spake2p::{Spake2pVerifierPassword, SPAKE2P_VERIFIER_SALT_ZEROED};
 use crate::sc::pase::Pase;
@@ -581,6 +582,7 @@ impl<'a> Matter<'a> {
                 state.fabrics.reset_persist(&mut store, buf)?;
                 state.basic_info_settings.reset_persist(&mut store, buf)?;
                 state.rtc.reset_persist(&mut store, buf)?;
+                #[cfg(feature = "case-resumption")]
                 state.resumption.reset_persist(&mut store, buf)?;
 
                 Ok::<_, Error>(())
@@ -604,6 +606,7 @@ impl<'a> Matter<'a> {
                 state.fabrics.load_persist(&mut store, buf)?;
                 state.basic_info_settings.load_persist(&mut store, buf)?;
                 state.rtc.load_persist(&mut store, buf)?;
+                #[cfg(feature = "case-resumption")]
                 state.resumption.load_persist(&mut store, buf)?;
 
                 Ok::<_, Error>(())
@@ -652,6 +655,7 @@ impl<'a> Matter<'a> {
     ///   scratch buffer.
     /// - `min_interval`: Minimum time between two consecutive persists
     ///   (see above).
+    #[cfg(feature = "case-resumption")]
     pub async fn run_persist_resumption<K: KvBlobStoreAccess>(
         &self,
         kv: K,
@@ -715,6 +719,7 @@ pub struct MatterState {
     /// CASE session resumption cache
     ///
     /// Public for unit tests
+    #[cfg(feature = "case-resumption")]
     pub resumption: ResumableSessions,
     /// The PASE session state
     pase: Pase,
@@ -736,6 +741,7 @@ impl MatterState {
         Self {
             fabrics: Fabrics::new(),
             sessions: Sessions::new(),
+            #[cfg(feature = "case-resumption")]
             resumption: ResumableSessions::new(),
             pase: Pase::new(),
             failsafe: FailSafe::new(),
@@ -746,11 +752,28 @@ impl MatterState {
     }
 
     /// Return an in-place initializer for MatterState
+    // NOTE: `init!` (pinned-init) rejects `#[cfg]` on its fields, so the
+    // `case-resumption` field forces two full variants of this initializer.
+    #[cfg(feature = "case-resumption")]
     fn init() -> impl Init<Self> {
         init!(Self {
             fabrics <- Fabrics::init(),
             sessions <- Sessions::init(),
             resumption <- crate::sc::case::ResumableSessions::init(),
+            pase <- Pase::init(),
+            failsafe <- FailSafe::init(),
+            basic_info_settings <- BasicInfoSettings::init(),
+            rtc <- Rtc::init(),
+            icd_mode: None,
+        })
+    }
+
+    /// Return an in-place initializer for MatterState
+    #[cfg(not(feature = "case-resumption"))]
+    fn init() -> impl Init<Self> {
+        init!(Self {
+            fabrics <- Fabrics::init(),
+            sessions <- Sessions::init(),
             pase <- Pase::init(),
             failsafe <- FailSafe::init(),
             basic_info_settings <- BasicInfoSettings::init(),

--- a/rs-matter/src/sc.rs
+++ b/rs-matter/src/sc.rs
@@ -36,6 +36,7 @@ use pase::PaseResponder;
 pub mod busy;
 pub mod case;
 pub mod checkin;
+#[cfg(feature = "groups")]
 pub mod mcsp;
 pub mod pase;
 
@@ -325,6 +326,7 @@ impl<'a, C: Crypto, H: AsyncScHandler> SecureChannel<'a, C, H> {
                     .handle(exchange)
                     .await
             }
+            #[cfg(feature = "groups")]
             OpCode::MsgCounterSyncReq => {
                 // The receive path has already checked this landed on a
                 // group session with a destination matching one of our

--- a/rs-matter/src/sc/case.rs
+++ b/rs-matter/src/sc/case.rs
@@ -24,11 +24,13 @@ use crate::cert::MAX_CERT_TLV_LEN;
 
 pub use initiator::CaseInitiator;
 pub use responder::CaseResponder;
+#[cfg(feature = "case-resumption")]
 pub use resumption::{ResumableSession, ResumableSessions, MAX_RESUMPTION_RECORDS};
 
 pub(crate) mod casep;
 mod initiator;
 mod responder;
+#[cfg(feature = "case-resumption")]
 pub mod resumption;
 
 // Two certificates (NOC and ICAC), plus ECDSA etc -> approx 950b, doing 1024 to be safe

--- a/rs-matter/src/sc/case/casep.rs
+++ b/rs-matter/src/sc/case/casep.rs
@@ -287,6 +287,9 @@ impl<'a, C: Crypto + 'a> CaseP<'a, C> {
     /// Meaningful only on the responder side; on the initiator side the
     /// resumption id is captured directly from `TBEData2` and never
     /// touches [`Self::start`], so this returns a zeroed value.
+    ///
+    /// Only consumed when seeding the resumption cache.
+    #[cfg(feature = "case-resumption")]
     pub fn resumption_id(&self) -> CaseResumptionIdRef<'_> {
         self.resumption_id.reference()
     }
@@ -757,137 +760,149 @@ impl<'a, C: Crypto + 'a> CaseP<'a, C> {
 // handshake — everything a resumption needs comes from the cached
 // [`ResumableSession`](crate::sc::case::ResumableSession) record and
 // from the incoming `Sigma1.initiatorRandom`.
+//
+// The whole block lives behind `case-resumption` in an inner `mod resume`
+// (re-exported into this module's namespace) so the feature can be gated
+// once rather than per item.
 // ============================================================================
 
-/// Nonce `NCASE_SigmaS1` used for `InitiatorResume1MIC`.
-pub(super) const RESUME1_MIC_NONCE: AeadNonceRef = AeadNonceRef::new(&[
-    0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x53, 0x31,
-]);
+#[cfg(feature = "case-resumption")]
+pub(super) use resume::*;
 
-/// Nonce `NCASE_SigmaS2` used for `Sigma2ResumeMIC`.
-pub(super) const RESUME2_MIC_NONCE: AeadNonceRef = AeadNonceRef::new(&[
-    0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x53, 0x32,
-]);
+#[cfg(feature = "case-resumption")]
+mod resume {
+    use super::*;
 
-/// KDF info string `"Sigma1_Resume"`.
-const S1RK_INFO: &[u8] = b"Sigma1_Resume";
+    /// Nonce `NCASE_SigmaS1` used for `InitiatorResume1MIC`.
+    pub(in crate::sc::case) const RESUME1_MIC_NONCE: AeadNonceRef = AeadNonceRef::new(&[
+        0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x53, 0x31,
+    ]);
 
-/// KDF info string `"Sigma2_Resume"`.
-const S2RK_INFO: &[u8] = b"Sigma2_Resume";
+    /// Nonce `NCASE_SigmaS2` used for `Sigma2ResumeMIC`.
+    pub(in crate::sc::case) const RESUME2_MIC_NONCE: AeadNonceRef = AeadNonceRef::new(&[
+        0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x53, 0x32,
+    ]);
 
-/// KDF info string `"SessionResumptionKeys"` — distinct from the
-/// regular `"SessionKeys"` info used at the end of a full handshake.
-const RESUMPTION_SEKEYS_INFO: &[u8] = b"SessionResumptionKeys";
+    /// KDF info string `"Sigma1_Resume"`.
+    const S1RK_INFO: &[u8] = b"Sigma1_Resume";
 
-/// Which resumption AEAD key to derive.
-#[derive(Copy, Clone)]
-pub(super) enum ResumeKeyKind {
-    /// `S1RK` — protects `InitiatorResume1MIC` on Sigma1.
-    S1rk,
-    /// `S2RK` — protects `Sigma2ResumeMIC` on Sigma2_Resume.
-    S2rk,
-}
+    /// KDF info string `"Sigma2_Resume"`.
+    const S2RK_INFO: &[u8] = b"Sigma2_Resume";
 
-impl ResumeKeyKind {
-    const fn info(self) -> &'static [u8] {
-        match self {
-            Self::S1rk => S1RK_INFO,
-            Self::S2rk => S2RK_INFO,
+    /// KDF info string `"SessionResumptionKeys"` — distinct from the
+    /// regular `"SessionKeys"` info used at the end of a full handshake.
+    const RESUMPTION_SEKEYS_INFO: &[u8] = b"SessionResumptionKeys";
+
+    /// Which resumption AEAD key to derive.
+    #[derive(Copy, Clone)]
+    pub(in crate::sc::case) enum ResumeKeyKind {
+        /// `S1RK` — protects `InitiatorResume1MIC` on Sigma1.
+        S1rk,
+        /// `S2RK` — protects `Sigma2ResumeMIC` on Sigma2_Resume.
+        S2rk,
+    }
+
+    impl ResumeKeyKind {
+        const fn info(self) -> &'static [u8] {
+            match self {
+                Self::S1rk => S1RK_INFO,
+                Self::S2rk => S2RK_INFO,
+            }
         }
     }
-}
 
-/// Derive the 128-bit `S1RK`/`S2RK` resumption AEAD key from the
-/// long-lived `shared_secret`, `initiator_random` and the
-/// `resumption_id` in effect for that side (old ID for `S1RK`, new ID
-/// for `S2RK`). Salt = `initiator_random || resumption_id`.
-pub(super) fn derive_resume_key<C: Crypto>(
-    crypto: &C,
-    kind: ResumeKeyKind,
-    shared_secret: crate::crypto::CanonPkcSharedSecretRef<'_>,
-    initiator_random: CaseRandomRef<'_>,
-    resumption_id: CaseResumptionIdRef<'_>,
-    out: &mut CanonAeadKey,
-) -> Result<(), Error> {
-    let mut salt = CryptoSensitive::<{ CASE_RANDOM_LEN + CASE_RESUMPTION_ID_LEN }>::new();
-    let salt_access: &mut [u8] = salt.access_mut();
-    salt_access[..CASE_RANDOM_LEN].copy_from_slice(initiator_random.access());
-    salt_access[CASE_RANDOM_LEN..].copy_from_slice(resumption_id.access());
+    /// Derive the 128-bit `S1RK`/`S2RK` resumption AEAD key from the
+    /// long-lived `shared_secret`, `initiator_random` and the
+    /// `resumption_id` in effect for that side (old ID for `S1RK`, new ID
+    /// for `S2RK`). Salt = `initiator_random || resumption_id`.
+    pub(in crate::sc::case) fn derive_resume_key<C: Crypto>(
+        crypto: &C,
+        kind: ResumeKeyKind,
+        shared_secret: crate::crypto::CanonPkcSharedSecretRef<'_>,
+        initiator_random: CaseRandomRef<'_>,
+        resumption_id: CaseResumptionIdRef<'_>,
+        out: &mut CanonAeadKey,
+    ) -> Result<(), Error> {
+        let mut salt = CryptoSensitive::<{ CASE_RANDOM_LEN + CASE_RESUMPTION_ID_LEN }>::new();
+        let salt_access: &mut [u8] = salt.access_mut();
+        salt_access[..CASE_RANDOM_LEN].copy_from_slice(initiator_random.access());
+        salt_access[CASE_RANDOM_LEN..].copy_from_slice(resumption_id.access());
 
-    crypto
-        .kdf()?
-        .expand(salt.access(), shared_secret, kind.info(), out)
-        .map_err(|_| ErrorCode::InvalidData)?;
+        crypto
+            .kdf()?
+            .expand(salt.access(), shared_secret, kind.info(), out)
+            .map_err(|_| ErrorCode::InvalidData)?;
 
-    Ok(())
-}
-
-/// Compute a `Resume{1,2}MIC` — the 16-byte AES-CCM tag over empty
-/// plaintext and empty AAD. AES-CCM with a zero-length plaintext
-/// returns a ciphertext that is exactly the tag.
-pub(super) fn compute_resume_mic<C: Crypto>(
-    crypto: &C,
-    key: CanonAeadKeyRef<'_>,
-    nonce: AeadNonceRef<'_>,
-    out: &mut [u8; AEAD_TAG_LEN],
-) -> Result<(), Error> {
-    let mut buf = [0u8; AEAD_TAG_LEN];
-    let mut cypher = crypto.aead()?;
-    let ct = cypher.encrypt_in_place(key, nonce, &[], &mut buf, 0)?;
-
-    // AES-CCM(plaintext="") produces `AEAD_TAG_LEN` bytes of tag and
-    // nothing else. Guard the invariant defensively.
-    if ct.len() != AEAD_TAG_LEN {
-        return Err(ErrorCode::InvalidData.into());
-    }
-    out.copy_from_slice(ct);
-
-    Ok(())
-}
-
-/// Verify a `Resume{1,2}MIC`. Returns `Ok(())` on success and an error
-/// (from the AEAD backend) on tag mismatch.
-pub(super) fn verify_resume_mic<C: Crypto>(
-    crypto: &C,
-    key: CanonAeadKeyRef<'_>,
-    nonce: AeadNonceRef<'_>,
-    mic: &[u8; AEAD_TAG_LEN],
-) -> Result<(), Error> {
-    let mut buf = [0u8; AEAD_TAG_LEN];
-    buf.copy_from_slice(mic);
-    let mut cypher = crypto.aead()?;
-    let pt = cypher.decrypt_in_place(key, nonce, &[], &mut buf)?;
-
-    // Empty plaintext expected.
-    if !pt.is_empty() {
-        return Err(ErrorCode::InvalidData.into());
+        Ok(())
     }
 
-    Ok(())
-}
+    /// Compute a `Resume{1,2}MIC` — the 16-byte AES-CCM tag over empty
+    /// plaintext and empty AAD. AES-CCM with a zero-length plaintext
+    /// returns a ciphertext that is exactly the tag.
+    pub(in crate::sc::case) fn compute_resume_mic<C: Crypto>(
+        crypto: &C,
+        key: CanonAeadKeyRef<'_>,
+        nonce: AeadNonceRef<'_>,
+        out: &mut [u8; AEAD_TAG_LEN],
+    ) -> Result<(), Error> {
+        let mut buf = [0u8; AEAD_TAG_LEN];
+        let mut cypher = crypto.aead()?;
+        let ct = cypher.encrypt_in_place(key, nonce, &[], &mut buf, 0)?;
 
-/// Derive the three resumption session keys (`I2RKey || R2IKey ||
-/// AttestationChallenge`) from the long-lived `shared_secret`,
-/// `initiator_random` and the Sigma1 `resumption_id` (the current
-/// pre-rotation ID). Note the info string and salt differ from the
-/// regular `compute_session_keys` used at the end of a full
-/// handshake.
-pub(super) fn compute_resumption_session_keys<C: Crypto>(
-    crypto: &C,
-    shared_secret: crate::crypto::CanonPkcSharedSecretRef<'_>,
-    initiator_random: CaseRandomRef<'_>,
-    resumption_id: CaseResumptionIdRef<'_>,
-    keys: &mut CaseSessionKeys,
-) -> Result<(), Error> {
-    let mut salt = CryptoSensitive::<{ CASE_RANDOM_LEN + CASE_RESUMPTION_ID_LEN }>::new();
-    let salt_access: &mut [u8] = salt.access_mut();
-    salt_access[..CASE_RANDOM_LEN].copy_from_slice(initiator_random.access());
-    salt_access[CASE_RANDOM_LEN..].copy_from_slice(resumption_id.access());
+        // AES-CCM(plaintext="") produces `AEAD_TAG_LEN` bytes of tag and
+        // nothing else. Guard the invariant defensively.
+        if ct.len() != AEAD_TAG_LEN {
+            return Err(ErrorCode::InvalidData.into());
+        }
+        out.copy_from_slice(ct);
 
-    crypto
-        .kdf()?
-        .expand(salt.access(), shared_secret, RESUMPTION_SEKEYS_INFO, keys)
-        .map_err(|_| ErrorCode::InvalidData)?;
+        Ok(())
+    }
 
-    Ok(())
+    /// Verify a `Resume{1,2}MIC`. Returns `Ok(())` on success and an error
+    /// (from the AEAD backend) on tag mismatch.
+    pub(in crate::sc::case) fn verify_resume_mic<C: Crypto>(
+        crypto: &C,
+        key: CanonAeadKeyRef<'_>,
+        nonce: AeadNonceRef<'_>,
+        mic: &[u8; AEAD_TAG_LEN],
+    ) -> Result<(), Error> {
+        let mut buf = [0u8; AEAD_TAG_LEN];
+        buf.copy_from_slice(mic);
+        let mut cypher = crypto.aead()?;
+        let pt = cypher.decrypt_in_place(key, nonce, &[], &mut buf)?;
+
+        // Empty plaintext expected.
+        if !pt.is_empty() {
+            return Err(ErrorCode::InvalidData.into());
+        }
+
+        Ok(())
+    }
+
+    /// Derive the three resumption session keys (`I2RKey || R2IKey ||
+    /// AttestationChallenge`) from the long-lived `shared_secret`,
+    /// `initiator_random` and the Sigma1 `resumption_id` (the current
+    /// pre-rotation ID). Note the info string and salt differ from the
+    /// regular `compute_session_keys` used at the end of a full
+    /// handshake.
+    pub(in crate::sc::case) fn compute_resumption_session_keys<C: Crypto>(
+        crypto: &C,
+        shared_secret: crate::crypto::CanonPkcSharedSecretRef<'_>,
+        initiator_random: CaseRandomRef<'_>,
+        resumption_id: CaseResumptionIdRef<'_>,
+        keys: &mut CaseSessionKeys,
+    ) -> Result<(), Error> {
+        let mut salt = CryptoSensitive::<{ CASE_RANDOM_LEN + CASE_RESUMPTION_ID_LEN }>::new();
+        let salt_access: &mut [u8] = salt.access_mut();
+        salt_access[..CASE_RANDOM_LEN].copy_from_slice(initiator_random.access());
+        salt_access[CASE_RANDOM_LEN..].copy_from_slice(resumption_id.access());
+
+        crypto
+            .kdf()?
+            .expand(salt.access(), shared_secret, RESUMPTION_SEKEYS_INFO, keys)
+            .map_err(|_| ErrorCode::InvalidData)?;
+
+        Ok(())
+    }
 }

--- a/rs-matter/src/sc/case/initiator.rs
+++ b/rs-matter/src/sc/case/initiator.rs
@@ -25,8 +25,10 @@ use core::num::NonZeroU8;
 
 use crate::alloc;
 use crate::cert::CertRef;
+#[cfg(feature = "case-resumption")]
+use crate::crypto::CanonAeadKey;
 use crate::crypto::{
-    CanonAeadKey, CanonPkcPublicKeyRef, CanonPkcSignature, CanonPkcSignatureRef, Crypto, Hash,
+    CanonPkcPublicKeyRef, CanonPkcSignature, CanonPkcSignatureRef, Crypto, Hash,
     AEAD_CANON_KEY_LEN, AEAD_TAG_LEN,
 };
 use crate::error::{Error, ErrorCode};
@@ -37,11 +39,16 @@ use crate::transport::session::{NocCatIds, ReservedSession, SessionMode};
 use crate::utils::init::InitMaybeUninit;
 use crate::utils::storage::ReadBuf;
 
+#[cfg(feature = "case-resumption")]
 use super::casep::{
     compute_resume_mic, compute_resumption_session_keys, derive_resume_key, verify_resume_mic,
-    CaseP, CaseRandom, CaseRandomRef, CaseSessionKeys, ResumeKeyKind, CASE_RESUMPTION_ID_LEN,
-    CASE_RESUMPTION_ID_ZEROED, RESUME1_MIC_NONCE, RESUME2_MIC_NONCE,
+    ResumeKeyKind, RESUME1_MIC_NONCE, RESUME2_MIC_NONCE,
 };
+use super::casep::{
+    CaseP, CaseRandom, CaseRandomRef, CaseSessionKeys, CASE_RESUMPTION_ID_LEN,
+    CASE_RESUMPTION_ID_ZEROED,
+};
+#[cfg(feature = "case-resumption")]
 use super::resumption::ResumableSession;
 use super::CASE_LARGE_BUF_SIZE;
 
@@ -72,6 +79,7 @@ struct TBEData2Decrypt<'a> {
 
 /// Sigma2_Resume response, parsed from the responder's message when it
 /// accepts a Sigma1-with-Resumption.
+#[cfg(feature = "case-resumption")]
 #[derive(FromTLV, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[tlvargs(start = 1, lifetime = "'a")]
@@ -146,6 +154,10 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
         // by populating tags 6 and 7 on Sigma1; the responder either
         // returns Sigma2_Resume (accepted) or Sigma2 (fell back to the
         // full handshake) — both are handled below.
+        //
+        // Without the `case-resumption` feature there is no cache, so we
+        // never offer resumption and always run the full handshake.
+        #[cfg(feature = "case-resumption")]
         let cached_record: Option<ResumableSession> = exchange.with_state(|state| {
             Ok(state
                 .resumption
@@ -183,27 +195,39 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
         // `Resume1MIC` so it can be spliced into Sigma1 below.
         // `initiator_random` is available now (produced by
         // `start_initiator`), so we can already derive `S1RK`.
+        //
+        // Without `case-resumption` these are always `(None, None)`, so the
+        // Sigma1 built below carries no resumption fields.
+        #[allow(clippy::type_complexity)]
         let (resume_rid_bytes, resume_mic_bytes): (
             Option<[u8; CASE_RESUMPTION_ID_LEN]>,
             Option<[u8; AEAD_TAG_LEN]>,
-        ) = if let Some(ref record) = cached_record {
-            let mut s1rk = CanonAeadKey::new();
-            derive_resume_key(
-                crypto,
-                ResumeKeyKind::S1rk,
-                record.shared_secret.reference(),
-                random.reference(),
-                record.resumption_id.reference(),
-                &mut s1rk,
-            )?;
+        );
+        #[cfg(feature = "case-resumption")]
+        {
+            (resume_rid_bytes, resume_mic_bytes) = if let Some(ref record) = cached_record {
+                let mut s1rk = CanonAeadKey::new();
+                derive_resume_key(
+                    crypto,
+                    ResumeKeyKind::S1rk,
+                    record.shared_secret.reference(),
+                    random.reference(),
+                    record.resumption_id.reference(),
+                    &mut s1rk,
+                )?;
 
-            let mut mic = [0u8; AEAD_TAG_LEN];
-            compute_resume_mic(crypto, s1rk.reference(), RESUME1_MIC_NONCE, &mut mic)?;
+                let mut mic = [0u8; AEAD_TAG_LEN];
+                compute_resume_mic(crypto, s1rk.reference(), RESUME1_MIC_NONCE, &mut mic)?;
 
-            (Some(*record.resumption_id.reference().access()), Some(mic))
-        } else {
-            (None, None)
-        };
+                (Some(*record.resumption_id.reference().access()), Some(mic))
+            } else {
+                (None, None)
+            };
+        }
+        #[cfg(not(feature = "case-resumption"))]
+        {
+            (resume_rid_bytes, resume_mic_bytes) = (None, None);
+        }
 
         // Step 3: Build and send Sigma1
         let mut tt_updated = false;
@@ -251,6 +275,10 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
             return Err(ErrorCode::Invalid.into());
         }
 
+        // We only ever offer resumption when `case-resumption` is on, so a
+        // spec-compliant responder never sends Sigma2_Resume otherwise; the
+        // branch (and its `finalize_sigma2_resume`) is compiled out.
+        #[cfg(feature = "case-resumption")]
         if response_opcode == OpCode::CASESigma2Resume as u8 {
             // Responder accepted our resumption request. Complete it
             // via `finalize_sigma2_resume`. If we didn't request
@@ -283,6 +311,10 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
         }
 
         // Step 5: Decrypt Sigma2 TBE and validate
+        // `peer_resumption_id` (the responder's ResumptionID from TBEData2,
+        // spec-mandated in full CASE) is only consumed to seed the resumption
+        // cache, so it is unused when `case-resumption` is off.
+        #[cfg_attr(not(feature = "case-resumption"), allow(unused_variables))]
         let (peer_catids, peer_resumption_id) = {
             let rx = exchange.rx()?;
             let raw_sigma2_payload = rx.payload();
@@ -524,19 +556,22 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
         // attempt resumption. The `resumption_id` came from `TBEData2`
         // in Sigma2 (`peer_resumption_id`); `SharedSecret`, peer id and
         // peer CATs are what we just committed to the `Session`.
-        exchange.with_state(|state| {
-            state.resumption.insert_or_update(ResumableSession {
-                fab_idx,
-                peer_nodeid: peer_node_id,
-                peer_cat_ids: peer_catids,
-                resumption_id: peer_resumption_id,
-                shared_secret: crate::crypto::CanonPkcSharedSecret::new_from_ref(
-                    initiator.casep.shared_secret(),
-                ),
-            });
-            Ok::<_, Error>(())
-        })?;
-        exchange.matter().transport().notify_resumption_dirty();
+        #[cfg(feature = "case-resumption")]
+        {
+            exchange.with_state(|state| {
+                state.resumption.insert_or_update(ResumableSession {
+                    fab_idx,
+                    peer_nodeid: peer_node_id,
+                    peer_cat_ids: peer_catids,
+                    resumption_id: peer_resumption_id,
+                    shared_secret: crate::crypto::CanonPkcSharedSecret::new_from_ref(
+                        initiator.casep.shared_secret(),
+                    ),
+                });
+                Ok::<_, Error>(())
+            })?;
+            exchange.matter().transport().notify_resumption_dirty();
+        }
 
         info!(
             "CASE session established: local_sessid={}, peer_sessid={}",
@@ -565,6 +600,9 @@ impl<'a, C: Crypto + 'a> CaseInitiator<'a, C> {
     /// On `Resume2MIC` verification failure the initiator sends
     /// `InvalidParameter` per Matter spec and returns an error; the
     /// reserved session is dropped uncomitted.
+    ///
+    /// Compiled only with the `case-resumption` feature.
+    #[cfg(feature = "case-resumption")]
     #[allow(clippy::too_many_arguments)]
     async fn finalize_sigma2_resume(
         exchange: &mut Exchange<'_>,

--- a/rs-matter/src/sc/case/responder.rs
+++ b/rs-matter/src/sc/case/responder.rs
@@ -17,30 +17,36 @@
 
 use core::{mem::MaybeUninit, num::NonZeroU8};
 
+#[cfg(feature = "case-resumption")]
 use rand_core::RngCore;
 
+#[cfg(feature = "case-resumption")]
 use super::casep::{
     compute_resume_mic, compute_resumption_session_keys, derive_resume_key, verify_resume_mic,
-    CaseP, CaseRandom, CaseResumptionId, CaseSessionKeys, ResumeKeyKind, CASE_RANDOM_LEN,
-    CASE_RESUMPTION_ID_LEN, RESUME1_MIC_NONCE, RESUME2_MIC_NONCE,
+    ResumeKeyKind, CASE_RANDOM_LEN, CASE_RESUMPTION_ID_LEN, RESUME1_MIC_NONCE, RESUME2_MIC_NONCE,
 };
+use super::casep::{CaseP, CaseRandom, CaseResumptionId, CaseSessionKeys};
+#[cfg(feature = "case-resumption")]
 use super::resumption::ResumableSession;
 use super::CASE_LARGE_BUF_SIZE;
 use crate::alloc;
 use crate::cert::CertRef;
-use crate::crypto::{
-    CanonAeadKey, CanonPkcSignature, CanonPkcSignatureRef, Crypto, Hash, AEAD_CANON_KEY_LEN,
-    AEAD_TAG_LEN,
-};
-use crate::error::{Error, ErrorCode};
+#[cfg(feature = "case-resumption")]
+use crate::crypto::{CanonAeadKey, AEAD_TAG_LEN};
+use crate::crypto::{CanonPkcSignature, CanonPkcSignatureRef, Crypto, Hash, AEAD_CANON_KEY_LEN};
+use crate::error::Error;
+#[cfg(feature = "case-resumption")]
+use crate::error::ErrorCode;
 use crate::sc::{
-    check_opcode, complete_with_status, sc_write, GeneralCode, OpCode, SCStatusCodes,
-    SessionParameters, StatusReport,
+    check_opcode, complete_with_status, sc_write, OpCode, SCStatusCodes, SessionParameters,
 };
+#[cfg(feature = "case-resumption")]
+use crate::sc::{GeneralCode, StatusReport};
 use crate::tlv::{get_root_node_struct, FromTLV, OctetStr, TLVElement, TLVTag, TLVWrite, ToTLV};
 use crate::transport::exchange::Exchange;
 use crate::transport::session::{NocCatIds, ReservedSession, SessionMode};
 use crate::utils::init::{init, Init, InitMaybeUninit};
+#[cfg(feature = "case-resumption")]
 use crate::utils::storage::ReadBuf;
 
 /// Sigma1 Request structure
@@ -115,6 +121,12 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
         // shortcuts to Sigma2_Resume + SigmaFinished. Any other case
         // (fields absent, unknown id, MIC mismatch) falls through to the
         // full Sigma1/2/3 flow.
+        //
+        // Without the `case-resumption` feature there is no cache and this
+        // is skipped entirely: every Sigma1 runs the full handshake, which
+        // is spec-compliant (resumption is optional) — a peer that offered
+        // resumption fields simply gets a full Sigma2 back.
+        #[cfg(feature = "case-resumption")]
         if self
             .try_handle_sigma1_resume(&mut exchange, &mut session)
             .await?
@@ -429,6 +441,7 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
                     // what we just loaded into the `Session`; the
                     // `resumption_id` was minted by the responder in
                     // `casep.start` and is still held on `self.casep`.
+                    #[cfg(feature = "case-resumption")]
                     state.resumption.insert_or_update(ResumableSession {
                         // Unwrap is safe: we are inside the `fabric` branch.
                         fab_idx: unwrap!(NonZeroU8::new(self.casep.local_fabric_idx())),
@@ -461,6 +474,7 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
 
             // The `state.resumption.insert_or_update` call above dirties
             // the cache; wake the background persist task.
+            #[cfg(feature = "case-resumption")]
             exchange.matter().transport().notify_resumption_dirty();
         }
 
@@ -469,6 +483,9 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
 
     /// Try to handle the received Sigma1 as a session-resumption
     /// request. Returns:
+    ///
+    /// (Compiled only with the `case-resumption` feature; the caller skips
+    /// the resume attempt entirely when it is off.)
     ///
     /// - `Ok(true)` — the resumption path fully handled the exchange
     ///   (whether successfully or with the initiator rejecting the
@@ -481,6 +498,7 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
     ///   resumption fields (per Matter spec's fall-through rule).
     /// - `Err(_)` — a hard error unrelated to resumption (I/O,
     ///   cryptographic backend failure). The exchange is aborted.
+    #[cfg(feature = "case-resumption")]
     async fn try_handle_sigma1_resume(
         &mut self,
         exchange: &mut Exchange<'_>,

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2022-2025 Project CHIP Authors
+ *    Copyright (c) 2022-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/rs-matter/src/tlv/traits.rs
+++ b/rs-matter/src/tlv/traits.rs
@@ -27,6 +27,7 @@ pub use builder::*;
 pub use container::*;
 pub use maybe::*;
 pub use octets::*;
+pub use skippable::*;
 pub use slice::*;
 pub use str::*;
 
@@ -37,6 +38,7 @@ mod container;
 mod maybe;
 mod octets;
 mod primitive;
+mod skippable;
 mod slice;
 mod str;
 mod vec;

--- a/rs-matter/src/tlv/traits/skippable.rs
+++ b/rs-matter/src/tlv/traits/skippable.rs
@@ -1,0 +1,232 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use pinned_init::init_from_closure;
+
+use crate::error::Error;
+use crate::tlv::{FromTLV, TLVElement, TLVTag, TLVWrite, ToTLV, TLV};
+use crate::utils::init::{try_init, Init, InitDefault, IntoFallibleInit};
+
+/// A wrapper for a type `T` which might not always be present in the TLV stream.
+///
+/// Unlike `Option<T>` and `Optional<T>` though, `Skippable<T>` is NOT initialized
+/// to `None` when the value is not present in the TLV stream, but to a default `T`.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Skippable<T> {
+    value: T,
+}
+
+impl<T> Skippable<T>
+where
+    T: Default + InitDefault,
+{
+    /// Create a new `Skippable<T>` with the default value of `T`.
+    pub fn new_default() -> Self {
+        Self::new(T::default())
+    }
+
+    /// Create a new `Skippable<T>` with the given value.
+    pub const fn new(value: T) -> Self {
+        Self { value }
+    }
+
+    /// Initialize a `Skippable<T>` with the default value of `T`.
+    pub fn init_default() -> impl Init<Self> {
+        Self::init(T::init_default().into_fallible())
+    }
+
+    /// Initialize a `Skippable<T>` with the given initializer.
+    pub fn init<I: Init<T, E>, E>(value: I) -> impl Init<Self, E> {
+        try_init!(Self {
+            value <- value,
+        }? E)
+    }
+
+    pub const fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub const fn value_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}
+
+impl<'a, T> FromTLV<'a> for Skippable<T>
+where
+    T: FromTLV<'a> + Default + InitDefault,
+{
+    fn from_tlv(element: &TLVElement<'a>) -> Result<Self, Error> {
+        if element.is_empty() {
+            Ok(Self::new_default())
+        } else {
+            Ok(Self::new(T::from_tlv(element)?))
+        }
+    }
+
+    fn init_from_tlv(element: TLVElement<'a>) -> impl Init<Self, Error> {
+        unsafe {
+            init_from_closure(move |slot| {
+                if element.is_empty() {
+                    Self::init(T::init_default().into_fallible()).__init(slot)
+                } else {
+                    Self::init(T::init_from_tlv(element)).__init(slot)
+                }
+            })
+        }
+    }
+}
+
+impl<T> ToTLV for Skippable<T>
+where
+    T: ToTLV,
+{
+    fn to_tlv<W: TLVWrite>(&self, tag: &TLVTag, tw: W) -> Result<(), Error> {
+        self.value.to_tlv(tag, tw)
+    }
+
+    fn tlv_iter(&self, tag: TLVTag) -> impl Iterator<Item = Result<TLV<'_>, Error>> {
+        self.value.tlv_iter(tag)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tlv::{FromTLV, TLVElement, TLVTag, ToTLV};
+    use crate::utils::init::InitMaybeUninit;
+    use crate::utils::storage::{Vec, WriteBuf};
+
+    use super::Skippable;
+
+    /// Serialize `t` (anonymous tag) into a fresh buffer and return the bytes.
+    fn to_bytes<T: ToTLV>(t: &T, buf: &mut [u8]) -> usize {
+        let mut wb = WriteBuf::new(buf);
+        t.to_tlv(&TLVTag::Anonymous, &mut wb).unwrap();
+        wb.get_tail()
+    }
+
+    // `Skippable<T>` requires `T: Default + InitDefault`, so these tests use
+    // `Vec<u16, N>` (which implements both) rather than a bare primitive.
+    type Inner = Vec<u16, 4>;
+
+    fn inner(items: &[u16]) -> Inner {
+        let mut v = Inner::new();
+        for &i in items {
+            v.push(i).unwrap();
+        }
+        v
+    }
+
+    /// A present value round-trips through `to_tlv` / `from_tlv`.
+    #[test]
+    fn present_value_roundtrips() {
+        let mut buf = [0u8; 32];
+        let len = to_bytes(&Skippable::new(inner(&[42, 43])), &mut buf);
+
+        let back = Skippable::<Inner>::from_tlv(&TLVElement::new(&buf[..len])).unwrap();
+        assert_eq!(back.value().as_slice(), &[42, 43]);
+    }
+
+    /// `from_tlv` on an EMPTY element yields the default value (not an error, and
+    /// not a `None` — `Skippable` has no `None` variant).
+    #[test]
+    fn missing_value_from_tlv_is_default() {
+        let empty = TLVElement::new(&[]);
+        assert!(empty.is_empty());
+
+        let s = Skippable::<Inner>::from_tlv(&empty).unwrap();
+        assert!(s.value().is_empty());
+    }
+
+    /// `init_from_tlv` mirrors `from_tlv`: default on empty, parsed otherwise.
+    #[test]
+    fn init_from_tlv_defaults_on_empty_and_parses_otherwise() {
+        // Empty -> default.
+        let mut slot = core::mem::MaybeUninit::<Skippable<Inner>>::uninit();
+        let s = slot
+            .try_init_with(Skippable::<Inner>::init_from_tlv(TLVElement::new(&[])))
+            .unwrap();
+        assert!(s.value().is_empty());
+
+        // Present -> parsed.
+        let mut buf = [0u8; 32];
+        let len = to_bytes(&Skippable::new(inner(&[7])), &mut buf);
+        let mut slot = core::mem::MaybeUninit::<Skippable<Inner>>::uninit();
+        let s = slot
+            .try_init_with(Skippable::<Inner>::init_from_tlv(TLVElement::new(
+                &buf[..len],
+            )))
+            .unwrap();
+        assert_eq!(s.value().as_slice(), &[7]);
+    }
+
+    /// The real use case (mirrors `Fabric` gaining a trailing `groups` field):
+    /// an older struct lacking the trailing `Skippable` field deserializes into
+    /// the newer struct with that field defaulted.
+    #[test]
+    fn missing_trailing_skippable_field_deserializes_to_default() {
+        // Older shape: two fields, no trailing field.
+        #[derive(Debug, ToTLV)]
+        struct Old {
+            a: u16,
+            b: u16,
+        }
+
+        // Newer shape: same positional tags plus a trailing `Skippable` field.
+        #[derive(Debug, FromTLV)]
+        struct New {
+            a: u16,
+            b: u16,
+            trailing: Skippable<Vec<u16, 4>>,
+        }
+
+        let mut buf = [0u8; 64];
+        let len = to_bytes(&Old { a: 7, b: 9 }, &mut buf);
+
+        let new = New::from_tlv(&TLVElement::new(&buf[..len])).unwrap();
+        assert_eq!((new.a, new.b), (7, 9));
+        assert!(new.trailing.value().is_empty());
+    }
+
+    /// A written `Skippable` field is read back unchanged (round-trip within a
+    /// struct, both fields present).
+    #[test]
+    fn trailing_skippable_field_roundtrips_when_present() {
+        #[derive(Debug, FromTLV, ToTLV)]
+        struct S {
+            a: u16,
+            trailing: Skippable<Vec<u16, 4>>,
+        }
+
+        let mut inner = Vec::new();
+        inner.push(1).unwrap();
+        inner.push(2).unwrap();
+
+        let mut buf = [0u8; 64];
+        let len = to_bytes(
+            &S {
+                a: 5,
+                trailing: Skippable::new(inner),
+            },
+            &mut buf,
+        );
+
+        let back = S::from_tlv(&TLVElement::new(&buf[..len])).unwrap();
+        assert_eq!(back.a, 5);
+        assert_eq!(back.trailing.value().as_slice(), &[1, 2]);
+    }
+}

--- a/rs-matter/src/tlv/traits/skippable.rs
+++ b/rs-matter/src/tlv/traits/skippable.rs
@@ -31,26 +31,13 @@ pub struct Skippable<T> {
     value: T,
 }
 
-impl<T> Skippable<T>
-where
-    T: Default + InitDefault,
-{
-    /// Create a new `Skippable<T>` with the default value of `T`.
-    pub fn new_default() -> Self {
-        Self::new(T::default())
-    }
-
-    /// Create a new `Skippable<T>` with the given value.
+impl<T> Skippable<T> {
+    /// Create a new Skippable with the given value.
     pub const fn new(value: T) -> Self {
         Self { value }
     }
 
-    /// Initialize a `Skippable<T>` with the default value of `T`.
-    pub fn init_default() -> impl Init<Self> {
-        Self::init(T::init_default().into_fallible())
-    }
-
-    /// Initialize a `Skippable<T>` with the given initializer.
+    /// Initialize a Skippable with the given initializer.
     pub fn init<I: Init<T, E>, E>(value: I) -> impl Init<Self, E> {
         try_init!(Self {
             value <- value,
@@ -62,6 +49,56 @@ where
     }
 
     pub const fn value_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}
+
+impl<T> Skippable<T>
+where
+    T: Default + InitDefault,
+{
+    /// Create a new Skippable with the default value of T.
+    pub fn new_default() -> Self {
+        Self::new(T::default())
+    }
+
+    /// Initialize a Skippable with the default value of T.
+    pub fn init_default() -> impl Init<Self> {
+        Self::init(T::init_default().into_fallible())
+    }
+}
+
+impl<T> Default for Skippable<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> InitDefault for Skippable<T>
+where
+    T: InitDefault,
+{
+    fn init_default() -> impl Init<Self> {
+        // Inline the inherent initializer's body rather than call
+        // `Self::init_default()`, which would resolve back to this trait
+        // method and recurse.
+        Self::init(T::init_default().into_fallible())
+    }
+}
+
+impl<T> core::ops::Deref for Skippable<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> core::ops::DerefMut for Skippable<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.value
     }
 }

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -23,7 +23,9 @@ use core::pin::pin;
 
 use domain::base::name::ToLabelIter;
 
-use embassy_futures::select::{select, select3, select4, Either};
+#[cfg(feature = "groups")]
+use embassy_futures::select::select4;
+use embassy_futures::select::{select, select3, Either};
 use embassy_time::{Duration, Timer};
 
 use rand_core::RngCore;
@@ -32,6 +34,7 @@ use crate::crypto::Crypto;
 use crate::dm::clusters::basic_info::BasicInfoConfig;
 use crate::dm::NodeId;
 use crate::error::{Error, ErrorCode};
+#[cfg(feature = "groups")]
 use crate::fabric::{MAX_FABRICS, MAX_GROUPS_PER_FABRIC};
 use crate::fmt::Bytes;
 use crate::sc::case::CaseInitiator;
@@ -46,6 +49,7 @@ use crate::transport::network::mdns::{
 };
 use crate::transport::network::{MatterRemoteService, NetworkMulticast};
 use crate::utils::init::{init, Init};
+#[cfg(feature = "groups")]
 use crate::utils::ipv6::compute_group_multicast_addr;
 use crate::utils::select::Coalesce;
 use crate::utils::storage::Vec;
@@ -74,7 +78,14 @@ pub mod session;
 pub const MATTER_SOCKET_BIND_ADDR: SocketAddr =
     SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, MATTER_PORT, 0, 0));
 
+#[cfg(feature = "groups")]
 const MAX_GROUP_ADDRS: usize = MAX_FABRICS * MAX_GROUPS_PER_FABRIC;
+/// Without multicast group support no group addresses are ever joined, so the
+/// join-list is zero-capacity. Keeping the field (rather than gating it) avoids
+/// splitting the in-place `Transport` initializer, and a `Vec<_, 0>` costs no
+/// RAM.
+#[cfg(not(feature = "groups"))]
+const MAX_GROUP_ADDRS: usize = 0;
 
 const ACCEPT_TIMEOUT_MS: u64 = 1000;
 
@@ -107,6 +118,7 @@ pub struct Transport {
     // TODO XXX FIXME: Needs multiple wakers for work-stealing executors
     tx: IfMutex<Packet<MAX_TX_BUF_SIZE>>,
     /// List of currently joined group addresses, used for managing multicast group membership.
+    /// Zero-capacity (and thus never populated) without the `groups` feature.
     group_addrs: IfMutex<Vec<Ipv6Addr, MAX_GROUP_ADDRS>>,
     /// Notification for when an exchange is dropped.
     exchange_dropped: Notification,
@@ -120,7 +132,10 @@ pub struct Transport {
     mdns_browse: Signal<MdnsBrowseState>,
     /// A notification that a session had been removed
     session_removed: Notification,
-    /// A notification that the groups have been modified
+    /// A notification that the groups have been modified.
+    /// Unused without the `groups` feature, but kept unconditionally so the
+    /// in-place `Transport` initializer needs no feature-specific variant.
+    #[cfg_attr(not(feature = "groups"), allow(dead_code))]
     groups_modified: Notification,
     /// A notification that the CASE session resumption cache has been
     /// mutated and should be re-persisted by the background persist
@@ -218,11 +233,13 @@ impl Transport {
 
     /// Notify that groups have changed (keys, key maps, or membership) and
     /// multicast registrations need updating.
+    #[cfg(feature = "groups")]
     pub(crate) fn notify_groups_changed(&self) {
         self.groups_modified.notify();
     }
 
     /// Wait until the groups have changed (see [`Transport::notify_groups_changed`]).
+    #[cfg(feature = "groups")]
     fn wait_groups_changed(&self) -> impl Future<Output = ()> + '_ {
         self.groups_modified.wait()
     }
@@ -1037,7 +1054,15 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
     }
 
     /// Run the transport runner with the given network send, receive and multicast implementations.
-    pub async fn run<S, R, M>(&mut self, send: S, recv: R, multicast: M) -> Result<(), Error>
+    ///
+    /// The `multicast` implementation is only used to manage group (multicast)
+    /// membership, so without the `groups` feature it is accepted but never used.
+    pub async fn run<S, R, M>(
+        &mut self,
+        send: S,
+        recv: R,
+        #[cfg_attr(not(feature = "groups"), allow(unused_variables))] multicast: M,
+    ) -> Result<(), Error>
     where
         S: NetworkSend,
         R: NetworkReceive,
@@ -1049,20 +1074,29 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
         // C++ E2E tests rely on this log line to determine when the tested app is ready
         debug!("APP STATUS: Starting event loop");
 
-        let mut joined = self.transport().group_addrs.lock().await;
-
         let send = IfMutex::new(send);
 
         let mut rx = pin!(self.process_rx(recv, &send));
         let mut tx = pin!(self.process_tx(&send));
         let mut orphaned = pin!(self.process_orphaned());
-        let mut groups = pin!(self.process_groups(multicast, &mut joined));
 
-        select4(&mut rx, &mut tx, &mut orphaned, &mut groups)
-            .coalesce()
-            .await
+        #[cfg(feature = "groups")]
+        {
+            let mut joined = self.transport().group_addrs.lock().await;
+            let mut groups = pin!(self.process_groups(multicast, &mut joined));
+
+            select4(&mut rx, &mut tx, &mut orphaned, &mut groups)
+                .coalesce()
+                .await
+        }
+
+        #[cfg(not(feature = "groups"))]
+        {
+            select3(&mut rx, &mut tx, &mut orphaned).coalesce().await
+        }
     }
 
+    #[cfg(feature = "groups")]
     async fn process_groups<M>(
         &self,
         mut multicast: M,
@@ -1724,18 +1758,21 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                     // Session created successfully: decode, indicate packet payload slice and process further
                     return session.post_recv(&packet.header);
                 }
-            } else if packet.header.plain.is_group_session() {
-                // Group (multicast) message — derive keys on-the-fly and decrypt
-                let (session, payload_range) = state.sessions.get_or_create_for_group_rx(
-                    &self.crypto,
-                    &state.fabrics,
-                    packet,
-                    self.matter.dev_det(),
-                )?;
-                set_payload(packet, payload_range);
-
-                return session.post_recv(&packet.header);
             } else {
+                #[cfg(feature = "groups")]
+                if packet.header.plain.is_group_session() {
+                    // Group (multicast) message — derive keys on-the-fly and decrypt
+                    let (session, payload_range) = state.sessions.get_or_create_for_group_rx(
+                        &self.crypto,
+                        &state.fabrics,
+                        packet,
+                        self.matter.dev_det(),
+                    )?;
+                    set_payload(packet, payload_range);
+
+                    return session.post_recv(&packet.header);
+                }
+
                 // Encrypted unicast packet with no matching session — cannot be decoded
                 set_payload(packet, (0, 0));
             }

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -37,11 +37,12 @@ use crate::error::{Error, ErrorCode};
 #[cfg(feature = "groups")]
 use crate::fabric::{MAX_FABRICS, MAX_GROUPS_PER_FABRIC};
 use crate::fmt::Bytes;
+#[cfg(not(feature = "case-responder-only"))]
 use crate::sc::case::CaseInitiator;
 use crate::sc::pase::PaseInitiator;
-use crate::sc::{
-    sc_write, OpCode, SCStatusCodes, SessionParameters, StatusReport, PROTO_ID_SECURE_CHANNEL,
-};
+#[cfg(not(feature = "case-responder-only"))]
+use crate::sc::SessionParameters;
+use crate::sc::{sc_write, OpCode, SCStatusCodes, StatusReport, PROTO_ID_SECURE_CHANNEL};
 use crate::tlv::TLVElement;
 use crate::transport::network::mdns::{
     commissionable_instance_id, score_ip_address, BrowseExclude, CommissionableFilter,
@@ -711,6 +712,26 @@ impl Transport {
             return self.initiate_for_session(matter, session_id);
         }
 
+        self.initiate_new_case(matter, crypto, fabric_idx, peer_node_id)
+            .await
+    }
+
+    /// Establish a fresh CASE session to an already-commissioned peer (resolving
+    /// its operational address over mDNS), then open an exchange on it. Called by
+    /// [`initiate`](Self::initiate) only when no live session to the peer exists.
+    ///
+    /// With the `case-responder-only` feature this is compiled out and replaced
+    /// by an immediate [`ErrorCode::NoSession`]: reporting (and every other
+    /// on-demand initiator) then reuses an existing session or fails, and the
+    /// linker drops the whole CASE-initiator and mDNS-resolver machinery.
+    #[cfg(not(feature = "case-responder-only"))]
+    async fn initiate_new_case<'a, C: Crypto>(
+        &self,
+        matter: &'a Matter<'a>,
+        crypto: C,
+        fabric_idx: NonZeroU8,
+        peer_node_id: NodeId,
+    ) -> Result<Exchange<'a>, Error> {
         // No CASE session: resolve the operational address and establish one.
         let compressed_fabric_id = matter.with_state(|state| {
             Ok::<_, Error>(state.fabrics.fabric(fabric_idx)?.compressed_fabric_id())
@@ -754,6 +775,23 @@ impl Transport {
         })?;
 
         self.initiate_for_session(matter, session_id)
+    }
+
+    /// The `case-responder-only` variant: never establish a new CASE session.
+    ///
+    /// See the other [`initiate_new_case`](Self::initiate_new_case) for why this
+    /// exists. Reporting (and any other on-demand initiator) reuses an existing
+    /// session or gets [`ErrorCode::NoSession`]; nothing here references the CASE
+    /// initiator or the mDNS resolver, so the linker can drop them.
+    #[cfg(feature = "case-responder-only")]
+    async fn initiate_new_case<'a, C: Crypto>(
+        &self,
+        _matter: &'a Matter<'a>,
+        _crypto: C,
+        _fabric_idx: NonZeroU8,
+        _peer_node_id: NodeId,
+    ) -> Result<Exchange<'a>, Error> {
+        Err(ErrorCode::NoSession.into())
     }
 
     /// Open an exchange over a fresh **unsecured** session to an already-

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -141,6 +141,11 @@ pub struct Transport {
     /// A notification that the CASE session resumption cache has been
     /// mutated and should be re-persisted by the background persist
     /// task (see [`crate::Matter::run_persist_resumption`]).
+    ///
+    /// Kept as a field unconditionally (a zero-cost `Notification`) so the
+    /// `new`/`init` constructors need no `case-resumption`-specific variant;
+    /// only the notify/wait accessors are gated.
+    #[cfg_attr(not(feature = "case-resumption"), allow(dead_code))]
     resumption_dirty: Notification,
     /// Device SAI (Secure Association Identifier)
     device_sai: Option<u32>,
@@ -258,6 +263,7 @@ impl Transport {
     /// Notify that the CASE session resumption cache was mutated and
     /// should be re-persisted. Fired from every code path that inserts,
     /// rotates or evicts a [`crate::sc::case::ResumableSession`].
+    #[cfg(feature = "case-resumption")]
     pub(crate) fn notify_resumption_dirty(&self) {
         self.resumption_dirty.notify();
     }
@@ -266,6 +272,7 @@ impl Transport {
     /// (see [`Transport::notify_resumption_dirty`]). Used by the
     /// [`crate::Matter::run_persist_resumption`] background task to
     /// know when to flush the cache to storage.
+    #[cfg(feature = "case-resumption")]
     pub(crate) fn wait_resumption_dirty(&self) -> impl Future<Output = ()> + '_ {
         self.resumption_dirty.wait()
     }

--- a/rs-matter/src/transport/dedup.rs
+++ b/rs-matter/src/transport/dedup.rs
@@ -103,9 +103,11 @@ impl RxCtrState {
 }
 
 /// Max number of unique group message senders tracked for replay protection.
+#[cfg(feature = "groups")]
 pub const MAX_GROUP_CTR_ENTRIES: usize = 16;
 
 /// A per-(fabric_idx, source_node_id) message counter entry for group messages.
+#[cfg(feature = "groups")]
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct GroupCtrEntry {
@@ -120,6 +122,7 @@ struct GroupCtrEntry {
 /// group session lifetimes, preventing replay attacks.
 ///
 /// When the store is full, the least-recently-used entry is evicted.
+#[cfg(feature = "groups")]
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GroupCtrStore {
@@ -127,6 +130,7 @@ pub struct GroupCtrStore {
     clock: u32,
 }
 
+#[cfg(feature = "groups")]
 impl GroupCtrStore {
     pub const fn new() -> Self {
         Self {
@@ -309,6 +313,7 @@ mod tests {
         assert_ndup(s.post_recv(0, NOT_ENCRYPTED, false));
     }
 
+    #[cfg(feature = "groups")]
     mod group_ctr {
         use super::super::GroupCtrStore;
 

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -1084,6 +1084,13 @@ impl<'a> Exchange<'a> {
     /// Establishing requires a running mDNS responder (e.g.
     /// `BuiltinMdns::run`) to service the resolve; without one the
     /// resolve times out and this returns [`ErrorCode::NotFound`].
+    ///
+    /// With the `case-responder-only` feature the establish path is compiled
+    /// out: only an existing session is reused, and if none exists this returns
+    /// [`ErrorCode::NoSession`] instead of opening a new one. This lets the linker
+    /// drop the CASE initiator and mDNS resolver from a node that never needs to
+    /// initiate CASE (a pure accessory that only reports over sessions its peers
+    /// established).
     #[inline(always)]
     pub async fn initiate<C: Crypto>(
         matter: &'a Matter<'a>,

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -29,7 +29,9 @@ use crate::crypto::{
 };
 use crate::dm::clusters::basic_info::BasicInfoConfig;
 use crate::error::{Error, ErrorCode};
+#[cfg(feature = "groups")]
 use crate::fabric::Fabrics;
+#[cfg(feature = "groups")]
 use crate::group_keys::KeySet;
 use crate::sc::SessionParameters;
 use crate::transport::exchange::ExchangeId;
@@ -39,13 +41,16 @@ use crate::utils::init::{init, Init, IntoFallibleInit};
 use crate::utils::storage::{ParseBuf, Vec, WriteBuf};
 use crate::{Matter, MatterState};
 
-use super::dedup::{GroupCtrStore, RxCtrState};
+#[cfg(feature = "groups")]
+use super::dedup::GroupCtrStore;
+use super::dedup::RxCtrState;
 use super::exchange::{ExchangeState, MessageMeta, Role};
 use super::mrp::{mrp_log, RetransEntry};
 use super::network::Address;
 use super::packet::PacketHdr;
 use super::plain_hdr::PlainHdr;
 use super::proto_hdr::ProtoHdr;
+#[cfg(feature = "groups")]
 use super::Packet;
 
 pub const MAX_CAT_IDS_PER_NOC: usize = 3;
@@ -254,6 +259,7 @@ impl Session {
         &self.mode
     }
 
+    #[cfg(feature = "groups")]
     pub(crate) fn set_session_mode(&mut self, mode: SessionMode) {
         self.mode = mode;
     }
@@ -907,6 +913,7 @@ pub struct Sessions {
     next_sess_id: u16,
     next_exch_id: u16,
     sessions: Vec<Session, MAX_SESSIONS>,
+    #[cfg(feature = "groups")]
     group_ctr_store: GroupCtrStore,
     /// The current Global Group Encrypted Data Message Counter reported
     /// to peers as the "Synchronized Counter" in `MsgCounterSyncRsp` and
@@ -921,6 +928,7 @@ pub struct Sessions {
     /// start. Peers will observe a fresh trust-first sync on their next
     /// MCSP exchange after we restart, which matches the fallback for
     /// any lost-sync-state scenario.
+    #[cfg(feature = "groups")]
     global_group_data_ctr: u32,
 }
 
@@ -930,36 +938,58 @@ impl Sessions {
     pub const fn new() -> Self {
         Self {
             sessions: Vec::new(),
+            #[cfg(feature = "groups")]
             group_ctr_store: GroupCtrStore::new(),
             next_sess_unique_id: 0,
             next_sess_id: 1,
             next_exch_id: 1,
+            #[cfg(feature = "groups")]
             global_group_data_ctr: 0,
         }
     }
 
     /// Create an in-place initializer for a new Sessions instance.
     pub fn init() -> impl Init<Self> {
-        init!(Self {
+        // The `init!` macro does not accept `#[cfg]` on fields, so the two
+        // group-only fields force two variants that differ only by them.
+        #[cfg(feature = "groups")]
+        let r = init!(Self {
             sessions <- Vec::init(),
             group_ctr_store: GroupCtrStore::new(),
             next_sess_unique_id: 0,
             next_sess_id: 1,
             next_exch_id: 1,
             global_group_data_ctr: 0,
-        })
+        });
+        #[cfg(not(feature = "groups"))]
+        let r = init!(Self {
+            sessions <- Vec::init(),
+            next_sess_unique_id: 0,
+            next_sess_id: 1,
+            next_exch_id: 1,
+        });
+        r
     }
 
     pub fn reset(&mut self) {
         self.sessions.clear();
-        self.group_ctr_store = GroupCtrStore::new();
+        #[cfg(feature = "groups")]
+        {
+            self.group_ctr_store = GroupCtrStore::new();
+        }
         self.next_sess_id = 1;
         self.next_exch_id = 1;
         // Deliberately keep `global_group_data_ctr`: a `reset` isn't a
         // factory reset, and rolling it back would break peers that
         // just learned it via MCSP.
     }
+}
 
+/// Group (multicast) session handling: on-the-fly key derivation for received
+/// group-encrypted messages, and the global group data-message counter. Behind
+/// the `groups` feature — a unicast-only device never creates group sessions.
+#[cfg(feature = "groups")]
+impl Sessions {
     /// Return the current Global Group Encrypted Data Message Counter,
     /// lazily initialized to a random value in `[1, 2^28 - 1]` on first
     /// access. The upper 4 bits are kept zero to leave headroom for
@@ -1248,7 +1278,9 @@ impl Sessions {
             None
         }
     }
+}
 
+impl Sessions {
     pub fn get_next_sess_id(&mut self) -> u16 {
         let mut next_sess_id: u16;
         loop {

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -113,8 +113,12 @@ pub struct Session {
     /// The ECDH shared secret computed during the original full CASE
     /// handshake, retained on the session for the sole purpose of
     /// populating [`crate::sc::case::ResumableSession`] records for
-    /// the resumption cache. Zeroed for non-CASE sessions. See
-    /// [`Self::get_shared_secret`].
+    /// the resumption cache. Zeroed for non-CASE sessions.
+    ///
+    /// Kept as a field unconditionally so the `new`/`init` constructors
+    /// need no `case-resumption`-specific variant; it is simply written
+    /// but never read when resumption is off.
+    #[cfg_attr(not(feature = "case-resumption"), allow(dead_code))]
     shared_secret: CanonPkcSharedSecret,
     att_challenge: AttChallenge,
     local_sess_id: u16,
@@ -344,6 +348,8 @@ impl Session {
     /// snapshot task to build [`crate::sc::case::ResumableSession`]
     /// records — the "SharedSecret" that the Matter spec lists as
     /// part of the Session Resumption State.
+    #[cfg(feature = "case-resumption")]
+    #[allow(dead_code)]
     pub fn get_shared_secret(&self) -> Option<CanonPkcSharedSecretRef<'_>> {
         match self.mode {
             SessionMode::Case { .. } => Some(self.shared_secret.reference()),

--- a/rs-matter/tests/case_resumption.rs
+++ b/rs-matter/tests/case_resumption.rs
@@ -32,7 +32,7 @@
 //! unchanged from #1 (and the `ResumptionID` did change), we know
 //! resumption happened on both sides.
 
-#![cfg(all(feature = "std", feature = "async-io"))]
+#![cfg(all(feature = "std", feature = "async-io", feature = "case-resumption"))]
 
 use core::num::NonZeroU8;
 use core::pin::pin;

--- a/rs-matter/tests/im/mod.rs
+++ b/rs-matter/tests/im/mod.rs
@@ -19,4 +19,5 @@ mod client_invokes;
 mod client_reads;
 mod client_subscribes;
 mod client_writes;
+#[cfg(feature = "persistent-subscriptions")]
 mod subscription_reboot;

--- a/rs-matter/tests/im/subscription_reboot.rs
+++ b/rs-matter/tests/im/subscription_reboot.rs
@@ -55,9 +55,6 @@ fn test_subscription_survives_reboot() {
     // what the first boot persists is what the second boot reads back.
     let kv = MemKvBlobStore::default();
 
-    // Persistence is opt-in; enable it on the (first-boot) state.
-    im.state.set_persist_subscriptions(true);
-
     let path = AttrPath::from_gp(&GenericPath::new(
         Some(0),
         Some(echo_cluster::ID),
@@ -120,7 +117,6 @@ fn test_subscription_survives_reboot() {
     // ---- Boot 2: a fresh subscription table, the same store. ----
     let state2: InteractionModelState<DummyNetworks, 3, E2E_EVENTS_BUF_SIZE> =
         InteractionModelState::new(DummyNetworks);
-    state2.set_persist_subscriptions(true);
 
     // The resumed subscription is primed, so the server initiates a `ReportData`
     // to the client on its own. We accept that server-initiated exchange and

--- a/rs-matter/tests/mcsp.rs
+++ b/rs-matter/tests/mcsp.rs
@@ -24,7 +24,7 @@
 //! DSIZ=1) and the group-session TX path (`pre_send` GROUP_SESSION +
 //! CONTROL_MSG framing, group op key encryption) in one shot.
 
-#![cfg(all(feature = "std", feature = "async-io"))]
+#![cfg(all(feature = "std", feature = "async-io", feature = "groups"))]
 
 #[allow(dead_code)]
 mod common;


### PR DESCRIPTION
These are functionalities which are intermingled with others, and therefore it is not so easy for the linker to remove them automatically if unused:
- Groups are optional and therefore now hidden behind a `groups` additive feature
- Ditto for persistent subscriptions (`persistent-subscriptions`)
- Ditto for CASE resumption (`case-resumption`)
- Finally, the `case-responder-only` feature alters how `Exchange::initiate` behaves, in that it _only_ tries to re-use an existing session which was already established by the other peer. It no longer does mDNS resolve and CASE renegotiation. **This allows for the `CaseInitiator` code to be dropped completely**, if the app does not need to initiate CASE sessions elsewhere (but is not exactly a compliant behavior, hence the opt-out behavior).

The whole thing saves ~ 10% Flash and a bit less SRAM.
