### PR TITLE
A new - ReportDataHandler - handler for InteractionModel

### DIFF
--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -16,6 +16,7 @@
  */
 
 use core::future::Future;
+use core::num::NonZeroU8;
 use core::pin::pin;
 
 use embassy_futures::select::select;
@@ -24,7 +25,7 @@ use crate::crypto::Crypto;
 use crate::dm::clusters::net_comm::NetworksAccess;
 use crate::dm::{EventId, EventNumber, Metadata};
 use crate::error::{Error, ErrorCode};
-use crate::im::encoding::{EventPriority, IMBuffer};
+use crate::im::encoding::{EventPriority, IMBuffer, NodeId};
 use crate::im::events::EventTLVWrite;
 use crate::persist::KvBlobStoreAccess;
 use crate::tlv::TLVElement;
@@ -447,6 +448,58 @@ where
     }
 }
 
+/// The identity of the subscription (and the peer that owns it) that a
+/// server-initiated `ReportData` message belongs to.
+///
+/// Reachable from a [`ReportContext`] via [`ReportContext::subscription`] and
+/// handed (indirectly) to a [`ReportDataHandler`] so it can route the report to
+/// the right in-flight subscription. The `(fabric_idx, peer_node_id,
+/// subscription_id)` triple is exactly the key a controller records when it
+/// establishes a subscription (see the IM client's `SubscribeEstablished`), and
+/// mirrors how the C++ SDK matches an unsolicited `ReportData` to its
+/// `ReadClient`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SubscriptionCtx {
+    /// The local fabric index the report arrived on.
+    pub fabric_idx: NonZeroU8,
+    /// The node ID of the peer (publisher) that sent the report.
+    pub peer_node_id: NodeId,
+    /// The subscription ID carried in the report, if any. `None` for an
+    /// unsolicited (subscription-less) `ReportData` — legal on the wire but not
+    /// expected in the controller subscription flow.
+    pub subscription_id: Option<u32>,
+}
+
+/// A context type passed to a [`ReportDataHandler`] when it processes a
+/// server-initiated `ReportData` message (the controller / subscriber role).
+///
+/// Like [`ReadContext`] / [`InvokeContext`], it is a [`HandlerContext`] — so the
+/// report handler has the same ambient access to the [`Matter`] stack, crypto,
+/// KV store, networks, node metadata and buffer pool as any cluster handler —
+/// plus the originating [`Exchange`] and the [`SubscriptionCtx`] identifying the
+/// subscription the report belongs to.
+pub trait ReportContext: HandlerContext {
+    /// The exchange the report arrived on.
+    fn exchange(&self) -> &Exchange<'_>;
+
+    /// The `(fabric, peer, subscription-id)` identity of the report.
+    fn subscription(&self) -> SubscriptionCtx;
+}
+
+impl<T> ReportContext for &T
+where
+    T: ReportContext,
+{
+    fn exchange(&self) -> &Exchange<'_> {
+        (**self).exchange()
+    }
+
+    fn subscription(&self) -> SubscriptionCtx {
+        (**self).subscription()
+    }
+}
+
 /// A concrete implementation of the `ReadContext` trait
 pub(crate) struct ReadContextInstance<'a, C> {
     exchange: &'a Exchange<'a>,
@@ -612,6 +665,120 @@ where
 {
     fn attr(&self) -> &AttrDetails {
         self.attr
+    }
+}
+
+/// A concrete implementation of the [`ReportContext`] trait.
+pub(crate) struct ReportContextInstance<'a, C> {
+    exchange: &'a Exchange<'a>,
+    context: C,
+    subscription: SubscriptionCtx,
+}
+
+impl<'a, C> ReportContextInstance<'a, C>
+where
+    C: HandlerContext,
+{
+    /// Construct a new instance.
+    #[inline(always)]
+    pub(crate) const fn new(
+        exchange: &'a Exchange<'a>,
+        context: C,
+        subscription: SubscriptionCtx,
+    ) -> Self {
+        Self {
+            exchange,
+            context,
+            subscription,
+        }
+    }
+}
+
+impl<C> HandlerContext for ReportContextInstance<'_, C>
+where
+    C: HandlerContext,
+{
+    fn matter(&self) -> &Matter<'_> {
+        self.context.matter()
+    }
+
+    fn crypto(&self) -> impl Crypto + '_ {
+        self.context.crypto()
+    }
+
+    fn kv(&self) -> impl KvBlobStoreAccess + '_ {
+        self.context.kv()
+    }
+
+    fn networks(&self) -> impl NetworksAccess + '_ {
+        self.context.networks()
+    }
+
+    fn metadata(&self) -> impl Metadata + '_ {
+        self.context.metadata()
+    }
+
+    fn handler(&self) -> impl AsyncHandler + '_ {
+        self.context.handler()
+    }
+
+    fn buffers(&self) -> impl Buffers<IMBuffer> + '_ {
+        self.context.buffers()
+    }
+}
+
+impl<C> AttrChangeNotifier for ReportContextInstance<'_, C>
+where
+    C: HandlerContext,
+{
+    fn notify_attr_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId, attr_id: AttrId) {
+        self.context
+            .notify_attr_changed(endpoint_id, cluster_id, attr_id);
+    }
+
+    fn notify_cluster_changed(&self, endpoint_id: EndptId, cluster_id: ClusterId) {
+        self.context.notify_cluster_changed(endpoint_id, cluster_id);
+    }
+
+    fn notify_endpoint_changed(&self, endpoint_id: EndptId) {
+        self.context.notify_endpoint_changed(endpoint_id);
+    }
+
+    fn notify_all_changed(&self) {
+        self.context.notify_all_changed();
+    }
+}
+
+impl<C> EventEmitter for ReportContextInstance<'_, C>
+where
+    C: HandlerContext,
+{
+    fn emit_event<F>(
+        &self,
+        endpoint_id: EndptId,
+        cluster_id: ClusterId,
+        event_id: EventId,
+        priority: EventPriority,
+        f: F,
+    ) -> Result<EventNumber, Error>
+    where
+        F: FnOnce(EventTLVWrite<'_>) -> Result<(), Error>,
+    {
+        self.context
+            .emit_event(endpoint_id, cluster_id, event_id, priority, f)
+    }
+}
+
+impl<C> ReportContext for ReportContextInstance<'_, C>
+where
+    C: HandlerContext,
+{
+    fn exchange(&self) -> &Exchange<'_> {
+        self.exchange
+    }
+
+    fn subscription(&self) -> SubscriptionCtx {
+        self.subscription
     }
 }
 
@@ -1343,9 +1510,11 @@ mod asynch {
     use crate::error::{Error, ErrorCode};
     use crate::utils::select::Coalesce;
 
+    use crate::im::encoding::{IMStatusCode, ReportDataResp};
+
     use super::{
         ChainedHandler, EmptyHandler, Handler, InvokeContext, NonBlockingHandler, ReadContext,
-        WriteContext,
+        ReportContext, WriteContext,
     };
 
     /// A handler for processing a single IM operation:
@@ -1522,6 +1691,89 @@ mod asynch {
 
         fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
             (**self).run(ctx)
+        }
+    }
+
+    /// A handler for consuming server-initiated `ReportData` messages — the
+    /// controller/subscriber side of the Interaction Model.
+    ///
+    /// After a controller establishes a subscription (via the IM client), the
+    /// publisher pushes `ReportData` messages on fresh inbound exchanges
+    /// throughout the subscription's lifetime. The
+    /// [`InteractionModel`](crate::im::InteractionModel) accepts those exchanges
+    /// (it already owns all inbound IM traffic), parses each `ReportData` chunk,
+    /// ACKs it at the IM layer, and hands the parsed chunk to this trait via
+    /// [`handle_report`](Self::handle_report).
+    ///
+    /// The report handler is a **separate, peer capability** of the
+    /// [`InteractionModel`], alongside the [`DataModel`] cluster handler — not a
+    /// supertrait of `DataModel`. A pure accessory does not supply one: the
+    /// `InteractionModel`'s report handler defaults to `()`, whose
+    /// implementation disowns every inbound report with
+    /// [`IMStatusCode::InvalidSubscription`] (the same status the C++ SDK returns
+    /// for an unmatched report, which the publisher uses to tear a stale
+    /// subscription down). A controller injects a real one via
+    /// [`InteractionModel::new_with_reports`](crate::im::InteractionModel::new_with_reports).
+    ///
+    /// `handle_report` is invoked **once per received chunk** with a
+    /// [`ReportContext`] (a [`HandlerContext`] carrying the originating exchange
+    /// and the subscription identity) plus the parsed [`ReportDataResp`]
+    /// (borrowing the exchange RX buffer). The `InteractionModel` owns the
+    /// multi-chunk loop and the inter-chunk `StatusResponse(Success)` acks; a
+    /// handler that cares about chunk boundaries reads `report.more_chunks` and
+    /// reassembles across calls itself.
+    pub trait ReportDataHandler {
+        /// Handle a single received `ReportData` chunk.
+        ///
+        /// Returning `Ok(())` makes the `InteractionModel` reply
+        /// `StatusResponse(Success)`; returning `Err(code)` makes it reply
+        /// `StatusResponse(code)` (e.g. [`IMStatusCode::InvalidSubscription`] to
+        /// disown a subscription the controller no longer tracks).
+        fn handle_report(
+            &self,
+            ctx: impl ReportContext,
+            report: &ReportDataResp<'_>,
+        ) -> impl Future<Output = Result<(), IMStatusCode>>;
+    }
+
+    impl<T> ReportDataHandler for &T
+    where
+        T: ReportDataHandler,
+    {
+        fn handle_report(
+            &self,
+            ctx: impl ReportContext,
+            report: &ReportDataResp<'_>,
+        ) -> impl Future<Output = Result<(), IMStatusCode>> {
+            (**self).handle_report(ctx, report)
+        }
+    }
+
+    impl<T> ReportDataHandler for &mut T
+    where
+        T: ReportDataHandler,
+    {
+        fn handle_report(
+            &self,
+            ctx: impl ReportContext,
+            report: &ReportDataResp<'_>,
+        ) -> impl Future<Output = Result<(), IMStatusCode>> {
+            (**self).handle_report(ctx, report)
+        }
+    }
+
+    /// The accessory-role default report handler: a device that never subscribes
+    /// to anything disowns every inbound report with
+    /// [`IMStatusCode::InvalidSubscription`]. This is the default type of the
+    /// `InteractionModel`'s report-handler generic, so existing accessory call
+    /// sites are unaffected.
+    impl ReportDataHandler for () {
+        async fn handle_report(
+            &self,
+            _ctx: impl ReportContext,
+            _report: &ReportDataResp<'_>,
+        ) -> Result<(), IMStatusCode> {
+            Err(IMStatusCode::InvalidSubscription)
         }
     }
 

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -41,7 +41,7 @@ use crate::dm::networks::wireless::{NoopWirelessNetCtl, WirelessMgr, MAX_CREDS_S
 use crate::dm::networks::NetChangeNotif;
 use crate::dm::{
     AsyncHandler, AttrChangeNotifier, AttrDetails, Attribute, DataModel, EventEmitter,
-    HandlerContext, MatchContextInstance, Metadata,
+    HandlerContext, MatchContextInstance, Metadata, ReportDataHandler,
 };
 use crate::error::{Error, ErrorCode};
 use crate::im::events::{EventReader, EventTLVWrite, Events, DEFAULT_MAX_EVENTS_BUF_SIZE};
@@ -220,6 +220,7 @@ pub struct InteractionModel<
     K,
     N,
     NC = NoopWirelessNetCtl,
+    R = (),
     const NS: usize = DEFAULT_MAX_SUBSCRIPTIONS,
     const NE: usize = DEFAULT_MAX_EVENTS_BUF_SIZE,
 > where
@@ -233,6 +234,10 @@ pub struct InteractionModel<
     subscriptions_buffers: SubscriptionsBuffers<'a, B, NS>,
     state: &'a InteractionModelState<N, NS, NE>,
     handler: T,
+    /// The controller-side `ReportData` consumer. Defaults to `()`, which
+    /// disowns every inbound report (the accessory role). A controller injects a
+    /// real one via [`InteractionModel::new_with_reports`].
+    report_handler: R,
 }
 
 /// A [`InteractionModelState`] for an Ethernet device: its network store is a fixed
@@ -252,9 +257,10 @@ pub type EthInteractionModel<
     T,
     K,
     NC = NoopWirelessNetCtl,
+    R = (),
     const NS: usize = DEFAULT_MAX_SUBSCRIPTIONS,
     const NE: usize = DEFAULT_MAX_EVENTS_BUF_SIZE,
-> = InteractionModel<'a, C, B, T, K, EthNetwork<'static>, NC, NS, NE>;
+> = InteractionModel<'a, C, B, T, K, EthNetwork<'static>, NC, R, NS, NE>;
 
 /// A [`InteractionModelState`] for a wireless device, parameterized by the concrete
 /// wireless network store `N` (e.g. `WifiNetworks<3>` or a Thread store). Pairs
@@ -275,12 +281,13 @@ pub type WirelessInteractionModel<
     K,
     N,
     NC,
+    R = (),
     const NS: usize = DEFAULT_MAX_SUBSCRIPTIONS,
     const NE: usize = DEFAULT_MAX_EVENTS_BUF_SIZE,
-> = InteractionModel<'a, C, B, T, K, N, NC, NS, NE>;
+> = InteractionModel<'a, C, B, T, K, N, NC, R, NS, NE>;
 
 impl<'a, C, B, T, K, N, const NS: usize, const NE: usize>
-    InteractionModel<'a, C, B, T, K, N, NoopWirelessNetCtl, NS, NE>
+    InteractionModel<'a, C, B, T, K, N, NoopWirelessNetCtl, (), NS, NE>
 where
     C: Crypto,
     B: Buffers<IMBuffer>,
@@ -328,7 +335,7 @@ where
 }
 
 impl<'a, C, B, T, K, N, NC, const NS: usize, const NE: usize>
-    InteractionModel<'a, C, B, T, K, N, NC, NS, NE>
+    InteractionModel<'a, C, B, T, K, N, NC, (), NS, NE>
 where
     C: Crypto,
     B: Buffers<IMBuffer>,
@@ -377,6 +384,59 @@ where
             subscriptions_buffers: SubscriptionsBuffers::new(),
             state,
             handler,
+            report_handler: (),
+        }
+    }
+}
+
+impl<'a, C, B, T, K, N, NC, R, const NS: usize, const NE: usize>
+    InteractionModel<'a, C, B, T, K, N, NC, R, NS, NE>
+where
+    C: Crypto,
+    B: Buffers<IMBuffer>,
+    T: DataModel,
+    K: KvBlobStoreAccess,
+    N: Networks,
+    R: ReportDataHandler,
+{
+    /// Create the data model with an explicit network controller `net_ctl` and a
+    /// [`ReportDataHandler`] `report_handler` — the controller / subscriber role.
+    ///
+    /// This is [`InteractionModel::new_with_net_ctl`] plus a report consumer:
+    /// after this node establishes subscriptions (via the IM client), the
+    /// publishers push `ReportData` on fresh inbound exchanges, which the
+    /// `InteractionModel` routes to `report_handler`. The default
+    /// (`new`/`new_with_net_ctl`) constructors leave the report handler as `()`,
+    /// which disowns every report — correct for a pure accessory.
+    ///
+    /// # Arguments
+    /// Same as [`InteractionModel::new_with_net_ctl`], plus:
+    /// - `report_handler` - an instance of type `R` implementing
+    ///   [`ReportDataHandler`], invoked once per received `ReportData` chunk.
+    #[inline(always)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_reports(
+        matter: &'a Matter<'a>,
+        crypto: C,
+        buffers: &'a B,
+        handler: T,
+        kv: K,
+        net_ctl: NC,
+        report_handler: R,
+        state: &'a InteractionModelState<N, NS, NE>,
+    ) -> Self {
+        state.subscriptions.clear();
+
+        Self {
+            matter,
+            crypto,
+            buffers,
+            kv,
+            net_ctl,
+            subscriptions_buffers: SubscriptionsBuffers::new(),
+            state,
+            handler,
+            report_handler,
         }
     }
 
@@ -591,6 +651,10 @@ where
                 error!("Received a groupcast message for opcode: SubscribeRequest")
             }
             OpCode::SubscribeRequest if !is_groupcast => self.subscribe(exchange).await?,
+            OpCode::ReportData if is_groupcast => {
+                error!("Received a groupcast message for opcode: ReportData")
+            }
+            OpCode::ReportData if !is_groupcast => self.handle_report_data(exchange).await?,
             OpCode::TimedRequest if !is_groupcast => {
                 Self::send_status(exchange, IMStatusCode::InvalidAction).await?
             }
@@ -862,6 +926,92 @@ where
             self.persist_subscriptions();
 
             self.state.subscriptions.notification.notify();
+        }
+
+        Ok(())
+    }
+
+    /// Handle a server-initiated `ReportData` message — the controller /
+    /// subscriber side of a subscription.
+    ///
+    /// After a controller establishes a subscription (via the IM client), the
+    /// publisher pushes `ReportData` messages on fresh inbound exchanges for the
+    /// life of the subscription. Those exchanges land here (the `InteractionModel`
+    /// owns all inbound IM traffic); we parse each chunk, hand it to the
+    /// `DataModel`'s [`ReportDataHandler`](crate::dm::ReportDataHandler) side, and
+    /// reply `StatusResponse` — `Success` when the handler accepts, or the
+    /// handler's chosen status (e.g. `InvalidSubscription`) when it disowns the
+    /// report. A pure accessory's handler always disowns reports, so this is inert
+    /// for the accessory role.
+    ///
+    /// Mirrors the priming-chunk loop the IM client walks during subscribe
+    /// establishment: for each chunk we ack with `StatusResponse(Success)` and
+    /// fetch the next until `more_chunks` clears. The terminal MRP ack is left to
+    /// the caller's `exchange.acknowledge()` (idempotent after our `send_status`).
+    async fn handle_report_data(&self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
+        // The peer identity is a property of the (secure) session, constant
+        // across every chunk of this report.
+        let (fabric_idx, peer_node_id) = exchange.with_state(|state| {
+            let sess = exchange.id().session(&mut state.sessions);
+
+            let fabric_idx =
+                NonZeroU8::new(sess.get_local_fabric_idx()).ok_or(ErrorCode::Invalid)?;
+            let peer_node_id = sess.get_peer_node_id().ok_or(ErrorCode::Invalid)?;
+
+            Ok((fabric_idx, peer_node_id))
+        })?;
+
+        loop {
+            let (result, more_chunks, suppress_response) = {
+                let rx = exchange.rx()?;
+                let report = ReportDataResp::from_tlv(&TLVElement::new(rx.payload()))?;
+
+                let subscription = crate::dm::SubscriptionCtx {
+                    fabric_idx,
+                    peer_node_id,
+                    subscription_id: report.subscription_id,
+                };
+
+                // The report context is a `HandlerContext` (matter/crypto/kv/…)
+                // over a shared borrow of the exchange, valid only for the
+                // duration of this handler call — after which we resume the
+                // mutable ack/fetch loop below.
+                let ctx = crate::dm::ReportContextInstance::new(&*exchange, self, subscription);
+
+                let result = self.report_handler.handle_report(ctx, &report).await;
+
+                (
+                    result,
+                    report.more_chunks.unwrap_or(false),
+                    report.suppress_response.unwrap_or(false),
+                )
+            };
+
+            // Spec forbids `suppress_response=true` alongside `more_chunks=true`.
+            if more_chunks && suppress_response {
+                return Self::send_status(exchange, IMStatusCode::InvalidAction).await;
+            }
+
+            // A non-Success handler result disowns the (sub)report; report the
+            // status and stop — no point ack-ing further chunks of a report we
+            // rejected.
+            if let Err(status) = result {
+                if !suppress_response {
+                    return Self::send_status(exchange, status).await;
+                }
+                return Ok(());
+            }
+
+            if !suppress_response {
+                Self::send_status(exchange, IMStatusCode::Success).await?;
+            }
+
+            if !more_chunks {
+                break;
+            }
+
+            // Next chunk rides in on the same exchange.
+            exchange.recv_fetch().await?;
         }
 
         Ok(())
@@ -1389,22 +1539,23 @@ where
     }
 }
 
-impl<C, B, T, K, N, NC, const NS: usize, const NE: usize> ExchangeHandler
-    for InteractionModel<'_, C, B, T, K, N, NC, NS, NE>
+impl<C, B, T, K, N, NC, R, const NS: usize, const NE: usize> ExchangeHandler
+    for InteractionModel<'_, C, B, T, K, N, NC, R, NS, NE>
 where
     C: Crypto,
     B: Buffers<IMBuffer>,
     T: DataModel,
     K: KvBlobStoreAccess,
     N: Networks,
+    R: ReportDataHandler,
 {
     async fn handle(&self, mut exchange: Exchange<'_>) -> Result<(), Error> {
         InteractionModel::handle(self, &mut exchange).await
     }
 }
 
-impl<C, B, T, K, N, NC, const NS: usize, const NE: usize> HandlerContext
-    for InteractionModel<'_, C, B, T, K, N, NC, NS, NE>
+impl<C, B, T, K, N, NC, R, const NS: usize, const NE: usize> HandlerContext
+    for InteractionModel<'_, C, B, T, K, N, NC, R, NS, NE>
 where
     C: Crypto,
     B: Buffers<IMBuffer>,
@@ -1441,8 +1592,8 @@ where
     }
 }
 
-impl<C, B, T, K, N, NC, const NS: usize, const NE: usize> AttrChangeNotifier
-    for InteractionModel<'_, C, B, T, K, N, NC, NS, NE>
+impl<C, B, T, K, N, NC, R, const NS: usize, const NE: usize> AttrChangeNotifier
+    for InteractionModel<'_, C, B, T, K, N, NC, R, NS, NE>
 where
     C: Crypto,
     B: Buffers<IMBuffer>,
@@ -1485,8 +1636,8 @@ where
     }
 }
 
-impl<C, B, T, K, N, NC, const NS: usize, const NE: usize> EventEmitter
-    for InteractionModel<'_, C, B, T, K, N, NC, NS, NE>
+impl<C, B, T, K, N, NC, R, const NS: usize, const NE: usize> EventEmitter
+    for InteractionModel<'_, C, B, T, K, N, NC, R, NS, NE>
 where
     C: Crypto,
     B: Buffers<IMBuffer>,

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -995,11 +995,13 @@ where
             // A non-Success handler result disowns the (sub)report; report the
             // status and stop — no point ack-ing further chunks of a report we
             // rejected.
+            //
+            // `SuppressResponse` only suppresses the *Success* StatusResponse: a
+            // failure status MUST always be sent (Matter Core spec), so the
+            // publisher can tear down a subscription we no longer track (e.g. our
+            // `InvalidSubscription`). Sending it regardless of `suppress_response`.
             if let Err(status) = result {
-                if !suppress_response {
-                    return Self::send_status(exchange, status).await;
-                }
-                return Ok(());
+                return Self::send_status(exchange, status).await;
             }
 
             if !suppress_response {

--- a/rs-matter/src/respond.rs
+++ b/rs-matter/src/respond.rs
@@ -24,7 +24,7 @@ use embassy_futures::select::{select, select_slice};
 use crate::crypto::Crypto;
 use crate::dm::clusters::net_comm;
 use crate::dm::networks::wireless::NoopWirelessNetCtl;
-use crate::dm::DataModel;
+use crate::dm::{DataModel, ReportDataHandler};
 use crate::error::Error;
 use crate::im::busy::BusyInteractionModel;
 use crate::im::events::DEFAULT_MAX_EVENTS_BUF_SIZE;
@@ -272,15 +272,16 @@ pub type DefaultExchangeHandler<
     K,
     N,
     NC = NoopWirelessNetCtl,
+    R = (),
     const NS: usize = DEFAULT_MAX_SUBSCRIPTIONS,
     const NE: usize = DEFAULT_MAX_EVENTS_BUF_SIZE,
 > = ChainedExchangeHandler<
-    &'d InteractionModel<'a, C, B, T, K, N, NC, NS, NE>,
+    &'d InteractionModel<'a, C, B, T, K, N, NC, R, NS, NE>,
     SecureChannel<'d, &'d C>,
 >;
 
-impl<'d, 'a, C, B, T, K, N, NC, const NS: usize, const NE: usize>
-    Responder<'a, DefaultExchangeHandler<'d, 'a, C, B, T, K, N, NC, NS, NE>>
+impl<'d, 'a, C, B, T, K, N, NC, R, const NS: usize, const NE: usize>
+    Responder<'a, DefaultExchangeHandler<'d, 'a, C, B, T, K, N, NC, R, NS, NE>>
 where
     B: Buffers<IMBuffer>,
 {
@@ -288,13 +289,14 @@ where
     /// (`SecureChannel` and `InteractionModel`) for handling the Secure Channel protocol and the Interaction Model protocol.
     #[inline(always)]
     pub const fn new_default(
-        data_model: &'d InteractionModel<'a, C, B, T, K, N, NC, NS, NE>,
+        data_model: &'d InteractionModel<'a, C, B, T, K, N, NC, R, NS, NE>,
     ) -> Self
     where
         C: Crypto,
         T: DataModel,
         K: KvBlobStoreAccess,
         N: net_comm::Networks,
+        R: ReportDataHandler,
     {
         Self::new(
             "Responder",
@@ -344,27 +346,29 @@ pub struct DefaultResponder<
     K,
     N,
     NC = NoopWirelessNetCtl,
+    R = (),
     const NS: usize = DEFAULT_MAX_SUBSCRIPTIONS,
     const NE: usize = DEFAULT_MAX_EVENTS_BUF_SIZE,
 > where
     B: Buffers<IMBuffer>,
 {
-    responder: Responder<'a, DefaultExchangeHandler<'d, 'a, C, B, T, K, N, NC, NS, NE>>,
+    responder: Responder<'a, DefaultExchangeHandler<'d, 'a, C, B, T, K, N, NC, R, NS, NE>>,
     busy_responder: Responder<'a, BusyExchangeHandler>,
 }
 
-impl<'d, 'a, C, B, T, K, N, NC, const NS: usize, const NE: usize>
-    DefaultResponder<'d, 'a, C, B, T, K, N, NC, NS, NE>
+impl<'d, 'a, C, B, T, K, N, NC, R, const NS: usize, const NE: usize>
+    DefaultResponder<'d, 'a, C, B, T, K, N, NC, R, NS, NE>
 where
     C: Crypto,
     B: Buffers<IMBuffer>,
     T: DataModel,
     K: KvBlobStoreAccess,
     N: net_comm::Networks,
+    R: ReportDataHandler,
 {
     /// Creates the responder composition.
     #[inline(always)]
-    pub const fn new(data_model: &'d InteractionModel<'a, C, B, T, K, N, NC, NS, NE>) -> Self {
+    pub const fn new(data_model: &'d InteractionModel<'a, C, B, T, K, N, NC, R, NS, NE>) -> Self {
         Self {
             responder: Responder::new_default(data_model),
             busy_responder: Responder::new_busy(data_model.matter(), RESPOND_BUSY_MS),
@@ -388,7 +392,7 @@ where
     ) -> &Responder<
         'a,
         ChainedExchangeHandler<
-            &'d InteractionModel<'a, C, B, T, K, N, NC, NS, NE>,
+            &'d InteractionModel<'a, C, B, T, K, N, NC, R, NS, NE>,
             SecureChannel<'d, &'d C>,
         >,
     > {

--- a/rs-matter/tests/im/subscription_reboot.rs
+++ b/rs-matter/tests/im/subscription_reboot.rs
@@ -25,22 +25,29 @@
 //! subscription is re-primed, promptly drives a `ReportData` back to the client
 //! without the client having to re-subscribe.
 
+use core::cell::Cell;
+
 use embassy_futures::block_on;
 use embassy_futures::select::{select, Either};
 
+use rs_matter::dm::clusters::net_comm::{DummyNetworks, NetworkType};
+use rs_matter::dm::networks::wireless::NoopWirelessNetCtl;
+use rs_matter::dm::{EmptyHandler, Node, ReportContext, ReportDataHandler, SubscriptionCtx};
 use rs_matter::im::client::{ImClient, SubscribeOutcome, TxOutcome};
+use rs_matter::im::encoding::ReportDataResp;
 use rs_matter::im::{
-    AttrPath, GenericPath, IMStatusCode, InteractionModelState, OpCode, StatusResp,
+    AttrPath, GenericPath, IMStatusCode, InteractionModel, InteractionModelState, OpCode,
+    StatusResp,
 };
-use rs_matter::persist::PERSISTENT_SUBSCRIPTIONS_START;
-use rs_matter::transport::exchange::Exchange;
+use rs_matter::persist::{DummyKvBlobStore, PERSISTENT_SUBSCRIPTIONS_START};
+use rs_matter::respond::Responder;
+use rs_matter::transport::exchange::{Exchange, MatterBuffers};
 use rs_matter::utils::select::Coalesce;
+use rs_matter::utils::sync::Notification;
 
 use crate::common::e2e::im::echo_cluster;
 use crate::common::e2e::{new_default_runner, E2E_EVENTS_BUF_SIZE};
 use crate::common::{init_env_logger, MemKvBlobStore};
-
-use rs_matter::dm::clusters::net_comm::DummyNetworks;
 
 /// Subscribe → persist → reboot the server (fresh table, same store) → resume →
 /// the resumed subscription reports back to the still-connected client.
@@ -150,5 +157,171 @@ fn test_subscription_survives_reboot() {
         got_report,
         OpCode::ReportData as u8,
         "the resumed subscription should have delivered a ReportData after reboot"
+    );
+}
+
+/// A [`ReportDataHandler`] that records the first report it is handed and signals
+/// completion, so the test can await the delivery and inspect it.
+#[derive(Default)]
+struct CapturingReports {
+    seen: Cell<u32>,
+    subscription: Cell<Option<SubscriptionCtx>>,
+    attrs: Cell<u32>,
+    done: Notification,
+}
+
+impl ReportDataHandler for CapturingReports {
+    async fn handle_report(
+        &self,
+        ctx: impl ReportContext,
+        report: &ReportDataResp<'_>,
+    ) -> Result<(), IMStatusCode> {
+        self.seen.set(self.seen.get() + 1);
+        self.subscription.set(Some(ctx.subscription()));
+
+        let mut attrs = 0;
+        if let Some(attr_reports) = &report.attr_reports {
+            for attr_resp in attr_reports.iter() {
+                if attr_resp.is_ok() {
+                    attrs += 1;
+                }
+            }
+        }
+        self.attrs.set(attrs);
+
+        // Ambient `HandlerContext` access is available too — e.g. `ctx.matter()`.
+        let _ = ctx.matter();
+
+        self.done.notify();
+
+        Ok(())
+    }
+}
+
+/// The same reboot-and-resume flow as above, but instead of hand-accepting the
+/// server-initiated `ReportData` and hand-writing the `StatusResponse`, the
+/// *controller* runs its own [`InteractionModel`] wired with a
+/// [`ReportDataHandler`] via [`InteractionModel::new_with_reports`]. This proves
+/// the generic controller-side report facility catches, parses, and ACKs a real
+/// server-initiated report end-to-end (the mechanism a live controller / health
+/// dashboard relies on).
+#[test]
+fn test_report_data_handler_catches_server_report() {
+    init_env_logger();
+
+    let im = new_default_runner();
+    im.add_default_acl();
+
+    let kv = MemKvBlobStore::default();
+
+    let path = AttrPath::from_gp(&GenericPath::new(
+        Some(0),
+        Some(echo_cluster::ID),
+        Some(echo_cluster::AttributesDiscriminants::Att1 as u32),
+    ));
+    let paths = [path];
+
+    // ---- Boot 1: subscribe and let the server persist the subscription. ----
+    block_on(
+        select(
+            im.run_with(im.handler(), &im.state, kv.clone(), false),
+            async {
+                let exchange = im.initiate_exchange().await?;
+                let mut sender = exchange.subscribe_sender().await?;
+
+                let mut chunk = loop {
+                    match sender.tx().await? {
+                        TxOutcome::BuildRequest(builder) => {
+                            sender = builder
+                                .keep_subs(true)?
+                                .min_int_floor(0)?
+                                .max_int_ceil(60)?
+                                .attr_requests_from(&paths)?
+                                .fabric_filtered(false)?
+                                .end()?;
+                        }
+                        TxOutcome::GotResponse(c) => break c,
+                    }
+                };
+
+                let established = loop {
+                    let _ = chunk.response()?;
+                    match chunk.complete().await? {
+                        SubscribeOutcome::NextChunk(next) => chunk = next,
+                        SubscribeOutcome::Established(est) => break est,
+                    }
+                };
+
+                assert_ne!(established.subscription_id, 0);
+
+                embassy_time::Timer::after(embassy_time::Duration::from_millis(200)).await;
+
+                Ok(())
+            },
+        )
+        .coalesce(),
+    )
+    .unwrap();
+
+    assert!(
+        kv.contains_key(PERSISTENT_SUBSCRIPTIONS_START),
+        "boot 1 should have persisted the subscription"
+    );
+
+    // ---- Boot 2: server resumes + pushes a report; the controller catches it
+    // via its own InteractionModel + ReportDataHandler. ----
+    let state2: InteractionModelState<DummyNetworks, 3, E2E_EVENTS_BUF_SIZE> =
+        InteractionModelState::new(DummyNetworks);
+
+    // The controller's own data model: no clusters served (empty node), it only
+    // consumes reports.
+    let ctrl_node = Node::new(&[]);
+    let ctrl_handler = (ctrl_node, EmptyHandler);
+    let ctrl_buffers: MatterBuffers = MatterBuffers::new();
+    let ctrl_state: InteractionModelState<DummyNetworks, 3, E2E_EVENTS_BUF_SIZE> =
+        InteractionModelState::new(DummyNetworks);
+    let reports = CapturingReports::default();
+
+    let ctrl_kv = im.matter_client().kv(DummyKvBlobStore);
+    let ctrl_dm = InteractionModel::new_with_reports(
+        im.matter_client(),
+        rs_matter::crypto::test_only_crypto(),
+        &ctrl_buffers,
+        ctrl_handler,
+        &ctrl_kv,
+        NoopWirelessNetCtl::new(NetworkType::Ethernet),
+        &reports,
+        &ctrl_state,
+    );
+    let ctrl_responder = Responder::new_default(&ctrl_dm);
+
+    block_on(async {
+        let server = im.run_with(im.handler(), &state2, kv.clone(), true);
+        let controller = ctrl_responder.run::<4>();
+        let wait = reports.done.wait();
+
+        match select(select(server, controller).coalesce(), wait).await {
+            Either::First(r) => panic!("a run loop exited before the report was caught: {r:?}"),
+            Either::Second(()) => {}
+        }
+    });
+
+    assert_eq!(
+        reports.seen.get(),
+        1,
+        "the ReportDataHandler should have been invoked exactly once"
+    );
+    assert_eq!(
+        reports.attrs.get(),
+        1,
+        "the report should carry the single subscribed attribute"
+    );
+    let sub = reports
+        .subscription
+        .get()
+        .expect("a SubscriptionCtx should have been captured");
+    assert!(
+        sub.subscription_id.is_some(),
+        "the report should carry a subscription id"
     );
 }


### PR DESCRIPTION
This new handler is filling-in a gap in our IM processing which is typically revealed when one wants to create a Controller peer.

We are not really processing `ReportData` IM messages, and a controller typically should, as they are the outcome of the subscriptions a controller would do to a bunch of accessories.