### PR TITLE
BTP Commissioner

### DIFF
--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -145,6 +145,11 @@ zbus = ["dep:zbus", "dep:serde", "os", "futures-lite", "libc", "uuid", "async-ch
 # BLE suppport for Linux (via BlueZ).
 # Prefer the BlueZ implementation over Bluer for production deployments, via `zbus`.
 bluer = ["dep:bluer", "os"]
+# Recognizing Matter onboarding QR codes in images (via `rqrr`), for commissioners
+# that scan a device's QR code rather than being handed its payload text.
+# Requires `std`; the image *decoding* (PNG/JPEG/camera/...) is the caller's job -
+# this only consumes 8-bit greyscale pixels. See `pairing::qr::scan`.
+qr-scan = ["std", "dep:rqrr"]
 # Umbrella set of features for typical OS-based non-baremetal deployments.
 os = ["std", "backtrace", "async-io", "critical-section/std", "embassy-sync/std", "embassy-time/std", "dep:if-addrs"]
 # Minimal set of features for targets with support for Rust STD (narrower than `os` above).
@@ -214,6 +219,7 @@ either = { version = "1", default-features = false }
 critical-section = "1.1"
 domain = { version = "0.12", default-features = false, features = ["heapless"] }
 qrcodegen-no-heap = "1.8"
+rqrr = { version = "0.10", default-features = false, optional = true }
 scopeguard = { version = "1", default-features = false }
 pinned-init = { version = "0.0.8", default-features = false }
 

--- a/rs-matter/src/onboard.rs
+++ b/rs-matter/src/onboard.rs
@@ -355,6 +355,40 @@ impl<'a, C: Crypto> Commissioner<'a, C> {
             .await
     }
 
+    /// Phase 2, resolving the device's operational address via mDNS.
+    ///
+    /// Identical to [`Self::complete_via_case`] except that, instead of being
+    /// handed a fixed `peer_addr`, it looks up the device's operational endpoint
+    /// via `_matter._tcp` mDNS from `(fabric, device_node_id)` (using
+    /// [`Exchange::initiate_plaintext_operational`]).
+    ///
+    /// This is the production phase-2 path: after phase 1 the device may only be
+    /// reachable at a *different* address than PASE used - most notably when the
+    /// device was commissioned over BLE and has since joined its operational
+    /// (Wi-Fi / Thread) network, where its operational IP is not known until it
+    /// announces itself. It requires the mDNS backend to be running (so the
+    /// resolve request is answered), and the device to have joined the network
+    /// and started announcing operationally.
+    pub async fn complete_via_case_operational(
+        &mut self,
+        phase1: &CommissionResult,
+    ) -> Result<(), Error> {
+        let fab_idx = self.fab_idx;
+
+        let exchange = Exchange::initiate_plaintext_operational(
+            self.matter,
+            &self.crypto,
+            fab_idx,
+            phase1.device_node_id,
+        )
+        .await?;
+        CaseInitiator::perform(exchange, &self.crypto, fab_idx, phase1.device_node_id).await?;
+
+        // CommissioningComplete on the CASE session.
+        self.commissioning_complete(fab_idx, phase1.device_node_id)
+            .await
+    }
+
     /// `GeneralCommissioning::ArmFailSafe(expiry, breadcrumb=0)`.
     pub(crate) async fn arm_fail_safe(
         &self,

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -28,6 +28,12 @@ use crate::utils::storage::WriteBuf;
 
 use super::*;
 
+#[cfg(feature = "qr-scan")]
+pub mod scan;
+
+/// The prefix of a Matter onboarding QR-code text payload.
+pub const QR_PREFIX: &str = "MT:";
+
 // See the spec. QR Code in the Matter specification
 const LONG_BITS: usize = 12;
 const VERSION_FIELD_LENGTH_IN_BITS: usize = 3;
@@ -427,9 +433,7 @@ impl<'a> QrPayload<'a, &'a [u8]> {
     /// payload (missing prefix, invalid base38, too short, or an out-of-range field).
     pub fn parse(qr: &str, buf: &'a mut [u8]) -> Result<Self, Error> {
         // Strip the `MT:` prefix.
-        let body = qr
-            .strip_prefix(Self::qr_prefix())
-            .ok_or(ErrorCode::InvalidData)?;
+        let body = qr.strip_prefix(QR_PREFIX).ok_or(ErrorCode::InvalidData)?;
 
         // Base38-decode the body into `buf`.
         let mut len = 0;
@@ -738,13 +742,6 @@ impl<'a> QrPayload<'a, ()> {
     ///   Compliance Ledger (see [`Self::vid_pid`]).
     pub fn comm_flow(&self) -> Option<CommFlowType> {
         matches!(self.comm_flow, CommFlowType::Standard).then_some(CommFlowType::Standard)
-    }
-}
-
-/// The `MT:` prefix shared by the encode and decode paths.
-impl<'a, T> QrPayload<'a, T> {
-    const fn qr_prefix() -> &'static str {
-        "MT:"
     }
 }
 

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -23,6 +23,7 @@ use verhoeff::Verhoeff;
 
 use crate::error::ErrorCode;
 use crate::tlv::{EitherIter, TLVElement, TLVTag, TLV};
+use crate::transport::network::mdns::CommissionableFilter;
 use crate::utils::codec::base38;
 use crate::utils::storage::WriteBuf;
 
@@ -549,6 +550,26 @@ impl<'a> QrPayload<'a, &'a [u8]> {
     pub const fn optional_data(&self) -> &'a [u8] {
         self.optional_data
     }
+
+    /// A [`CommissionableFilter`] that discovers the device this QR code describes.
+    ///
+    /// A QR code carries the **full 12-bit** discriminator, so this filters on
+    /// `discriminator` and can narrow discovery to a single device. (Contrast
+    /// [`QrPayload::<()>::commissionable_filter`], built from a manual pairing code,
+    /// which can only filter on the short discriminator.)
+    ///
+    /// Only the discriminator is set. The vendor and product IDs are deliberately
+    /// *not* included even though the QR carries them: per the Matter Core spec a
+    /// device may advertise an **anonymized** Product ID of 0 during discovery, so
+    /// filtering on the QR's PID would fail to find such a device. Add them to the
+    /// returned filter if the extra selectivity is wanted and the device is known
+    /// not to anonymize.
+    pub fn commissionable_filter(&self) -> CommissionableFilter {
+        CommissionableFilter {
+            discriminator: Some(self.discriminator()),
+            ..Default::default()
+        }
+    }
 }
 
 impl<'a> QrPayload<'a, ()> {
@@ -742,6 +763,25 @@ impl<'a> QrPayload<'a, ()> {
     ///   Compliance Ledger (see [`Self::vid_pid`]).
     pub fn comm_flow(&self) -> Option<CommFlowType> {
         matches!(self.comm_flow, CommFlowType::Standard).then_some(CommFlowType::Standard)
+    }
+
+    /// A [`CommissionableFilter`] that discovers the device this manual pairing code
+    /// describes.
+    ///
+    /// A manual pairing code only carries the **short** (4-bit) discriminator, so
+    /// this necessarily filters on `short_discriminator` - which narrows discovery
+    /// to 1-in-16 devices rather than to exactly one. Getting this right is the
+    /// whole point of the method: the short value must not end up in the filter's
+    /// full-discriminator field, where it would match nothing.
+    ///
+    /// The vendor and product IDs are not included even when the 21-digit variant
+    /// carries them, since a device may advertise an anonymized Product ID of 0
+    /// during discovery.
+    pub fn commissionable_filter(&self) -> CommissionableFilter {
+        CommissionableFilter {
+            short_discriminator: Some(self.short_discriminator()),
+            ..Default::default()
+        }
     }
 }
 
@@ -1482,6 +1522,34 @@ mod tests {
             };
             assert_eq!(comm_data.compute_pairing_code(), code);
         }
+    }
+
+    #[test]
+    fn commissionable_filter_uses_the_right_discriminator_field() {
+        // A QR carries the full 12-bit discriminator...
+        let mut buf = [0; 128];
+        let qr = unwrap!(
+            QrPayload::parse("MT:-24J0AFN00KA064IJ3P0IXZB0DK5N1K8SQ1RYCU1-A40", &mut buf),
+            "Failed to parse"
+        );
+        let filter = qr.commissionable_filter();
+
+        assert_eq!(filter.discriminator, Some(3840));
+        assert_eq!(filter.short_discriminator, None);
+
+        // ... while a manual pairing code only carries the upper 4 bits, which must
+        // land in `short_discriminator` (0xF00 >> 8 == 15) and *not* in the
+        // full-discriminator field, where it would match nothing.
+        let manual = unwrap!(QrPayload::parse_pairing_code("34970112332"), "Failed");
+        let filter = manual.commissionable_filter();
+
+        assert_eq!(filter.short_discriminator, Some(15));
+        assert_eq!(filter.discriminator, None);
+
+        // Neither constrains vendor/product: a device may advertise an anonymized
+        // Product ID of 0 during discovery.
+        assert_eq!(filter.vendor_id, None);
+        assert_eq!(filter.product_id, None);
     }
 
     #[test]

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -19,8 +19,10 @@ use core::iter::Empty;
 
 use qrcodegen_no_heap::{QrCode, QrCodeEcc, Version};
 
+use verhoeff::Verhoeff;
+
 use crate::error::ErrorCode;
-use crate::tlv::{EitherIter, TLVTag, TLV};
+use crate::tlv::{EitherIter, TLVElement, TLVTag, TLV};
 use crate::utils::codec::base38;
 use crate::utils::storage::WriteBuf;
 
@@ -400,6 +402,396 @@ where
                         .flat_map(TLV::result_into_bytes_iter),
                 ),
         )
+    }
+}
+
+impl<'a> QrPayload<'a, &'a [u8]> {
+    /// Parse a Matter onboarding QR-code text (an `MT:` payload) into a [`QrPayload`].
+    ///
+    /// This is the inverse of the [`QrPayload::as_str`] / [`QrPayload::emit_chars`]
+    /// encoding path, and the entry point a commissioner uses to turn a scanned QR
+    /// string into the discriminator, passcode, VID/PID etc. it needs to commission
+    /// the device.
+    ///
+    /// `buf` is a scratch buffer that the parsed payload borrows from: the trailing
+    /// optional-TLV data (and hence any serial number decoded out of it) points into
+    /// it, so `buf` must outlive the returned payload. A buffer of
+    /// [`TOTAL_PAYLOAD_DATA_SIZE_IN_BYTES`] plus the optional-data length is enough;
+    /// the base38 body never decodes to more bytes than the input string.
+    ///
+    /// The returned payload's `optional_data` is the raw optional-TLV byte slice (an
+    /// anonymous TLV structure), which is empty when the QR carries no optional data.
+    ///
+    /// # Errors
+    /// Returns [`ErrorCode::InvalidData`] if the string is not a well-formed `MT:`
+    /// payload (missing prefix, invalid base38, too short, or an out-of-range field).
+    pub fn parse(qr: &str, buf: &'a mut [u8]) -> Result<Self, Error> {
+        // Strip the `MT:` prefix.
+        let body = qr
+            .strip_prefix(Self::qr_prefix())
+            .ok_or(ErrorCode::InvalidData)?;
+
+        // Base38-decode the body into `buf`.
+        let mut len = 0;
+        for byte in base38::decode(body) {
+            let byte = byte?;
+            *buf.get_mut(len).ok_or(ErrorCode::BufferTooSmall)? = byte;
+            len += 1;
+        }
+        let decoded = &buf[..len];
+
+        // The fixed part of the payload is `TOTAL_PAYLOAD_DATA_SIZE_IN_BITS` bits
+        // (`TOTAL_PAYLOAD_DATA_SIZE_IN_BYTES` bytes); anything beyond it is the
+        // optional-TLV data.
+        if decoded.len() < TOTAL_PAYLOAD_DATA_SIZE_IN_BYTES {
+            return Err(ErrorCode::InvalidData.into());
+        }
+
+        let mut reader = BitReader::new(decoded);
+
+        // Read the fixed fields in the same order (and LSB-first bit order) as
+        // `emit_all_bits` writes them.
+        let version = reader.read(VERSION_FIELD_LENGTH_IN_BITS)? as u8;
+        let vid = reader.read(VENDOR_IDFIELD_LENGTH_IN_BITS)? as u16;
+        let pid = reader.read(PRODUCT_IDFIELD_LENGTH_IN_BITS)? as u16;
+        let comm_flow =
+            CommFlowType::from_bits(reader.read(COMMISSIONING_FLOW_FIELD_LENGTH_IN_BITS)? as u8)?;
+        let discovery_capabilities = DiscoveryCapabilities::from_bits_truncate(
+            reader.read(RENDEZVOUS_INFO_FIELD_LENGTH_IN_BITS)? as u8,
+        );
+        let discriminator = reader.read(PAYLOAD_DISCRIMINATOR_FIELD_LENGTH_IN_BITS)? as u16;
+        let passcode = reader.read(SETUP_PINCODE_FIELD_LENGTH_IN_BITS)?;
+        // Padding bits (must be present but are ignored).
+        let _ = reader.read(PADDING_FIELD_LENGTH_IN_BITS)?;
+
+        // The remaining whole bytes are the optional-TLV data.
+        let optional_data = &decoded[TOTAL_PAYLOAD_DATA_SIZE_IN_BYTES..];
+
+        // If present, the serial number is a context-`SERIAL_NUMBER_TAG` UTF-8 string
+        // in the anonymous optional-TLV structure. Borrow it out of the blob.
+        let serial_no = Self::parse_serial_no(optional_data).unwrap_or("");
+
+        let payload = Self {
+            version,
+            discovery_capabilities,
+            comm_flow,
+            comm_data: BasicCommData {
+                password: passcode.to_le_bytes().into(),
+                discriminator,
+            },
+            vid,
+            pid,
+            serial_no,
+            optional_data,
+        };
+
+        Ok(payload)
+    }
+
+    /// Extract the serial number (context tag [`SERIAL_NUMBER_TAG`]) from the
+    /// optional-TLV structure, if present.
+    fn parse_serial_no(optional_data: &'a [u8]) -> Option<&'a str> {
+        if optional_data.is_empty() {
+            return None;
+        }
+
+        let root = TLVElement::new(optional_data);
+        let serial = root.structure().ok()?.find_ctx(SERIAL_NUMBER_TAG).ok()?;
+
+        serial.utf8().ok()
+    }
+
+    /// The payload version (always 0 for v1 QR codes).
+    pub const fn version(&self) -> u8 {
+        self.version
+    }
+
+    /// The device's advertised discovery capabilities.
+    pub const fn discovery_capabilities(&self) -> DiscoveryCapabilities {
+        self.discovery_capabilities
+    }
+
+    /// The commissioning flow type.
+    pub const fn comm_flow(&self) -> CommFlowType {
+        self.comm_flow
+    }
+
+    /// The 12-bit discriminator.
+    pub const fn discriminator(&self) -> u16 {
+        self.comm_data.discriminator
+    }
+
+    /// The setup passcode (PIN).
+    pub fn passcode(&self) -> u32 {
+        u32::from_le_bytes(*self.comm_data.password.access())
+    }
+
+    /// The Vendor ID.
+    pub const fn vid(&self) -> u16 {
+        self.vid
+    }
+
+    /// The Product ID.
+    pub const fn pid(&self) -> u16 {
+        self.pid
+    }
+
+    /// The serial number, or an empty string if the QR carries none.
+    pub const fn serial_no(&self) -> &'a str {
+        self.serial_no
+    }
+
+    /// The raw optional-TLV data (an anonymous TLV structure), empty if absent.
+    pub const fn optional_data(&self) -> &'a [u8] {
+        self.optional_data
+    }
+}
+
+impl<'a> QrPayload<'a, ()> {
+    /// Parse a Matter **manual pairing code** (the 11- or 21-digit decimal string
+    /// printed on a device, e.g. `34970112332` / `3497-0112-332`) into a
+    /// [`QrPayload`].
+    ///
+    /// This is the "typed by a human" onboarding format, and it is the counterpart
+    /// of [`BasicCommData::compute_pairing_code`]. It is deliberately a *different*
+    /// `T` from [`QrPayload::parse`] (`()` rather than `&[u8]`), because a manual
+    /// pairing code carries strictly less information than a QR code, and the
+    /// resulting payload must not be mistaken for one:
+    ///
+    /// - Only the **upper 4 bits** of the discriminator are carried (the "short
+    ///   discriminator"). Per the Matter Core spec: *"For machine-readable formats,
+    ///   the full 12-bit Discriminator is used. For the Manual Pairing Code, only
+    ///   the upper 4 bits out of the 12-bit Discriminator are used."* Read it via
+    ///   [`Self::short_discriminator`] - there is deliberately no `discriminator()`
+    ///   accessor on this `T`, so a 4-bit value can never be mistaken for a 12-bit
+    ///   one.
+    /// - **No discovery capabilities** are carried, so a commissioner cannot know
+    ///   whether to look for the device over BLE, SoftAP or IP, and must try all of
+    ///   them.
+    /// - **No serial number and no optional TLV data** are carried (hence `T = ()`).
+    /// - The commissioning flow is only *implied* - see [`Self::comm_flow`].
+    ///
+    /// The Verhoeff check digit is verified. Separators (`-` and spaces) are
+    /// ignored, so both the compact and the "pretty" printed forms are accepted.
+    ///
+    /// # Errors
+    /// Returns [`ErrorCode::InvalidData`] if the code is not a well-formed v1 manual
+    /// pairing code: wrong length, a non-digit, a bad check digit, a first digit of
+    /// 8 or 9 (which per spec indicates a future format version), a VID/PID-present
+    /// flag inconsistent with the length, or an out-of-range digit group.
+    pub fn parse_pairing_code(code: &str) -> Result<Self, Error> {
+        /// Length of the manual pairing code without vendor/product IDs.
+        const SHORT_CODE_LEN: usize = 11;
+        /// Length of the manual pairing code with vendor/product IDs.
+        const LONG_CODE_LEN: usize = 21;
+
+        // Strip the separators of the "pretty" form (e.g. `3497-0112-332`).
+        let mut digits: heapless::String<LONG_CODE_LEN> = heapless::String::new();
+        for ch in code.chars() {
+            if matches!(ch, '-' | ' ') {
+                continue;
+            }
+
+            if !ch.is_ascii_digit() {
+                return Err(ErrorCode::InvalidData.into());
+            }
+
+            digits
+                .push(ch)
+                .map_err(|_| Error::from(ErrorCode::InvalidData))?;
+        }
+
+        let long_form = match digits.len() {
+            SHORT_CODE_LEN => false,
+            LONG_CODE_LEN => true,
+            _ => return Err(ErrorCode::InvalidData.into()),
+        };
+
+        // The trailing check digit protects against typos and transpositions.
+        if !digits.validate_verhoeff_check_digit() {
+            return Err(ErrorCode::InvalidData.into());
+        }
+
+        // DIGIT[1] := (VID_PID_PRESENT << 2) | (DISCRIMINATOR >> 10)
+        //
+        // A leading digit of 8 or 9 is invalid for v1 and would indicate a future
+        // payload version.
+        let digit1 = Self::digits_at(&digits, 0, 1)?;
+        if digit1 > 7 {
+            return Err(ErrorCode::InvalidData.into());
+        }
+
+        let vid_pid_present = digit1 >> 2 == 1;
+        // The flag and the code length must agree.
+        if vid_pid_present != long_form {
+            return Err(ErrorCode::InvalidData.into());
+        }
+
+        // The two most significant bits (11..10) of the discriminator.
+        let disc_bits_11_10 = (digit1 & 0x3) as u16;
+
+        // DIGIT[2..6] := ((DISCRIMINATOR & 0x300) << 6) | (PASSCODE & 0x3FFF)
+        let group = Self::digits_at(&digits, 1, 5)?;
+        if group > 0xFFFF {
+            return Err(ErrorCode::InvalidData.into());
+        }
+
+        // Bits 9..8 of the discriminator, and the low 14 bits of the passcode.
+        let disc_bits_9_8 = ((group >> 14) & 0x3) as u16;
+        let passcode_low = group & 0x3FFF;
+
+        // DIGIT[7..10] := (PASSCODE >> 14)
+        let passcode_high = Self::digits_at(&digits, 6, 4)?;
+        if passcode_high > 0x1FFF {
+            return Err(ErrorCode::InvalidData.into());
+        }
+
+        let passcode = (passcode_high << 14) | passcode_low;
+
+        // The short discriminator is exactly the upper 4 bits (11..8) of the full
+        // 12-bit discriminator.
+        let short_discriminator = (disc_bits_11_10 << 2) | disc_bits_9_8;
+
+        // DIGIT[11..15] := VENDOR_ID, DIGIT[16..20] := PRODUCT_ID (long form only)
+        let (vid, pid) = if long_form {
+            let vid = Self::digits_at(&digits, 10, 5)?;
+            let pid = Self::digits_at(&digits, 15, 5)?;
+
+            if vid > 0xFFFF || pid > 0xFFFF {
+                return Err(ErrorCode::InvalidData.into());
+            }
+
+            (vid as u16, pid as u16)
+        } else {
+            (0, 0)
+        };
+
+        Ok(Self {
+            // Not carried; a valid v1 code is version 0 by construction (a leading
+            // digit of 8 or 9 - i.e. a future version - is rejected above).
+            version: 0,
+            // Not carried at all. Empty means "unknown - try every transport",
+            // rather than "the device supports none".
+            discovery_capabilities: DiscoveryCapabilities::empty(),
+            // Not carried directly; per spec the *variant* implies it, and doubles as
+            // our short/long-form discriminant. See `Self::comm_flow`.
+            comm_flow: if long_form {
+                CommFlowType::Custom
+            } else {
+                CommFlowType::Standard
+            },
+            comm_data: BasicCommData {
+                password: passcode.to_le_bytes().into(),
+                // NOTE: this 12-bit field holds the 4-bit *short* discriminator for a
+                // manual pairing code. Only `short_discriminator()` exposes it.
+                discriminator: short_discriminator,
+            },
+            vid,
+            pid,
+            // Not carried.
+            serial_no: "",
+            // A manual pairing code has no optional data - hence `T = ()`.
+            optional_data: (),
+        })
+    }
+
+    /// Parse `len` decimal digits starting at `offset`.
+    fn digits_at(digits: &str, offset: usize, len: usize) -> Result<u32, Error> {
+        digits
+            .get(offset..offset + len)
+            .ok_or(ErrorCode::InvalidData)?
+            .parse()
+            .map_err(|_| ErrorCode::InvalidData.into())
+    }
+
+    /// The **short** (4-bit) discriminator - the upper 4 bits of the device's full
+    /// 12-bit discriminator.
+    ///
+    /// This is all a manual pairing code carries, so it can only narrow discovery to
+    /// 1-in-16 devices. Feed it to
+    /// [`CommissionableFilter::short_discriminator`](crate::transport::network::mdns::CommissionableFilter),
+    /// *not* to the full-discriminator filter.
+    pub const fn short_discriminator(&self) -> u8 {
+        self.comm_data.discriminator as u8
+    }
+
+    /// The setup passcode (PIN). Carried in full (27 bits).
+    pub fn passcode(&self) -> u32 {
+        u32::from_le_bytes(*self.comm_data.password.access())
+    }
+
+    /// The Vendor and Product IDs, if this is the 21-digit variant that carries them
+    /// (`None` for the 11-digit variant).
+    pub fn vid_pid(&self) -> Option<(u16, u16)> {
+        (!matches!(self.comm_flow, CommFlowType::Standard)).then_some((self.vid, self.pid))
+    }
+
+    /// The commissioning flow, as far as the code determines it.
+    ///
+    /// A manual pairing code has no dedicated commissioning-flow field; per the
+    /// Matter Core spec the *variant* implies it:
+    /// - The 11-digit variant (no VID/PID) means the commissioner *"SHALL assume it
+    ///   is a standard flow device"* - so this returns `Some(CommFlowType::Standard)`.
+    /// - The 21-digit variant (with VID/PID) is used for **both** the User-intent and
+    ///   the Custom flow, and the code alone cannot distinguish them - so this
+    ///   returns `None`. To resolve it, look the VID/PID up in the Distributed
+    ///   Compliance Ledger (see [`Self::vid_pid`]).
+    pub fn comm_flow(&self) -> Option<CommFlowType> {
+        matches!(self.comm_flow, CommFlowType::Standard).then_some(CommFlowType::Standard)
+    }
+}
+
+/// The `MT:` prefix shared by the encode and decode paths.
+impl<'a, T> QrPayload<'a, T> {
+    const fn qr_prefix() -> &'static str {
+        "MT:"
+    }
+}
+
+impl CommFlowType {
+    /// Decode a 2-bit commissioning-flow field.
+    fn from_bits(bits: u8) -> Result<Self, Error> {
+        match bits {
+            0 => Ok(Self::Standard),
+            1 => Ok(Self::UserIntent),
+            2 => Ok(Self::Custom),
+            _ => Err(ErrorCode::InvalidData.into()),
+        }
+    }
+}
+
+/// A little-endian, LSB-first bit reader over a byte slice - the inverse of the
+/// `emit_bits` bit order used by the QR encoder (`(input >> i) & 1`).
+struct BitReader<'a> {
+    data: &'a [u8],
+    /// Absolute bit position of the next bit to read.
+    pos: usize,
+}
+
+impl<'a> BitReader<'a> {
+    const fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    /// Read `len` bits (0..=32) as a little-endian value, LSB-first.
+    fn read(&mut self, len: usize) -> Result<u32, Error> {
+        debug_assert!(len <= 32);
+
+        if self.pos + len > self.data.len() * 8 {
+            return Err(ErrorCode::InvalidData.into());
+        }
+
+        let mut value = 0u32;
+        for i in 0..len {
+            let bit_pos = self.pos + i;
+            let byte = self.data[bit_pos / 8];
+            let bit = (byte >> (bit_pos % 8)) & 1;
+            value |= (bit as u32) << i;
+        }
+
+        self.pos += len;
+
+        Ok(value)
     }
 }
 
@@ -1003,5 +1395,133 @@ mod tests {
         let mut buf = [0; 1024];
         let data_str = unwrap!(qr_code_data.as_str(&mut buf), "Failed to encode").0;
         assert_eq!(data_str, QR_CODE)
+    }
+
+    #[test]
+    fn parse_qr_basic() {
+        // Same vector as `can_base38_encode` (BLE, no optional data).
+        const QR_CODE: &str = "MT:YNJV7VSC00CMVH7SR00";
+
+        let mut buf = [0; 128];
+        let payload = unwrap!(QrPayload::parse(QR_CODE, &mut buf), "Failed to parse");
+
+        assert_eq!(payload.version(), 0);
+        assert_eq!(payload.vid(), 9050);
+        assert_eq!(payload.pid(), 65279);
+        assert_eq!(payload.comm_flow(), CommFlowType::Standard);
+        assert_eq!(payload.discovery_capabilities(), DiscoveryCapabilities::BLE);
+        assert_eq!(payload.discriminator(), 2976);
+        assert_eq!(payload.passcode(), 34567890);
+        assert_eq!(payload.serial_no(), "");
+        assert!(payload.optional_data().is_empty());
+    }
+
+    #[test]
+    fn parse_qr_with_serial_no() {
+        // Same vector as `can_base38_encode_with_vendor_data` (IP, serial number).
+        const QR_CODE: &str = "MT:-24J0AFN00KA064IJ3P0IXZB0DK5N1K8SQ1RYCU1-A40";
+
+        let mut buf = [0; 128];
+        let payload = unwrap!(QrPayload::parse(QR_CODE, &mut buf), "Failed to parse");
+
+        assert_eq!(payload.vid(), 65521);
+        assert_eq!(payload.pid(), 32769);
+        assert_eq!(payload.discovery_capabilities(), DiscoveryCapabilities::IP);
+        assert_eq!(payload.discriminator(), 3840);
+        assert_eq!(payload.passcode(), 20202021);
+        assert_eq!(payload.serial_no(), "1234567890");
+        assert!(!payload.optional_data().is_empty());
+    }
+
+    #[test]
+    fn parse_qr_round_trips_through_encode() {
+        // Parse a QR, then re-encode from the parsed *fields* and expect the same
+        // string. (We rebuild via the fields rather than replaying the raw optional
+        // blob, since the encoder re-wraps the serial number into the optional-TLV
+        // structure itself - here the serial is the only optional content.)
+        const QR_CODE: &str = "MT:-24J0AFN00KA064IJ3P0IXZB0DK5N1K8SQ1RYCU1-A40";
+
+        let mut buf = [0; 128];
+        let payload = unwrap!(QrPayload::parse(QR_CODE, &mut buf), "Failed to parse");
+
+        let reencoded = QrPayload::new(
+            payload.discovery_capabilities(),
+            payload.comm_flow(),
+            payload.comm_data.clone(),
+            payload.vid(),
+            payload.pid(),
+            payload.serial_no(),
+            no_optional_data,
+        );
+
+        let mut out = [0; 256];
+        let s = unwrap!(reencoded.as_str(&mut out), "Failed to encode").0;
+        assert_eq!(s, QR_CODE);
+    }
+
+    #[test]
+    fn parse_pairing_code_round_trips_with_encoder() {
+        // The two vectors from `code.rs`'s `can_compute_pairing_code`, parsed back.
+        for (code, passcode, discriminator) in [
+            ("00876800071", 123456_u32, 250_u16),
+            ("26318621095", 34567890, 2976),
+        ] {
+            let payload = unwrap!(QrPayload::parse_pairing_code(code), "Failed to parse");
+
+            assert_eq!(payload.passcode(), passcode);
+            // Only the upper 4 bits of the discriminator survive a manual code.
+            assert_eq!(payload.short_discriminator(), (discriminator >> 8) as u8);
+            // The 11-digit variant implies the standard flow and carries no VID/PID.
+            assert_eq!(payload.comm_flow(), Some(CommFlowType::Standard));
+            assert_eq!(payload.vid_pid(), None);
+            // Nothing tells us how to reach the device.
+            assert!(payload.discovery_capabilities.is_empty());
+
+            // And the code we parsed re-computes from the parsed passcode + a
+            // discriminator whose upper 4 bits match.
+            let comm_data = BasicCommData {
+                password: payload.passcode().to_le_bytes().into(),
+                discriminator,
+            };
+            assert_eq!(comm_data.compute_pairing_code(), code);
+        }
+    }
+
+    #[test]
+    fn parse_pairing_code_accepts_pretty_form() {
+        // The canonical CHIP test device: discriminator 3840, passcode 20202021.
+        let compact = unwrap!(QrPayload::parse_pairing_code("34970112332"), "compact");
+        let pretty = unwrap!(QrPayload::parse_pairing_code("3497-0112-332"), "pretty");
+
+        assert_eq!(compact.passcode(), 20202021);
+        assert_eq!(compact.short_discriminator(), 15); // 3840 >> 8
+        assert_eq!(pretty.passcode(), compact.passcode());
+        assert_eq!(pretty.short_discriminator(), compact.short_discriminator());
+    }
+
+    #[test]
+    fn parse_pairing_code_rejects_bad_input() {
+        // Bad Verhoeff check digit (last digit of the valid code bumped).
+        assert!(QrPayload::parse_pairing_code("34970112333").is_err());
+        // Not a digit.
+        assert!(QrPayload::parse_pairing_code("3497011233X").is_err());
+        // Wrong length (neither 11 nor 21).
+        assert!(QrPayload::parse_pairing_code("3497011233").is_err());
+        // A leading digit of 8/9 indicates a future payload version, not v1.
+        assert!(QrPayload::parse_pairing_code("94970112332").is_err());
+        // VID/PID-present flag set (leading digit >= 4) but only 11 digits.
+        assert!(QrPayload::parse_pairing_code("74970112332").is_err());
+    }
+
+    #[test]
+    fn parse_qr_rejects_bad_input() {
+        let mut buf = [0; 128];
+
+        // Missing `MT:` prefix.
+        assert!(QrPayload::parse("YNJV7VSC00CMVH7SR00", &mut buf).is_err());
+        // Invalid base38 character (`!`).
+        assert!(QrPayload::parse("MT:YNJV7VSC00CMVH7SR0!", &mut buf).is_err());
+        // Too short to hold the fixed payload.
+        assert!(QrPayload::parse("MT:00", &mut buf).is_err());
     }
 }

--- a/rs-matter/src/pairing/qr/scan.rs
+++ b/rs-matter/src/pairing/qr/scan.rs
@@ -1,0 +1,217 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Recognizing a Matter onboarding QR code *in an image*.
+//!
+//! These functions take **8-bit greyscale (luma) pixels plus the image dimensions**,
+//! and nothing else - deliberately the narrowest useful currency. It is what QR
+//! recognition actually needs, every source produces it cheaply (a camera's YUV
+//! frame already *has* luma as its Y plane), and it keeps image-format decoding -
+//! and the dependencies that come with it - out of `rs-matter`. Loading a file, or
+//! pulling a frame off a camera, is the caller's job.
+//!
+//! # Example
+//!
+//! ```ignore
+//! // `img` is whatever the caller already has - here, via the `image` crate.
+//! let luma = image::open("qr.png")?.to_luma8();
+//!
+//! let text = scan_luma(luma.width() as _, luma.height() as _, &luma)?;
+//!
+//! let mut buf = [0; 128];
+//! let payload = QrPayload::parse(&text, &mut buf)?;
+//! ```
+
+use crate::error::{Error, ErrorCode};
+
+use rqrr::{MetaData, PreparedImage};
+
+use super::QR_PREFIX;
+
+use alloc::string::String;
+
+extern crate alloc;
+
+/// Scan an 8-bit greyscale image for a Matter onboarding QR code, returning its
+/// `MT:...` text.
+///
+/// `luma` is the row-major pixel buffer (`0` = black, `255` = white) and must hold
+/// at least `width * height` bytes; any trailing bytes are ignored, so a buffer
+/// with padding is fine as long as its rows are not strided (for strided sources,
+/// use [`scan_luma_with`]).
+///
+/// # Errors
+/// - [`ErrorCode::InvalidData`] if `luma` is too small for `width * height`.
+/// - [`ErrorCode::NotFound`] if the image contains no readable Matter QR code.
+pub fn scan_luma(width: usize, height: usize, luma: &[u8]) -> Result<String, Error> {
+    if luma.len() < width * height {
+        return Err(ErrorCode::InvalidData.into());
+    }
+
+    scan_luma_with(width, height, |x, y| luma[y * width + x])
+}
+
+/// Scan an 8-bit greyscale image for a Matter onboarding QR code, sampling the
+/// pixels through `fill` rather than from a buffer.
+///
+/// `fill(x, y)` returns the luminance at that pixel (`0` = black, `255` = white).
+/// This is the zero-copy entry point: it lets a caller convert RGBA to luma on the
+/// fly, or read a camera frame's Y plane through its row stride, without building
+/// an intermediate greyscale image.
+///
+/// # Errors
+/// [`ErrorCode::NotFound`] if the image contains no readable Matter QR code.
+pub fn scan_luma_with<F>(width: usize, height: usize, fill: F) -> Result<String, Error>
+where
+    F: FnMut(usize, usize) -> u8,
+{
+    let mut img = PreparedImage::prepare_from_greyscale(width, height, fill);
+    let grids = img.detect_grids();
+
+    first_matter_qr(grids.into_iter().map(|grid| grid.decode()))
+}
+
+/// Scan a black-and-white bitmap for a Matter onboarding QR code.
+///
+/// `fill(x, y)` returns `true` where the pixel is *black*. This suits sources that
+/// are already binary - a rendered symbol, or an image a caller has thresholded
+/// itself. For photographs prefer [`scan_luma`] / [`scan_luma_with`], which let the
+/// recognizer do its own (much better) binarisation.
+///
+/// # Errors
+/// [`ErrorCode::NotFound`] if the image contains no readable Matter QR code.
+pub fn scan_bitmap<F>(width: usize, height: usize, fill: F) -> Result<String, Error>
+where
+    F: FnMut(usize, usize) -> bool,
+{
+    // Note: unlike the greyscale path, this skips `rqrr`'s binarisation pass - the
+    // input is already black-and-white.
+    let mut img = PreparedImage::prepare_from_bitmap(width, height, fill);
+    let grids = img.detect_grids();
+
+    first_matter_qr(grids.into_iter().map(|grid| grid.decode()))
+}
+
+/// Pick the first Matter QR code out of everything recognized in an image.
+///
+/// An image may legitimately contain several QR codes (a Wi-Fi code, a URL, a
+/// vCard...), so codes that do not carry a Matter payload are skipped rather than
+/// returned or treated as an error. Codes that fail to decode at all (partially
+/// occluded, too blurry) are likewise skipped, so one bad symbol does not mask a
+/// good one elsewhere in the frame.
+///
+/// Generic over the decode error `E` so that this - the only part worth sharing
+/// between the entry points above - does not have to name `rqrr`'s image-buffer
+/// types, which it does not re-export.
+fn first_matter_qr<E>(
+    decoded: impl Iterator<Item = Result<(MetaData, String), E>>,
+) -> Result<String, Error> {
+    for res in decoded {
+        let Ok((_meta, content)) = res else {
+            continue;
+        };
+
+        if content.starts_with(QR_PREFIX) {
+            return Ok(content);
+        }
+    }
+
+    Err(ErrorCode::NotFound.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dm::devices::test::TEST_DEV_DET;
+    use crate::pairing::qr::{CommFlowType, Qr, QrPayload};
+    use crate::pairing::DiscoveryCapabilities;
+    use crate::BasicCommData;
+
+    use super::*;
+
+    /// Render a QR code to a bitmap and read it back, exercising the whole chain:
+    /// payload -> `MT:` text -> QR symbol -> recognition -> text -> parsed payload.
+    ///
+    /// Each module is drawn as `SCALE` pixels, surrounded by the 4-module quiet zone
+    /// the recognizer needs to lock onto the symbol.
+    #[test]
+    fn scan_round_trips_a_rendered_qr() {
+        const SCALE: usize = 4;
+        const QUIET: usize = 4;
+
+        let comm_data = BasicCommData {
+            password: 20202021_u32.to_le_bytes().into(),
+            discriminator: 3840,
+        };
+
+        let payload = QrPayload::new_from_basic_info(
+            DiscoveryCapabilities::BLE,
+            CommFlowType::Standard,
+            comm_data,
+            &TEST_DEV_DET,
+            super::super::no_optional_data,
+        );
+
+        let mut str_buf = [0; 256];
+        let text = unwrap!(payload.as_str(&mut str_buf), "Failed to encode").0;
+
+        // Render the text as an actual QR symbol.
+        let mut tmp_buf = [0; 2048];
+        let mut out_buf = [0; 2048];
+        let qr = unwrap!(
+            Qr::compute(text, &mut tmp_buf, &mut out_buf),
+            "Failed to render"
+        );
+
+        let modules = qr.size() as usize;
+        let side = (modules + 2 * QUIET) * SCALE;
+
+        // ... and recognize it back. `true` == black == a set module.
+        let scanned = unwrap!(
+            scan_bitmap(side, side, |x, y| {
+                let mx = (x / SCALE) as i32 - QUIET as i32;
+                let my = (y / SCALE) as i32 - QUIET as i32;
+
+                qr.get_module(mx, my)
+            }),
+            "Failed to scan"
+        );
+
+        assert_eq!(scanned, text);
+
+        // And the recognized text parses back to what we started from.
+        let mut parse_buf = [0; 128];
+        let parsed = unwrap!(
+            QrPayload::parse(&scanned, &mut parse_buf),
+            "Failed to parse"
+        );
+
+        assert_eq!(parsed.discriminator(), 3840);
+        assert_eq!(parsed.passcode(), 20202021);
+        assert_eq!(parsed.vid(), TEST_DEV_DET.vid);
+        assert_eq!(parsed.pid(), TEST_DEV_DET.pid);
+    }
+
+    #[test]
+    fn scan_finds_nothing_in_a_blank_image() {
+        assert!(scan_luma(64, 64, &[255; 64 * 64]).is_err());
+    }
+
+    #[test]
+    fn scan_luma_rejects_a_short_buffer() {
+        assert!(scan_luma(64, 64, &[255; 16]).is_err());
+    }
+}

--- a/rs-matter/src/pairing/qr/scan.rs
+++ b/rs-matter/src/pairing/qr/scan.rs
@@ -58,7 +58,9 @@ extern crate alloc;
 /// - [`ErrorCode::InvalidData`] if `luma` is too small for `width * height`.
 /// - [`ErrorCode::NotFound`] if the image contains no readable Matter QR code.
 pub fn scan_luma(width: usize, height: usize, luma: &[u8]) -> Result<String, Error> {
-    if luma.len() < width * height {
+    let pixels = width.checked_mul(height).ok_or(ErrorCode::InvalidData)?;
+
+    if luma.len() < pixels {
         return Err(ErrorCode::InvalidData.into());
     }
 

--- a/rs-matter/src/transport/network/btp.rs
+++ b/rs-matter/src/transport/network/btp.rs
@@ -117,6 +117,29 @@ impl Btp {
             .lock(|inner| inner.borrow_mut().set_relaxed_mtu_nego(relaxed_mtu_nego));
     }
 
+    /// Set the BTP role.
+    ///
+    /// - `false` (the default) - the GATT Peripheral role, i.e. rs-matter is the Accessory/Device.
+    ///   The peer (Commissioner) initiates the BTP handshake by writing a Handshake Request on `C1`;
+    ///   we respond with a Handshake Response indicated on `C2`.
+    /// - `true` - the GATT Central role, i.e. rs-matter is the Controller/Commissioner.
+    ///   We initiate the BTP handshake ourselves by writing a Handshake Request on the peer's `C1`
+    ///   characteristic (surfaced via `process_outgoing`), and the peer responds with a Handshake
+    ///   Response, which we consume via `process_incoming` on the peer's `C2` indications.
+    ///
+    /// This must be called (with `true`) *before* the first `process_outgoing`/`process_incoming`
+    /// when acting as a Central, so that the pending initial handshake is emitted.
+    ///
+    /// See the [`Btp`] type documentation for the full Peripheral vs Central contract.
+    pub fn set_initiator(&self, initiator: bool) {
+        self.inner.lock(|inner| {
+            inner.borrow_mut().session.set_initiator(initiator);
+
+            // A freshly-flagged initiator has a handshake pending to emit.
+            self.outg_notif.notify();
+        });
+    }
+
     /// Set the BTP timeouts, by configuring the ACK timeout and the connection idle timeout.
     ///
     /// Only used by the unit tests.
@@ -412,7 +435,18 @@ impl BtpInner {
 
                     return Ok(len);
                 }
-            } else {
+            } else if self.session.is_established() {
+                // The queued SDU is addressed to a *different* peer than the
+                // current session - it is stale, drop it.
+                //
+                // We must only do this once the session is established. As an
+                // initiator (GATT Central), an SDU (e.g. the PASE
+                // PBKDFParamRequest) can be queued *before* the BTP handshake
+                // completes, i.e. while the session address is still unset
+                // (all-zero). Dropping it then would silently lose the first
+                // Matter message and stall commissioning; instead we keep it
+                // queued until the handshake response establishes the session,
+                // and send it afterwards.
                 self.outgoing_sdu.reset();
             }
         }
@@ -753,5 +787,83 @@ mod test {
 
         // BTP should - in X seconds - ACK again
         expect_outgoing(&btp, &[8, 1, 2]);
+    }
+
+    /// Pump any pending outgoing frame from `from` into `to`. Returns whether a
+    /// frame was moved.
+    fn pump(from: &Btp, from_addr: BtAddr, to: &Btp, gatt_mtu: Option<u16>) -> bool {
+        let mut buf = [0u8; 512];
+        let len = from.process_outgoing(gatt_mtu, &mut buf).unwrap();
+        if len == 0 {
+            return false;
+        }
+        to.process_incoming(gatt_mtu, from_addr, &buf[..len]).unwrap();
+        true
+    }
+
+    /// End-to-end BTP handshake + first data packet between an **initiator**
+    /// (GATT Central) and a **responder** (GATT Peripheral), both in-process.
+    ///
+    /// This is the regression test for the controller-side (initiator) BTP path:
+    /// the initiator queues a Matter SDU *before* the handshake has completed
+    /// (exactly as a commissioner does when it sends the PASE PBKDFParamRequest),
+    /// and that SDU must survive the handshake and be delivered to the responder.
+    #[test]
+    fn test_initiator_handshake_then_data() {
+        const INITIATOR_ADDR: BtAddr = BtAddr([0xaa; 6]);
+        const RESPONDER_ADDR: BtAddr = BtAddr([0xbb; 6]);
+
+        let gatt_mtu = Some(0xc8);
+
+        let initiator = Btp::new();
+        initiator.set_initiator(true);
+
+        let responder = Btp::new();
+
+        // The commissioner queues its first Matter message (a PASE
+        // PBKDFParamRequest, here stubbed) *before* the BTP handshake completes.
+        let sdu: &[u8] = &[1, 2, 3, 4, 5];
+        send_to(&initiator, RESPONDER_ADDR, sdu);
+
+        // Handshake: initiator -> request -> responder.
+        assert!(pump(&initiator, INITIATOR_ADDR, &responder, gatt_mtu));
+        // Responder -> response -> initiator.
+        assert!(pump(&responder, RESPONDER_ADDR, &initiator, gatt_mtu));
+
+        // Now the initiator's queued SDU must flow to the responder. Pump every
+        // frame the initiator has to send (data segments + acks) into the
+        // responder until the responder can deliver the full SDU.
+        for _ in 0..8 {
+            if !pump(&initiator, INITIATOR_ADDR, &responder, gatt_mtu) {
+                break;
+            }
+        }
+
+        let mut buf = [0u8; 512];
+        let (len, addr) = embassy_futures::block_on(responder.recv(&mut buf)).unwrap();
+        assert_eq!(addr, INITIATOR_ADDR);
+        assert_eq!(&buf[..len], sdu);
+
+        // Now the reverse direction: the responder replies with its own SDU (as a
+        // device would with the PASE PBKDFParamResponse). This exercises the
+        // initiator's receive-sequence handling - the responder's Handshake
+        // Response was its seq 0, so its first data segment is seq 1, and the
+        // initiator must accept it rather than rejecting it as out-of-sequence.
+        let reply: &[u8] = &[9, 8, 7, 6];
+        send_to(&responder, INITIATOR_ADDR, reply);
+
+        for _ in 0..8 {
+            if !pump(&responder, RESPONDER_ADDR, &initiator, gatt_mtu) {
+                break;
+            }
+        }
+
+        let (len, addr) = embassy_futures::block_on(initiator.recv(&mut buf)).unwrap();
+        assert_eq!(addr, RESPONDER_ADDR);
+        assert_eq!(&buf[..len], reply);
+    }
+
+    fn send_to(btp: &Btp, addr: BtAddr, data: &[u8]) {
+        embassy_futures::block_on(btp.send(data, addr)).unwrap();
     }
 }

--- a/rs-matter/src/transport/network/btp.rs
+++ b/rs-matter/src/transport/network/btp.rs
@@ -797,7 +797,8 @@ mod test {
         if len == 0 {
             return false;
         }
-        to.process_incoming(gatt_mtu, from_addr, &buf[..len]).unwrap();
+        to.process_incoming(gatt_mtu, from_addr, &buf[..len])
+            .unwrap();
         true
     }
 

--- a/rs-matter/src/transport/network/btp.rs
+++ b/rs-matter/src/transport/network/btp.rs
@@ -867,4 +867,25 @@ mod test {
     fn send_to(btp: &Btp, addr: BtAddr, data: &[u8]) {
         embassy_futures::block_on(btp.send(data, addr)).unwrap();
     }
+
+    /// An initiator must survive a peer/stack reporting a nonsensically small GATT
+    /// MTU. BlueZ hands us whatever it has in `GattCharacteristic1.MTU`, and an MTU
+    /// below the BTP header size once left the proposed window size dividing by
+    /// zero - a panic on external input.
+    #[test]
+    fn test_initiator_handshake_tolerates_a_tiny_gatt_mtu() {
+        for gatt_mtu in [Some(0), Some(1), Some(3), Some(20), Some(0xFFFF), None] {
+            let btp = Btp::new();
+            btp.set_initiator(true);
+
+            let mut buf = [0u8; 512];
+            let len = btp
+                .process_outgoing(gatt_mtu, &mut buf)
+                .unwrap_or_else(|e| panic!("gatt_mtu {gatt_mtu:?} failed: {e:?}"));
+
+            // Whatever the peer claimed, we must emit a well-formed handshake
+            // request proposing a usable (non-zero) window.
+            assert!(len > 0, "gatt_mtu {gatt_mtu:?} produced no handshake");
+        }
+    }
 }

--- a/rs-matter/src/transport/network/btp/gatt.rs
+++ b/rs-matter/src/transport/network/btp/gatt.rs
@@ -18,8 +18,18 @@
 use core::iter::{empty, once};
 
 use crate::dm::clusters::basic_info::BasicInfoConfig;
+use crate::transport::network::mdns::CommissionableFilter;
 
 use super::{GATT_HEADER_SIZE, MAX_BTP_SEGMENT_SIZE};
+
+/// The AD structure type for "Service Data - 16-bit UUID" (AD2), as per the BLE Core spec.
+const AD_TYPE_SERVICE_DATA_UUID16: u8 = 0x16;
+/// The length, in bytes, of the Matter commissionable service-data payload
+/// (the bytes _following_ the 2-byte service UUID16 in the AD2 record), as per
+/// the Matter Core spec, section "5.4.2.5.6. Advertising Data".
+const MATTER_SERVICE_DATA_PAYLOAD_LEN: usize = 8;
+/// The Matter BLE advertisement OpCode designating a commissionable device.
+const MATTER_ADV_OPCODE_COMMISSIONABLE: u8 = 0x00;
 
 #[cfg(all(feature = "os", feature = "bluer", target_os = "linux"))]
 pub mod bluer;
@@ -49,12 +59,28 @@ pub const C3_MAX_LEN: usize = 512;
 
 /// Encapsulates the advertising data for the Matter BTP protocol.
 ///
+/// This type is used in two directions:
+/// - By an Accessory (GATT Peripheral) to **serialize** the advertising data it
+///   broadcasts while commissionable (see [`AdvData::iter`] and friends).
+/// - By a Commissioner (GATT Central) to **parse** a scanned advertisement and
+///   decide whether it designates the commissionable device it is looking for
+///   (see [`AdvData::parse_adv`] / [`AdvData::parse_service_data`] and
+///   [`AdvData::matches`]) - the BLE-side analogue of resolving a commissionable
+///   node from an mDNS TXT record.
+///
 /// See section "5.4.2.5.6. Advertising Data" in the Core Matter spec
-#[derive(Clone)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdvData {
     vid: u16,
     pid: u16,
     discriminator: u16,
+    /// Whether the device signals that it carries additional (BLE) advertising
+    /// data (bit 0 of the last byte of the Matter service-data payload).
+    ///
+    /// Always `false` for advertisements produced by this stack; decoded from
+    /// the wire when parsing a peer's advertisement.
+    additional_data: bool,
 }
 
 impl AdvData {
@@ -64,7 +90,30 @@ impl AdvData {
             vid: dev_det.vid,
             pid: dev_det.pid,
             discriminator,
+            additional_data: false,
         }
+    }
+
+    /// The Vendor ID carried by this advertising data.
+    pub const fn vid(&self) -> u16 {
+        self.vid
+    }
+
+    /// The Product ID carried by this advertising data.
+    pub const fn pid(&self) -> u16 {
+        self.pid
+    }
+
+    /// The 12-bit discriminator carried by this advertising data.
+    pub const fn discriminator(&self) -> u16 {
+        self.discriminator
+    }
+
+    /// Whether the advertised device signals that it carries additional (BLE)
+    /// advertising data. See the field of the same name; commissioners do not
+    /// usually need to inspect this.
+    pub const fn additional_data(&self) -> bool {
+        self.additional_data
     }
 
     /// Return an iterator over the binary representation of the advertising data.
@@ -120,8 +169,335 @@ impl AdvData {
             self.vid.to_le_bytes()[1],
             self.pid.to_le_bytes()[0],
             self.pid.to_le_bytes()[1],
-            0, // No additional data
+            self.additional_data as u8, // Additional-data flag (bit 0)
         ]
         .into_iter()
+    }
+
+    /// Parse the advertising data out of a full, raw BLE advertising-data blob
+    /// (a sequence of `length`-prefixed AD structures, i.e. `[len, type, ..len-1 bytes..]*`).
+    ///
+    /// This walks the AD structures, looks for the "Service Data - 16-bit UUID"
+    /// (`0x16`) structure whose UUID is the Matter service UUID (`0xFFF6`), and
+    /// decodes its payload.
+    ///
+    /// Returns `None` if the blob contains no (valid) Matter commissionable
+    /// service-data structure. Use this when the OS/GATT stack hands you the raw
+    /// advertising bytes; if it instead de-multiplexes service data by UUID for
+    /// you (as BlueZ and `bluer` do), use [`AdvData::parse_service_data`] with
+    /// the `0xFFF6` service-data value directly.
+    pub fn parse_adv(adv: &[u8]) -> Option<Self> {
+        for (ad_type, ad_payload) in AdStructures::new(adv) {
+            if ad_type == AD_TYPE_SERVICE_DATA_UUID16 {
+                // The service-data payload starts with the 2-byte (LE) UUID16.
+                let (uuid16, service_data) = ad_payload.split_first_chunk::<2>()?;
+
+                if u16::from_le_bytes(*uuid16) == MATTER_BLE_SERVICE_UUID16 {
+                    return Self::parse_service_data(service_data);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Parse the advertising data out of the Matter service-data payload - i.e.
+    /// the bytes of the `0xFFF6` "Service Data - 16-bit UUID" advertising
+    /// structure that _follow_ the 2-byte service UUID.
+    ///
+    /// This is the layout produced by [`AdvData::service_payload_iter`] and is
+    /// what most OS GATT stacks (BlueZ, `bluer`) hand back when they expose
+    /// advertised service data as a `UUID -> bytes` map.
+    ///
+    /// Returns `None` if the payload is not a valid, commissionable Matter
+    /// service-data payload.
+    pub fn parse_service_data(payload: &[u8]) -> Option<Self> {
+        // As per spec the payload is exactly 8 bytes. Be lenient and accept a
+        // longer payload (future extensions), but never a shorter one.
+        if payload.len() < MATTER_SERVICE_DATA_PAYLOAD_LEN {
+            return None;
+        }
+
+        // Byte 0 is the Matter BLE OpCode; only "Commissionable" (0) is a
+        // commissionable device.
+        if payload[0] != MATTER_ADV_OPCODE_COMMISSIONABLE {
+            return None;
+        }
+
+        // Bytes 1..=2 are a 16-bit LE field whose low 12 bits are the
+        // discriminator and whose high 4 bits are the advertising version
+        // (currently 0). Mask off the version so we get the plain discriminator.
+        let discriminator = u16::from_le_bytes([payload[1], payload[2]]) & 0x0FFF;
+        let vid = u16::from_le_bytes([payload[3], payload[4]]);
+        let pid = u16::from_le_bytes([payload[5], payload[6]]);
+        let additional_data = payload[7] & 0x01 != 0;
+
+        Some(Self {
+            vid,
+            pid,
+            discriminator,
+            additional_data,
+        })
+    }
+
+    /// Whether this advertised commissionable device matches **all** of the
+    /// non-`None` fields of the provided [`CommissionableFilter`] (AND
+    /// semantics); an empty filter matches every commissionable device.
+    ///
+    /// This mirrors [`CommissionableFilter::matches`] (the mDNS TXT-record path)
+    /// over the subset of fields a BLE advertisement carries:
+    /// - `discriminator` (full 12-bit) and `short_discriminator` (upper 4 bits)
+    ///   are matched against the advertised discriminator;
+    /// - `vendor_id` / `product_id` are matched against the advertised VID / PID.
+    ///
+    /// A BLE advertisement does not carry a device type, and being advertised at
+    /// all already implies commissioning mode, so a filter that constrains
+    /// `device_type` never matches a BLE advertisement, and
+    /// `commissioning_mode_only` is always satisfied.
+    pub fn matches(&self, filter: &CommissionableFilter) -> bool {
+        if let Some(want) = filter.discriminator {
+            if self.discriminator != want {
+                return false;
+            }
+        }
+
+        if let Some(want) = filter.short_discriminator {
+            // Short discriminator is the upper 4 bits of the 12-bit discriminator.
+            if (self.discriminator >> 8) as u8 != want {
+                return false;
+            }
+        }
+
+        if let Some(want) = filter.vendor_id {
+            if self.vid != want {
+                return false;
+            }
+        }
+
+        if let Some(want) = filter.product_id {
+            if self.pid != want {
+                return false;
+            }
+        }
+
+        // A BLE advertisement carries no device type; a filter that requires one
+        // cannot be satisfied by BLE discovery.
+        if filter.device_type.is_some() {
+            return false;
+        }
+
+        // `commissioning_mode_only` is implicit: a commissionable advertisement
+        // (OpCode 0) is, by definition, in commissioning mode.
+
+        true
+    }
+}
+
+/// An iterator over the individual AD structures of a raw BLE advertising-data
+/// blob, yielding `(ad_type, ad_payload)` for each well-formed
+/// `[length, type, ..payload..]` structure and stopping at the first malformed
+/// or zero-length structure (as per the BLE Core spec, a zero-length structure
+/// marks the end of significant data).
+struct AdStructures<'a> {
+    rem: &'a [u8],
+}
+
+impl<'a> AdStructures<'a> {
+    const fn new(adv: &'a [u8]) -> Self {
+        Self { rem: adv }
+    }
+}
+
+impl<'a> Iterator for AdStructures<'a> {
+    type Item = (u8, &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (&len, rest) = self.rem.split_first()?;
+
+        // A zero-length structure marks the end of significant data.
+        let len = len as usize;
+        if len == 0 || len > rest.len() {
+            self.rem = &[];
+            return None;
+        }
+
+        let (structure, rest) = rest.split_at(len);
+        self.rem = rest;
+
+        // `len` counts the type byte plus the payload, so `structure` is
+        // non-empty here.
+        let (&ad_type, payload) = structure.split_first()?;
+
+        Some((ad_type, payload))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::transport::network::mdns::CommissionableFilter;
+
+    use super::AdvData;
+
+    /// A sample `AdvData` with a 12-bit discriminator that exercises the
+    /// version-nibble masking on parse.
+    fn sample() -> AdvData {
+        AdvData {
+            vid: 0xFFF1,
+            pid: 0x8000,
+            discriminator: 0xF00,
+            additional_data: false,
+        }
+    }
+
+    /// The parsed form of [`sample`], via the service-data payload round-trip.
+    fn sample_parsed() -> AdvData {
+        let payload: heapless::Vec<u8, 16> = sample().service_payload_iter().collect();
+        AdvData::parse_service_data(&payload).unwrap()
+    }
+
+    #[test]
+    fn parse_service_data_round_trips_adv_data() {
+        let adv = sample();
+        let parsed = sample_parsed();
+
+        assert_eq!(parsed, adv);
+        assert_eq!(parsed.discriminator(), adv.discriminator());
+        assert_eq!(parsed.vid(), adv.vid());
+        assert_eq!(parsed.pid(), adv.pid());
+        assert!(!parsed.additional_data());
+    }
+
+    #[test]
+    fn parse_service_data_round_trips_additional_data_flag() {
+        let adv = AdvData {
+            additional_data: true,
+            ..sample()
+        };
+        let payload: heapless::Vec<u8, 16> = adv.service_payload_iter().collect();
+        let parsed = AdvData::parse_service_data(&payload).unwrap();
+
+        assert!(parsed.additional_data());
+        assert_eq!(parsed, adv);
+    }
+
+    #[test]
+    fn parse_full_adv_round_trips_adv_data() {
+        let adv = sample();
+
+        // The full AD blob is the AD1 (Flags) record chained with the AD2
+        // (UUID16 + Service Data) record.
+        let blob: heapless::Vec<u8, 32> = adv.iter().collect();
+
+        let parsed = AdvData::parse_adv(&blob).unwrap();
+
+        assert_eq!(parsed, adv);
+    }
+
+    #[test]
+    fn parse_adv_ignores_unrelated_records() {
+        // A blob with a Flags record, an unrelated 16-bit service-data record,
+        // and finally the Matter one - the parser must skip to the Matter one.
+        let adv = sample();
+
+        let mut blob: heapless::Vec<u8, 64> = heapless::Vec::new();
+        // Flags
+        blob.extend([0x02, 0x01, 0x06]);
+        // Unrelated Service Data - UUID16 (0x1234), 3 payload bytes
+        blob.extend([0x06, 0x16, 0x34, 0x12, 0xAA, 0xBB, 0xCC]);
+        // The Matter one
+        blob.extend(adv.service_iter());
+
+        let parsed = AdvData::parse_adv(&blob).unwrap();
+        assert_eq!(parsed.discriminator(), adv.discriminator());
+    }
+
+    #[test]
+    fn parse_service_data_rejects_non_commissionable_opcode() {
+        let mut payload: heapless::Vec<u8, 16> = sample().service_payload_iter().collect();
+        payload[0] = 0x01; // Not "Commissionable"
+
+        assert!(AdvData::parse_service_data(&payload).is_none());
+    }
+
+    #[test]
+    fn parse_service_data_rejects_short_payload() {
+        assert!(AdvData::parse_service_data(&[0, 1, 2, 3]).is_none());
+    }
+
+    #[test]
+    fn parse_adv_returns_none_without_matter_service_data() {
+        // Just a Flags record - no Matter service data.
+        assert!(AdvData::parse_adv(&[0x02, 0x01, 0x06]).is_none());
+    }
+
+    #[test]
+    fn parse_adv_tolerates_truncated_trailing_record() {
+        let adv = sample();
+        let mut blob: heapless::Vec<u8, 64> = adv.iter().collect();
+        // Append a malformed record claiming more bytes than are present.
+        blob.extend([0x05, 0x16, 0x00]);
+
+        // The Matter record precedes the malformed one, so it's still found.
+        assert!(AdvData::parse_adv(&blob).is_some());
+    }
+
+    #[test]
+    fn matches_filter_by_full_and_short_discriminator() {
+        let parsed = sample_parsed();
+
+        // Exact discriminator 0xF00
+        let mut filter = CommissionableFilter {
+            discriminator: Some(0xF00),
+            ..Default::default()
+        };
+        assert!(parsed.matches(&filter));
+
+        filter.discriminator = Some(0xF01);
+        assert!(!parsed.matches(&filter));
+
+        // Short discriminator = upper 4 bits of 0xF00 = 0xF
+        let filter = CommissionableFilter {
+            short_discriminator: Some(0xF),
+            ..Default::default()
+        };
+        assert!(parsed.matches(&filter));
+
+        let filter = CommissionableFilter {
+            short_discriminator: Some(0x0),
+            ..Default::default()
+        };
+        assert!(!parsed.matches(&filter));
+    }
+
+    #[test]
+    fn matches_filter_by_vid_pid() {
+        let parsed = sample_parsed();
+
+        let filter = CommissionableFilter {
+            vendor_id: Some(0xFFF1),
+            product_id: Some(0x8000),
+            ..Default::default()
+        };
+        assert!(parsed.matches(&filter));
+
+        let filter = CommissionableFilter {
+            vendor_id: Some(0x1234),
+            ..Default::default()
+        };
+        assert!(!parsed.matches(&filter));
+    }
+
+    #[test]
+    fn empty_filter_matches_any_commissionable_adv() {
+        assert!(sample_parsed().matches(&CommissionableFilter::default()));
+    }
+
+    #[test]
+    fn device_type_filter_never_matches_ble() {
+        let filter = CommissionableFilter {
+            device_type: Some(0x0100),
+            ..Default::default()
+        };
+        assert!(!sample_parsed().matches(&filter));
     }
 }

--- a/rs-matter/src/transport/network/btp/gatt.rs
+++ b/rs-matter/src/transport/network/btp/gatt.rs
@@ -188,13 +188,20 @@ impl AdvData {
     /// the `0xFFF6` service-data value directly.
     pub fn parse_adv(adv: &[u8]) -> Option<Self> {
         for (ad_type, ad_payload) in AdStructures::new(adv) {
-            if ad_type == AD_TYPE_SERVICE_DATA_UUID16 {
-                // The service-data payload starts with the 2-byte (LE) UUID16.
-                let (uuid16, service_data) = ad_payload.split_first_chunk::<2>()?;
+            if ad_type != AD_TYPE_SERVICE_DATA_UUID16 {
+                continue;
+            }
 
-                if u16::from_le_bytes(*uuid16) == MATTER_BLE_SERVICE_UUID16 {
-                    return Self::parse_service_data(service_data);
-                }
+            // The service-data payload starts with the 2-byte (LE) UUID16. A
+            // structure too short to hold one is malformed - skip it and keep
+            // looking, rather than giving up on the whole advertisement: the Matter
+            // record may well be further along.
+            let Some((uuid16, service_data)) = ad_payload.split_first_chunk::<2>() else {
+                continue;
+            };
+
+            if u16::from_le_bytes(*uuid16) == MATTER_BLE_SERVICE_UUID16 {
+                return Self::parse_service_data(service_data);
             }
         }
 
@@ -408,6 +415,22 @@ mod test {
         blob.extend(adv.service_iter());
 
         let parsed = AdvData::parse_adv(&blob).unwrap();
+        assert_eq!(parsed.discriminator(), adv.discriminator());
+    }
+
+    #[test]
+    fn parse_adv_skips_a_malformed_service_data_record() {
+        // A service-data record too short to even hold its UUID16, *before* the
+        // Matter one. It must be skipped rather than abandoning the whole scan.
+        let adv = sample();
+
+        let mut blob: heapless::Vec<u8, 64> = heapless::Vec::new();
+        // Service Data - UUID16 with a 1-byte payload: not even a full UUID.
+        blob.extend([0x02, 0x16, 0x34]);
+        // The Matter one.
+        blob.extend(adv.service_iter());
+
+        let parsed = unwrap!(AdvData::parse_adv(&blob), "Failed to parse");
         assert_eq!(parsed.discriminator(), adv.discriminator());
     }
 

--- a/rs-matter/src/transport/network/btp/gatt/bluer.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluer.rs
@@ -15,9 +15,10 @@
  *    limitations under the License.
  */
 
-//! A `GattPeripheral` implementation using the BlueZ GATT stack via the `bluer` crate.
+//! A GATT Peripheral implementation using the BlueZ GATT stack via the `bluer` crate.
 
 use core::iter::once;
+use core::pin::pin;
 
 use bluer::adv::Advertisement;
 use bluer::agent::Agent;
@@ -26,20 +27,29 @@ use bluer::gatt::local::{
     CharacteristicControlEvent, CharacteristicNotify, CharacteristicNotifyMethod,
     CharacteristicWrite, CharacteristicWriteMethod, CharacteristicWriteRequest, Service,
 };
-use bluer::gatt::CharacteristicWriter;
-use bluer::Uuid;
+use bluer::gatt::remote::Characteristic as RemoteCharacteristic;
+use bluer::gatt::{CharacteristicWriter, WriteOp};
+use bluer::{Adapter, AdapterEvent, Address, DiscoveryFilter, DiscoveryTransport, Uuid};
 
-use embassy_futures::select::{select, select4, Either};
+use embassy_futures::select::{select, select3, select4, Either};
+use embassy_time::{Duration, Timer};
 
 use tokio::sync::mpsc::Receiver;
 use tokio_stream::StreamExt;
 
-use crate::error::Error;
+use crate::error::{Error, ErrorCode};
 use crate::transport::network::btp::Btp;
+use crate::transport::network::mdns::CommissionableFilter;
 use crate::transport::network::BtAddr;
 use crate::utils::select::Coalesce;
 
-use super::{AdvData, C1_CHARACTERISTIC_UUID, C2_CHARACTERISTIC_UUID, MATTER_BLE_SERVICE_UUID};
+use super::{
+    AdvData, C1_CHARACTERISTIC_UUID, C2_CHARACTERISTIC_UUID, MATTER_BLE_SERVICE_UUID,
+};
+
+/// The default amount of time [`scan`] will scan for a matching commissionable
+/// advertisement before giving up.
+pub const DEFAULT_SCAN_TIMEOUT_SECS: u16 = 60;
 
 /// Run the GATT peripheral service.
 ///
@@ -180,6 +190,345 @@ pub async fn run_peripheral(
         .coalesce()
         .await?;
     }
+}
+
+/// Scan BLE advertisements for commissionable Matter devices and report each match to `on_found`.
+///
+/// This is the discovery half of the Controller / Commissioner role (the connect half is
+/// [`run_central`]) - the BLE analogue of an mDNS commissionable browse. It puts the adapter into
+/// LE discovery (restricted to the Matter service UUID), and for every discovered device whose
+/// advertised service data both parses as a commissionable Matter advertisement and matches
+/// `filter`, it invokes `on_found(addr, &adv)`.
+///
+/// `on_found` decides when to stop: returning `Some(value)` stops the scan and makes `scan` return
+/// `Ok(value)`; returning `None` keeps scanning. Each matching device is reported at most once. If
+/// the timeout elapses with no accepted match, `scan` returns `Err(NoNetworkInterface)`.
+///
+/// The common "connect to the first match" case is simply:
+///
+/// ```ignore
+/// let addr = scan(None, &filter, None, |addr, _adv| Some(addr)).await?;
+/// run_central(None, addr, &btp).await?;
+/// ```
+///
+/// # Arguments
+/// - `adapter_name`: The Bluetooth adapter to use. If `None`, the default adapter is used.
+/// - `filter`: The commissionable-device filter to match advertisements against. An empty filter
+///   matches every commissionable Matter device seen.
+/// - `scan_timeout`: How long to scan before giving up. If `None`, [`DEFAULT_SCAN_TIMEOUT_SECS`].
+/// - `on_found`: Callback invoked for each newly-matched device; returning `Some` stops the scan.
+pub async fn scan<F, R>(
+    adapter_name: Option<&str>,
+    filter: &CommissionableFilter,
+    scan_timeout: Option<u16>,
+    mut on_found: F,
+) -> Result<R, Error>
+where
+    F: FnMut(BtAddr, &AdvData) -> Option<R>,
+{
+    let session = bluer::Session::new().await?;
+    let adapter = open_adapter(&session, adapter_name).await?;
+
+    adapter.set_powered(true).await?;
+
+    info!(
+        "Scanning for a commissionable Matter device on Bluetooth adapter {} (filter: {:?})",
+        adapter.name(),
+        filter
+    );
+
+    // Restrict discovery to LE devices advertising the Matter service UUID, so BlueZ populates the
+    // devices' service data.
+    let discovery_filter = DiscoveryFilter {
+        uuids: once(Uuid::from_u128(MATTER_BLE_SERVICE_UUID)).collect(),
+        transport: DiscoveryTransport::Le,
+        ..Default::default()
+    };
+    adapter.set_discovery_filter(discovery_filter).await?;
+
+    let device_events = adapter.discover_devices().await?;
+    let mut device_events = pin!(device_events);
+
+    // Devices already reported to `on_found`, so we report each at most once.
+    let mut reported: heapless::Vec<BtAddr, 16> = heapless::Vec::new();
+
+    let scan_fut = async {
+        // First, sweep devices BlueZ already knows about (they won't generate `DeviceAdded`).
+        for addr in adapter.device_addresses().await? {
+            if let Some(result) =
+                try_match_device(&adapter, addr, filter, &mut reported, &mut on_found).await?
+            {
+                return Ok(Some(result));
+            }
+        }
+
+        // Then follow the discovery event stream.
+        while let Some(event) = device_events.next().await {
+            if let AdapterEvent::DeviceAdded(addr) = event {
+                if let Some(result) =
+                    try_match_device(&adapter, addr, filter, &mut reported, &mut on_found).await?
+                {
+                    return Ok(Some(result));
+                }
+            }
+        }
+
+        Ok::<Option<R>, Error>(None)
+    };
+
+    let timeout = Timer::after(Duration::from_secs(
+        scan_timeout.unwrap_or(DEFAULT_SCAN_TIMEOUT_SECS) as u64,
+    ));
+
+    let outcome = match select(scan_fut, timeout).await {
+        Either::First(result) => result?,
+        Either::Second(_) => None,
+    };
+
+    outcome.ok_or_else(|| {
+        warn!("No commissionable Matter device matching the filter was found within the scan timeout");
+        ErrorCode::NoNetworkInterface.into()
+    })
+}
+
+/// If the device at `addr` advertises Matter service data that parses and matches `filter`, and it
+/// has not been reported yet, invoke `on_found` and return its result.
+async fn try_match_device<F, R>(
+    adapter: &Adapter,
+    addr: Address,
+    filter: &CommissionableFilter,
+    reported: &mut heapless::Vec<BtAddr, 16>,
+    on_found: &mut F,
+) -> Result<Option<R>, Error>
+where
+    F: FnMut(BtAddr, &AdvData) -> Option<R>,
+{
+    let bt_addr = BtAddr(addr.0);
+
+    if reported.contains(&bt_addr) {
+        return Ok(None);
+    }
+
+    let Ok(device) = adapter.device(addr) else {
+        return Ok(None);
+    };
+
+    // The advertised service data (a `UUID -> bytes` map); look for the Matter one.
+    let Ok(Some(service_data)) = device.service_data().await else {
+        return Ok(None);
+    };
+
+    let Some(bytes) = service_data.get(&Uuid::from_u128(MATTER_BLE_SERVICE_UUID)) else {
+        return Ok(None);
+    };
+
+    let Some(adv) = AdvData::parse_service_data(bytes) else {
+        return Ok(None);
+    };
+
+    if !adv.matches(filter) {
+        return Ok(None);
+    }
+
+    // Report each matching device at most once. If the dedup buffer is full we simply stop
+    // deduplicating (and may re-report); never drop an actual match on the floor.
+    let _ = reported.push(bt_addr);
+
+    debug!("Matched commissionable device {} (adv: {:?})", bt_addr, adv);
+
+    Ok(on_found(bt_addr, &adv))
+}
+
+/// Run the GATT central (Commissioner-side) BTP transport using the `bluer` crate.
+///
+/// This is the connect-and-pump half of the Controller / Commissioner role (the discovery half is
+/// [`scan`]). Given the Bluetooth address of a commissionable device (as returned by [`scan`]), it:
+/// - Connects to the device as a GATT Central and discovers the Matter GATT service, together with
+///   its `C1` (write) and `C2` (indicate) characteristics.
+/// - Subscribes to `C2` indications, feeding them into [`Btp::process_incoming`], and writes the
+///   BTP output from [`Btp::process_outgoing`] to `C1` (as an acknowledged GATT Write Request).
+/// - Drives `btp` in the initiator role (it calls [`Btp::set_initiator`] with `true`), so the
+///   BTP handshake is started by us.
+///
+/// The caller passes commissioning requests to the device as `Address::Btp(addr)` while
+/// `matter.run(.., &btp, &btp, ..)` pumps the transport.
+///
+/// This function returns once the peer disconnects, the session times out, or an error occurs.
+/// It does not loop / reconnect - a Commissioner establishes one BTP session for the duration of
+/// commissioning.
+///
+/// `addr` must belong to a device that BlueZ already knows about (i.e. one that has been discovered
+/// at least once - typically via a preceding [`scan`] on the same adapter).
+///
+/// # Arguments
+/// - `adapter_name`: The Bluetooth adapter to use. If `None`, the default adapter is used. It must
+///   be the same adapter the device was discovered on.
+/// - `addr`: The Bluetooth address of the device to connect to (from [`scan`]).
+/// - `btp`: The BTP session to drive.
+pub async fn run_central(
+    adapter_name: Option<&str>,
+    addr: BtAddr,
+    btp: &Btp,
+) -> Result<(), Error> {
+    let session = bluer::Session::new().await?;
+
+    // Register a "NoInputNoOutput" agent that will accept all incoming requests.
+    let _handle = session.register_agent(Agent::default()).await?;
+
+    let adapter = open_adapter(&session, adapter_name).await?;
+    adapter.set_powered(true).await?;
+
+    let device = adapter.device(Address(addr.0))?;
+
+    info!("Connecting to commissionable device {}", addr);
+
+    device.connect().await?;
+
+    // Discover the Matter GATT service and its C1/C2 characteristics. `Device::services()`
+    // internally waits for the remote GATT services to be resolved first.
+    let (c1, c2) = discover_matter_characteristics(&device).await?;
+
+    debug!("Discovered Matter GATT characteristics C1/C2");
+
+    // Subscribe to C2 indications before we start the handshake, so we don't miss the peer's
+    // Handshake Response.
+    let c2_notify = c2.notify().await?;
+    let mut c2_notify = pin!(c2_notify);
+
+    // We are the initiator: drive the BTP handshake from our side.
+    //
+    // NOTE: we deliberately do NOT `btp.reset()` here - resetting would race with,
+    // and wipe, any Matter SDU the caller has already queued (e.g. the PASE
+    // PBKDFParamRequest a commissioner sends as soon as the transport is up). The
+    // caller resets + sets the initiator role before driving Matter traffic.
+    btp.set_initiator(true);
+
+    // We pass `None` for the GATT MTU (as the peripheral side does), relying on the BTP handshake
+    // to negotiate the effective MTU. `bluer`'s simple `write`/`notify` don't surface it anyway.
+    let gatt_mtu = None;
+
+    select3(
+        wait_central_complete(btp, &device),
+        process_c2_indications(btp, addr, gatt_mtu, &mut c2_notify),
+        process_c1_writes(btp, gatt_mtu, &c1, &mut [0; 512]),
+    )
+    .coalesce()
+    .await
+}
+
+/// Feed C2 indications into the BTP session.
+async fn process_c2_indications(
+    btp: &Btp,
+    peer_addr: BtAddr,
+    gatt_mtu: Option<u16>,
+    c2_notify: &mut (impl StreamExt<Item = Vec<u8>> + Unpin),
+) -> Result<(), Error> {
+    while let Some(value) = c2_notify.next().await {
+        trace!("Received C2 indication from peer {}: {:?}", peer_addr, value);
+
+        btp.process_incoming(gatt_mtu, peer_addr, &value)?;
+    }
+
+    // The notification stream ended - treat as a disconnect.
+    Ok(())
+}
+
+/// Drive BTP output and write it to characteristic `C1` (as an acknowledged GATT Write Request).
+async fn process_c1_writes(
+    btp: &Btp,
+    gatt_mtu: Option<u16>,
+    c1: &RemoteCharacteristic,
+    buf: &mut [u8],
+) -> Result<(), Error> {
+    // BTP writes to `C1` are GATT "Write Requests" (acknowledged `ATT_WRITE_REQ`),
+    // as mandated by the Matter Core spec (§4.19.4: clients use the GATT Write
+    // Characteristic Value sub-procedure). Beyond conformance, awaiting each Write
+    // Response is the client-to-server half of BTP flow control: it paces the
+    // segments of a multi-segment SDU (e.g. the AddNOC request) one at a time, so
+    // the server's ATT layer doesn't drop back-to-back segments.
+    let req = bluer::gatt::remote::CharacteristicWriteRequest {
+        op_type: WriteOp::Request,
+        ..Default::default()
+    };
+
+    loop {
+        let len = btp.process_outgoing(gatt_mtu, buf)?;
+
+        if len > 0 {
+            trace!("Writing to C1: {:?}", &buf[..len]);
+
+            c1.write_ext(&buf[..len], &req).await?;
+        } else {
+            btp.wait_outgoing().await;
+        }
+    }
+}
+
+/// Wait for the BTP session to complete because it timed out (no data from the peer for the BTP
+/// idle timeout).
+///
+/// We deliberately do NOT also race a `Connected == false` watch here: BlueZ can briefly report a
+/// device as not-connected during a busy session (e.g. an LE connection-parameter update right
+/// after PASE), which would spuriously abort commissioning. A genuine disconnect surfaces promptly
+/// as an error from the `C1` write / `C2` notify paths instead.
+async fn wait_central_complete(btp: &Btp, _device: &bluer::Device) -> Result<(), Error> {
+    btp.wait_timeout().await;
+    info!("Timeout while waiting for data from the peer");
+
+    Ok(())
+}
+
+/// Find the `C1` (write) and `C2` (indicate) characteristics of the Matter GATT service on the
+/// connected device.
+async fn discover_matter_characteristics(
+    device: &bluer::Device,
+) -> Result<(RemoteCharacteristic, RemoteCharacteristic), Error> {
+    let matter_service_uuid = Uuid::from_u128(MATTER_BLE_SERVICE_UUID);
+    let c1_uuid = Uuid::from_u128(C1_CHARACTERISTIC_UUID);
+    let c2_uuid = Uuid::from_u128(C2_CHARACTERISTIC_UUID);
+
+    for service in device.services().await? {
+        if service.uuid().await? != matter_service_uuid {
+            continue;
+        }
+
+        let mut c1 = None;
+        let mut c2 = None;
+
+        for chr in service.characteristics().await? {
+            let uuid = chr.uuid().await?;
+            if uuid == c1_uuid {
+                c1 = Some(chr);
+            } else if uuid == c2_uuid {
+                c2 = Some(chr);
+            }
+        }
+
+        let c1 = c1.ok_or_else(|| {
+            warn!("The Matter GATT service is missing the C1 characteristic");
+            Error::from(ErrorCode::NoNetworkInterface)
+        })?;
+        let c2 = c2.ok_or_else(|| {
+            warn!("The Matter GATT service is missing the C2 characteristic");
+            Error::from(ErrorCode::NoNetworkInterface)
+        })?;
+
+        return Ok((c1, c2));
+    }
+
+    warn!("The connected device does not expose the Matter GATT service");
+    Err(ErrorCode::NoNetworkInterface.into())
+}
+
+/// Open the Bluetooth adapter designated by `adapter_name`, or the default adapter if `None`.
+async fn open_adapter(session: &bluer::Session, adapter_name: Option<&str>) -> Result<Adapter, Error> {
+    let adapter = if let Some(adapter_name) = adapter_name {
+        session.adapter(adapter_name)?
+    } else {
+        session.default_adapter().await?
+    };
+
+    Ok(adapter)
 }
 
 /// Process incoming writes on characteristic `C1` and pass them to the BTP session for processing.

--- a/rs-matter/src/transport/network/btp/gatt/bluer.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluer.rs
@@ -43,9 +43,7 @@ use crate::transport::network::mdns::CommissionableFilter;
 use crate::transport::network::BtAddr;
 use crate::utils::select::Coalesce;
 
-use super::{
-    AdvData, C1_CHARACTERISTIC_UUID, C2_CHARACTERISTIC_UUID, MATTER_BLE_SERVICE_UUID,
-};
+use super::{AdvData, C1_CHARACTERISTIC_UUID, C2_CHARACTERISTIC_UUID, MATTER_BLE_SERVICE_UUID};
 
 /// The default amount of time [`scan`] will scan for a matching commissionable
 /// advertisement before giving up.
@@ -286,7 +284,9 @@ where
     };
 
     outcome.ok_or_else(|| {
-        warn!("No commissionable Matter device matching the filter was found within the scan timeout");
+        warn!(
+            "No commissionable Matter device matching the filter was found within the scan timeout"
+        );
         ErrorCode::NoNetworkInterface.into()
     })
 }
@@ -365,11 +365,7 @@ where
 ///   be the same adapter the device was discovered on.
 /// - `addr`: The Bluetooth address of the device to connect to (from [`scan`]).
 /// - `btp`: The BTP session to drive.
-pub async fn run_central(
-    adapter_name: Option<&str>,
-    addr: BtAddr,
-    btp: &Btp,
-) -> Result<(), Error> {
+pub async fn run_central(adapter_name: Option<&str>, addr: BtAddr, btp: &Btp) -> Result<(), Error> {
     let session = bluer::Session::new().await?;
 
     // Register a "NoInputNoOutput" agent that will accept all incoming requests.
@@ -424,7 +420,11 @@ async fn process_c2_indications(
     c2_notify: &mut (impl StreamExt<Item = Vec<u8>> + Unpin),
 ) -> Result<(), Error> {
     while let Some(value) = c2_notify.next().await {
-        trace!("Received C2 indication from peer {}: {:?}", peer_addr, value);
+        trace!(
+            "Received C2 indication from peer {}: {:?}",
+            peer_addr,
+            value
+        );
 
         btp.process_incoming(gatt_mtu, peer_addr, &value)?;
     }
@@ -521,7 +521,10 @@ async fn discover_matter_characteristics(
 }
 
 /// Open the Bluetooth adapter designated by `adapter_name`, or the default adapter if `None`.
-async fn open_adapter(session: &bluer::Session, adapter_name: Option<&str>) -> Result<Adapter, Error> {
+async fn open_adapter(
+    session: &bluer::Session,
+    adapter_name: Option<&str>,
+) -> Result<Adapter, Error> {
     let adapter = if let Some(adapter_name) = adapter_name {
         session.adapter(adapter_name)?
     } else {

--- a/rs-matter/src/transport/network/btp/gatt/bluer.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluer.rs
@@ -49,6 +49,16 @@ use super::{AdvData, C1_CHARACTERISTIC_UUID, C2_CHARACTERISTIC_UUID, MATTER_BLE_
 /// advertisement before giving up.
 pub const DEFAULT_SCAN_TIMEOUT_SECS: u16 = 60;
 
+/// How many times [`run_central`] will attempt the initial GATT connection before
+/// giving up, and how long it waits between attempts.
+///
+/// A connect issued right after discovery has stopped can lose a race with the
+/// stack still tearing the scan down (surfacing as `le-connection-abort-by-local`).
+/// The device was just seen advertising, so a connect failure here is almost always
+/// transient - a short, bounded retry turns it into a non-event.
+const CONNECT_ATTEMPTS: u8 = 4;
+const CONNECT_RETRY_DELAY_MS: u64 = 500;
+
 /// Run the GATT peripheral service.
 ///
 /// What this means in details:
@@ -382,7 +392,7 @@ pub async fn run_central(adapter_name: Option<&str>, addr: BtAddr, btp: &Btp) ->
 
     info!("Connecting to commissionable device {}", addr);
 
-    device.connect().await?;
+    connect_with_retry(&device).await?;
 
     // Discover the Matter GATT service and its C1/C2 characteristics. `Device::services()`
     // internally waits for the remote GATT services to be resolved first.
@@ -492,6 +502,27 @@ async fn wait_central_complete(btp: &Btp, _device: &bluer::Device) -> Result<(),
     info!("Timeout while waiting for data from the peer");
 
     Ok(())
+}
+
+/// Connect to the device, retrying a bounded number of times on transient failures
+/// (notably `le-connection-abort-by-local`; see [`CONNECT_ATTEMPTS`]).
+async fn connect_with_retry(device: &bluer::Device) -> Result<(), Error> {
+    for attempt in 1..=CONNECT_ATTEMPTS {
+        match device.connect().await {
+            Ok(()) => return Ok(()),
+            Err(e) if attempt < CONNECT_ATTEMPTS => {
+                warn!(
+                    "Connect attempt {}/{} failed ({:?}); retrying",
+                    attempt, CONNECT_ATTEMPTS, e
+                );
+                Timer::after(Duration::from_millis(CONNECT_RETRY_DELAY_MS)).await;
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    // Unreachable: the last attempt either returns `Ok` or the `Err` arm above.
+    Err(ErrorCode::NoNetworkInterface.into())
 }
 
 /// Find the `C1` (write) and `C2` (indicate) characteristics of the Matter GATT service on the

--- a/rs-matter/src/transport/network/btp/gatt/bluer.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluer.rs
@@ -420,6 +420,18 @@ async fn process_c2_indications(
     c2_notify: &mut (impl StreamExt<Item = Vec<u8>> + Unpin),
 ) -> Result<(), Error> {
     while let Some(value) = c2_notify.next().await {
+        // An empty payload is never a valid BTP frame, and handing one to the BTP
+        // layer would fail the whole session rather than ignore a stray indication.
+        //
+        // The `zbus` backend *must* filter these, as BlueZ delivers the
+        // characteristic's initial (empty) `Value` as a property change right after
+        // subscribing. `bluer` hands us a real notification stream instead, so here
+        // this is belt-and-braces - but it costs one comparison, and what it guards
+        // against is a dropped connection.
+        if value.is_empty() {
+            continue;
+        }
+
         trace!(
             "Received C2 indication from peer {}: {:?}",
             peer_addr,

--- a/rs-matter/src/transport/network/btp/gatt/bluer.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluer.rs
@@ -244,23 +244,27 @@ where
     };
     adapter.set_discovery_filter(discovery_filter).await?;
 
-    let device_events = adapter.discover_devices().await?;
+    // `discover_devices_with_changes`, not `discover_devices`: both include the
+    // devices BlueZ already knows about, but only this one re-emits `DeviceAdded`
+    // *every time a device's properties change*.
+    //
+    // That matters, and is easy to get wrong. BlueZ populates a device's properties
+    // asynchronously, so the advertised service data we match on is routinely absent
+    // at the moment the device first shows up - and a device BlueZ already knows
+    // never "appears" again at all. With plain `discover_devices` we would look at
+    // each device exactly once, quite possibly before its service data landed, and
+    // then wait forever. (This is the same trap the `zbus` backend sidesteps by
+    // re-reading the object tree on a timer; `bluer` just gives us a better tool.)
+    let device_events = adapter.discover_devices_with_changes().await?;
     let mut device_events = pin!(device_events);
 
     // Devices already reported to `on_found`, so we report each at most once.
+    // Note this only suppresses re-reporting a device we already *matched*: one that
+    // does not match yet (e.g. no service data so far) is left out, so a later
+    // `DeviceAdded` for it gets another look.
     let mut reported: heapless::Vec<BtAddr, 16> = heapless::Vec::new();
 
     let scan_fut = async {
-        // First, sweep devices BlueZ already knows about (they won't generate `DeviceAdded`).
-        for addr in adapter.device_addresses().await? {
-            if let Some(result) =
-                try_match_device(&adapter, addr, filter, &mut reported, &mut on_found).await?
-            {
-                return Ok(Some(result));
-            }
-        }
-
-        // Then follow the discovery event stream.
         while let Some(event) = device_events.next().await {
             if let AdapterEvent::DeviceAdded(addr) = event {
                 if let Some(result) =

--- a/rs-matter/src/transport/network/btp/gatt/bluez.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluez.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-//! A `GattPeripheral` implementation using the BlueZ GATT stack over dBus.
+//! A GATT Peripheral implementation using the BlueZ GATT stack over dBus.
 
 use core::iter::once;
 use core::marker::PhantomData;
@@ -31,6 +31,9 @@ use async_channel::{Receiver, Sender};
 use async_io::Async;
 
 use embassy_futures::select::{select, select3, Either};
+use embassy_time::{Duration, Instant, Timer};
+
+use futures_lite::StreamExt;
 
 use uuid::Uuid;
 
@@ -41,10 +44,14 @@ use zbus::{interface, Connection};
 
 use crate::error::{Error, ErrorCode};
 use crate::transport::network::btp::Btp;
+use crate::transport::network::mdns::CommissionableFilter;
 use crate::transport::network::BtAddr;
 use crate::utils::select::Coalesce;
 use crate::utils::zbus_proxies::bluez::adapter::AdapterProxy;
+use crate::utils::zbus_proxies::bluez::device::DeviceProxy;
+use crate::utils::zbus_proxies::bluez::gatt_characteristic::GattCharacteristicProxy;
 use crate::utils::zbus_proxies::bluez::gatt_manager::GattManagerProxy;
+use crate::utils::zbus_proxies::bluez::gatt_service::GattServiceProxy;
 use crate::utils::zbus_proxies::bluez::le_advertising_manager::LEAdvertisingManagerProxy;
 
 use super::{AdvData, C1_CHARACTERISTIC_UUID, C2_CHARACTERISTIC_UUID, MATTER_BLE_SERVICE_UUID};
@@ -53,6 +60,53 @@ const BLUEZ_MATTER_BLE_SERVICE_UUID: Uuid = Uuid::from_u128(MATTER_BLE_SERVICE_U
 const BLUEZ_MATTER_C1_CHARACTERISTIC_UUID: Uuid = Uuid::from_u128(C1_CHARACTERISTIC_UUID);
 const BLUEZ_MATTER_C2_CHARACTERISTIC_UUID: Uuid = Uuid::from_u128(C2_CHARACTERISTIC_UUID);
 const BLUEZ_PATH_PREFIX: &str = "/org/projectchip/rs_matter/bluez";
+
+/// The default amount of time [`run_central`] will scan for a matching
+/// commissionable advertisement before giving up.
+pub const DEFAULT_SCAN_TIMEOUT_SECS: u16 = 60;
+
+/// Build a `Device1` proxy bound to a specific device object path.
+///
+/// The BlueZ proxies are declared with `assume_defaults = true`, so their
+/// `new(connection)` constructor bakes in a default path; to target a specific
+/// object we go through the proxy builder.
+async fn device_proxy<'a>(
+    connection: &'a Connection,
+    path: &OwnedObjectPath,
+) -> Result<DeviceProxy<'a>, Error> {
+    // These proxies are `assume_defaults = true` (no `default_service`), so the
+    // destination defaults to the interface name (`org.bluez.Device1`) unless we
+    // set it explicitly - it must be `org.bluez`.
+    Ok(DeviceProxy::builder(connection)
+        .destination("org.bluez")?
+        .path(path.clone())?
+        .build()
+        .await?)
+}
+
+/// Build a `GattService1` proxy bound to a specific object path.
+async fn gatt_service_proxy<'a>(
+    connection: &'a Connection,
+    path: &OwnedObjectPath,
+) -> Result<GattServiceProxy<'a>, Error> {
+    Ok(GattServiceProxy::builder(connection)
+        .destination("org.bluez")?
+        .path(path.clone())?
+        .build()
+        .await?)
+}
+
+/// Build a `GattCharacteristic1` proxy bound to a specific object path.
+async fn gatt_characteristic_proxy<'a>(
+    connection: &'a Connection,
+    path: &OwnedObjectPath,
+) -> Result<GattCharacteristicProxy<'a>, Error> {
+    Ok(GattCharacteristicProxy::builder(connection)
+        .destination("org.bluez")?
+        .path(path.clone())?
+        .build()
+        .await?)
+}
 
 pub async fn run_peripheral(
     connection: &Connection,
@@ -115,6 +169,512 @@ pub async fn run_peripheral(
 
         notifier_created.store(false, Ordering::SeqCst);
     }
+}
+
+/// Run the GATT central (Commissioner-side) BTP transport using the BlueZ GATT stack over dBus.
+///
+/// This is the connect-and-pump half of the Controller / Commissioner role (the discovery half is
+/// [`scan`]). Given the Bluetooth address of a commissionable device (as returned by [`scan`]), it:
+/// - Connects to the device as a GATT Central and discovers the Matter GATT service, together with
+///   its `C1` (write) and `C2` (indicate) characteristics.
+/// - Subscribes to `C2` indications, feeding them into [`Btp::process_incoming`], and writes the
+///   BTP output from [`Btp::process_outgoing`] to `C1` (as an acknowledged GATT Write Request).
+/// - Drives `btp` in the initiator role (it calls [`Btp::set_initiator`] with `true`), so the
+///   BTP handshake is started by us.
+///
+/// The caller passes commissioning requests to the device as `Address::Btp(addr)` while
+/// `matter.run(.., &btp, &btp, ..)` pumps the transport (i.e. `run_central` is `select`-ed against
+/// `matter.run`).
+///
+/// This function returns once the peer disconnects, the session times out, or an error occurs.
+/// It does not loop / reconnect - a Commissioner establishes one BTP session for the duration of
+/// commissioning.
+///
+/// `addr` must belong to a device that BlueZ already knows about (i.e. one that has been discovered
+/// at least once - typically via a preceding [`scan`] on the same adapter). Otherwise BlueZ has no
+/// object for it and the connect fails.
+///
+/// # Arguments
+/// - `connection`: The dBus (system-bus) connection to BlueZ.
+/// - `adapter_name`: The Bluetooth adapter to use. If `None`, the first suitable adapter is used.
+///   It must be the same adapter the device was discovered on.
+/// - `addr`: The Bluetooth address of the device to connect to (from [`scan`]).
+/// - `btp`: The BTP session to drive.
+pub async fn run_central(
+    connection: &Connection,
+    adapter_name: Option<&str>,
+    addr: BtAddr,
+    btp: &Btp,
+) -> Result<(), Error> {
+    let adapter_path = adapter_path_for_central(connection, adapter_name).await?;
+
+    let adapter = AdapterProxy::new(connection, adapter_path.as_ref()).await?;
+    adapter.set_powered(true).await?;
+
+    // BlueZ device object paths are a deterministic function of the adapter path and the peer MAC:
+    // `<adapter_path>/dev_AA_BB_CC_DD_EE_FF`.
+    let device_path = device_path_for(&adapter_path, addr)?;
+
+    info!("Connecting to commissionable device {} ({})", device_path, addr);
+
+    let device = device_proxy(connection, &device_path).await?;
+
+    device.connect().await?;
+
+    wait_services_resolved(&device).await?;
+
+    // Discover the Matter GATT service and its C1/C2 characteristics.
+    let (c1, c2) = discover_matter_characteristics(connection, &device_path).await?;
+
+    // The negotiated ATT MTU, as reported by BlueZ on the characteristic. It may be `0`/unknown
+    // on older BlueZ; in that case the BTP handshake falls back to the minimum MTU.
+    let gatt_mtu = c1.mtu().await.ok().filter(|mtu| *mtu > 0);
+
+    debug!("Discovered Matter GATT characteristics C1/C2, ATT MTU: {:?}", gatt_mtu);
+
+    // Subscribe to C2 indications before we start the handshake, so we don't miss the peer's
+    // Handshake Response.
+    c2.start_notify().await?;
+
+    let mut value_changed = c2.receive_value_changed().await;
+
+    // We are the initiator: drive the BTP handshake from our side.
+    //
+    // NOTE: we deliberately do NOT `btp.reset()` here. The caller is expected to
+    // have reset the session and set the initiator role *before* it started
+    // driving Matter traffic through this `Btp` - resetting here would race with,
+    // and wipe, any Matter SDU the caller has already queued (e.g. the PASE
+    // PBKDFParamRequest a commissioner sends as soon as the transport is up).
+    btp.set_initiator(true);
+
+    let result = select3(
+        wait_central_complete(btp, &device_path, connection),
+        process_c2_indications(btp, addr, gatt_mtu, &mut value_changed),
+        process_c1_writes(btp, gatt_mtu, &c1, &mut [0; 512]),
+    )
+    .coalesce()
+    .await;
+
+    // Best-effort teardown so a subsequent commissioning attempt starts clean.
+    let _ = c2.stop_notify().await;
+
+    result
+}
+
+/// Scan BLE advertisements for commissionable Matter devices and report each match to `on_found`.
+///
+/// This is the discovery half of the Controller / Commissioner role (the connect half is
+/// [`run_central`]) - the BLE analogue of an mDNS commissionable browse. It puts the adapter into
+/// LE discovery (the Matter service UUID is matched per-device from the advertised service data,
+/// not via a discovery filter - see the note in the body), and for every discovered device whose
+/// advertised service data both parses as a commissionable Matter advertisement and matches
+/// `filter`, it invokes `on_found(addr, &adv)`.
+///
+/// `on_found` decides when to stop: returning `Some(value)` stops the scan and makes `scan` return
+/// `Ok(value)`; returning `None` keeps scanning. Each matching device is reported at most once. If
+/// the timeout elapses with no accepted match, `scan` returns `Err(NoNetworkInterface)`.
+///
+/// The common "connect to the first match" case is simply:
+///
+/// ```ignore
+/// let addr = scan(&conn, None, &filter, None, |addr, _adv| Some(addr)).await?;
+/// run_central(&conn, None, addr, &btp).await?;
+/// ```
+///
+/// # Arguments
+/// - `connection`: The dBus (system-bus) connection to BlueZ.
+/// - `adapter_name`: The Bluetooth adapter to use. If `None`, the first suitable adapter is used.
+/// - `filter`: The commissionable-device filter to match advertisements against. An empty filter
+///   matches every commissionable Matter device seen.
+/// - `scan_timeout`: How long to scan before giving up. If `None`, [`DEFAULT_SCAN_TIMEOUT_SECS`].
+/// - `on_found`: Callback invoked for each newly-matched device; returning `Some` stops the scan.
+pub async fn scan<F, R>(
+    connection: &Connection,
+    adapter_name: Option<&str>,
+    filter: &CommissionableFilter,
+    scan_timeout: Option<u16>,
+    mut on_found: F,
+) -> Result<R, Error>
+where
+    F: FnMut(BtAddr, &AdvData) -> Option<R>,
+{
+    let adapter_path = adapter_path_for_central(connection, adapter_name).await?;
+
+    let adapter = AdapterProxy::new(connection, adapter_path.as_ref()).await?;
+    adapter.set_powered(true).await?;
+
+    info!(
+        "Scanning for a commissionable Matter device on Bluetooth adapter {} (filter: {:?})",
+        adapter_path, filter
+    );
+
+    // Constrain discovery to LE, so BlueZ populates `Device1.ServiceData` for advertising devices.
+    //
+    // Note: we deliberately do NOT set a `UUIDs` service-UUID filter here. In
+    // practice, passing `UUIDs` to `SetDiscoveryFilter` over this D-Bus binding
+    // leaves the adapter's `Discovering` property `false` (BlueZ accepts the call
+    // but never actually starts scanning), so no advertisements ever arrive. We
+    // instead filter to the Matter service UUID in `report_matching_devices` when
+    // we inspect each device's advertised service data - which we have to do
+    // anyway to parse the advertisement.
+    let transport = Value::from("le");
+    let mut discovery_filter: HashMap<&str, &Value<'_>> = HashMap::new();
+    discovery_filter.insert("Transport", &transport);
+
+    adapter.set_discovery_filter(discovery_filter).await?;
+    adapter.start_discovery().await?;
+
+    // Poll the object tree for matching devices. We poll (rather than only relying on
+    // `InterfacesAdded`) so that devices already known to BlueZ, and service-data that arrives via
+    // `PropertiesChanged` on an existing device, are both handled uniformly.
+    let om = ObjectManagerProxy::new(connection, "org.bluez", "/").await?;
+
+    let deadline = Instant::now() + Duration::from_secs(scan_timeout.unwrap_or(DEFAULT_SCAN_TIMEOUT_SECS) as u64);
+
+    // Devices already reported to `on_found`, so we report each at most once.
+    let mut reported: heapless::Vec<BtAddr, 16> = heapless::Vec::new();
+
+    let outcome = loop {
+        if let Some(result) =
+            report_matching_devices(&om, &adapter_path, filter, &mut reported, &mut on_found).await?
+        {
+            break Some(result);
+        }
+
+        if Instant::now() >= deadline {
+            break None;
+        }
+
+        Timer::after(Duration::from_millis(250)).await;
+    };
+
+    // Stop discovery (best-effort) before returning.
+    let _ = adapter.stop_discovery().await;
+
+    outcome.ok_or_else(|| {
+        warn!("No commissionable Matter device matching the filter was found within the scan timeout");
+        ErrorCode::NoNetworkInterface.into()
+    })
+}
+
+/// Feed C2 indications (BlueZ surfaces them as `Value` property changes) into the BTP session.
+async fn process_c2_indications(
+    btp: &Btp,
+    peer_addr: BtAddr,
+    gatt_mtu: Option<u16>,
+    value_changed: &mut zbus::proxy::PropertyStream<'_, Vec<u8>>,
+) -> Result<(), Error> {
+    while let Some(change) = value_changed.next().await {
+        let value = change.get().await?;
+
+        // BlueZ emits the characteristic's *current* `Value` (initially empty) as
+        // the first property change right after `start_notify()`, before any real
+        // indication has arrived. It also may re-deliver an unchanged value. An
+        // empty payload is never a valid BTP frame, so skip it rather than feeding
+        // it to the BTP layer (which would reject it as invalid).
+        if value.is_empty() {
+            continue;
+        }
+
+        trace!("Received C2 indication from peer {}: {:?}", peer_addr, value);
+
+        btp.process_incoming(gatt_mtu, peer_addr, &value)?;
+    }
+
+    // The property stream ended - treat as a disconnect.
+    Ok(())
+}
+
+/// Drive BTP output and write it to characteristic `C1` (as a GATT Write Request).
+async fn process_c1_writes(
+    btp: &Btp,
+    gatt_mtu: Option<u16>,
+    c1: &GattCharacteristicProxy<'_>,
+    buf: &mut [u8],
+) -> Result<(), Error> {
+    // BTP writes to `C1` are GATT "Write Requests" (i.e. *acknowledged*
+    // `ATT_WRITE_REQ`), as mandated by the Matter Core spec (§4.19.4:
+    // "Clients SHALL exclusively use GATT Write Characteristic Value sub-procedure
+    // to send data to servers" - which is the acknowledged write). BlueZ's write
+    // type for that is `"request"`.
+    //
+    // This is not just a conformance detail: the per-write GATT acknowledgement is
+    // the client-to-server half of BTP flow control. With an unacknowledged
+    // "Write Command", back-to-back segments of a multi-segment SDU (e.g. the
+    // AddNOC request) get packed into one BLE connection event and are dropped by
+    // the server's ATT layer (observed as `GATTS_SendRsp ... Sending response
+    // failed` on ESP-IDF, then a BTP sequence gap and a disconnect). Awaiting the
+    // Write Response before sending the next segment prevents that.
+    let mut options = HashMap::new();
+    let write_type = Value::from("request");
+    options.insert("type", &write_type);
+
+    loop {
+        let len = btp.process_outgoing(gatt_mtu, buf)?;
+
+        if len > 0 {
+            trace!("Writing to C1: {:?}", &buf[..len]);
+
+            // `write_value` (an `ATT_WRITE_REQ`) completes only when the server
+            // returns its Write Response, so segments are paced one at a time.
+            c1.write_value(&buf[..len], options.clone()).await?;
+        } else {
+            btp.wait_outgoing().await;
+        }
+    }
+}
+
+/// Wait for the BTP session to complete because it timed out (no data from the peer for the BTP
+/// idle timeout).
+///
+/// We deliberately do NOT also race a `Connected == false` watch here. BlueZ can briefly report a
+/// device as not-connected during a busy session (e.g. an LE connection-parameter update right
+/// after PASE), which would spuriously abort commissioning. A genuine disconnect surfaces promptly
+/// as an error from the `C1` write / `C2` notify paths instead, and a truly idle session is caught
+/// by the BTP timeout below.
+async fn wait_central_complete(
+    btp: &Btp,
+    _device_path: &OwnedObjectPath,
+    _connection: &Connection,
+) -> Result<(), Error> {
+    btp.wait_timeout().await;
+    info!("Timeout while waiting for data from the peer");
+
+    Ok(())
+}
+
+/// Look through the BlueZ object tree for `Device1` objects on `adapter_path` whose advertised
+/// Matter service data both parses and matches `filter`, and report each not-yet-reported one to
+/// `on_found`. Returns `Some(result)` as soon as `on_found` returns `Some` (stopping the scan).
+async fn report_matching_devices<F, R>(
+    om: &ObjectManagerProxy<'_>,
+    adapter_path: &OwnedObjectPath,
+    filter: &CommissionableFilter,
+    reported: &mut heapless::Vec<BtAddr, 16>,
+    on_found: &mut F,
+) -> Result<Option<R>, Error>
+where
+    F: FnMut(BtAddr, &AdvData) -> Option<R>,
+{
+    let matter_uuid = BLUEZ_MATTER_BLE_SERVICE_UUID.to_string();
+
+    let objects = om.get_managed_objects().await?;
+
+    for (path, interfaces) in objects {
+        let Some(device) = interfaces.get("org.bluez.Device1") else {
+            continue;
+        };
+
+        // Only consider devices on our adapter.
+        if !path.as_str().starts_with(adapter_path.as_str()) {
+            continue;
+        }
+
+        // Pull the advertised service data (a `UUID -> bytes` map) and look for the Matter one.
+        let Some(service_data) = device.get("ServiceData") else {
+            continue;
+        };
+
+        let Ok(service_data) = <HashMap<String, OwnedValue>>::try_from(service_data.clone()) else {
+            continue;
+        };
+
+        let Some(matter_data) = service_data
+            .iter()
+            .find(|(uuid, _)| uuid.eq_ignore_ascii_case(&matter_uuid))
+            .map(|(_, data)| data)
+        else {
+            continue;
+        };
+
+        let Ok(bytes) = <Vec<u8>>::try_from(matter_data.clone()) else {
+            continue;
+        };
+
+        let Some(adv) = AdvData::parse_service_data(&bytes) else {
+            continue;
+        };
+
+        if !adv.matches(filter) {
+            continue;
+        }
+
+        let Ok(addr) = bt_addr_from_device_path(&path.as_ref()) else {
+            continue;
+        };
+
+        // Report each matching device at most once.
+        if reported.contains(&addr) {
+            continue;
+        }
+
+        // If the dedup buffer is full we simply stop deduplicating (and may re-report); never drop
+        // an actual match on the floor.
+        let _ = reported.push(addr);
+
+        debug!("Matched commissionable device {} ({}) (adv: {:?})", path, addr, adv);
+
+        if let Some(result) = on_found(addr, &adv) {
+            return Ok(Some(result));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Construct the BlueZ `Device1` object path for a peer MAC on the given adapter:
+/// `<adapter_path>/dev_AA_BB_CC_DD_EE_FF`. This is the inverse of [`bt_addr_from_device_path`].
+fn device_path_for(adapter_path: &OwnedObjectPath, addr: BtAddr) -> Result<OwnedObjectPath, Error> {
+    let [a, b, c, d, e, f] = addr.0;
+    let path = format!(
+        "{}/dev_{:02X}_{:02X}_{:02X}_{:02X}_{:02X}_{:02X}",
+        adapter_path.as_str(),
+        a,
+        b,
+        c,
+        d,
+        e,
+        f
+    );
+
+    Ok(path.try_into()?)
+}
+
+/// Wait until the device reports that its GATT services have been resolved.
+async fn wait_services_resolved(device: &DeviceProxy<'_>) -> Result<(), Error> {
+    if device.services_resolved().await.unwrap_or(false) {
+        return Ok(());
+    }
+
+    let mut resolved_changed = device.receive_services_resolved_changed().await;
+
+    while let Some(change) = resolved_changed.next().await {
+        if change.get().await.unwrap_or(false) {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+/// Find the `C1` (write) and `C2` (indicate) characteristics of the Matter GATT service on the
+/// connected device.
+async fn discover_matter_characteristics<'a>(
+    connection: &'a Connection,
+    device_path: &OwnedObjectPath,
+) -> Result<(GattCharacteristicProxy<'a>, GattCharacteristicProxy<'a>), Error> {
+    let om = ObjectManagerProxy::new(connection, "org.bluez", "/").await?;
+    let objects = om.get_managed_objects().await?;
+
+    // Find the Matter GATT service under this device.
+    let mut service_path: Option<OwnedObjectPath> = None;
+    for (path, interfaces) in &objects {
+        if !path.as_str().starts_with(device_path.as_str()) {
+            continue;
+        }
+
+        if interfaces.contains_key("org.bluez.GattService1") {
+            let service = gatt_service_proxy(connection, path).await?;
+            if service
+                .uuid()
+                .await
+                .map(|uuid| uuid.eq_ignore_ascii_case(&BLUEZ_MATTER_BLE_SERVICE_UUID.to_string()))
+                .unwrap_or(false)
+            {
+                service_path = Some(path.clone());
+                break;
+            }
+        }
+    }
+
+    let service_path = service_path.ok_or_else(|| {
+        warn!("The connected device does not expose the Matter GATT service");
+        Error::from(ErrorCode::NoNetworkInterface)
+    })?;
+
+    // Find C1 and C2 under the service.
+    let mut c1: Option<GattCharacteristicProxy<'a>> = None;
+    let mut c2: Option<GattCharacteristicProxy<'a>> = None;
+
+    for (path, interfaces) in &objects {
+        if !path.as_str().starts_with(service_path.as_str()) {
+            continue;
+        }
+
+        if !interfaces.contains_key("org.bluez.GattCharacteristic1") {
+            continue;
+        }
+
+        let chr = gatt_characteristic_proxy(connection, path).await?;
+        let Ok(uuid) = chr.uuid().await else {
+            continue;
+        };
+
+        if uuid.eq_ignore_ascii_case(&BLUEZ_MATTER_C1_CHARACTERISTIC_UUID.to_string()) {
+            c1 = Some(chr);
+        } else if uuid.eq_ignore_ascii_case(&BLUEZ_MATTER_C2_CHARACTERISTIC_UUID.to_string()) {
+            c2 = Some(chr);
+        }
+    }
+
+    let c1 = c1.ok_or_else(|| {
+        warn!("The Matter GATT service is missing the C1 characteristic");
+        Error::from(ErrorCode::NoNetworkInterface)
+    })?;
+    let c2 = c2.ok_or_else(|| {
+        warn!("The Matter GATT service is missing the C2 characteristic");
+        Error::from(ErrorCode::NoNetworkInterface)
+    })?;
+
+    Ok((c1, c2))
+}
+
+/// Extract a [`BtAddr`] from a BlueZ device object path of the form
+/// `/org/bluez/<adapter>/dev_XX_XX_XX_XX_XX_XX`.
+fn bt_addr_from_device_path(path: &ObjectPath<'_>) -> Result<BtAddr, Error> {
+    let bt_addr_str = path
+        .as_str()
+        .rsplit('/')
+        .next()
+        .and_then(|last| last.strip_prefix("dev_"))
+        .ok_or(ErrorCode::InvalidData)?;
+
+    let bt_addr = bt_addr_str
+        .split('_')
+        .map(|s| u8::from_str_radix(s, 16).map_err(|_| Error::from(ErrorCode::InvalidData)))
+        .collect::<Result<heapless::Vec<_, 6>, _>>()?;
+
+    bt_addr
+        .into_array()
+        .map(BtAddr)
+        .map_err(|_| ErrorCode::InvalidData.into())
+}
+
+/// Get the path to a Bluetooth adapter suitable for the Central role.
+///
+/// Unlike the Peripheral role (which needs `GattManager1` + `LEAdvertisingManager1`), the Central
+/// role only needs an `Adapter1`.
+async fn adapter_path_for_central(
+    connection: &Connection,
+    adapter_name: Option<&str>,
+) -> Result<OwnedObjectPath, Error> {
+    let om = ObjectManagerProxy::new(connection, "org.bluez", "/").await?;
+
+    let objects = om.get_managed_objects().await?;
+
+    objects
+        .into_iter()
+        .find(|(path, interfaces)| {
+            if interfaces.contains_key("org.bluez.Adapter1") {
+                adapter_name
+                    .map(|adapter_name| path.as_str().split('/').next_back() == Some(adapter_name))
+                    .unwrap_or(true)
+            } else {
+                false
+            }
+        })
+        .map(|(path, _)| path)
+        .ok_or_else(|| ErrorCode::NoNetworkInterface.into())
 }
 
 /// Process incoming writes on characteristic `C1` and pass them to the BTP session for processing.

--- a/rs-matter/src/transport/network/btp/gatt/bluez.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluez.rs
@@ -38,6 +38,7 @@ use futures_lite::StreamExt;
 use uuid::Uuid;
 
 use zbus::fdo::{ObjectManager, ObjectManagerProxy};
+use zbus::names::OwnedInterfaceName;
 use zbus::object_server::Interface;
 use zbus::zvariant::{ObjectPath, OwnedFd, OwnedObjectPath, OwnedValue, Value};
 use zbus::{interface, Connection};
@@ -51,7 +52,6 @@ use crate::utils::zbus_proxies::bluez::adapter::AdapterProxy;
 use crate::utils::zbus_proxies::bluez::device::DeviceProxy;
 use crate::utils::zbus_proxies::bluez::gatt_characteristic::GattCharacteristicProxy;
 use crate::utils::zbus_proxies::bluez::gatt_manager::GattManagerProxy;
-use crate::utils::zbus_proxies::bluez::gatt_service::GattServiceProxy;
 use crate::utils::zbus_proxies::bluez::le_advertising_manager::LEAdvertisingManagerProxy;
 
 use super::{AdvData, C1_CHARACTERISTIC_UUID, C2_CHARACTERISTIC_UUID, MATTER_BLE_SERVICE_UUID};
@@ -64,6 +64,10 @@ const BLUEZ_PATH_PREFIX: &str = "/org/projectchip/rs_matter/bluez";
 /// The default amount of time [`run_central`] will scan for a matching
 /// commissionable advertisement before giving up.
 pub const DEFAULT_SCAN_TIMEOUT_SECS: u16 = 60;
+
+/// How often [`scan`] re-reads BlueZ's object tree looking for a matching device.
+/// See the note in [`scan`] on why this polls, and on the cost per tick.
+const SCAN_POLL_INTERVAL_MS: u64 = 1000;
 
 /// Build a `Device1` proxy bound to a specific device object path.
 ///
@@ -84,16 +88,19 @@ async fn device_proxy<'a>(
         .await?)
 }
 
-/// Build a `GattService1` proxy bound to a specific object path.
-async fn gatt_service_proxy<'a>(
-    connection: &'a Connection,
-    path: &OwnedObjectPath,
-) -> Result<GattServiceProxy<'a>, Error> {
-    Ok(GattServiceProxy::builder(connection)
-        .destination("org.bluez")?
-        .path(path.clone())?
-        .build()
-        .await?)
+/// Read an interface's `UUID` property straight out of a `GetManagedObjects` reply.
+///
+/// That reply already carries every property of every interface, so asking BlueZ
+/// again - a proxy plus a D-Bus round-trip per object - would be pure overhead when
+/// all we want is to find the objects we care about. Returns `None` if the object
+/// does not implement `iface`, or has no readable `UUID`.
+fn iface_uuid(
+    interfaces: &HashMap<OwnedInterfaceName, HashMap<String, OwnedValue>>,
+    iface: &str,
+) -> Option<String> {
+    let uuid = interfaces.get(iface)?.get("UUID")?;
+
+    String::try_from(uuid.clone()).ok()
 }
 
 /// Build a `GattCharacteristic1` proxy bound to a specific object path.
@@ -330,9 +337,20 @@ where
     adapter.set_discovery_filter(discovery_filter).await?;
     adapter.start_discovery().await?;
 
-    // Poll the object tree for matching devices. We poll (rather than only relying on
-    // `InterfacesAdded`) so that devices already known to BlueZ, and service-data that arrives via
-    // `PropertiesChanged` on an existing device, are both handled uniformly.
+    // Poll the object tree for matching devices.
+    //
+    // Polling - rather than subscribing to `InterfacesAdded` - is a deliberate
+    // simplification: a device that BlueZ *already* knows about emits no
+    // `InterfacesAdded` at all, and its advertised service data arrives later as a
+    // `PropertiesChanged` on the existing object, so a signal-driven scanner has to
+    // merge both streams to be correct. Re-reading the tree handles all of it
+    // uniformly.
+    //
+    // The cost is a `GetManagedObjects` per tick, which serializes BlueZ's whole
+    // object tree (~13 KB / ~6 ms on a typical desktop, but it grows with the number
+    // of known devices). Hence `SCAN_POLL_INTERVAL_MS` is a compromise: frequent
+    // enough that discovery still feels instant next to a multi-second commissioning
+    // flow, infrequent enough not to churn D-Bus for the length of the scan.
     let om = ObjectManagerProxy::new(connection, "org.bluez", "/").await?;
 
     let deadline = Instant::now()
@@ -359,7 +377,7 @@ where
                 return Ok(None);
             }
 
-            Timer::after(Duration::from_millis(250)).await;
+            Timer::after(Duration::from_millis(SCAN_POLL_INTERVAL_MS)).await;
         }
     }
     .await;
@@ -593,6 +611,8 @@ async fn discover_matter_characteristics<'a>(
     let om = ObjectManagerProxy::new(connection, "org.bluez", "/").await?;
     let objects = om.get_managed_objects().await?;
 
+    let matter_service_uuid = BLUEZ_MATTER_BLE_SERVICE_UUID.to_string();
+
     // Find the Matter GATT service under this device.
     let mut service_path: Option<OwnedObjectPath> = None;
     for (path, interfaces) in &objects {
@@ -600,17 +620,13 @@ async fn discover_matter_characteristics<'a>(
             continue;
         }
 
-        if interfaces.contains_key("org.bluez.GattService1") {
-            let service = gatt_service_proxy(connection, path).await?;
-            if service
-                .uuid()
-                .await
-                .map(|uuid| uuid.eq_ignore_ascii_case(&BLUEZ_MATTER_BLE_SERVICE_UUID.to_string()))
-                .unwrap_or(false)
-            {
-                service_path = Some(path.clone());
-                break;
-            }
+        let Some(uuid) = iface_uuid(interfaces, "org.bluez.GattService1") else {
+            continue;
+        };
+
+        if uuid.eq_ignore_ascii_case(&matter_service_uuid) {
+            service_path = Some(path.clone());
+            break;
         }
     }
 
@@ -623,24 +639,23 @@ async fn discover_matter_characteristics<'a>(
     let mut c1: Option<GattCharacteristicProxy<'a>> = None;
     let mut c2: Option<GattCharacteristicProxy<'a>> = None;
 
+    let c1_uuid = BLUEZ_MATTER_C1_CHARACTERISTIC_UUID.to_string();
+    let c2_uuid = BLUEZ_MATTER_C2_CHARACTERISTIC_UUID.to_string();
+
     for (path, interfaces) in &objects {
         if !path.as_str().starts_with(service_path.as_str()) {
             continue;
         }
 
-        if !interfaces.contains_key("org.bluez.GattCharacteristic1") {
-            continue;
-        }
-
-        let chr = gatt_characteristic_proxy(connection, path).await?;
-        let Ok(uuid) = chr.uuid().await else {
+        let Some(uuid) = iface_uuid(interfaces, "org.bluez.GattCharacteristic1") else {
             continue;
         };
 
-        if uuid.eq_ignore_ascii_case(&BLUEZ_MATTER_C1_CHARACTERISTIC_UUID.to_string()) {
-            c1 = Some(chr);
-        } else if uuid.eq_ignore_ascii_case(&BLUEZ_MATTER_C2_CHARACTERISTIC_UUID.to_string()) {
-            c2 = Some(chr);
+        // Only the two characteristics we actually use are worth a proxy.
+        if uuid.eq_ignore_ascii_case(&c1_uuid) {
+            c1 = Some(gatt_characteristic_proxy(connection, path).await?);
+        } else if uuid.eq_ignore_ascii_case(&c2_uuid) {
+            c2 = Some(gatt_characteristic_proxy(connection, path).await?);
         }
     }
 

--- a/rs-matter/src/transport/network/btp/gatt/bluez.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluez.rs
@@ -215,7 +215,10 @@ pub async fn run_central(
     // `<adapter_path>/dev_AA_BB_CC_DD_EE_FF`.
     let device_path = device_path_for(&adapter_path, addr)?;
 
-    info!("Connecting to commissionable device {} ({})", device_path, addr);
+    info!(
+        "Connecting to commissionable device {} ({})",
+        device_path, addr
+    );
 
     let device = device_proxy(connection, &device_path).await?;
 
@@ -230,7 +233,10 @@ pub async fn run_central(
     // on older BlueZ; in that case the BTP handshake falls back to the minimum MTU.
     let gatt_mtu = c1.mtu().await.ok().filter(|mtu| *mtu > 0);
 
-    debug!("Discovered Matter GATT characteristics C1/C2, ATT MTU: {:?}", gatt_mtu);
+    debug!(
+        "Discovered Matter GATT characteristics C1/C2, ATT MTU: {:?}",
+        gatt_mtu
+    );
 
     // Subscribe to C2 indications before we start the handshake, so we don't miss the peer's
     // Handshake Response.
@@ -329,14 +335,16 @@ where
     // `PropertiesChanged` on an existing device, are both handled uniformly.
     let om = ObjectManagerProxy::new(connection, "org.bluez", "/").await?;
 
-    let deadline = Instant::now() + Duration::from_secs(scan_timeout.unwrap_or(DEFAULT_SCAN_TIMEOUT_SECS) as u64);
+    let deadline = Instant::now()
+        + Duration::from_secs(scan_timeout.unwrap_or(DEFAULT_SCAN_TIMEOUT_SECS) as u64);
 
     // Devices already reported to `on_found`, so we report each at most once.
     let mut reported: heapless::Vec<BtAddr, 16> = heapless::Vec::new();
 
     let outcome = loop {
         if let Some(result) =
-            report_matching_devices(&om, &adapter_path, filter, &mut reported, &mut on_found).await?
+            report_matching_devices(&om, &adapter_path, filter, &mut reported, &mut on_found)
+                .await?
         {
             break Some(result);
         }
@@ -352,7 +360,9 @@ where
     let _ = adapter.stop_discovery().await;
 
     outcome.ok_or_else(|| {
-        warn!("No commissionable Matter device matching the filter was found within the scan timeout");
+        warn!(
+            "No commissionable Matter device matching the filter was found within the scan timeout"
+        );
         ErrorCode::NoNetworkInterface.into()
     })
 }
@@ -376,7 +386,11 @@ async fn process_c2_indications(
             continue;
         }
 
-        trace!("Received C2 indication from peer {}: {:?}", peer_addr, value);
+        trace!(
+            "Received C2 indication from peer {}: {:?}",
+            peer_addr,
+            value
+        );
 
         btp.process_incoming(gatt_mtu, peer_addr, &value)?;
     }
@@ -512,7 +526,10 @@ where
         // an actual match on the floor.
         let _ = reported.push(addr);
 
-        debug!("Matched commissionable device {} ({}) (adv: {:?})", path, addr, adv);
+        debug!(
+            "Matched commissionable device {} ({}) (adv: {:?})",
+            path, addr, adv
+        );
 
         if let Some(result) = on_found(addr, &adv) {
             return Ok(Some(result));

--- a/rs-matter/src/transport/network/btp/gatt/bluez.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluez.rs
@@ -69,6 +69,17 @@ pub const DEFAULT_SCAN_TIMEOUT_SECS: u16 = 60;
 /// See the note in [`scan`] on why this polls, and on the cost per tick.
 const SCAN_POLL_INTERVAL_MS: u64 = 1000;
 
+/// How many times [`run_central`] will attempt the initial GATT connection before
+/// giving up, and how long it waits between attempts.
+///
+/// A connect issued right after discovery has stopped can lose a race with BlueZ
+/// still tearing the scan down, which surfaces as
+/// `org.bluez.Error.Failed: le-connection-abort-by-local`. The device was just seen
+/// advertising, so a connect failure here is almost always transient - a short,
+/// bounded retry turns it into a non-event instead of a failed commission.
+const CONNECT_ATTEMPTS: u8 = 4;
+const CONNECT_RETRY_DELAY_MS: u64 = 500;
+
 /// Build a `Device1` proxy bound to a specific device object path.
 ///
 /// The BlueZ proxies are declared with `assume_defaults = true`, so their
@@ -229,7 +240,7 @@ pub async fn run_central(
 
     let device = device_proxy(connection, &device_path).await?;
 
-    device.connect().await?;
+    connect_with_retry(&device).await?;
 
     wait_services_resolved(&device).await?;
 
@@ -583,6 +594,27 @@ fn device_path_for(adapter_path: &OwnedObjectPath, addr: BtAddr) -> Result<Owned
     );
 
     Ok(path.try_into()?)
+}
+
+/// Connect to the device, retrying a bounded number of times on transient failures
+/// (notably `le-connection-abort-by-local`; see [`CONNECT_ATTEMPTS`]).
+async fn connect_with_retry(device: &DeviceProxy<'_>) -> Result<(), Error> {
+    for attempt in 1..=CONNECT_ATTEMPTS {
+        match device.connect().await {
+            Ok(()) => return Ok(()),
+            Err(e) if attempt < CONNECT_ATTEMPTS => {
+                warn!(
+                    "Connect attempt {}/{} failed ({:?}); retrying",
+                    attempt, CONNECT_ATTEMPTS, e
+                );
+                Timer::after(Duration::from_millis(CONNECT_RETRY_DELAY_MS)).await;
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    // Unreachable: the last attempt either returns `Ok` or the `Err` arm above.
+    Err(ErrorCode::NoNetworkInterface.into())
 }
 
 /// Wait until the device reports that its GATT services have been resolved.

--- a/rs-matter/src/transport/network/btp/gatt/bluez.rs
+++ b/rs-matter/src/transport/network/btp/gatt/bluez.rs
@@ -341,23 +341,33 @@ where
     // Devices already reported to `on_found`, so we report each at most once.
     let mut reported: heapless::Vec<BtAddr, 16> = heapless::Vec::new();
 
-    let outcome = loop {
-        if let Some(result) =
-            report_matching_devices(&om, &adapter_path, filter, &mut reported, &mut on_found)
-                .await?
-        {
-            break Some(result);
-        }
+    // NOTE: the polling loop is wrapped so that discovery is stopped on *every* way
+    // out, errors included. A leaked discovery does more than waste power: BlueZ
+    // fails a connect that races an active discovery with
+    // `le-connection-abort-by-local`, so it would break the very next
+    // `run_central`.
+    let outcome: Result<Option<R>, Error> = async {
+        loop {
+            if let Some(result) =
+                report_matching_devices(&om, &adapter_path, filter, &mut reported, &mut on_found)
+                    .await?
+            {
+                return Ok(Some(result));
+            }
 
-        if Instant::now() >= deadline {
-            break None;
-        }
+            if Instant::now() >= deadline {
+                return Ok(None);
+            }
 
-        Timer::after(Duration::from_millis(250)).await;
-    };
+            Timer::after(Duration::from_millis(250)).await;
+        }
+    }
+    .await;
 
     // Stop discovery (best-effort) before returning.
     let _ = adapter.stop_discovery().await;
+
+    let outcome = outcome?;
 
     outcome.ok_or_else(|| {
         warn!(

--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -682,15 +682,10 @@ impl Session {
         gatt_mtu: Option<u16>,
         buf: &mut [u8],
     ) -> Result<usize, Error> {
-        // Propose our best MTU and a window size derived from it (the same
-        // computation the responder uses to bound the window). The initiator's
-        // proposed window is the ceiling the responder clamps against, so it must
-        // be a sensible non-zero value - `self.window_size` is still 0 here (the
-        // window is only established once the response arrives), so we must NOT
-        // use it, or we would propose a window of 0 and the peer would reject the
-        // handshake and disconnect.
-        let mtu = gatt_mtu.unwrap_or(MIN_MTU);
-        let window_size = Self::initial_window_size(mtu.saturating_sub(GATT_HEADER_SIZE as u16));
+        let mtu = gatt_mtu
+            .map(|g| g.clamp(MIN_MTU, MAX_MTU))
+            .unwrap_or(MIN_MTU);
+        let window_size = Self::initial_window_size(mtu - GATT_HEADER_SIZE as u16);
 
         let req = HandshakeReq {
             versions: 4,

--- a/rs-matter/src/transport/network/btp/session.rs
+++ b/rs-matter/src/transport/network/btp/session.rs
@@ -429,7 +429,11 @@ impl Session {
         self.version = 0;
         self.mtu = 0;
         self.window_size = 0;
-        self.handshake_pending = false;
+        // Preserve the role across a reset. An initiator (GATT Central) must
+        // re-arm its pending handshake so that the next connection starts with
+        // us sending the Handshake Request; a responder (Peripheral) waits for
+        // the peer's request, so it stays `false`.
+        self.handshake_pending = self.initiator;
         self.recv_window.reset();
         self.send_window.reset();
     }
@@ -438,7 +442,6 @@ impl Session {
         self.relaxed_mtu_nego = relaxed_mtu_nego;
     }
 
-    #[allow(unused)]
     pub fn set_initiator(&mut self, initiator: bool) {
         self.initiator = initiator;
         self.handshake_pending = initiator;
@@ -458,11 +461,35 @@ impl Session {
         self.recv_window.level = window_size;
         self.send_window.window_size = window_size;
         self.send_window.level = window_size;
+
+        if self.initiator {
+            // As the initiator (GATT Central), the peer's Handshake *Response* is,
+            // per the Matter Core spec, the peer's implicit BTP sequence number 0.
+            // So the peer's first *data* segment is seq 1, and we must record that
+            // we've "received" seq 0 - otherwise the sequence-integrity check
+            // rejects the peer's first data packet (it expects seq 0, gets 1).
+            //
+            // (The responder side has no matching adjustment: our Handshake
+            // *Request* carries no sequence number, so the responder correctly
+            // expects our first data segment at seq 0.)
+            self.recv_window.ack_seq = 0;
+        }
     }
 
     /// Return the address of the remote peer.
     pub fn address(&self) -> BtAddr {
         self.address
+    }
+
+    /// Whether the session has been established (its BTP handshake has completed
+    /// and a window has been negotiated).
+    ///
+    /// Until this is true - notably in the window between an initiator sending
+    /// its Handshake Request and receiving the Response - the session has no
+    /// negotiated address/window yet, and outgoing SDUs must be held rather than
+    /// sent or discarded.
+    pub fn is_established(&self) -> bool {
+        self.address != BtAddr([0; 6])
     }
 
     #[allow(unused)]
@@ -655,10 +682,20 @@ impl Session {
         gatt_mtu: Option<u16>,
         buf: &mut [u8],
     ) -> Result<usize, Error> {
+        // Propose our best MTU and a window size derived from it (the same
+        // computation the responder uses to bound the window). The initiator's
+        // proposed window is the ceiling the responder clamps against, so it must
+        // be a sensible non-zero value - `self.window_size` is still 0 here (the
+        // window is only established once the response arrives), so we must NOT
+        // use it, or we would propose a window of 0 and the peer would reject the
+        // handshake and disconnect.
+        let mtu = gatt_mtu.unwrap_or(MIN_MTU);
+        let window_size = Self::initial_window_size(mtu.saturating_sub(GATT_HEADER_SIZE as u16));
+
         let req = HandshakeReq {
             versions: 4,
-            mtu: gatt_mtu.unwrap_or(MIN_MTU),
-            window_size: self.window_size, // TODO
+            mtu,
+            window_size,
         };
 
         let mut wb = WriteBuf::new(buf);
@@ -675,7 +712,13 @@ impl Session {
         hdr.encode(&mut wb)?;
         req.encode(&mut wb)?;
 
-        self.send_window.post_send();
+        // NOTE: unlike the Handshake *Response* (and unlike regular data), we do
+        // NOT `post_send()` here. As the initiator, the send window does not exist
+        // yet at request time - it is established from the peer's Handshake
+        // Response in `process_rx_handshake_resp` -> `setup()`. A `post_send()` on
+        // the still-zero window would underflow `level` (0 - 1). The handshake
+        // request is a pre-window control frame; flow control begins only once the
+        // window is negotiated.
 
         Ok(wb.get_tail())
     }

--- a/rs-matter/src/transport/network/mdns/avahi.rs
+++ b/rs-matter/src/transport/network/mdns/avahi.rs
@@ -45,14 +45,6 @@ use crate::Matter;
 const AVAHI_IF_UNSPEC: i32 = -1;
 /// Avahi constant for "any protocol" (IPv4 or IPv6)
 const AVAHI_PROTO_UNSPEC: i32 = -1;
-/// Avahi address-family constants. `ResolveService` returns a single address in
-/// the requested family, so to gather both (and let the transport prefer IPv6 —
-/// see `score_ip_address`) we resolve once per family.
-const AVAHI_PROTO_INET: i32 = 0;
-const AVAHI_PROTO_INET6: i32 = 1;
-/// Resolve in IPv6-then-IPv4 order so that, on a single-address consumer, the
-/// preferred family is tried first.
-const AVAHI_RESOLVE_PROTOS: [i32; 2] = [AVAHI_PROTO_INET6, AVAHI_PROTO_INET];
 
 /// Interval (ms) at which a running browse re-checks whether it is still in
 /// flight (first match consumed, or caller timed out / dropped).
@@ -116,16 +108,31 @@ impl AvahiMdns {
 
     /// Service operational-resolve requests via Avahi over DBus.
     ///
-    /// Resolves the requested instance (`name`/`type`/`local`) and deposits the
-    /// address + MRP params; retries (with a yield) while the resolve is still in
-    /// flight, since the target may not have answered yet.
+    /// This uses a **live `ServiceBrowser`** on the operational service type
+    /// (`_matter._tcp`) and only resolves the target once the browser reports the
+    /// matching instance appearing — rather than polling Avahi's `ResolveService`
+    /// on the target's name.
+    ///
+    /// That distinction matters a great deal in practice. `ResolveService` on an
+    /// instance that does not exist *yet* blocks for Avahi's full resolve timeout
+    /// (~5 s) before failing, and does not aggressively re-query afterwards — so
+    /// polling it while waiting for a device to come up wastes ~5 s per attempt
+    /// and can lag many tens of seconds behind the record actually being
+    /// published. This is exactly the situation for a device that has just been
+    /// told to join Thread: its operational `_matter._tcp` record appears (via the
+    /// Border Router's SRP advertising proxy) a fraction of a second after it
+    /// attaches, and a browser fires `ItemNew` for it essentially immediately,
+    /// whereas name-resolve polling would only notice it much later. Once the
+    /// instance exists, resolving it is near-instant.
     async fn run_resolve(matter: &Matter<'_>, connection: &Connection) -> Result<(), Error> {
         loop {
             let service = matter.transport().wait_mdns_resolve_request().await;
 
+            // The label we're looking for (e.g. `<compressed-fabric>-<node-id>`),
+            // and the full instance name to deposit under.
             let mut name_buf: heapless::String<128> = heapless::String::new();
             service.instance_name(&mut name_buf);
-            let label = name_buf
+            let target_label = name_buf
                 .split('.')
                 .next()
                 .unwrap_or(name_buf.as_str())
@@ -134,15 +141,51 @@ impl AvahiMdns {
 
             let avahi = Server2Proxy::new(connection).await?;
 
+            // A live browser on the operational service type. `ItemNew` fires as
+            // soon as Avahi sees the record on the wire.
+            let browser_path = avahi
+                .service_browser_prepare(AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, service_type, "", 0)
+                .await?;
+            let browser = ServiceBrowserProxy::builder(connection)
+                .path(browser_path)?
+                .build()
+                .await?;
+            let mut item_new_stream = browser.receive_item_new().await?;
+            browser.start().await?;
+
             while matter.transport().mdns_resolve_in_flight() {
-                // Resolve both address families (Avahi returns one address per
-                // call) and deposit them together; the transport prefers IPv6
-                // (link-local → ULA → global → IPv4) via `score_ip_address`.
-                let (ips, port, txt, scope_id) =
-                    resolve_all_families(&avahi, AVAHI_IF_UNSPEC, &label, service_type).await;
+                let item = pin!(item_new_stream.next());
+                let tick = pin!(Timer::after(Duration::from_millis(BROWSE_POLL_INTERVAL_MS)));
+
+                let signal = match select(item, tick).await {
+                    Either::First(Some(signal)) => signal,
+                    Either::First(None) => break, // browser stream ended
+                    Either::Second(_) => continue, // re-check in-flight
+                };
+
+                let Ok(args) = signal.args() else { continue };
+
+                // Only the instance we're waiting for.
+                if !args.name.eq_ignore_ascii_case(&target_label) {
+                    continue;
+                }
+
+                // The instance exists now, so this resolve is near-instant.
+                let (name, ips, port, txt, scope_id) = resolve_browsed_all_families(
+                    &avahi,
+                    args.interface,
+                    args.protocol,
+                    args.name,
+                    args.type_,
+                    args.domain,
+                )
+                .await;
+
+                let _ = name;
                 if !ips.is_empty() {
                     let txt_pairs = txt_pairs(&txt);
-                    // Match is by the full instance name we requested.
+                    // Deposit under the full requested instance name (the transport
+                    // matches on it). `name` from the browser is the bare label.
                     matter
                         .transport()
                         .try_deposit_mdns_resolve(&MdnsRemoteService {
@@ -153,8 +196,10 @@ impl AvahiMdns {
                             scope_id,
                         });
                 }
+            }
 
-                Timer::after(Duration::from_millis(BROWSE_POLL_INTERVAL_MS)).await;
+            if let Err(e) = browser.free().await {
+                warn!("Failed to free Avahi browser: {:?}", e);
             }
         }
     }
@@ -372,62 +417,19 @@ fn txt_pairs(txt: &[Vec<u8>]) -> Vec<(&str, &str)> {
     pairs
 }
 
-/// Resolve an instance (`label`.`service_type`.local) across both address
-/// families, returning all resolved IPs plus the port and TXT (from the first
-/// successful family). Avahi's `ResolveService` returns a single address per
-/// call, so we call it once per family — see [`AVAHI_RESOLVE_PROTOS`].
-async fn resolve_all_families(
-    avahi: &Server2Proxy<'_>,
-    interface: i32,
-    label: &str,
-    service_type: &str,
-) -> (Vec<IpAddr>, u16, Vec<Vec<u8>>, u32) {
-    let mut ips: Vec<IpAddr> = Vec::new();
-    let mut port = 0u16;
-    let mut txt: Vec<Vec<u8>> = Vec::new();
-    // The interface index of the link-local result, used as the IPv6 scope id so
-    // a `fe80::` address is routable. Avahi returns the interface per resolve;
-    // only link-local needs it.
-    let mut scope_id = 0u32;
-
-    for aproto in AVAHI_RESOLVE_PROTOS {
-        match avahi
-            .resolve_service(
-                interface,
-                AVAHI_PROTO_UNSPEC,
-                label,
-                service_type,
-                "local",
-                aproto,
-                0,
-            )
-            .await
-        {
-            Ok((iface, _proto, _name, _type, _domain, _host, _ap, address, p, t, _fl)) => {
-                if let Ok(ip) = address.parse::<IpAddr>() {
-                    if is_link_local_v6(&ip) && iface > 0 {
-                        scope_id = iface as u32;
-                    }
-                    if !ips.contains(&ip) {
-                        ips.push(ip);
-                    }
-                    port = p;
-                    if txt.is_empty() {
-                        txt = t;
-                    }
-                }
-            }
-            Err(e) => debug!("Avahi resolve of {label} (aproto {aproto}) failed: {e:?}"),
-        }
-    }
-
-    (ips, port, txt, scope_id)
-}
-
-/// Like [`resolve_all_families`] but for a *browsed* instance (identified by the
-/// browser's `name`/`type_`/`domain`), also returning the resolved instance
-/// name. The browser's own `protocol` is passed through for interface/family
-/// scoping; the per-call `aprotocol` still varies to gather both families.
+/// Resolve a *browsed* instance (identified by the browser's
+/// `name`/`type_`/`domain`), returning the resolved instance name plus its
+/// address, port and TXT.
+///
+/// We resolve with `aprotocol = AVAHI_PROTO_UNSPEC` in a **single** call, letting
+/// Avahi return the address it already has for this browsed instance. We do *not*
+/// loop over IPv6 then IPv4: `ResolveService` for an address family the instance
+/// does not have blocks for Avahi's full ~5 s resolve timeout before failing, and
+/// a Thread device typically advertises only an IPv6 (mesh-local) address — so a
+/// per-family loop would stall ~5 s on the missing IPv4 every time, which (given
+/// the caller's own resolve timeout) makes the resolve appear to fail even though
+/// the record is right there. One UNSPEC resolve returns immediately with the
+/// address that exists, which is all CASE needs to reach the peer.
 #[allow(clippy::type_complexity)]
 async fn resolve_browsed_all_families(
     avahi: &Server2Proxy<'_>,
@@ -441,34 +443,36 @@ async fn resolve_browsed_all_families(
     let mut ips: Vec<IpAddr> = Vec::new();
     let mut port = 0u16;
     let mut txt: Vec<Vec<u8>> = Vec::new();
-    // Interface index of the link-local result → IPv6 scope id (see
-    // `resolve_all_families`).
+    // Interface index of a link-local result → IPv6 scope id, so a `fe80::`
+    // address is routable.
     let mut scope_id = 0u32;
 
-    for aproto in AVAHI_RESOLVE_PROTOS {
-        match avahi
-            .resolve_service(interface, protocol, name, type_, domain, aproto, 0)
-            .await
-        {
-            Ok((iface, _proto, rname, _type, _domain, _host, _ap, address, p, t, _fl)) => {
-                if let Ok(ip) = address.parse::<IpAddr>() {
-                    if is_link_local_v6(&ip) && iface > 0 {
-                        scope_id = iface as u32;
-                    }
-                    if !ips.contains(&ip) {
-                        ips.push(ip);
-                    }
-                    instance_name = rname;
-                    port = p;
-                    if txt.is_empty() {
-                        txt = t;
-                    }
-                } else {
-                    warn!("Could not parse IP address: {address}");
+    match avahi
+        .resolve_service(
+            interface,
+            protocol,
+            name,
+            type_,
+            domain,
+            AVAHI_PROTO_UNSPEC,
+            0,
+        )
+        .await
+    {
+        Ok((iface, _proto, rname, _type, _domain, _host, _ap, address, p, t, _fl)) => {
+            if let Ok(ip) = address.parse::<IpAddr>() {
+                if is_link_local_v6(&ip) && iface > 0 {
+                    scope_id = iface as u32;
                 }
+                ips.push(ip);
+                instance_name = rname;
+                port = p;
+                txt = t;
+            } else {
+                warn!("Could not parse IP address: {address}");
             }
-            Err(e) => debug!("Avahi resolve (browsed, aproto {aproto}) failed: {e:?}"),
         }
+        Err(e) => debug!("Avahi resolve (browsed) failed: {e:?}"),
     }
 
     (instance_name, ips, port, txt, scope_id)

--- a/rs-matter/src/transport/network/mdns/avahi.rs
+++ b/rs-matter/src/transport/network/mdns/avahi.rs
@@ -41,6 +41,48 @@ use crate::utils::zbus_proxies::avahi::server2::Server2Proxy;
 use crate::utils::zbus_proxies::avahi::service_browser::ServiceBrowserProxy;
 use crate::Matter;
 
+/// Frees an Avahi `ServiceBrowser` even if the future that owns it is cancelled
+/// (dropped) mid-loop - otherwise the browser leaks on the daemon.
+///
+/// The normal path calls [`BrowserGuard::free`], releasing the browser
+/// asynchronously and disarming the guard. Only a cancellation leaves it armed, in
+/// which case `Drop` frees it with a **blocking** call - safe here because zbus
+/// drives the D-Bus connection's I/O on its own task, independently of the future
+/// being torn down, so `block_on` can complete rather than deadlock. (The same
+/// `block_on`-in-`Drop` idiom is used for D-Bus cleanup elsewhere in the crate, e.g.
+/// the NetworkManager and wpa_supplicant controllers.)
+struct BrowserGuard<'b, 'a> {
+    browser: &'b ServiceBrowserProxy<'a>,
+    armed: bool,
+}
+
+impl<'b, 'a> BrowserGuard<'b, 'a> {
+    fn new(browser: &'b ServiceBrowserProxy<'a>) -> Self {
+        Self {
+            browser,
+            armed: true,
+        }
+    }
+
+    /// Free the browser asynchronously (the non-cancelled path) and disarm the
+    /// blocking `Drop` fallback.
+    async fn free(mut self) {
+        self.armed = false;
+        if let Err(e) = self.browser.free().await {
+            warn!("Failed to free Avahi browser: {:?}", e);
+        }
+    }
+}
+
+impl Drop for BrowserGuard<'_, '_> {
+    fn drop(&mut self) {
+        if self.armed {
+            // Reached only if the future was cancelled before `free` was called.
+            let _ = futures_lite::future::block_on(self.browser.free());
+        }
+    }
+}
+
 /// Avahi constant for "any interface"
 const AVAHI_IF_UNSPEC: i32 = -1;
 /// Avahi constant for "any protocol" (IPv4 or IPv6)
@@ -153,6 +195,9 @@ impl AvahiMdns {
             let mut item_new_stream = browser.receive_item_new().await?;
             browser.start().await?;
 
+            // Frees the browser on cancellation too (see `BrowserGuard`).
+            let guard = BrowserGuard::new(&browser);
+
             while matter.transport().mdns_resolve_in_flight() {
                 let item = pin!(item_new_stream.next());
                 let tick = pin!(Timer::after(Duration::from_millis(BROWSE_POLL_INTERVAL_MS)));
@@ -198,9 +243,7 @@ impl AvahiMdns {
                 }
             }
 
-            if let Err(e) = browser.free().await {
-                warn!("Failed to free Avahi browser: {:?}", e);
-            }
+            guard.free().await;
         }
     }
 
@@ -228,6 +271,9 @@ impl AvahiMdns {
                 .await?;
             let mut item_new_stream = browser.receive_item_new().await?;
             browser.start().await?;
+
+            // Frees the browser on cancellation too (see `BrowserGuard`).
+            let guard = BrowserGuard::new(&browser);
 
             while matter.transport().mdns_browse_in_flight() {
                 let item = pin!(item_new_stream.next());
@@ -268,9 +314,7 @@ impl AvahiMdns {
                 }
             }
 
-            if let Err(e) = browser.free().await {
-                warn!("Failed to free Avahi browser: {:?}", e);
-            }
+            guard.free().await;
         }
     }
 


### PR DESCRIPTION
This PR is seeking to address one of the few remaining gaps of the "build my own commissioner and/or controller with rs-matter" use-case.

Namely, the ability to:
- Scan over BLE for commissionable devices actively advertising themselves (similar to the existing "browse" mDNS code-path)
- Connect (as a GATT Central) over BLE + BTP to such a device and commission it
- Push Operational Network credentials to the accessory

Also:
- Parse a QR string and a pairing code into a QrPayload instance
- Convert a QR image into a QR string