### PR TITLE
Exchange initiators - use a random exchange ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-* Multicast groups support is now under a `groups` opt-in feature to save flash size
-* CASE session resumption support - under a `case-resumption` Cargo feature
-* Persistent subscriptions now supported
+* Exchange initiators - use a random exchange ID (#509)
+* Support for commissioning over BTP (#507)
+* A new - ReportDataHandler - handler for InteractionModel (#506)
+* Multicast groups support is now under a `groups` opt-in feature to save flash size (#505)
+* CASE session resumption support - under a `case-resumption` Cargo feature (#503)
+* Persistent subscriptions now supported (#504)
   * Subscriptions can be persisted and resumed across a reboot (opt-in via a new `persistent-subscriptions` Cargo feature, off by default)
   * New `case-responder-only` Cargo feature (off by default): `Exchange::initiate` never establishes a new CASE session (it only reuses an existing one, else fails), letting the linker drop the CASE initiator and mDNS resolver from a pure accessory that only reports over sessions its peers established
   * Fix: A subscription is no longer pinned to its establishing session which was incorrect
   * Fix: A not-yet-primed subscription with a `MinIntervalFloor` of 0 is now reported immediately instead of never
   * Fix: A failed report no longer advances the subscription's watermark, so the changes/events it was carrying are retried instead of silently dropped
+* Secure Channel Handler (#502)  
 * (Breaking) ICD support: Check-In Protocol, ICD cluster handler, mDNS advertisements (#501)
 * Warn on packet retransmission (#500)
   * (Breaking) Rename feature `debug-tlv-payload` to `log-tlv-payload`

--- a/rs-matter/src/crypto/canon.rs
+++ b/rs-matter/src/crypto/canon.rs
@@ -226,9 +226,9 @@ impl<const N: usize> CryptoSensitive<N> {
 
     /// Zeroizes the cryptographic material held by this instance.
     pub fn zeroize(&mut self) {
-        for b in &mut self.data {
-            *b = 0;
-        }
+        // TODO: Depend on the `zeroize` crate to ensure that the compiler does not optimize this out.
+        // TODO: Implement some sort of pinning to ensure that the compiler does move this type when on-stack.
+        self.data.fill(0);
     }
 
     /// Get a reference to this cryptographic material.

--- a/rs-matter/src/sc.rs
+++ b/rs-matter/src/sc.rs
@@ -356,6 +356,26 @@ impl<C: Crypto, H: AsyncScHandler> ExchangeHandler for SecureChannel<'_, C, H> {
     }
 }
 
+/// Check the opcode of the received message like [`check_opcode`], additionally
+/// reporting a mismatch to the peer with a `StatusReport(FAILURE, INVALID_PARAMETER)`
+/// before bailing out with an error.
+async fn expect_opcode(exchange: &mut Exchange<'_>, opcode: OpCode) -> Result<(), Error> {
+    let result = check_opcode(exchange, opcode);
+
+    if let Err(err) = result {
+        if !exchange.rx()?.meta().is_sc_status() {
+            // Best-effort: the handshake has failed regardless of whether the
+            // report makes it to the peer, and the opcode mismatch is the more
+            // informative error to propagate.
+            let _ = complete_with_status(exchange, SCStatusCodes::InvalidParameter, &[]).await;
+        }
+
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
 /// Check that the opcode of the received message matches the expected one.
 /// Logs an error if that's not the case, and if the opcode is `StatusReport`,
 /// it also logs the details of the status report.

--- a/rs-matter/src/sc/case/responder.rs
+++ b/rs-matter/src/sc/case/responder.rs
@@ -38,7 +38,8 @@ use crate::error::Error;
 #[cfg(feature = "case-resumption")]
 use crate::error::ErrorCode;
 use crate::sc::{
-    check_opcode, complete_with_status, sc_write, OpCode, SCStatusCodes, SessionParameters,
+    check_opcode, complete_with_status, expect_opcode, sc_write, OpCode, SCStatusCodes,
+    SessionParameters,
 };
 #[cfg(feature = "case-resumption")]
 use crate::sc::{GeneralCode, StatusReport};
@@ -304,7 +305,7 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
         exchange: &mut Exchange<'_>,
         mut session: ReservedSession<'_>,
     ) -> Result<(), Error> {
-        check_opcode(exchange, OpCode::CASESigma3)?;
+        expect_opcode(exchange, OpCode::CASESigma3).await?;
 
         let status = exchange.with_state(|state| {
             let sess = exchange.id().session(&mut state.sessions);

--- a/rs-matter/src/sc/pase/responder.rs
+++ b/rs-matter/src/sc/pase/responder.rs
@@ -29,7 +29,7 @@ use crate::crypto::{
 use crate::dm::AttrChangeNotifier;
 use crate::error::{Error, ErrorCode};
 use crate::sc::pase::spake2p::{Spake2P, Spake2pRandom, Spake2pRandomRef, Spake2pSessionKeys};
-use crate::sc::{check_opcode, complete_with_status, OpCode, SCStatusCodes};
+use crate::sc::{check_opcode, complete_with_status, expect_opcode, OpCode, SCStatusCodes};
 use crate::tlv::{get_root_node_struct, FromTLV, OctetStr, TLVElement, TagType, ToTLV};
 use crate::transport::exchange::Exchange;
 use crate::transport::session::{ReservedSession, SessionMode};
@@ -289,7 +289,7 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
     /// closed between PBKDF and Pake1 and the request was silently
     /// dropped.
     async fn handle_pasepake1(&mut self, exchange: &mut Exchange<'_>) -> Result<bool, Error> {
-        check_opcode(exchange, OpCode::PASEPake1)?;
+        expect_opcode(exchange, OpCode::PASEPake1).await?;
 
         let req = get_root_node_struct(exchange.rx()?.payload())?;
         let pake1 = Pake1::from_tlv(&req)?;
@@ -355,7 +355,7 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
         exchange: &mut Exchange<'_>,
         mut session: ReservedSession<'_>,
     ) -> Result<bool, Error> {
-        check_opcode(exchange, OpCode::PASEPake3)?;
+        expect_opcode(exchange, OpCode::PASEPake3).await?;
 
         let req = get_root_node_struct(exchange.rx()?.payload())?;
         let pake3 = Pake3::from_tlv(&req)?;

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -716,7 +716,7 @@ impl Transport {
         })?;
 
         if let Some(session_id) = existing {
-            return self.initiate_for_session(matter, session_id);
+            return self.initiate_for_session(matter, &crypto, session_id);
         }
 
         self.initiate_new_case(matter, crypto, fabric_idx, peer_node_id)
@@ -781,7 +781,7 @@ impl Transport {
             Ok::<_, Error>(session.id)
         })?;
 
-        self.initiate_for_session(matter, session_id)
+        self.initiate_for_session(matter, &crypto, session_id)
     }
 
     /// The `case-responder-only` variant: never establish a new CASE session.
@@ -859,7 +859,7 @@ impl Transport {
         })?;
 
         if let Some(session_id) = existing {
-            return self.initiate_for_session(matter, session_id);
+            return self.initiate_for_session(matter, &crypto, session_id);
         }
 
         // Establish a new PASE session to this peer.
@@ -874,12 +874,13 @@ impl Transport {
                 .ok_or_else(|| Error::from(ErrorCode::NoSession))
         })?;
 
-        self.initiate_for_session(matter, session_id)
+        self.initiate_for_session(matter, &crypto, session_id)
     }
 
-    pub(crate) fn initiate_for_session<'a>(
+    pub(crate) fn initiate_for_session<'a, C: Crypto>(
         &self,
         matter: &'a Matter<'a>,
+        crypto: C,
         session_id: u32,
     ) -> Result<Exchange<'a>, Error> {
         matter.with_state(|state| {
@@ -890,7 +891,7 @@ impl Transport {
                 .filter(|sess| !sess.is_expired())
                 .ok_or(ErrorCode::NoSession)?;
 
-            let exch_id = state.sessions.get_next_exch_id();
+            let exch_id = state.sessions.get_next_exch_id(&crypto)?;
 
             // `unwrap` is safe because we know we have a session or else the early return from above would've triggered
             // The reason why we call `get_for_node` twice is to ensure that we don't waste an `exch_id` in case
@@ -947,9 +948,9 @@ impl Transport {
         crypto: C,
         peer_addr: Address,
     ) -> Result<Exchange<'a>, Error> {
-        let session_id = self.create_plaintext_session(matter, crypto, peer_addr)?;
+        let session_id = self.create_plaintext_session(matter, &crypto, peer_addr)?;
 
-        self.initiate_for_session(matter, session_id)
+        self.initiate_for_session(matter, &crypto, session_id)
     }
 
     /// Create a new unsecured (plain-text) session to a given peer address.
@@ -1468,7 +1469,7 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                         .get_for_rx(&packet.peer, &packet.header.plain))
                     .id;
 
-                    packet.header.proto.exch_id = state.sessions.get_next_exch_id();
+                    packet.header.proto.exch_id = state.sessions.get_next_exch_id(&self.crypto)?;
                     packet.header.proto.set_initiator();
 
                     // See above why `unwrap` is safe
@@ -1997,7 +1998,7 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
         id: u32,
         encode: bool,
     ) -> Result<(), Error> {
-        packet.header.proto.exch_id = sessions.get_next_exch_id();
+        packet.header.proto.exch_id = sessions.get_next_exch_id(&self.crypto)?;
         packet.header.proto.set_initiator();
 
         // It is a responsibility of the caller to ensure that this method is called with a valid session ID

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -716,7 +716,7 @@ impl Transport {
         })?;
 
         if let Some(session_id) = existing {
-            return self.initiate_for_session(matter, &crypto, session_id);
+            return self.initiate_for_session(matter, crypto, session_id);
         }
 
         self.initiate_new_case(matter, crypto, fabric_idx, peer_node_id)
@@ -781,7 +781,7 @@ impl Transport {
             Ok::<_, Error>(session.id)
         })?;
 
-        self.initiate_for_session(matter, &crypto, session_id)
+        self.initiate_for_session(matter, crypto, session_id)
     }
 
     /// The `case-responder-only` variant: never establish a new CASE session.
@@ -859,7 +859,7 @@ impl Transport {
         })?;
 
         if let Some(session_id) = existing {
-            return self.initiate_for_session(matter, &crypto, session_id);
+            return self.initiate_for_session(matter, crypto, session_id);
         }
 
         // Establish a new PASE session to this peer.
@@ -874,7 +874,7 @@ impl Transport {
                 .ok_or_else(|| Error::from(ErrorCode::NoSession))
         })?;
 
-        self.initiate_for_session(matter, &crypto, session_id)
+        self.initiate_for_session(matter, crypto, session_id)
     }
 
     pub(crate) fn initiate_for_session<'a, C: Crypto>(
@@ -891,7 +891,7 @@ impl Transport {
                 .filter(|sess| !sess.is_expired())
                 .ok_or(ErrorCode::NoSession)?;
 
-            let exch_id = state.sessions.get_next_exch_id(&crypto)?;
+            let exch_id = state.sessions.get_next_exch_id(crypto)?;
 
             // `unwrap` is safe because we know we have a session or else the early return from above would've triggered
             // The reason why we call `get_for_node` twice is to ensure that we don't waste an `exch_id` in case
@@ -950,7 +950,7 @@ impl Transport {
     ) -> Result<Exchange<'a>, Error> {
         let session_id = self.create_plaintext_session(matter, &crypto, peer_addr)?;
 
-        self.initiate_for_session(matter, &crypto, session_id)
+        self.initiate_for_session(matter, crypto, session_id)
     }
 
     /// Create a new unsecured (plain-text) session to a given peer address.

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -1138,8 +1138,14 @@ impl<'a> Exchange<'a> {
 
     /// Create a new initiator exchange on the provided Matter stack for the provided session ID.
     #[inline(always)]
-    pub fn initiate_for_session(matter: &'a Matter<'a>, session_id: u32) -> Result<Self, Error> {
-        matter.transport().initiate_for_session(matter, session_id)
+    pub fn initiate_for_session<C: Crypto>(
+        matter: &'a Matter<'a>,
+        crypto: C,
+        session_id: u32,
+    ) -> Result<Self, Error> {
+        matter
+            .transport()
+            .initiate_for_session(matter, crypto, session_id)
     }
 
     /// Create a new initiator exchange on a new plaintext session to

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -948,7 +948,7 @@ impl Sessions {
             group_ctr_store: GroupCtrStore::new(),
             next_sess_unique_id: 0,
             next_sess_id: 1,
-            next_exch_id: 1,
+            next_exch_id: 0,
             #[cfg(feature = "groups")]
             global_group_data_ctr: 0,
         }
@@ -964,7 +964,7 @@ impl Sessions {
             group_ctr_store: GroupCtrStore::new(),
             next_sess_unique_id: 0,
             next_sess_id: 1,
-            next_exch_id: 1,
+            next_exch_id: 0,
             global_group_data_ctr: 0,
         });
         #[cfg(not(feature = "groups"))]
@@ -972,7 +972,7 @@ impl Sessions {
             sessions <- Vec::init(),
             next_sess_unique_id: 0,
             next_sess_id: 1,
-            next_exch_id: 1,
+            next_exch_id: 0,
         });
         r
     }
@@ -984,7 +984,7 @@ impl Sessions {
             self.group_ctr_store = GroupCtrStore::new();
         }
         self.next_sess_id = 1;
-        self.next_exch_id = 1;
+        self.next_exch_id = 0;
         // Deliberately keep `global_group_data_ctr`: a `reset` isn't a
         // factory reset, and rolling it back would break peers that
         // just learned it via MCSP.
@@ -1310,7 +1310,19 @@ impl Sessions {
         next_sess_id
     }
 
-    pub fn get_next_exch_id(&mut self) -> u16 {
+    pub fn get_next_exch_id<C: Crypto>(&mut self, crypto: C) -> Result<u16, Error> {
+        if self.next_exch_id == 0 {
+            // Per the Matter Core spec, the first exchange ID of an initiator
+            // node must be a random integer, with all subsequent ones
+            // incrementing by one. Seeding is lazy because the constructors
+            // have no access to an RNG (`Sessions::new` is `const`).
+            //
+            // `0` is unambiguous as the "not seeded yet" sentinel, because the
+            // counter below never assumes that value.
+            let candidate = crypto.rand()?.next_u32() as u16;
+            self.next_exch_id = if candidate == 0 { 1 } else { candidate };
+        }
+
         let mut next_exch_id: u16;
         loop {
             next_exch_id = self.next_exch_id;
@@ -1334,7 +1346,8 @@ impl Sessions {
                 break;
             }
         }
-        next_exch_id
+
+        Ok(next_exch_id)
     }
 
     pub fn get_session_for_eviction(&mut self) -> Option<&mut Session> {


### PR DESCRIPTION
Alternative fix for the problem behind #407: a restarted rs-matter-based initiator deterministically reused exchange ID `1`, colliding with a stale exchange on the responder and stalling CASE until the client's retry timeout.

- **Randomize the first exchange ID** (spec: *"The first Exchange ID for a given Initiator Node SHALL be a random integer"*). `Sessions::next_exch_id` is now lazily seeded from the RNG on first use (`0` = unseeded sentinel), incrementing thereafter as before. `Exchange::initiate_for_session` now takes `crypto`, consistent with the other `initiate*` APIs.
- **Fail fast on unexpected opcodes**: the PASE/CASE responders now answer an unexpected mid-handshake message (Pake1/Pake3/Sigma3 waits) with `StatusReport(FAILURE, INVALID_PARAMETER)` instead of silently abandoning the exchange, so a confused peer fails immediately rather than timing out. StatusReports are never answered with another StatusReport.