### PR TITLE
Fix CASE Sigma2 retransmissions with randomized ECDSA

### DIFF
--- a/rs-matter/src/sc/case/responder.rs
+++ b/rs-matter/src/sc/case/responder.rs
@@ -232,6 +232,13 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
             self.casep.local_fabric_idx()
         );
 
+        // `send_with` can call its closure again for an MRP retransmission.
+        // ECDSA signing may be randomized, so generate the signature only once
+        // to keep every Sigma2 byte-identical and avoid reusing the Sigma2 AEAD
+        // nonce with different plaintext.
+        let mut signature = MaybeUninit::<CanonPkcSignature>::uninit(); // TODO MEDIUM BUFFER
+        let signature = signature.init_with(CanonPkcSignature::init());
+        let mut signature_generated = false;
         let mut tt_updated = false;
         exchange
             .send_with(|exchange, tw| {
@@ -243,18 +250,19 @@ impl<'a, C: Crypto> CaseResponder<'a, C> {
                         return sc_write(tw, SCStatusCodes::NoSharedTrustRoots, &[]);
                     };
 
-                    let mut signature = MaybeUninit::<CanonPkcSignature>::uninit(); // TODO MEDIUM BUFFER
-                    let signature = signature.init_with(CanonPkcSignature::init());
+                    if !signature_generated {
+                        // Use the remainder of the TX buffer as scratch space for computing the
+                        // signature.
+                        let sign_buf = tw.empty_as_mut_slice();
 
-                    // Use the remainder of the TX buffer as scratch space for computing the signature
-                    let sign_buf = tw.empty_as_mut_slice();
-
-                    self.casep.compute_sigma2_signature(
-                        self.crypto,
-                        fabric,
-                        sign_buf,
-                        signature,
-                    )?;
+                        self.casep.compute_sigma2_signature(
+                            self.crypto,
+                            fabric,
+                            sign_buf,
+                            signature,
+                        )?;
+                        signature_generated = true;
+                    }
 
                     tw.start_struct(&TLVTag::Anonymous)?;
                     tw.str(&TLVTag::Context(1), our_random.access())?;

--- a/rs-matter/tests/case.rs
+++ b/rs-matter/tests/case.rs
@@ -23,6 +23,7 @@ use embassy_futures::select::{select, Either};
 use embassy_time::{Duration, Timer};
 
 use log::info;
+use std::sync::Mutex;
 
 use rs_matter::cert::gen::VALID_FOREVER;
 use rs_matter::cert::MAX_CERT_TLV_AND_ASN1_LEN;
@@ -36,11 +37,13 @@ use rs_matter::onboard::cac::RcacGenerator;
 use rs_matter::onboard::noc::NocGenerator;
 use rs_matter::respond::Responder;
 use rs_matter::sc::case::CaseInitiator;
-use rs_matter::sc::SecureChannel;
+use rs_matter::sc::{OpCode, SecureChannel, PROTO_ID_SECURE_CHANNEL};
 use rs_matter::transport::exchange::Exchange;
-use rs_matter::transport::network::{Address, NoNetwork};
+use rs_matter::transport::network::{Address, NetworkSend, NoNetwork};
+use rs_matter::transport::packet::PacketHdr;
 
 use rs_matter::utils::select::Coalesce;
+use rs_matter::utils::storage::ParseBuf;
 use rs_matter::Matter;
 
 use crate::common::{create_localhost_socket_pair, init_env_logger, run_device_controller};
@@ -51,6 +54,55 @@ mod common;
 const TEST_FABRIC_ID: u64 = 1;
 const CONTROLLER_NODE_ID: u64 = 100;
 const DEVICE_NODE_ID: u64 = 200;
+
+struct DropFirstSigma2<'a> {
+    socket: &'a async_io::Async<std::net::UdpSocket>,
+    enabled: bool,
+    first_two_packets: &'a Mutex<Vec<Vec<u8>>>,
+}
+
+impl NetworkSend for DropFirstSigma2<'_> {
+    async fn send_to(&mut self, data: &[u8], addr: Address) -> Result<(), Error> {
+        if self.enabled {
+            let mut packets = self.first_two_packets.lock().unwrap();
+
+            if packets.is_empty() && is_sigma2(data) {
+                packets.push(data.to_vec());
+
+                // Simulate loss of the initial Sigma2.
+                return Ok(());
+            } else if packets.len() == 1 {
+                if is_sigma2(data) {
+                    packets.push(data.to_vec());
+                } else {
+                    // Do not let a later standalone ACK advance the initiator's
+                    // peer message counter past the pending Sigma2 retry.
+                    return Ok(());
+                }
+            }
+        }
+
+        let mut socket = self.socket;
+        NetworkSend::send_to(&mut socket, data, addr).await
+    }
+}
+
+fn is_sigma2(data: &[u8]) -> bool {
+    let mut data = data.to_vec();
+    let mut pb = ParseBuf::new(data.as_mut_slice());
+    let mut header = PacketHdr::new();
+
+    if header.decode_plain_hdr(&mut pb).is_err()
+        || header
+            .decode_remaining(test_only_crypto(), None, 0, &mut pb)
+            .is_err()
+    {
+        return false;
+    }
+
+    header.proto.proto_id == PROTO_ID_SECURE_CHANNEL
+        && header.proto.proto_opcode == OpCode::CASESigma2 as u8
+}
 
 /// Test that a full CASE handshake succeeds between two in-process Matter instances.
 ///
@@ -69,6 +121,19 @@ const DEVICE_NODE_ID: u64 = 200;
 /// `tests/commissioning.rs`.
 #[test]
 fn test_case_handshake() {
+    run_case_handshake_test(false);
+}
+
+/// Test that retransmitting Sigma2 produces the same packet and still completes CASE.
+///
+/// `Exchange::send_with` rebuilds a packet when MRP requests a retransmission.
+/// Dropping the responder's first Sigma2 forces that path.
+#[test]
+fn test_case_handshake_with_sigma2_retransmission() {
+    run_case_handshake_test(true);
+}
+
+fn run_case_handshake_test(drop_first_sigma2: bool) {
     init_env_logger();
 
     futures_lite::future::block_on(async {
@@ -183,10 +248,20 @@ fn test_case_handshake() {
 
         let sc = SecureChannel::new(&crypto, &());
         let responder = Responder::new("device", sc, &device_matter, 0);
+        let first_two_packets = Mutex::new(Vec::new());
 
         let device_fut = async {
             select(
-                device_matter.run(&crypto, &device_socket, &device_socket, NoNetwork),
+                device_matter.run(
+                    &crypto,
+                    DropFirstSigma2 {
+                        socket: &device_socket,
+                        enabled: drop_first_sigma2,
+                        first_two_packets: &first_two_packets,
+                    },
+                    &device_socket,
+                    NoNetwork,
+                ),
                 responder.run::<4>(),
             )
             .coalesce()
@@ -229,9 +304,23 @@ fn test_case_handshake() {
 
         // ---- 7. Run device and controller concurrently ----
 
-        run_device_controller(device_fut, controller_fut)
-            .await
-            .unwrap();
+        let result = run_device_controller(device_fut, controller_fut).await;
+
+        if drop_first_sigma2 {
+            let packets = first_two_packets.lock().unwrap();
+
+            assert_eq!(
+                packets.len(),
+                2,
+                "expected the initial Sigma2 and one retransmission"
+            );
+            assert_eq!(
+                packets[0], packets[1],
+                "CASE Sigma2 must be byte-identical when retransmitted"
+            );
+        }
+
+        result.unwrap();
     });
 }
 


### PR DESCRIPTION
When testing on-boarding of ESP32-C6 to SmartThings hub with Thread protocol I often ended up with "Sigma3 AEAD decrypt failed: InvalidData" errors. The current leading theory for this error is that we end up with some retransmission of Sigma2 messages.

The `exchange.with_state` method documentation states that the closure is expected to produce the exact same message when called multiple times:
https://github.com/project-chip/rs-matter/blob/de83bdc71e92fbc97edbaa5a470a76e2f6ff8cef/rs-matter/src/transport/exchange.rs#L1439

However, the `compute_sigma2_signature` method used inside the closure relies on random number generator when computing the signature:
https://github.com/project-chip/rs-matter/blob/de83bdc71e92fbc97edbaa5a470a76e2f6ff8cef/rs-matter/src/sc/case/responder.rs#L252-L257
https://github.com/project-chip/rs-matter/blob/de83bdc71e92fbc97edbaa5a470a76e2f6ff8cef/rs-matter/src/crypto/backend/mbedtls.rs#L1310-L1319

There's a prior art for computing Sigma3 signature outside of the `exchange.with_state` closure:
https://github.com/project-chip/rs-matter/blob/de83bdc71e92fbc97edbaa5a470a76e2f6ff8cef/rs-matter/src/sc/case/initiator.rs#L439-L451

That said, this PR tries to move the signature computation outside of the `exchange.with_state` closure to resolve the issue. It also updates the handshake test to simulate the packet drop. Most of the code was written by Codex with GPT 5.6 Sol model, so take it with grain of salt. I'm more than happy to accomodate any changes requested or close this PR in favor of an alternative fix if one is proposed.