### PR TITLE
Matter 1.6 Groupcast support

### DIFF
--- a/examples/src/bin/system_tests.rs
+++ b/examples/src/bin/system_tests.rs
@@ -55,6 +55,7 @@ use rs_matter::dm::clusters::eth_diag::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::fixed_label::{self, FixedLabelEntry, FixedLabelHandler};
 use rs_matter::dm::clusters::gen_comm::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::gen_diag::{self, ClusterHandler as _, GenDiag};
+use rs_matter::dm::clusters::groupcast::{self, ClusterHandler as _, GroupcastHandler};
 use rs_matter::dm::clusters::groups::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::grp_key_mgmt::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::icd_mgmt::{ClusterHandler as _, Icd, IcdMgmtHandler, IcdModeConfig};
@@ -99,8 +100,8 @@ use rs_matter::dm::endpoints::{self, ROOT_ENDPOINT_ID};
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::{
-    Async, AttrChangeNotifier, Cluster, DataModel, Dataver, Endpoint, EpClMatcher, Node,
-    SemanticTag,
+    Async, AttrChangeNotifier, Cluster, DataModel, Dataver, DeviceType, Endpoint, EpClMatcher,
+    Node, SemanticTag,
 };
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::PROTO_ID_INTERACTION_MODEL;
@@ -315,7 +316,14 @@ fn main() -> Result<(), Error> {
     let dlog_buffers: &MatterBuffers<2> = DLOG_BUFFERS.uninit().init_with(MatterBuffers::init());
 
     let app_pipe = parse_app_pipe_override();
-    let node: &'static Node<'static> = if app_pipe.is_some() {
+
+    // `--groupcast` (mirroring upstream's dedicated groupcast app variants)
+    // selects the Groupcast-enabled composition - see `NODE_GROUPCAST`.
+    let groupcast = std::env::args().any(|arg| arg == "--groupcast");
+
+    let node: &'static Node<'static> = if groupcast {
+        &NODE_GROUPCAST
+    } else if app_pipe.is_some() {
         &NODE_BINFO_PROVISIONAL
     } else {
         &NODE
@@ -652,108 +660,151 @@ const DESC_CLUSTER_TAGS_AND_UNIQUE_ID: Cluster<'static> =
         desc::AttributeId::TagList | desc::AttributeId::EndpointUniqueID
     ));
 
+/// The device types of EP0: Root Node + the OTA roles + Power Source.
+///
+/// EP0 hosts the OTA Provider (0x0029) and Requestor (0x002A) clusters for
+/// the `OTA_*` itests. Declaring the matching device types alongside the
+/// Root Node makes them part of this endpoint's composition rather than
+/// "extra" clusters, which `TC_IDM_10_5` (device-type conformance) rejects.
+/// `DEV_TYPE_POWER_SOURCE` is declared alongside Root Node per Device
+/// Library 2.1.4 for the same reason.
+const EP0_DEVICE_TYPES: &[DeviceType] = devices!(
+    DEV_TYPE_ROOT_NODE,
+    DEV_TYPE_OTA_REQUESTOR,
+    DEV_TYPE_OTA_PROVIDER,
+    DEV_TYPE_POWER_SOURCE
+);
+
+/// The EP0 cluster set of the default [`NODE`]:
+/// - `TimeSynchronization` claims `TIME_SYNC_CLIENT` so the device advertises
+///   `TrustedTimeSource` + `SetTrustedTimeSource` — exercised by
+///   `TC_TIMESYNC_2_13`, consumed by [`time_sync::client::TimeSyncClient`];
+/// - `Groups` is re-added because `TestGroupMessaging` exercises
+///   group-addressed writes against root-endpoint attributes;
+/// - OTA Provider/Requestor are always present, inert unless the OTA harness
+///   passes `--filepath` / `--otaDownloadPath`;
+/// - Diagnostic Logs serves logs only when started with the log-file flags;
+/// - ICD Management (Check-In Protocol only) for the `TC_ICDM_*` itests;
+/// - PowerSource (featureless/wired) for `TC_PS_2_3` and
+///   `is_battery_powered()`-style probes.
+const EP0_CLUSTERS: &[Cluster<'static>] = clusters!(
+    eth,
+    time_sync(time_zone, time_sync_client);
+    groups::GroupsHandler::CLUSTER,
+    user_label::CLUSTER,
+    binding::CLUSTER,
+    OTA_PROVIDER_CLUSTER,
+    OTA_REQUESTOR_CLUSTER,
+    DIAGNOSTIC_LOGS_CLUSTER,
+    ICD_MGMT_CLUSTER,
+    power_source::CLUSTER
+);
+
+/// The EP0 cluster set of [`NODE_GROUPCAST`] (selected via the `--groupcast`
+/// flag, mirroring upstream's dedicated groupcast-enabled app variants):
+/// [`EP0_CLUSTERS`] plus
+/// - the Groupcast cluster (0x0065, provisional) with all three features
+///   (Listener + Sender + PerGroup), for the `TC_GC_*` itests;
+/// - `acl(aux)`: the Access Control cluster advertises the provisional
+///   `AUXILIARY` feature + `AuxiliaryACL` attribute, which the Groupcast
+///   cluster synthesizes entries into (`TC_GC_2_2/2_4/2_5` read them;
+///   `TC_ACE_1_6` relies on the access they grant).
+///
+/// This is deliberately NOT the default composition: with `AUXILIARY`
+/// advertised, wildcard-target Group-auth ACL entries no longer cover the
+/// root endpoint (Matter Core spec), which would break `TestGroupMessaging`'s
+/// legacy group-addressed writes to EP0 attributes - upstream likewise runs
+/// that suite against a non-groupcast app.
+const EP0_CLUSTERS_GROUPCAST: &[Cluster<'static>] = clusters!(
+    eth,
+    acl(aux),
+    time_sync(time_zone, time_sync_client);
+    groups::GroupsHandler::CLUSTER,
+    groupcast::GroupcastHandler::CLUSTER,
+    user_label::CLUSTER,
+    binding::CLUSTER,
+    OTA_PROVIDER_CLUSTER,
+    OTA_REQUESTOR_CLUSTER,
+    DIAGNOSTIC_LOGS_CLUSTER,
+    ICD_MGMT_CLUSTER,
+    power_source::CLUSTER
+);
+
+/// Build the EP0 endpoint for the given cluster set.
+///
+/// `Binding` (cluster ID 0x001E) is wired on EP0 too because `TestBinding`
+/// exercises writes against both endpoints and asserts per-endpoint
+/// isolation. Pairing Binding-server with a client cluster declaration in
+/// `client_clusters` is the rs-matter way to advertise "this endpoint will
+/// initiate `OnOff` interactions" via `Descriptor::ClientList`.
+const fn ep0(clusters: &'static [Cluster<'static>]) -> Endpoint<'static> {
+    Endpoint::new_with_clients(
+        ROOT_ENDPOINT_ID,
+        EP0_DEVICE_TYPES,
+        clusters,
+        &[on_off::FULL_CLUSTER.id],
+    )
+}
+
 const NODE: Node<'static> = Node {
-    endpoints: &[
-        // `Binding` (cluster ID 0x001E) is wired on EP0 too because
-        // `TestBinding` exercises writes against both endpoints
-        // (see step "Write binding table (endpoint 0)" in the
-        // YAML) and asserts per-endpoint isolation. Pairing
-        // Binding-server with a client cluster declaration in
-        // `client_clusters` is the rs-matter way to advertise
-        // "this endpoint will initiate `OnOff` interactions" via
-        // `Descriptor::ClientList`.
-        Endpoint::new_with_clients(
-            ROOT_ENDPOINT_ID,
-            // EP0 hosts the OTA Provider (0x0029) and Requestor (0x002A) clusters for
-            // the `OTA_*` itests. Declaring the matching device types alongside the
-            // Root Node makes them part of this endpoint's composition rather than
-            // "extra" clusters, which `TC_IDM_10_5` (device-type conformance) rejects.
-            devices!(
-                DEV_TYPE_ROOT_NODE,
-                DEV_TYPE_OTA_REQUESTOR,
-                DEV_TYPE_OTA_PROVIDER,
-                // Declared alongside Root Node per Device Library 2.1.4; makes
-                // the `PowerSource` cluster below part of the endpoint's
-                // composition rather than an undeclared extra (`TC_IDM_10_5`).
-                DEV_TYPE_POWER_SOURCE
-            ),
-            clusters!(
-                eth,
-                // Claim `TimeSynchronization.TIME_SYNC_CLIENT`
-                // (Matter Core Spec) so the device advertises the
-                // `TrustedTimeSource` attribute + `SetTrustedTimeSource`
-                // command — exercised by `TC_TIMESYNC_2_13` and
-                // consumed by [`time_sync::client::TimeSyncClient`].
-                time_sync(time_zone, time_sync_client);
-                groups::GroupsHandler::CLUSTER,
-                user_label::CLUSTER,
-                binding::CLUSTER,
-                // OTA Software Update Provider (0x0029) + Requestor (0x002A) for
-                // the `OTA_*` itests. Always present (matter permits extra
-                // clusters on an endpoint); inert unless the OTA harness drives
-                // them via `--filepath` / `--otaDownloadPath`. The OTA test's
-                // `AnnounceOTAProvider` targets endpoint 0, so they live here.
-                OTA_PROVIDER_CLUSTER,
-                OTA_REQUESTOR_CLUSTER,
-                // Diagnostic Logs (0x0032) for the `TestDiagnosticLogs` itest.
-                // Always present; serves logs only when started with the log-file
-                // flags, otherwise answers `NoLogs`.
-                DIAGNOSTIC_LOGS_CLUSTER,
-                // ICD Management (0x0046), Check-In Protocol only, for the
-                // `TC_ICDM_*` itests.
-                ICD_MGMT_CLUSTER,
-                // PowerSource (0x002F), featureless/wired, for `TC_PS_2_3` and
-                // for `is_battery_powered()`-style probes by test helpers.
-                power_source::CLUSTER
-            ),
-            &[on_off::FULL_CLUSTER.id],
-        ),
-        // `FixedLabel` (cluster ID 0x0040) is wired on EP1 because
-        // `TC_FLABEL_2_1` runs with `--endpoint 1` and skips cleanly
-        // via `has_attribute(FixedLabel.LabelList)` when the cluster
-        // is absent; adding it here turns the skip into an actual
-        // content + read-only-write check.
-        //
-        // `Binding` is wired on EP1 to satisfy `TestBinding`, which
-        // writes/reads its primary table here. Paired with a
-        // client-cluster declaration so `Descriptor::ClientList`
-        // truthfully advertises the intent to control OnOff bulbs.
-        Endpoint::new_with_clients(
-            1,
-            devices!(DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_POWER_SOURCE),
-            clusters!(
-                DESC_CLUSTER_TAGS_AND_UNIQUE_ID,
-                identify::CLUSTER,
-                groups::GroupsHandler::CLUSTER,
-                fixed_label::CLUSTER,
-                binding::CLUSTER,
-                TestOnOffDeviceLogic::CLUSTER,
-                // Mandatory for the On/Off Light device type
-                SCENES_FULL_CLUSTER,
-                UnitTestingHandler::CLUSTER,
-                // Second PowerSource instance (see `POWER_SOURCE_EP1`).
-                power_source::CLUSTER
-            ),
-            &[on_off::FULL_CLUSTER.id],
-        )
-        .with_tags(TAGS_EP1)
-        .with_unique_id(UNIQUE_ID_EP1),
-        Endpoint::new(
-            2,
-            devices!(DEV_TYPE_ON_OFF_LIGHT),
-            clusters!(
-                DESC_CLUSTER_TAGS_AND_UNIQUE_ID,
-                identify::CLUSTER,
-                groups::GroupsHandler::CLUSTER,
-                TestOnOffDeviceLogic::CLUSTER,
-                // Mandatory for the On/Off Light device type
-                SCENES_FULL_CLUSTER
-            ),
-        )
-        .with_tags(TAGS_EP2)
-        .with_unique_id(UNIQUE_ID_EP2),
-    ],
+    endpoints: &[ep0(EP0_CLUSTERS), EP1, EP2],
 };
+
+/// Like [`NODE`], but with the Groupcast cluster (and the aux-ACL-enabled
+/// Access Control metadata) on EP0 - see [`EP0_CLUSTERS_GROUPCAST`].
+/// Selected via the `--groupcast` flag, which only the `TC_GC_*` (and,
+/// later, `TC_ACE_1_6`) itests pass.
+const NODE_GROUPCAST: Node<'static> = Node {
+    endpoints: &[ep0(EP0_CLUSTERS_GROUPCAST), EP1, EP2],
+};
+
+/// EP1 of all node variants.
+///
+/// `FixedLabel` (cluster ID 0x0040) is wired on EP1 because `TC_FLABEL_2_1`
+/// runs with `--endpoint 1` and skips cleanly via
+/// `has_attribute(FixedLabel.LabelList)` when the cluster is absent; adding
+/// it here turns the skip into an actual content + read-only-write check.
+///
+/// `Binding` is wired on EP1 to satisfy `TestBinding`, which writes/reads its
+/// primary table here. Paired with a client-cluster declaration so
+/// `Descriptor::ClientList` truthfully advertises the intent to control OnOff
+/// bulbs.
+const EP1: Endpoint<'static> = Endpoint::new_with_clients(
+    1,
+    devices!(DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_POWER_SOURCE),
+    clusters!(
+        DESC_CLUSTER_TAGS_AND_UNIQUE_ID,
+        identify::CLUSTER,
+        groups::GroupsHandler::CLUSTER,
+        fixed_label::CLUSTER,
+        binding::CLUSTER,
+        TestOnOffDeviceLogic::CLUSTER,
+        // Mandatory for the On/Off Light device type
+        SCENES_FULL_CLUSTER,
+        UnitTestingHandler::CLUSTER,
+        // Second PowerSource instance (see `POWER_SOURCE_EP1`).
+        power_source::CLUSTER
+    ),
+    &[on_off::FULL_CLUSTER.id],
+)
+.with_tags(TAGS_EP1)
+.with_unique_id(UNIQUE_ID_EP1);
+
+/// EP2 of all node variants.
+const EP2: Endpoint<'static> = Endpoint::new(
+    2,
+    devices!(DEV_TYPE_ON_OFF_LIGHT),
+    clusters!(
+        DESC_CLUSTER_TAGS_AND_UNIQUE_ID,
+        identify::CLUSTER,
+        groups::GroupsHandler::CLUSTER,
+        TestOnOffDeviceLogic::CLUSTER,
+        // Mandatory for the On/Off Light device type
+        SCENES_FULL_CLUSTER
+    ),
+)
+.with_tags(TAGS_EP2)
+.with_unique_id(UNIQUE_ID_EP2);
 
 /// The OTA Software Update Provider cluster metadata, exactly as served by
 /// [`OtaProviderHandler`] (so `NODE`'s declaration matches the handler).
@@ -857,50 +908,8 @@ const NODE_BINFO_PROVISIONAL: Node<'static> = Node {
             ),
             &[on_off::FULL_CLUSTER.id],
         ),
-        // `FixedLabel` (cluster ID 0x0040) is wired on EP1 because
-        // `TC_FLABEL_2_1` runs with `--endpoint 1` and skips cleanly
-        // via `has_attribute(FixedLabel.LabelList)` when the cluster
-        // is absent; adding it here turns the skip into an actual
-        // content + read-only-write check.
-        //
-        // `Binding` is wired on EP1 to satisfy `TestBinding`, which
-        // writes/reads its primary table here. Paired with a
-        // client-cluster declaration so `Descriptor::ClientList`
-        // truthfully advertises the intent to control OnOff bulbs.
-        Endpoint::new_with_clients(
-            1,
-            devices!(DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_POWER_SOURCE),
-            clusters!(
-                DESC_CLUSTER_TAGS_AND_UNIQUE_ID,
-                identify::CLUSTER,
-                groups::GroupsHandler::CLUSTER,
-                fixed_label::CLUSTER,
-                binding::CLUSTER,
-                TestOnOffDeviceLogic::CLUSTER,
-                // Mandatory for the On/Off Light device type
-                SCENES_FULL_CLUSTER,
-                UnitTestingHandler::CLUSTER,
-                // Second PowerSource instance (see `POWER_SOURCE_EP1`).
-                power_source::CLUSTER
-            ),
-            &[on_off::FULL_CLUSTER.id],
-        )
-        .with_tags(TAGS_EP1)
-        .with_unique_id(UNIQUE_ID_EP1),
-        Endpoint::new(
-            2,
-            devices!(DEV_TYPE_ON_OFF_LIGHT),
-            clusters!(
-                DESC_CLUSTER_TAGS_AND_UNIQUE_ID,
-                identify::CLUSTER,
-                groups::GroupsHandler::CLUSTER,
-                TestOnOffDeviceLogic::CLUSTER,
-                // Mandatory for the On/Off Light device type
-                SCENES_FULL_CLUSTER
-            ),
-        )
-        .with_tags(TAGS_EP2)
-        .with_unique_id(UNIQUE_ID_EP2),
+        EP1,
+        EP2,
     ],
 };
 
@@ -964,6 +973,18 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                 ),
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
+            // Groupcast at the root endpoint - the unified group-management
+            // interface over the same per-fabric group table Groups uses.
+            .chain(
+                EpClMatcher::new(
+                    Some(ROOT_ENDPOINT_ID),
+                    Some(groupcast::GroupcastHandler::CLUSTER.id),
+                ),
+                Async(
+                    GroupcastHandler::new(Dataver::new_rand(&mut rand), groupcast::Feature::all())
+                        .adapt(),
+                ),
+            )
             // UserLabel handler at the root endpoint. Wired here for
             // the same per-fixture-exception reason as Groups above:
             // `TestUserLabelClusterConstraints` and the persistence-
@@ -995,6 +1016,18 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             .chain(
                 EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+            )
+            // Groupcast at the root endpoint - the unified group-management
+            // interface over the same per-fabric group table Groups uses.
+            .chain(
+                EpClMatcher::new(
+                    Some(ROOT_ENDPOINT_ID),
+                    Some(groupcast::GroupcastHandler::CLUSTER.id),
+                ),
+                Async(
+                    GroupcastHandler::new(Dataver::new_rand(&mut rand), groupcast::Feature::all())
+                        .adapt(),
+                ),
             )
             .chain(
                 EpClMatcher::new(Some(1), Some(fixed_label::CLUSTER.id)),
@@ -1036,6 +1069,18 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             .chain(
                 EpClMatcher::new(Some(2), Some(groups::GroupsHandler::CLUSTER.id)),
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+            )
+            // Groupcast at the root endpoint - the unified group-management
+            // interface over the same per-fabric group table Groups uses.
+            .chain(
+                EpClMatcher::new(
+                    Some(ROOT_ENDPOINT_ID),
+                    Some(groupcast::GroupcastHandler::CLUSTER.id),
+                ),
+                Async(
+                    GroupcastHandler::new(Dataver::new_rand(&mut rand), groupcast::Feature::all())
+                        .adapt(),
+                ),
             )
             .chain(
                 EpClMatcher::new(Some(2), Some(TestOnOffDeviceLogic::CLUSTER.id)),

--- a/examples/src/bin/system_tests.rs
+++ b/examples/src/bin/system_tests.rs
@@ -1017,18 +1017,6 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                 EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
-            // Groupcast at the root endpoint - the unified group-management
-            // interface over the same per-fabric group table Groups uses.
-            .chain(
-                EpClMatcher::new(
-                    Some(ROOT_ENDPOINT_ID),
-                    Some(groupcast::GroupcastHandler::CLUSTER.id),
-                ),
-                Async(
-                    GroupcastHandler::new(Dataver::new_rand(&mut rand), groupcast::Feature::all())
-                        .adapt(),
-                ),
-            )
             .chain(
                 EpClMatcher::new(Some(1), Some(fixed_label::CLUSTER.id)),
                 Async(
@@ -1069,18 +1057,6 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             .chain(
                 EpClMatcher::new(Some(2), Some(groups::GroupsHandler::CLUSTER.id)),
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
-            )
-            // Groupcast at the root endpoint - the unified group-management
-            // interface over the same per-fabric group table Groups uses.
-            .chain(
-                EpClMatcher::new(
-                    Some(ROOT_ENDPOINT_ID),
-                    Some(groupcast::GroupcastHandler::CLUSTER.id),
-                ),
-                Async(
-                    GroupcastHandler::new(Dataver::new_rand(&mut rand), groupcast::Feature::all())
-                        .adapt(),
-                ),
             )
             .chain(
                 EpClMatcher::new(Some(2), Some(TestOnOffDeviceLogic::CLUSTER.id)),

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -324,6 +324,8 @@ impl defmt::Format for AccessorSubjects {
 pub struct Accessor<'a> {
     /// The fabric index of the accessor
     pub(crate) fab_idx: u8,
+    /// Whether AUX ACL was enabled at the time this accessor was instantiated
+    aux_acl_enabled: bool,
     /// Accessor's subject: could be node-id, NoC CAT, group id
     subjects: AccessorSubjects,
     /// The auth mode of this session. Might be `None` for plain-text sessions
@@ -335,7 +337,7 @@ pub struct Accessor<'a> {
 
 impl<'a> Accessor<'a> {
     /// Create a new Accessor object for the given session
-    pub fn for_session(session: &Session, matter: &'a Matter<'a>) -> Self {
+    pub fn for_session(session: &Session, matter: &'a Matter<'a>, aux_acl_enabled: bool) -> Self {
         match session.get_session_mode() {
             SessionMode::Case {
                 fab_idx, cat_ids, ..
@@ -347,21 +349,31 @@ impl<'a> Accessor<'a> {
                         let _ = subject.add_catid(i);
                     }
                 }
-                Accessor::new(fab_idx.get(), subject, Some(AuthMode::Case), matter)
+                Accessor::new(
+                    fab_idx.get(),
+                    aux_acl_enabled,
+                    subject,
+                    Some(AuthMode::Case),
+                    matter,
+                )
             }
             SessionMode::Pase { fab_idx } => Accessor::new(
                 *fab_idx,
+                aux_acl_enabled,
                 AccessorSubjects::new(1),
                 Some(AuthMode::Pase),
                 matter,
             ),
             SessionMode::Group { fab_idx, group_id } => Accessor::new(
                 fab_idx.get(),
+                aux_acl_enabled,
                 AccessorSubjects::new(*group_id as u64),
                 Some(AuthMode::Group),
                 matter,
             ),
-            SessionMode::PlainText => Accessor::new(0, AccessorSubjects::new(1), None, matter),
+            SessionMode::PlainText => {
+                Accessor::new(0, aux_acl_enabled, AccessorSubjects::new(1), None, matter)
+            }
         }
     }
 
@@ -369,17 +381,20 @@ impl<'a> Accessor<'a> {
     ///
     /// # Arguments
     /// - `fab_idx`: The fabric index of the accessor (0 means no fabric index)
+    /// - `aux_acl_enabled`: Whether AUX ACL was enabled at the time this accessor was instantiated
     /// - `subjects`: The subjects of the accessor
     /// - `auth_mode`: The auth mode of the accessor
     /// - `matter`: The Matter instance
     pub const fn new(
         fab_idx: u8,
+        aux_acl_enabled: bool,
         subjects: AccessorSubjects,
         auth_mode: Option<AuthMode>,
         matter: &'a Matter<'a>,
     ) -> Self {
         Self {
             fab_idx,
+            aux_acl_enabled,
             subjects,
             auth_mode,
             matter,
@@ -388,6 +403,11 @@ impl<'a> Accessor<'a> {
 
     pub fn fab_idx(&self) -> Result<NonZeroU8, Error> {
         NonZeroU8::new(self.fab_idx).ok_or(ErrorCode::UnsupportedAccess.into())
+    }
+
+    /// Return whether AUX ACL was enabled at the time this accessor was instantiated
+    pub const fn aux_acl_enabled(&self) -> bool {
+        self.aux_acl_enabled
     }
 
     /// Return the subjects of the accessor
@@ -474,7 +494,6 @@ pub struct AccessDesc<'a> {
     /// The target permissions
     target_perms: Option<Access>,
     // The operation being done
-    // TODO: Currently this is Access, but we need a way to represent the 'invoke' somehow too
     operation: Access,
     /// The device types of the endpoint hosting `path`. Used by ACL `Target`
     /// entries that filter by `DeviceType` (Matter Core spec).
@@ -540,11 +559,10 @@ impl<'a> AccessReq<'a> {
     /// permissions
     pub fn allow(&self) -> bool {
         self.accessor.matter.with_state(|state| {
-            let allow = state.fabrics.allow(self);
+            let allow = state.fabrics.allow(self, self.accessor.aux_acl_enabled());
 
             #[cfg(feature = "groups")]
-            let allow = allow
-                || state.fabrics.aux_acl_enabled && self.allow_groupcast_auxiliary(&state.fabrics);
+            let allow = allow || self.allow_groupcast_auxiliary(&state.fabrics);
 
             allow
         })
@@ -557,6 +575,10 @@ impl<'a> AccessReq<'a> {
     /// the Matter Core spec).
     #[cfg(feature = "groups")]
     fn allow_groupcast_auxiliary(&self, fabrics: &crate::fabric::Fabrics) -> bool {
+        if !self.accessor.aux_acl_enabled() {
+            return false;
+        }
+
         if self.accessor.auth_mode != Some(AuthMode::Group) {
             return false;
         }
@@ -872,11 +894,11 @@ impl AclEntry {
 
     /// Check if the ACL entry allows access to the given accessor and object
     ///
-    /// `aux_feature` conveys whether the node advertises the Access Control
+    /// `aux_acl_enabled` conveys whether the node advertises the Access Control
     /// cluster's `AUXILIARY` feature, which changes how wildcard-target
     /// Group-auth entries are evaluated - see [`Self::match_access_desc`].
-    pub fn allow(&self, req: &AccessReq, aux_feature: bool) -> bool {
-        self.match_accessor(req.accessor) && self.match_access_desc(&req.object, aux_feature)
+    pub fn allow(&self, req: &AccessReq, aux_acl_enabled: bool) -> bool {
+        self.match_accessor(req.accessor) && self.match_access_desc(&req.object, aux_acl_enabled)
     }
 
     /// Add a subject to the ACL entry
@@ -925,13 +947,13 @@ impl AclEntry {
                 .unwrap_or(false)
     }
 
-    fn match_access_desc(&self, object: &AccessDesc, aux_feature: bool) -> bool {
+    fn match_access_desc(&self, object: &AccessDesc, aux_acl_enabled: bool) -> bool {
         // Per the Matter Core spec, when the Access Control cluster's
         // `AUXILIARY` feature is advertised, an empty (wildcard) targets
         // list on a Group-auth entry grants access to all endpoints
         // *except* the root endpoint; without the feature it covers the
         // whole node. (Explicitly-listed targets are unaffected.)
-        if aux_feature
+        if aux_acl_enabled
             && matches!(self.auth_mode, AuthMode::Group)
             && object.path.endpoint == Some(crate::dm::endpoints::ROOT_ENDPOINT_ID)
             && self
@@ -1020,6 +1042,7 @@ pub(crate) mod tests {
         let matter = test_matter();
         let accessor = Accessor::new(
             0,
+            false,
             AccessorSubjects::new(112233),
             Some(AuthMode::Pase),
             &matter,
@@ -1033,6 +1056,7 @@ pub(crate) mod tests {
 
         let accessor = Accessor::new(
             2,
+            false,
             AccessorSubjects::new(112233),
             Some(AuthMode::Case),
             &matter,
@@ -1077,6 +1101,7 @@ pub(crate) mod tests {
 
         let accessor = Accessor::new(
             1,
+            false,
             AccessorSubjects::new(112233),
             Some(AuthMode::Case),
             &matter,
@@ -1113,7 +1138,7 @@ pub(crate) mod tests {
         let mut subjects = AccessorSubjects::new(112233);
         subjects.add_catid(gen_noc_cat(allow_cat, v2)).unwrap();
 
-        let accessor = Accessor::new(1, subjects, Some(AuthMode::Case), &matter);
+        let accessor = Accessor::new(1, false, subjects, Some(AuthMode::Case), &matter);
         let path = GenericPath::new(Some(1), Some(1234), None);
         let mut req = AccessReq::new(&accessor, path, Access::READ, &[]);
         req.set_target_perms(Access::RWVA);
@@ -1153,7 +1178,7 @@ pub(crate) mod tests {
         let mut subjects = AccessorSubjects::new(112233);
         subjects.add_catid(gen_noc_cat(allow_cat, v3)).unwrap();
 
-        let accessor = Accessor::new(1, subjects, Some(AuthMode::Case), &matter);
+        let accessor = Accessor::new(1, false, subjects, Some(AuthMode::Case), &matter);
         let path = GenericPath::new(Some(1), Some(1234), None);
         let mut req = AccessReq::new(&accessor, path, Access::READ, &[]);
         req.set_target_perms(Access::RWVA);
@@ -1181,6 +1206,7 @@ pub(crate) mod tests {
 
         let accessor = Accessor::new(
             1,
+            false,
             AccessorSubjects::new(112233),
             Some(AuthMode::Case),
             &matter,
@@ -1250,6 +1276,7 @@ pub(crate) mod tests {
 
         let accessor = Accessor::new(
             1,
+            false,
             AccessorSubjects::new(112233),
             Some(AuthMode::Case),
             &matter,
@@ -1302,6 +1329,7 @@ pub(crate) mod tests {
         let path = GenericPath::new(Some(1), Some(1234), None);
         let accessor2 = Accessor::new(
             1,
+            false,
             AccessorSubjects::new(112233),
             Some(AuthMode::Case),
             &matter,
@@ -1310,6 +1338,7 @@ pub(crate) mod tests {
         req1.set_target_perms(Access::RWVA);
         let accessor3 = Accessor::new(
             2,
+            false,
             AccessorSubjects::new(112233),
             Some(AuthMode::Case),
             &matter,
@@ -1352,6 +1381,7 @@ pub(crate) mod tests {
 
         let accessor = Accessor::new(
             FAB_1.get(),
+            false,
             AccessorSubjects::new(GROUP_ID),
             Some(AuthMode::Group),
             &matter,
@@ -1367,7 +1397,13 @@ pub(crate) mod tests {
             assert!(req.allow());
         }
 
-        matter.with_state(|state| state.fabrics.aux_acl_enabled = true);
+        let accessor = Accessor::new(
+            FAB_1.get(),
+            true,
+            AccessorSubjects::new(GROUP_ID),
+            Some(AuthMode::Group),
+            &matter,
+        );
 
         // With the feature: the root endpoint is excluded...
         let mut req = AccessReq::new(&accessor, ep0.clone(), Access::WRITE, &[]);

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -498,15 +498,8 @@ impl<'a> AccessReq<'a> {
     /// the endpoint that hosts `path`; pass an empty slice when this is not
     /// applicable (e.g. for unit tests that don't exercise `DeviceType` ACL
     /// targets).
-    pub const fn new(accessor: &'a Accessor, path: GenericPath, operation: Access) -> Self {
-        Self::new_with_device_types(accessor, path, operation, &[])
-    }
-
-    /// Create an access request object that also carries the device types of
-    /// the access target's endpoint, so that ACL entries with a `Target` of
-    /// kind `DeviceType` can be evaluated.
-    pub const fn new_with_device_types(
-        accessor: &'a Accessor,
+    pub const fn new(
+        accessor: &'a Accessor<'a>,
         path: GenericPath,
         operation: Access,
         device_types: &'a [DeviceType],
@@ -547,20 +540,11 @@ impl<'a> AccessReq<'a> {
     /// permissions
     pub fn allow(&self) -> bool {
         self.accessor.matter.with_state(|state| {
-            // Whether the node advertises the Access Control cluster's
-            // `AUXILIARY` feature; when set, wildcard-target Group-auth
-            // entries no longer cover the root endpoint (Matter Core spec).
-            //
-            // NOTE: entries surfaced via the `AuxiliaryACL` attribute are
-            // *derived* state - checked below against the producing
-            // feature's own state (the Groupcast group table), NOT against a
-            // materialized entry list (rs-matter deliberately does not store
-            // synthesized ACL entries - see `dm::clusters::acl::CLUSTER_AUX`).
-            let allow = state.fabrics.allow(self, state.aux_acl_enabled);
+            let allow = state.fabrics.allow(self);
 
             #[cfg(feature = "groups")]
-            let allow =
-                allow || state.aux_acl_enabled && self.allow_groupcast_auxiliary(&state.fabrics);
+            let allow = allow
+                || state.fabrics.aux_acl_enabled && self.allow_groupcast_auxiliary(&state.fabrics);
 
             allow
         })
@@ -1041,7 +1025,7 @@ pub(crate) mod tests {
             &matter,
         );
         let path = GenericPath::new(Some(1), Some(1234), None);
-        let mut req_pase = AccessReq::new(&accessor, path, Access::READ);
+        let mut req_pase = AccessReq::new(&accessor, path, Access::READ, &[]);
         req_pase.set_target_perms(Access::RWVA);
 
         // Always allow for PASE sessions
@@ -1054,7 +1038,7 @@ pub(crate) mod tests {
             &matter,
         );
         let path = GenericPath::new(Some(1), Some(1234), None);
-        let mut req = AccessReq::new(&accessor, path, Access::READ);
+        let mut req = AccessReq::new(&accessor, path, Access::READ, &[]);
         req.set_target_perms(Access::RWVA);
 
         // Default deny for CASE
@@ -1098,7 +1082,7 @@ pub(crate) mod tests {
             &matter,
         );
         let path = GenericPath::new(Some(1), Some(1234), None);
-        let mut req = AccessReq::new(&accessor, path, Access::READ);
+        let mut req = AccessReq::new(&accessor, path, Access::READ, &[]);
         req.set_target_perms(Access::RWVA);
 
         // Deny for subject mismatch
@@ -1131,7 +1115,7 @@ pub(crate) mod tests {
 
         let accessor = Accessor::new(1, subjects, Some(AuthMode::Case), &matter);
         let path = GenericPath::new(Some(1), Some(1234), None);
-        let mut req = AccessReq::new(&accessor, path, Access::READ);
+        let mut req = AccessReq::new(&accessor, path, Access::READ, &[]);
         req.set_target_perms(Access::RWVA);
 
         // Deny for CAT id mismatch
@@ -1171,7 +1155,7 @@ pub(crate) mod tests {
 
         let accessor = Accessor::new(1, subjects, Some(AuthMode::Case), &matter);
         let path = GenericPath::new(Some(1), Some(1234), None);
-        let mut req = AccessReq::new(&accessor, path, Access::READ);
+        let mut req = AccessReq::new(&accessor, path, Access::READ, &[]);
         req.set_target_perms(Access::RWVA);
 
         // Deny for CAT id mismatch
@@ -1202,7 +1186,7 @@ pub(crate) mod tests {
             &matter,
         );
         let path = GenericPath::new(Some(1), Some(1234), None);
-        let mut req = AccessReq::new(&accessor, path, Access::READ);
+        let mut req = AccessReq::new(&accessor, path, Access::READ, &[]);
         req.set_target_perms(Access::RWVA);
 
         // Deny for target mismatch
@@ -1284,7 +1268,7 @@ pub(crate) mod tests {
         add_acl(&matter, FAB_1, new).unwrap();
 
         // Write on an RWVA without admin access - deny
-        let mut req = AccessReq::new(&accessor, path.clone(), Access::WRITE);
+        let mut req = AccessReq::new(&accessor, path.clone(), Access::WRITE, &[]);
         req.set_target_perms(Access::RWVA);
         assert_eq!(req.allow(), false);
 
@@ -1300,7 +1284,7 @@ pub(crate) mod tests {
         add_acl(&matter, FAB_1, new).unwrap();
 
         // Write on an RWVA with admin access - allow
-        let mut req = AccessReq::new(&accessor, path, Access::WRITE);
+        let mut req = AccessReq::new(&accessor, path, Access::WRITE, &[]);
         req.set_target_perms(Access::RWVA);
         assert_eq!(req.allow(), true);
     }
@@ -1322,7 +1306,7 @@ pub(crate) mod tests {
             Some(AuthMode::Case),
             &matter,
         );
-        let mut req1 = AccessReq::new(&accessor2, path.clone(), Access::READ);
+        let mut req1 = AccessReq::new(&accessor2, path.clone(), Access::READ, &[]);
         req1.set_target_perms(Access::RWVA);
         let accessor3 = Accessor::new(
             2,
@@ -1330,7 +1314,7 @@ pub(crate) mod tests {
             Some(AuthMode::Case),
             &matter,
         );
-        let mut req2 = AccessReq::new(&accessor3, path, Access::READ);
+        let mut req2 = AccessReq::new(&accessor3, path, Access::READ, &[]);
         req2.set_target_perms(Access::RWVA);
 
         // Allow for subject match - target is wildcard - Fabric idx 2
@@ -1378,20 +1362,20 @@ pub(crate) mod tests {
 
         // Without the feature: the wildcard covers the whole node
         for path in [ep0.clone(), ep1.clone()] {
-            let mut req = AccessReq::new(&accessor, path, Access::WRITE);
+            let mut req = AccessReq::new(&accessor, path, Access::WRITE, &[]);
             req.set_target_perms(Access::WO);
             assert!(req.allow());
         }
 
-        matter.with_state(|state| state.aux_acl_enabled = true);
+        matter.with_state(|state| state.fabrics.aux_acl_enabled = true);
 
         // With the feature: the root endpoint is excluded...
-        let mut req = AccessReq::new(&accessor, ep0.clone(), Access::WRITE);
+        let mut req = AccessReq::new(&accessor, ep0.clone(), Access::WRITE, &[]);
         req.set_target_perms(Access::WO);
         assert!(!req.allow());
 
         // ...other endpoints are unaffected...
-        let mut req = AccessReq::new(&accessor, ep1, Access::WRITE);
+        let mut req = AccessReq::new(&accessor, ep1, Access::WRITE, &[]);
         req.set_target_perms(Access::WO);
         assert!(req.allow());
 
@@ -1402,7 +1386,7 @@ pub(crate) mod tests {
         entry.add_target(Target::new(Some(0), None, None)).unwrap();
         add_acl(&matter, FAB_1, entry).unwrap();
 
-        let mut req = AccessReq::new(&accessor, ep0, Access::WRITE);
+        let mut req = AccessReq::new(&accessor, ep0, Access::WRITE, &[]);
         req.set_target_perms(Access::WO);
         assert!(req.allow());
     }

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -546,9 +546,19 @@ impl<'a> AccessReq<'a> {
     /// _accessor_ the necessary privileges to access the target as per its
     /// permissions
     pub fn allow(&self) -> bool {
-        self.accessor
-            .matter
-            .with_state(|state| state.fabrics.allow(self))
+        self.accessor.matter.with_state(|state| {
+            // Whether the node advertises the Access Control cluster's
+            // `AUXILIARY` feature; when set, wildcard-target Group-auth
+            // entries no longer cover the root endpoint (Matter Core spec).
+            //
+            // NOTE: entries surfaced via the `AuxiliaryACL` attribute are
+            // *derived* state - when a producing feature (e.g. a future
+            // Groupcast cluster) exists, its grants are to be checked here
+            // against the producer's own state, NOT against a materialized
+            // entry list (rs-matter deliberately does not store synthesized
+            // ACL entries - see `dm::clusters::acl::CLUSTER_AUX`).
+            state.fabrics.allow(self, state.aux_acl_enabled)
+        })
     }
 }
 
@@ -646,6 +656,14 @@ impl AclEntry {
                 let targets = entry.targets().map_err(|_| ErrorCode::ConstraintError)?.ok_or(ErrorCode::ConstraintError)?;
                 let auxiliary_type = entry.auxiliary_type().map_err(|_| ErrorCode::ConstraintError)?;
 
+                // Per the Matter Core spec, the `AuxiliaryType` field SHALL
+                // NOT be present in entries in the (writable) `ACL`
+                // attribute - it is reserved for the server-generated
+                // entries in `AuxiliaryACL`.
+                if auxiliary_type.is_some() {
+                    Err(ErrorCode::ConstraintError)?;
+                }
+
                 if
                     // As per spec, PASE auth mode is reserved for future use
                     matches!(auth_mode, AccessControlEntryAuthModeEnum::PASE)
@@ -657,7 +675,6 @@ impl AclEntry {
 
                 e.privilege = privilege.into();
                 e.auth_mode = auth_mode.into();
-                e.auxiliary_type = auxiliary_type;
 
                 // Start with null subjects and targets
                 // so that we can keep those to null if we receive empty subjects' array or empty targets' array
@@ -828,8 +845,12 @@ impl AclEntry {
     }
 
     /// Check if the ACL entry allows access to the given accessor and object
-    pub fn allow(&self, req: &AccessReq) -> bool {
-        self.match_accessor(req.accessor) && self.match_access_desc(&req.object)
+    ///
+    /// `aux_feature` conveys whether the node advertises the Access Control
+    /// cluster's `AUXILIARY` feature, which changes how wildcard-target
+    /// Group-auth entries are evaluated - see [`Self::match_access_desc`].
+    pub fn allow(&self, req: &AccessReq, aux_feature: bool) -> bool {
+        self.match_accessor(req.accessor) && self.match_access_desc(&req.object, aux_feature)
     }
 
     /// Add a subject to the ACL entry
@@ -878,7 +899,23 @@ impl AclEntry {
                 .unwrap_or(false)
     }
 
-    fn match_access_desc(&self, object: &AccessDesc) -> bool {
+    fn match_access_desc(&self, object: &AccessDesc, aux_feature: bool) -> bool {
+        // Per the Matter Core spec, when the Access Control cluster's
+        // `AUXILIARY` feature is advertised, an empty (wildcard) targets
+        // list on a Group-auth entry grants access to all endpoints
+        // *except* the root endpoint; without the feature it covers the
+        // whole node. (Explicitly-listed targets are unaffected.)
+        if aux_feature
+            && matches!(self.auth_mode, AuthMode::Group)
+            && object.path.endpoint == Some(crate::dm::endpoints::ROOT_ENDPOINT_ID)
+            && self
+                .targets
+                .as_opt_ref()
+                .is_none_or(|targets| targets.is_empty())
+        {
+            return false;
+        }
+
         let allow = self.targets.as_opt_ref().is_none_or(|targets| {
             // Targets array null or empty implies allow for all targets
             // Otherwise, check if the target matches any of the ACL entry's targets
@@ -1271,4 +1308,62 @@ pub(crate) mod tests {
         assert_eq!(req1.allow(), false);
         assert_eq!(req2.allow(), true);
     }
+
+    /// With the `AUXILIARY` feature advertised, a wildcard-target Group-auth
+    /// entry no longer covers the root endpoint (but explicit targets and
+    /// other endpoints are unaffected).
+    #[test]
+    fn test_aux_wildcard_group_excludes_root_endpoint() {
+        let matter = test_matter();
+        add_fabric(&matter);
+
+        const GROUP_ID: u64 = 0x12AB;
+
+        // A regular (writable) ACL entry: Group auth, wildcard targets
+        let mut entry = AclEntry::new(None, Privilege::OPERATE, AuthMode::Group);
+        entry.add_subject(GROUP_ID).unwrap();
+        add_acl(&matter, FAB_1, entry).unwrap();
+
+        let accessor = Accessor::new(
+            FAB_1.get(),
+            AccessorSubjects::new(GROUP_ID),
+            Some(AuthMode::Group),
+            &matter,
+        );
+
+        let ep0 = GenericPath::new(Some(0), Some(1234), None);
+        let ep1 = GenericPath::new(Some(1), Some(1234), None);
+
+        // Without the feature: the wildcard covers the whole node
+        for path in [ep0.clone(), ep1.clone()] {
+            let mut req = AccessReq::new(&accessor, path, Access::WRITE);
+            req.set_target_perms(Access::WO);
+            assert!(req.allow());
+        }
+
+        matter.with_state(|state| state.aux_acl_enabled = true);
+
+        // With the feature: the root endpoint is excluded...
+        let mut req = AccessReq::new(&accessor, ep0.clone(), Access::WRITE);
+        req.set_target_perms(Access::WO);
+        assert!(!req.allow());
+
+        // ...other endpoints are unaffected...
+        let mut req = AccessReq::new(&accessor, ep1, Access::WRITE);
+        req.set_target_perms(Access::WO);
+        assert!(req.allow());
+
+        // ...and an entry explicitly targeting the root endpoint still works.
+        remove_all_acl(&matter, FAB_1);
+        let mut entry = AclEntry::new(None, Privilege::OPERATE, AuthMode::Group);
+        entry.add_subject(GROUP_ID).unwrap();
+        entry.add_target(Target::new(Some(0), None, None)).unwrap();
+        add_acl(&matter, FAB_1, entry).unwrap();
+
+        let mut req = AccessReq::new(&accessor, ep0, Access::WRITE);
+        req.set_target_perms(Access::WO);
+        assert!(req.allow());
+    }
+
 }
+

--- a/rs-matter/src/acl.rs
+++ b/rs-matter/src/acl.rs
@@ -552,13 +552,55 @@ impl<'a> AccessReq<'a> {
             // entries no longer cover the root endpoint (Matter Core spec).
             //
             // NOTE: entries surfaced via the `AuxiliaryACL` attribute are
-            // *derived* state - when a producing feature (e.g. a future
-            // Groupcast cluster) exists, its grants are to be checked here
-            // against the producer's own state, NOT against a materialized
-            // entry list (rs-matter deliberately does not store synthesized
-            // ACL entries - see `dm::clusters::acl::CLUSTER_AUX`).
-            state.fabrics.allow(self, state.aux_acl_enabled)
+            // *derived* state - checked below against the producing
+            // feature's own state (the Groupcast group table), NOT against a
+            // materialized entry list (rs-matter deliberately does not store
+            // synthesized ACL entries - see `dm::clusters::acl::CLUSTER_AUX`).
+            let allow = state.fabrics.allow(self, state.aux_acl_enabled);
+
+            #[cfg(feature = "groups")]
+            let allow =
+                allow || state.aux_acl_enabled && self.allow_groupcast_auxiliary(&state.fabrics);
+
+            allow
         })
+    }
+
+    /// Check whether access is granted by an auxiliary ACL entry synthesized
+    /// from the Groupcast group table: a Group-auth accessor whose group has
+    /// `HasAuxiliaryACL` set is granted the `Operate` privilege on the
+    /// group's endpoints (see the Groupcast Auxiliary ACL Handling section of
+    /// the Matter Core spec).
+    #[cfg(feature = "groups")]
+    fn allow_groupcast_auxiliary(&self, fabrics: &crate::fabric::Fabrics) -> bool {
+        if self.accessor.auth_mode != Some(AuthMode::Group) {
+            return false;
+        }
+
+        let Ok(fab_idx) = self.accessor.fab_idx() else {
+            return false;
+        };
+
+        let Some(fabric) = fabrics.get(fab_idx) else {
+            return false;
+        };
+
+        // Synthesized entries always carry concrete endpoint targets
+        let Some(endpoint) = self.object.path.endpoint else {
+            return false;
+        };
+
+        let granted = fabric.groups().iter().any(|entry| {
+            entry.has_aux_acl()
+                && entry.endpoints.contains(&endpoint)
+                && self.accessor.subjects.matches(entry.group_id as u64)
+        });
+
+        granted
+            && self
+                .object
+                .target_perms
+                .is_some_and(|access| access.is_ok(self.object.operation, Privilege::OPERATE))
     }
 }
 
@@ -1364,6 +1406,4 @@ pub(crate) mod tests {
         req.set_target_perms(Access::WO);
         assert!(req.allow());
     }
-
 }
-

--- a/rs-matter/src/dm/clusters.rs
+++ b/rs-matter/src/dm/clusters.rs
@@ -34,6 +34,8 @@ pub mod fixed_label;
 pub mod gen_comm;
 pub mod gen_diag;
 #[cfg(feature = "groups")]
+pub mod groupcast;
+#[cfg(feature = "groups")]
 pub mod groups;
 pub mod grp_key_mgmt;
 pub mod icd_mgmt;

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -134,7 +134,6 @@ impl AclHandler {
 
         Ok(())
     }
-
 }
 
 /// `AccessControl` cluster metadata that additionally advertises the
@@ -192,6 +191,59 @@ pub fn notify_auxiliary_access_updated(
     .map(|_event_number| ())
 }
 
+impl AclHandler {
+    /// Serialize one synthesized `AuxiliaryACL` entry, applying the same
+    /// fabric-sensitive redaction as the writable-`ACL` read: entries of
+    /// other fabrics expose only their fabric index.
+    #[cfg(feature = "groups")]
+    fn build_auxiliary_entry<P: TLVBuilderParent>(
+        accessing_fab_idx: u8,
+        fab_idx: NonZeroU8,
+        group_id: u16,
+        endpoints: &[crate::dm::EndptId],
+        builder: AccessControlEntryStructBuilder<P>,
+    ) -> Result<P, Error> {
+        use crate::tlv::Nullable;
+
+        let same_fab_idx = accessing_fab_idx == fab_idx.get();
+
+        builder
+            .privilege(same_fab_idx.then_some(AccessControlEntryPrivilegeEnum::Operate))?
+            .auth_mode(same_fab_idx.then_some(AccessControlEntryAuthModeEnum::Group))?
+            .subjects()?
+            .with_some_if(same_fab_idx, |builder| {
+                builder.with_non_null(
+                    Nullable::some([group_id as u64]),
+                    |subjects, mut builder| {
+                        for subject in subjects {
+                            builder = builder.push(subject)?;
+                        }
+
+                        builder.end()
+                    },
+                )
+            })?
+            .targets()?
+            .with_some_if(same_fab_idx, |builder| {
+                builder.with_non_null(Nullable::some(endpoints), |endpoints, mut builder| {
+                    for endpoint in *endpoints {
+                        builder = builder
+                            .push()?
+                            .cluster(Nullable::none())?
+                            .endpoint(Nullable::some(*endpoint))?
+                            .device_type(Nullable::none())?
+                            .end()?;
+                    }
+
+                    builder.end()
+                })
+            })?
+            .auxiliary_type(same_fab_idx.then_some(AccessControlAuxiliaryTypeEnum::Groupcast))?
+            .fabric_index(Some(fab_idx.get()))?
+            .end()
+    }
+}
+
 impl ClusterHandler for AclHandler {
     const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required)).with_cmds(with!());
 
@@ -223,16 +275,76 @@ impl ClusterHandler for AclHandler {
             AccessControlEntryStructBuilder<P>,
         >,
     ) -> Result<P, Error> {
-        // No producing feature (e.g. Groupcast) exists yet, so there are no
-        // synthesized entries to derive - the attribute is an empty list.
-        // When a producer lands, the entries are to be computed here on the
-        // fly from its state (see the note on [`CLUSTER_AUX`]).
-        let _ = ctx;
+        // The entries are *derived* on the fly from the producing feature's
+        // state - the Groupcast group table - never stored (see the note on
+        // [`CLUSTER_AUX`]). Without the `groups` feature no producer exists,
+        // and the attribute is an empty list.
+        #[cfg(feature = "groups")]
+        {
+            ctx.exchange().with_state(|state| {
+                let attr = ctx.attr();
 
-        match builder {
-            ArrayAttributeRead::ReadAll(builder) => builder.end(),
-            ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
-            ArrayAttributeRead::ReadNone(builder) => builder.end(),
+                // One synthesized entry per (fabric, aux-flagged group,
+                // targets-capacity chunk of its endpoints)
+                let mut entries = state
+                    .fabrics
+                    .iter()
+                    .filter(|fabric| !attr.fab_filter || fabric.fab_idx().get() == attr.fab_idx)
+                    .flat_map(|fabric| {
+                        fabric
+                            .groups()
+                            .iter()
+                            .filter(|entry| entry.has_aux_acl() && !entry.endpoints.is_empty())
+                            .flat_map(move |entry| {
+                                entry
+                                    .endpoints
+                                    .chunks(acl::MAX_TARGETS_PER_ACL_ENTRY)
+                                    .map(move |endpoints| (fabric, entry.group_id, endpoints))
+                            })
+                    });
+
+                match builder {
+                    ArrayAttributeRead::ReadAll(mut builder) => {
+                        for (fabric, group_id, endpoints) in entries {
+                            builder = Self::build_auxiliary_entry(
+                                attr.fab_idx,
+                                fabric.fab_idx(),
+                                group_id,
+                                endpoints,
+                                builder.push()?,
+                            )?;
+                        }
+
+                        builder.end()
+                    }
+                    ArrayAttributeRead::ReadOne(index, builder) => {
+                        let Some((fabric, group_id, endpoints)) = entries.nth(index as usize)
+                        else {
+                            return Err(ErrorCode::ConstraintError.into());
+                        };
+
+                        Self::build_auxiliary_entry(
+                            attr.fab_idx,
+                            fabric.fab_idx(),
+                            group_id,
+                            endpoints,
+                            builder,
+                        )
+                    }
+                    ArrayAttributeRead::ReadNone(builder) => builder.end(),
+                }
+            })
+        }
+
+        #[cfg(not(feature = "groups"))]
+        {
+            let _ = ctx;
+
+            match builder {
+                ArrayAttributeRead::ReadAll(builder) => builder.end(),
+                ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
+                ArrayAttributeRead::ReadNone(builder) => builder.end(),
+            }
         }
     }
 
@@ -246,9 +358,7 @@ impl ClusterHandler for AclHandler {
             let enabled = ctx.metadata().access(|node| {
                 node.endpoint(ROOT_ENDPOINT_ID)
                     .and_then(|endpoint| endpoint.cluster(FULL_CLUSTER.id))
-                    .is_some_and(|cluster| {
-                        cluster.feature_map & Feature::AUXILIARY.bits() != 0
-                    })
+                    .is_some_and(|cluster| cluster.feature_map & Feature::AUXILIARY.bits() != 0)
             });
 
             ctx.matter()

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -20,9 +20,10 @@
 use core::num::NonZeroU8;
 
 use crate::acl::{self, AclEntry, AuthMode, MAX_ACL_ENTRIES_PER_FABRIC};
+use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::dm::{
-    ArrayAttributeRead, ArrayAttributeWrite, AttrDetails, Cluster, Dataver, InvokeContext,
-    ReadContext, WriteContext,
+    ArrayAttributeRead, ArrayAttributeWrite, AttrDetails, Cluster, Dataver, HandlerContext,
+    InvokeContext, LifecycleOp, Metadata, ReadContext, WriteContext,
 };
 use crate::error::{Error, ErrorCode};
 use crate::fabric::{Fabric, FabricPersist, Fabrics};
@@ -133,6 +134,62 @@ impl AclHandler {
 
         Ok(())
     }
+
+}
+
+/// `AccessControl` cluster metadata that additionally advertises the
+/// provisional `AUXILIARY` feature and the `AuxiliaryACL` attribute.
+///
+/// Use this in place of [`AclHandler::CLUSTER`] on nodes where features (e.g.
+/// a future Groupcast cluster) synthesize auxiliary ACL entries. At startup,
+/// `AclHandler` inspects the node metadata and - when (and only when) this
+/// feature is advertised - switches the access-control evaluation of
+/// wildcard-target Group-auth entries to exclude the root endpoint, as the
+/// Matter Core spec mandates for nodes with the feature.
+///
+/// Auxiliary entries are *derived* state, and rs-matter deliberately
+/// allocates no storage for them: a producing feature computes them on the
+/// fly from its own state, both when the `AuxiliaryACL` attribute is read
+/// and during access-control evaluation. Until such a producer exists, the
+/// attribute reads as an empty list.
+///
+/// It is deliberately not the default: the feature is provisional, and on a
+/// node with no auxiliary-entry producer an always-empty `AuxiliaryACL` would
+/// be noise.
+pub const CLUSTER_AUX: Cluster<'static> = FULL_CLUSTER
+    .with_attrs(with!(required; AttributeId::AuxiliaryACL))
+    .with_cmds(with!())
+    .with_features(Feature::AUXILIARY.bits());
+
+/// Notify the data model that the `AuxiliaryACL` attribute changed, and emit
+/// the `AuxiliaryAccessUpdated` event.
+///
+/// Producers of auxiliary ACL entries call this once per batch of
+/// [`AuxiliaryAcl::replace`] calls that reported a change (the Matter Core
+/// spec asks for the event to be generated only once per batch of changes).
+///
+/// `admin_node_id` is the node ID of the administrator whose action led to
+/// the change, or `None` (reported as `Null`) when the change is internally
+/// initiated. `fab_idx` is the fabric whose entries changed (the event is
+/// fabric-sensitive).
+pub fn notify_auxiliary_access_updated(
+    ctx: &impl HandlerContext,
+    admin_node_id: Option<u64>,
+    fab_idx: NonZeroU8,
+) -> Result<(), Error> {
+    ctx.notify_attr_changed(
+        ROOT_ENDPOINT_ID,
+        FULL_CLUSTER.id,
+        AttributeId::AuxiliaryACL as _,
+    );
+
+    AuxiliaryAccessUpdated::emit_for(ctx, ROOT_ENDPOINT_ID, |event| {
+        event
+            .admin_node_id(Nullable::new(admin_node_id))?
+            .fabric_index(Some(fab_idx.get()))?
+            .end()
+    })
+    .map(|_event_number| ())
 }
 
 impl ClusterHandler for AclHandler {
@@ -156,6 +213,49 @@ impl ClusterHandler for AclHandler {
     ) -> Result<P, Error> {
         ctx.exchange()
             .with_state(|state| self.acl(&state.fabrics, ctx.attr(), builder))
+    }
+
+    fn auxiliary_acl<P: TLVBuilderParent>(
+        &self,
+        ctx: impl ReadContext,
+        builder: ArrayAttributeRead<
+            AccessControlEntryStructArrayBuilder<P>,
+            AccessControlEntryStructBuilder<P>,
+        >,
+    ) -> Result<P, Error> {
+        // No producing feature (e.g. Groupcast) exists yet, so there are no
+        // synthesized entries to derive - the attribute is an empty list.
+        // When a producer lands, the entries are to be computed here on the
+        // fly from its state (see the note on [`CLUSTER_AUX`]).
+        let _ = ctx;
+
+        match builder {
+            ArrayAttributeRead::ReadAll(builder) => builder.end(),
+            ArrayAttributeRead::ReadOne(_, _) => Err(ErrorCode::ConstraintError.into()),
+            ArrayAttributeRead::ReadNone(builder) => builder.end(),
+        }
+    }
+
+    fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
+        if matches!(op, LifecycleOp::Startup) {
+            // Enable the auxiliary-ACL store when (and only when) the node's
+            // Access Control cluster metadata advertises the `AUXILIARY`
+            // feature (see [`CLUSTER_AUX`]), deriving the runtime behavior
+            // from the single source of truth - the node metadata. The
+            // Access Control cluster only ever lives on the root endpoint.
+            let enabled = ctx.metadata().access(|node| {
+                node.endpoint(ROOT_ENDPOINT_ID)
+                    .and_then(|endpoint| endpoint.cluster(FULL_CLUSTER.id))
+                    .is_some_and(|cluster| {
+                        cluster.feature_map & Feature::AUXILIARY.bits() != 0
+                    })
+            });
+
+            ctx.matter()
+                .with_state(|state| state.aux_acl_enabled = enabled);
+        }
+
+        Ok(())
     }
 
     fn subjects_per_access_control_entry(&self, _ctx: impl ReadContext) -> Result<u16, Error> {

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -23,7 +23,7 @@ use crate::acl::{self, AclEntry, AuthMode, MAX_ACL_ENTRIES_PER_FABRIC};
 use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::dm::{
     ArrayAttributeRead, ArrayAttributeWrite, AttrDetails, Cluster, Dataver, HandlerContext,
-    InvokeContext, LifecycleOp, Metadata, NodeId, ReadContext, WriteContext,
+    InvokeContext, NodeId, ReadContext, WriteContext,
 };
 use crate::error::{Error, ErrorCode};
 use crate::fabric::{Fabric, FabricPersist, Fabrics};
@@ -291,26 +291,6 @@ impl ClusterHandler for AclHandler {
         }
     }
 
-    fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
-        if matches!(op, LifecycleOp::Startup) {
-            // Enable the auxiliary-ACL store when (and only when) the node's
-            // Access Control cluster metadata advertises the `AUXILIARY`
-            // feature (see [`CLUSTER_AUX`]), deriving the runtime behavior
-            // from the single source of truth - the node metadata. The
-            // Access Control cluster only ever lives on the root endpoint.
-            let enabled = ctx.metadata().access(|node| {
-                node.endpoint(ROOT_ENDPOINT_ID)
-                    .and_then(|endpoint| endpoint.cluster(FULL_CLUSTER.id))
-                    .is_some_and(|cluster| cluster.feature_map & Feature::AUXILIARY.bits() != 0)
-            });
-
-            ctx.matter()
-                .with_state(|state| state.fabrics.aux_acl_enabled = enabled);
-        }
-
-        Ok(())
-    }
-
     fn subjects_per_access_control_entry(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
         Ok(acl::MAX_SUBJECTS_PER_ACL_ENTRY as _)
     }
@@ -333,7 +313,7 @@ impl ClusterHandler for AclHandler {
     ) -> Result<(), Error> {
         let mut persist = FabricPersist::new(ctx.kv());
 
-        let accessor = ctx.exchange().accessor()?;
+        let accessor = ctx.accessor()?;
         let admin_node_id: Nullable<u64> = match accessor.peer_node_id() {
             Some(id) => Nullable::some(id),
             None => Nullable::none(),

--- a/rs-matter/src/dm/clusters/acl.rs
+++ b/rs-matter/src/dm/clusters/acl.rs
@@ -23,7 +23,7 @@ use crate::acl::{self, AclEntry, AuthMode, MAX_ACL_ENTRIES_PER_FABRIC};
 use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::dm::{
     ArrayAttributeRead, ArrayAttributeWrite, AttrDetails, Cluster, Dataver, HandlerContext,
-    InvokeContext, LifecycleOp, Metadata, ReadContext, WriteContext,
+    InvokeContext, LifecycleOp, Metadata, NodeId, ReadContext, WriteContext,
 };
 use crate::error::{Error, ErrorCode};
 use crate::fabric::{Fabric, FabricPersist, Fabrics};
@@ -134,64 +134,7 @@ impl AclHandler {
 
         Ok(())
     }
-}
 
-/// `AccessControl` cluster metadata that additionally advertises the
-/// provisional `AUXILIARY` feature and the `AuxiliaryACL` attribute.
-///
-/// Use this in place of [`AclHandler::CLUSTER`] on nodes where features (e.g.
-/// a future Groupcast cluster) synthesize auxiliary ACL entries. At startup,
-/// `AclHandler` inspects the node metadata and - when (and only when) this
-/// feature is advertised - switches the access-control evaluation of
-/// wildcard-target Group-auth entries to exclude the root endpoint, as the
-/// Matter Core spec mandates for nodes with the feature.
-///
-/// Auxiliary entries are *derived* state, and rs-matter deliberately
-/// allocates no storage for them: a producing feature computes them on the
-/// fly from its own state, both when the `AuxiliaryACL` attribute is read
-/// and during access-control evaluation. Until such a producer exists, the
-/// attribute reads as an empty list.
-///
-/// It is deliberately not the default: the feature is provisional, and on a
-/// node with no auxiliary-entry producer an always-empty `AuxiliaryACL` would
-/// be noise.
-pub const CLUSTER_AUX: Cluster<'static> = FULL_CLUSTER
-    .with_attrs(with!(required; AttributeId::AuxiliaryACL))
-    .with_cmds(with!())
-    .with_features(Feature::AUXILIARY.bits());
-
-/// Notify the data model that the `AuxiliaryACL` attribute changed, and emit
-/// the `AuxiliaryAccessUpdated` event.
-///
-/// Producers of auxiliary ACL entries call this once per batch of
-/// [`AuxiliaryAcl::replace`] calls that reported a change (the Matter Core
-/// spec asks for the event to be generated only once per batch of changes).
-///
-/// `admin_node_id` is the node ID of the administrator whose action led to
-/// the change, or `None` (reported as `Null`) when the change is internally
-/// initiated. `fab_idx` is the fabric whose entries changed (the event is
-/// fabric-sensitive).
-pub fn notify_auxiliary_access_updated(
-    ctx: &impl HandlerContext,
-    admin_node_id: Option<u64>,
-    fab_idx: NonZeroU8,
-) -> Result<(), Error> {
-    ctx.notify_attr_changed(
-        ROOT_ENDPOINT_ID,
-        FULL_CLUSTER.id,
-        AttributeId::AuxiliaryACL as _,
-    );
-
-    AuxiliaryAccessUpdated::emit_for(ctx, ROOT_ENDPOINT_ID, |event| {
-        event
-            .admin_node_id(Nullable::new(admin_node_id))?
-            .fabric_index(Some(fab_idx.get()))?
-            .end()
-    })
-    .map(|_event_number| ())
-}
-
-impl AclHandler {
     /// Serialize one synthesized `AuxiliaryACL` entry, applying the same
     /// fabric-sensitive redaction as the writable-`ACL` read: entries of
     /// other fabrics expose only their fabric index.
@@ -362,7 +305,7 @@ impl ClusterHandler for AclHandler {
             });
 
             ctx.matter()
-                .with_state(|state| state.aux_acl_enabled = enabled);
+                .with_state(|state| state.fabrics.aux_acl_enabled = enabled);
         }
 
         Ok(())
@@ -527,18 +470,45 @@ impl ClusterHandler for AclHandler {
     }
 }
 
+/// `AccessControl` cluster metadata that additionally advertises the
+/// provisional `AUXILIARY` feature and the `AuxiliaryACL` attribute.
+///
+/// Use this in place of [`AclHandler::CLUSTER`] on nodes where features (e.g.
+/// a Groupcast cluster) synthesize auxiliary ACL entries.
+///
+/// At startup, `AclHandler` inspects the node metadata and - when this
+/// feature is advertised - switches the access-control evaluation of
+/// wildcard-target Group-auth entries to exclude the root endpoint, as the
+/// Matter Core spec mandates for nodes with the feature.
+pub const CLUSTER_AUX: Cluster<'static> = FULL_CLUSTER
+    .with_attrs(with!(required; AttributeId::AuxiliaryACL))
+    .with_cmds(with!())
+    .with_features(Feature::AUXILIARY.bits());
+
+/// Notify the data model that the `AuxiliaryACL` attribute changed, and emit
+/// the `AuxiliaryAccessUpdated` event.
+pub fn notify_auxiliary_access_updated(
+    ctx: &impl HandlerContext,
+    admin_node_id: Option<NodeId>,
+    fab_idx: NonZeroU8,
+) -> Result<(), Error> {
+    ctx.notify_attr_changed(
+        ROOT_ENDPOINT_ID,
+        FULL_CLUSTER.id,
+        AttributeId::AuxiliaryACL as _,
+    );
+
+    AuxiliaryAccessUpdated::emit_for(ctx, ROOT_ENDPOINT_ID, |event| {
+        event
+            .admin_node_id(Nullable::new(admin_node_id))?
+            .fabric_index(Some(fab_idx.get()))?
+            .end()
+    })
+    .map(|_event_number| ())
+}
+
 /// Emit one `AccessControlEntryChanged` event with the given change type and
 /// the entry's contents serialized into `LatestValue`.
-///
-/// Callers pass in the `admin_node_id` / `admin_passcode_id` derived from the
-/// requesting accessor (CASE → node id, PASE → passcode id 0). For changes
-/// originating from internal flows that do not have a requester (e.g. the
-/// auto-created admin entry on AddNOC, which runs over PASE), pass null/0.
-///
-/// The event is emitted on endpoint 0 (the AccessControl cluster always lives
-/// there), via `emit_for` so the helper can be used from cluster handlers
-/// other than ACL itself (e.g. from the OperationalCredentials handler when
-/// AddNOC seeds the initial admin entry).
 pub(crate) fn emit_acl_entry_changed<E>(
     emitter: E,
     admin_node_id: Nullable<u64>,

--- a/rs-matter/src/dm/clusters/groupcast.rs
+++ b/rs-matter/src/dm/clusters/groupcast.rs
@@ -89,6 +89,13 @@ const TESTING_SECS_FALLBACK: u16 = 60;
 
 /// Return the `Groupcast` cluster metadata for the given feature combination.
 ///
+/// A node hosting the Groupcast cluster must also make its Access Control
+/// cluster advertise the `AUXILIARY` feature - compose the root-endpoint ACL
+/// metadata via the `acl(aux)` option of the [`crate::clusters!`] /
+/// [`crate::root_endpoint!`] macros (or `acl::CLUSTER_AUX` directly).
+/// [`GroupcastHandler`] verifies this at startup and refuses to start
+/// otherwise.
+///
 /// Note that the command set is served in full; on a composition without the
 /// `Listener` feature, `ConfigureAuxiliaryACL` (conformance `LN`) should be
 /// excluded by the application via a custom `with_cmds` filter.
@@ -102,22 +109,156 @@ pub const fn cluster(features: Feature) -> Cluster<'static> {
 /// The state of an ongoing `GroupcastTesting` test session.
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-struct Testing {
+pub(crate) struct TestingMode {
     /// The fabric that armed the testing mode (`FabricUnderTest`).
-    fab_idx: NonZeroU8,
+    pub(crate) fab_idx: NonZeroU8,
     /// The test operation being executed.
-    #[allow(unused)]
-    operation: GroupcastTestingEnum,
+    pub(crate) operation: GroupcastTestingEnum,
     /// When the testing mode auto-expires.
-    deadline: Instant,
+    pub(crate) deadline: Instant,
+}
+
+/// A `GroupcastTesting` diagnostic observation, recorded at the place where
+/// it happens (the transport's group-message RX path, the Interaction
+/// Model's group-invoke processing) and turned into a `GroupcastTesting`
+/// *event* by [`GroupcastHandler::run`] - the recording sites have no access
+/// to the Interaction Model's event machinery.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub(crate) struct TestingObservation {
+    pub(crate) src_ip: Option<[u8; 16]>,
+    pub(crate) dst_ip: Option<[u8; 16]>,
+    pub(crate) group_id: Option<u16>,
+    pub(crate) endpoint_id: Option<EndptId>,
+    pub(crate) cluster_id: Option<u32>,
+    pub(crate) element_id: Option<u32>,
+    pub(crate) access_allowed: Option<bool>,
+    pub(crate) result: GroupcastTestResultEnum,
+}
+
+/// The bridge between the places that *observe* Groupcast test conditions
+/// (the transport RX path, the Interaction Model's invoke processing, the
+/// `GroupcastTesting` command) and the [`GroupcastHandler`], which owns the
+/// `FabricUnderTest` reporting and the `GroupcastTesting` event emission.
+///
+/// Lives on [`crate::Matter`] so that all three parties can reach it.
+pub(crate) struct TestingBridge {
+    state: Mutex<RefCell<TestingBridgeState>>,
+    changed: Notification,
+}
+
+struct TestingBridgeState {
+    mode: Option<TestingMode>,
+    pending: Vec<TestingObservation, MAX_PENDING_OBSERVATIONS>,
+}
+
+/// Max buffered testing observations; when full, new observations are
+/// dropped (the CHIP test harness tolerates missing duplicates - it re-sends
+/// and de-duplicates).
+const MAX_PENDING_OBSERVATIONS: usize = 4;
+
+impl TestingBridge {
+    /// Create a new bridge, with testing disabled.
+    pub(crate) const fn new() -> Self {
+        Self {
+            state: Mutex::new(RefCell::new(TestingBridgeState {
+                mode: None,
+                pending: Vec::new(),
+            })),
+            changed: Notification::new(),
+        }
+    }
+
+    /// Set (or clear) the testing mode; wakes [`GroupcastHandler::run`].
+    pub(crate) fn set_mode(&self, mode: Option<TestingMode>) {
+        self.state.lock(|state| state.borrow_mut().mode = mode);
+        self.changed.notify();
+    }
+
+    /// The current testing mode, if any (including one that has expired but
+    /// has not been swept by [`GroupcastHandler::run`] yet - callers that
+    /// care use [`Self::armed`]).
+    pub(crate) fn mode(&self) -> Option<TestingMode> {
+        self.state.lock(|state| state.borrow().mode)
+    }
+
+    /// The current *unexpired* testing mode arming the given operation, if
+    /// any.
+    pub(crate) fn armed(&self, operation: GroupcastTestingEnum) -> Option<TestingMode> {
+        self.mode()
+            .filter(|mode| mode.operation == operation && Instant::now() < mode.deadline)
+    }
+
+    /// Record a testing observation (dropped when the buffer is full);
+    /// wakes [`GroupcastHandler::run`] to turn it into an event.
+    pub(crate) fn observe(&self, observation: TestingObservation) {
+        self.state.lock(|state| {
+            let _ = state.borrow_mut().pending.push(observation);
+        });
+        self.changed.notify();
+    }
+
+    /// Take the oldest pending observation, if any.
+    fn pop(&self) -> Option<TestingObservation> {
+        self.state.lock(|state| {
+            let pending = &mut state.borrow_mut().pending;
+            (!pending.is_empty()).then(|| pending.remove(0))
+        })
+    }
+
+    /// Wait for a mode change or a new observation.
+    async fn wait_changed(&self) {
+        self.changed.wait().await
+    }
+}
+
+/// The IPv6 octets of the multicast address the given group uses, for the
+/// `GroupcastTesting` event's `DestinationIpAddress` field.
+///
+/// The transport does not surface the actual UDP destination address of a
+/// received datagram, so it is reconstructed from the group's multicast
+/// address policy; for an unknown group (e.g. the no-key-available case) the
+/// IANA-assigned address is assumed, as `IanaAddr` is the default policy.
+pub(crate) fn group_dst_ip(fabrics: &Fabrics, fab_idx: NonZeroU8, group_id: u16) -> [u8; 16] {
+    fabrics
+        .get(fab_idx)
+        .and_then(|fabric| {
+            fabric
+                .groups()
+                .get(group_id)
+                .map(|entry| match entry.effective_mcast_policy() {
+                    MulticastAddrPolicyEnum::IanaAddr => {
+                        crate::utils::ipv6::IANA_GROUPCAST_MULTICAST_ADDR.octets()
+                    }
+                    MulticastAddrPolicyEnum::PerGroup => {
+                        crate::utils::ipv6::compute_group_multicast_addr(
+                            fabric.fabric_id(),
+                            group_id,
+                        )
+                        .octets()
+                    }
+                })
+        })
+        .unwrap_or(crate::utils::ipv6::IANA_GROUPCAST_MULTICAST_ADDR.octets())
+}
+
+/// The IPv6 octets of a transport [`Address`], for the `GroupcastTesting`
+/// event's `SourceIpAddress` field (IPv4 addresses are V4-mapped).
+pub(crate) fn addr_ip(addr: &crate::transport::network::Address) -> Option<[u8; 16]> {
+    let crate::transport::network::Address::Udp(addr) = addr else {
+        return None;
+    };
+
+    Some(match addr.ip() {
+        core::net::IpAddr::V6(ip) => ip.octets(),
+        core::net::IpAddr::V4(ip) => ip.to_ipv6_mapped().octets(),
+    })
 }
 
 /// The system implementation of a handler for the Groupcast Matter cluster.
 pub struct GroupcastHandler {
     dataver: Dataver,
     features: Feature,
-    testing: Mutex<RefCell<Option<Testing>>>,
-    testing_changed: Notification,
 }
 
 impl GroupcastHandler {
@@ -128,12 +269,7 @@ impl GroupcastHandler {
     /// this handler is composed with (see [`cluster`]) - it drives the
     /// feature-conditional command validation.
     pub const fn new(dataver: Dataver, features: Feature) -> Self {
-        Self {
-            dataver,
-            features,
-            testing: Mutex::new(RefCell::new(None)),
-            testing_changed: Notification::new(),
-        }
+        Self { dataver, features }
     }
 
     /// Adapt the handler instance to the generic `rs-matter` `Handler` trait
@@ -348,28 +484,103 @@ impl ClusterHandler for GroupcastHandler {
         self.dataver.changed();
     }
 
-    fn lifecycle(&self, _ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
+    fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
         if matches!(op, LifecycleOp::Startup) {
+            // Groupcast synthesizes auxiliary ACL entries, so a node hosting
+            // it must advertise the Access Control cluster's `AUXILIARY`
+            // feature (compose the ACL cluster metadata via `acl(aux)` /
+            // `CLUSTER_AUX`). Failing to do so would leave the synthesized
+            // grants both invisible (the `AuxiliaryACL` attribute absent)
+            // and inert (not consulted during access-control evaluation) -
+            // a silent misconfiguration, so fail startup loudly instead.
+            //
+            // Only validated when the Groupcast cluster is actually part of
+            // the node metadata: a merely-chained handler (e.g. an app with
+            // a runtime-selected composition) is inert and needs nothing.
+            let (composed, aux_advertised) = ctx.metadata().access(|node| {
+                let root = node.endpoint(crate::dm::endpoints::ROOT_ENDPOINT_ID);
+
+                let composed =
+                    root.is_some_and(|endpoint| endpoint.cluster(FULL_CLUSTER.id).is_some());
+
+                let aux_advertised = root
+                    .and_then(|endpoint| {
+                        endpoint.cluster(crate::dm::clusters::acl::FULL_CLUSTER.id)
+                    })
+                    .is_some_and(|cluster| {
+                        cluster.feature_map & crate::dm::clusters::acl::Feature::AUXILIARY.bits()
+                            != 0
+                    });
+
+                (composed, aux_advertised)
+            });
+
+            if composed && !aux_advertised {
+                error!(
+                    "The Groupcast cluster requires the Access Control cluster                      to advertise the AUXILIARY feature - compose the node's                      root-endpoint ACL metadata via `acl(aux)` or `CLUSTER_AUX`"
+                );
+
+                return Err(ErrorCode::Invalid.into());
+            }
+
             // Per the Matter Core spec, `FabricUnderTest` is zero when the
             // server initializes - testing mode does not survive a reboot.
-            self.testing.lock(|testing| *testing.borrow_mut() = None);
+            ctx.matter().groupcast_testing().set_mode(None);
         }
 
         Ok(())
     }
 
     async fn run(&self, ctx: impl HandlerContext) -> Result<(), Error> {
-        // Expire the `GroupcastTesting` mode when its deadline passes,
-        // reporting the `FabricUnderTest` change to subscribers.
+        // Two duties, both driven by the testing bridge:
+        // - turn recorded testing observations into `GroupcastTesting`
+        //   events (the observing sites - transport RX, IM invoke - have no
+        //   access to the event machinery);
+        // - expire the testing mode when its deadline passes, reporting the
+        //   `FabricUnderTest` change to subscribers.
+        let bridge = ctx.matter().groupcast_testing();
+
         loop {
-            let deadline = self
-                .testing
-                .lock(|testing| testing.borrow().as_ref().map(|t| t.deadline));
+            while let Some(observation) = bridge.pop() {
+                // Fabric-sensitive event, attributed to the fabric under
+                // test (observations are only recorded while armed)
+                let Some(mode) = bridge.mode() else {
+                    continue;
+                };
+
+                let emitted = GroupcastTesting::emit_for(
+                    &ctx,
+                    crate::dm::endpoints::ROOT_ENDPOINT_ID,
+                    |event| {
+                        event
+                            .source_ip_address(
+                                observation.src_ip.as_ref().map(|ip| crate::tlv::Octets(ip)),
+                            )?
+                            .destination_ip_address(
+                                observation.dst_ip.as_ref().map(|ip| crate::tlv::Octets(ip)),
+                            )?
+                            .group_id(observation.group_id)?
+                            .endpoint_id(observation.endpoint_id)?
+                            .cluster_id(observation.cluster_id)?
+                            .element_id(observation.element_id)?
+                            .access_allowed(observation.access_allowed)?
+                            .groupcast_test_result(observation.result)?
+                            .fabric_index(Some(mode.fab_idx.get()))?
+                            .end()
+                    },
+                );
+
+                if let Err(e) = emitted {
+                    warn!("Failed to emit a GroupcastTesting event: {:?}", e);
+                }
+            }
+
+            let deadline = bridge.mode().map(|mode| mode.deadline);
 
             match deadline {
                 Some(deadline) => {
                     if Instant::now() >= deadline {
-                        self.testing.lock(|testing| *testing.borrow_mut() = None);
+                        bridge.set_mode(None);
 
                         self.dataver_changed();
                         ctx.notify_attr_changed(
@@ -378,10 +589,10 @@ impl ClusterHandler for GroupcastHandler {
                             AttributeId::FabricUnderTest as _,
                         );
                     } else {
-                        select(Timer::at(deadline), self.testing_changed.wait()).await;
+                        select(Timer::at(deadline), bridge.wait_changed()).await;
                     }
                 }
-                None => self.testing_changed.wait().await,
+                None => bridge.wait_changed().await,
             }
         }
     }
@@ -435,17 +646,17 @@ impl ClusterHandler for GroupcastHandler {
             .with_state(|state| Ok(Self::used_mcast_addrs(&state.fabrics)))
     }
 
-    fn fabric_under_test(&self, _ctx: impl ReadContext) -> Result<FabricIndex, Error> {
-        Ok(self.testing.lock(|testing| {
-            testing
-                .borrow()
-                .as_ref()
-                // Lazily treat an expired-but-not-yet-swept testing mode as
-                // disabled (the `run` loop sweeps and notifies shortly after)
-                .filter(|t| Instant::now() < t.deadline)
-                .map(|t| t.fab_idx.get())
-                .unwrap_or(0)
-        }))
+    fn fabric_under_test(&self, ctx: impl ReadContext) -> Result<FabricIndex, Error> {
+        Ok(ctx
+            .exchange()
+            .matter()
+            .groupcast_testing()
+            .mode()
+            // Lazily treat an expired-but-not-yet-swept testing mode as
+            // disabled (the `run` loop sweeps and notifies shortly after)
+            .filter(|mode| Instant::now() < mode.deadline)
+            .map(|mode| mode.fab_idx.get())
+            .unwrap_or(0))
     }
 
     fn handle_join_group(
@@ -803,42 +1014,31 @@ impl ClusterHandler for GroupcastHandler {
             return Err(ErrorCode::ConstraintError.into());
         }
 
+        let bridge = ctx.exchange().matter().groupcast_testing();
+
         match operation {
-            GroupcastTestingEnum::DisableTesting => {
-                self.testing.lock(|testing| *testing.borrow_mut() = None);
-            }
-            GroupcastTestingEnum::EnableListenerTesting => {
-                if !self.listener() {
+            GroupcastTestingEnum::DisableTesting => bridge.set_mode(None),
+            GroupcastTestingEnum::EnableListenerTesting
+            | GroupcastTestingEnum::EnableSenderTesting => {
+                let feature_ok = match operation {
+                    GroupcastTestingEnum::EnableListenerTesting => self.listener(),
+                    _ => self.sender(),
+                };
+                if !feature_ok {
                     return Err(ErrorCode::ConstraintError.into());
                 }
 
                 let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
-                self.testing.lock(|testing| {
-                    *testing.borrow_mut() = Some(Testing {
-                        fab_idx,
-                        operation,
-                        deadline: Instant::now() + Duration::from_secs(duration_secs as _),
-                    })
-                });
-            }
-            GroupcastTestingEnum::EnableSenderTesting => {
-                if !self.sender() {
-                    return Err(ErrorCode::ConstraintError.into());
-                }
-
-                let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
-                self.testing.lock(|testing| {
-                    *testing.borrow_mut() = Some(Testing {
-                        fab_idx,
-                        operation,
-                        deadline: Instant::now() + Duration::from_secs(duration_secs as _),
-                    })
-                });
+                bridge.set_mode(Some(TestingMode {
+                    fab_idx,
+                    operation,
+                    deadline: Instant::now() + Duration::from_secs(duration_secs as _),
+                }));
             }
         }
 
-        // Rearm the expiry timer in `run` and report `FabricUnderTest`
-        self.testing_changed.notify();
+        // `set_mode` has rearmed the expiry timer in `run`; report
+        // `FabricUnderTest`
         self.dataver_changed();
         ctx.notify_own_endpoint_changed();
 

--- a/rs-matter/src/dm/clusters/groupcast.rs
+++ b/rs-matter/src/dm/clusters/groupcast.rs
@@ -379,7 +379,7 @@ impl GroupcastHandler {
     /// privilege on this cluster (required for the `UseAuxiliaryACL` field
     /// of `JoinGroup`, which is otherwise a `Manage`-privilege command).
     fn accessor_is_admin(&self, ctx: &impl InvokeContext) -> Result<bool, Error> {
-        let accessor = ctx.exchange().accessor()?;
+        let accessor = ctx.accessor()?;
         let cmd = ctx.cmd();
 
         let path = GenericPath::new(
@@ -783,7 +783,7 @@ impl ClusterHandler for GroupcastHandler {
             return Err(ErrorCode::UnsupportedAccess.into());
         }
 
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let peer_node_id = Self::peer_node_id(&ctx);
 
         let aux_changed = ctx.exchange().with_state(|state| {
@@ -889,7 +889,7 @@ impl ClusterHandler for GroupcastHandler {
             endpoints = Some(list);
         }
 
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let peer_node_id = Self::peer_node_id(&ctx);
         let sender = self.sender();
 
@@ -1021,7 +1021,7 @@ impl ClusterHandler for GroupcastHandler {
             }
         }
 
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
 
         ctx.exchange().with_state(|state| {
             let fabric = state.fabrics.fabric_mut(fab_idx)?;
@@ -1044,7 +1044,7 @@ impl ClusterHandler for GroupcastHandler {
         let group_id = request.group_id()?;
         let use_auxiliary_acl = request.use_auxiliary_acl()?;
 
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let peer_node_id = Self::peer_node_id(&ctx);
 
         let aux_changed = ctx.exchange().with_state(|state| {
@@ -1108,7 +1108,7 @@ impl ClusterHandler for GroupcastHandler {
                     return Err(ErrorCode::ConstraintError.into());
                 }
 
-                let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+                let fab_idx = ctx.accessor()?.fab_idx()?;
                 bridge.set_mode(Some(TestingMode {
                     fab_idx,
                     operation,

--- a/rs-matter/src/dm/clusters/groupcast.rs
+++ b/rs-matter/src/dm/clusters/groupcast.rs
@@ -49,6 +49,7 @@ use crate::group_keys::{GroupEpochKeyEntry, GroupKeySet};
 use crate::im::{FabricIndex, GenericPath};
 use crate::tlv::TLVBuilderParent;
 use crate::utils::cell::RefCell;
+use crate::utils::init::{init, Init};
 use crate::utils::storage::Vec;
 use crate::utils::sync::blocking::Mutex;
 use crate::utils::sync::Notification;
@@ -86,6 +87,11 @@ const MAX_CMD_ENDPOINTS: usize = 20;
 const TESTING_SECS_MIN: u16 = 10;
 const TESTING_SECS_MAX: u16 = 1200;
 const TESTING_SECS_FALLBACK: u16 = 60;
+
+/// Max buffered testing observations; when full, new observations are
+/// dropped (the CHIP test harness tolerates missing duplicates - it re-sends
+/// and de-duplicates).
+const MAX_PENDING_OBSERVATIONS: usize = 4;
 
 /// Return the `Groupcast` cluster metadata for the given feature combination.
 ///
@@ -136,6 +142,72 @@ pub(crate) struct TestingObservation {
     pub(crate) result: GroupcastTestResultEnum,
 }
 
+impl TestingObservation {
+    /// The IPv6 octets of the multicast address the given group uses, for the
+    /// `GroupcastTesting` event's `DestinationIpAddress` field.
+    ///
+    /// The transport does not surface the actual UDP destination address of a
+    /// received datagram, so it is reconstructed from the group's multicast
+    /// address policy; for an unknown group (e.g. the no-key-available case) the
+    /// IANA-assigned address is assumed, as `IanaAddr` is the default policy.
+    pub(crate) fn group_dst_ip(fabrics: &Fabrics, fab_idx: NonZeroU8, group_id: u16) -> [u8; 16] {
+        fabrics
+            .get(fab_idx)
+            .and_then(|fabric| {
+                fabric
+                    .groups()
+                    .get(group_id)
+                    .map(|entry| match entry.effective_mcast_policy() {
+                        MulticastAddrPolicyEnum::IanaAddr => {
+                            crate::utils::ipv6::IANA_GROUPCAST_MULTICAST_ADDR.octets()
+                        }
+                        MulticastAddrPolicyEnum::PerGroup => {
+                            crate::utils::ipv6::compute_group_multicast_addr(
+                                fabric.fabric_id(),
+                                group_id,
+                            )
+                            .octets()
+                        }
+                    })
+            })
+            .unwrap_or(crate::utils::ipv6::IANA_GROUPCAST_MULTICAST_ADDR.octets())
+    }
+
+    /// The IPv6 octets of a transport [`Address`], for the `GroupcastTesting`
+    /// event's `SourceIpAddress` field (IPv4 addresses are V4-mapped).
+    pub(crate) fn addr_ip(addr: &crate::transport::network::Address) -> Option<[u8; 16]> {
+        let crate::transport::network::Address::Udp(addr) = addr else {
+            return None;
+        };
+
+        Some(match addr.ip() {
+            core::net::IpAddr::V6(ip) => ip.octets(),
+            core::net::IpAddr::V4(ip) => ip.to_ipv6_mapped().octets(),
+        })
+    }
+}
+
+struct TestingBridgeState {
+    mode: Option<TestingMode>,
+    pending: Vec<TestingObservation, MAX_PENDING_OBSERVATIONS>,
+}
+
+impl TestingBridgeState {
+    const fn new() -> Self {
+        Self {
+            mode: None,
+            pending: Vec::new(),
+        }
+    }
+
+    fn init() -> impl Init<Self> {
+        init!(Self {
+            mode: None,
+            pending <- Vec::init(),
+        })
+    }
+}
+
 /// The bridge between the places that *observe* Groupcast test conditions
 /// (the transport RX path, the Interaction Model's invoke processing, the
 /// `GroupcastTesting` command) and the [`GroupcastHandler`], which owns the
@@ -147,26 +219,20 @@ pub(crate) struct TestingBridge {
     changed: Notification,
 }
 
-struct TestingBridgeState {
-    mode: Option<TestingMode>,
-    pending: Vec<TestingObservation, MAX_PENDING_OBSERVATIONS>,
-}
-
-/// Max buffered testing observations; when full, new observations are
-/// dropped (the CHIP test harness tolerates missing duplicates - it re-sends
-/// and de-duplicates).
-const MAX_PENDING_OBSERVATIONS: usize = 4;
-
 impl TestingBridge {
     /// Create a new bridge, with testing disabled.
     pub(crate) const fn new() -> Self {
         Self {
-            state: Mutex::new(RefCell::new(TestingBridgeState {
-                mode: None,
-                pending: Vec::new(),
-            })),
+            state: Mutex::new(RefCell::new(TestingBridgeState::new())),
             changed: Notification::new(),
         }
+    }
+
+    pub(crate) fn init() -> impl Init<Self> {
+        init!(Self {
+            state <- Mutex::init(RefCell::init(TestingBridgeState::init())),
+            changed <- Notification::init(),
+        })
     }
 
     /// Set (or clear) the testing mode; wakes [`GroupcastHandler::run`].
@@ -210,49 +276,6 @@ impl TestingBridge {
     async fn wait_changed(&self) {
         self.changed.wait().await
     }
-}
-
-/// The IPv6 octets of the multicast address the given group uses, for the
-/// `GroupcastTesting` event's `DestinationIpAddress` field.
-///
-/// The transport does not surface the actual UDP destination address of a
-/// received datagram, so it is reconstructed from the group's multicast
-/// address policy; for an unknown group (e.g. the no-key-available case) the
-/// IANA-assigned address is assumed, as `IanaAddr` is the default policy.
-pub(crate) fn group_dst_ip(fabrics: &Fabrics, fab_idx: NonZeroU8, group_id: u16) -> [u8; 16] {
-    fabrics
-        .get(fab_idx)
-        .and_then(|fabric| {
-            fabric
-                .groups()
-                .get(group_id)
-                .map(|entry| match entry.effective_mcast_policy() {
-                    MulticastAddrPolicyEnum::IanaAddr => {
-                        crate::utils::ipv6::IANA_GROUPCAST_MULTICAST_ADDR.octets()
-                    }
-                    MulticastAddrPolicyEnum::PerGroup => {
-                        crate::utils::ipv6::compute_group_multicast_addr(
-                            fabric.fabric_id(),
-                            group_id,
-                        )
-                        .octets()
-                    }
-                })
-        })
-        .unwrap_or(crate::utils::ipv6::IANA_GROUPCAST_MULTICAST_ADDR.octets())
-}
-
-/// The IPv6 octets of a transport [`Address`], for the `GroupcastTesting`
-/// event's `SourceIpAddress` field (IPv4 addresses are V4-mapped).
-pub(crate) fn addr_ip(addr: &crate::transport::network::Address) -> Option<[u8; 16]> {
-    let crate::transport::network::Address::Udp(addr) = addr else {
-        return None;
-    };
-
-    Some(match addr.ip() {
-        core::net::IpAddr::V6(ip) => ip.octets(),
-        core::net::IpAddr::V4(ip) => ip.to_ipv6_mapped().octets(),
-    })
 }
 
 /// The system implementation of a handler for the Groupcast Matter cluster.
@@ -365,7 +388,7 @@ impl GroupcastHandler {
             Some(cmd.cmd_id),
         );
 
-        let mut req = AccessReq::new(&accessor, path, Access::WRITE);
+        let mut req = AccessReq::new(&accessor, path, Access::WRITE, &[]);
         req.set_target_perms(Access::WRITE | Access::NEED_ADMIN);
 
         Ok(req.allow())
@@ -798,6 +821,7 @@ impl ClusterHandler for GroupcastHandler {
                     .map(|entry| entry.effective_mcast_policy())
                     .unwrap_or(MulticastAddrPolicyEnum::IanaAddr),
             };
+
             if Self::used_mcast_addrs_with(&state.fabrics, fab_idx, group_id, target_policy)
                 > MAX_MCAST_ADDR_COUNT
             {
@@ -819,6 +843,7 @@ impl ClusterHandler for GroupcastHandler {
             // Matter Core spec, failures here are ignored, leaving the effect
             // of the prior successful steps unchanged.
             let mut aux_changed = false;
+
             if let Some(use_auxiliary_acl) = use_auxiliary_acl {
                 let groups = fabric.groups_mut();
                 if groups.set_has_aux_acl(group_id, use_auxiliary_acl) {
@@ -853,6 +878,7 @@ impl ClusterHandler for GroupcastHandler {
         let group_id = request.group_id()?;
 
         let mut endpoints = None;
+
         if let Some(req_endpoints) = request.endpoints()? {
             let mut list = Vec::<EndptId, MAX_CMD_ENDPOINTS>::new();
             for endpoint in &req_endpoints {

--- a/rs-matter/src/dm/clusters/groupcast.rs
+++ b/rs-matter/src/dm/clusters/groupcast.rs
@@ -309,6 +309,41 @@ impl GroupcastHandler {
         count + iana as u16
     }
 
+    /// The number of distinct multicast addresses that would be in use if
+    /// the given group had the given multicast-address policy (whether the
+    /// group exists yet or not) - the prospective form of
+    /// [`Self::used_mcast_addrs`], for the `JoinGroup` capacity check.
+    fn used_mcast_addrs_with(
+        fabrics: &Fabrics,
+        fab_idx: NonZeroU8,
+        group_id: u16,
+        policy: MulticastAddrPolicyEnum,
+    ) -> u16 {
+        let mut iana = false;
+        let mut count = 0;
+
+        for fabric in fabrics.iter() {
+            for entry in fabric.groups().iter() {
+                if fabric.fab_idx() == fab_idx && entry.group_id == group_id {
+                    // Replaced by the target policy below
+                    continue;
+                }
+
+                match entry.effective_mcast_policy() {
+                    MulticastAddrPolicyEnum::IanaAddr => iana = true,
+                    MulticastAddrPolicyEnum::PerGroup => count += 1,
+                }
+            }
+        }
+
+        match policy {
+            MulticastAddrPolicyEnum::IanaAddr => iana = true,
+            MulticastAddrPolicyEnum::PerGroup => count += 1,
+        }
+
+        count + iana as u16
+    }
+
     /// The number of distinct group IDs across all fabrics.
     fn total_group_count(fabrics: &Fabrics) -> usize {
         fabrics
@@ -517,7 +552,9 @@ impl ClusterHandler for GroupcastHandler {
 
             if composed && !aux_advertised {
                 error!(
-                    "The Groupcast cluster requires the Access Control cluster                      to advertise the AUXILIARY feature - compose the node's                      root-endpoint ACL metadata via `acl(aux)` or `CLUSTER_AUX`"
+                    "The Groupcast cluster requires the Access Control cluster \
+                     to advertise the AUXILIARY feature - compose the node's \
+                     root-endpoint ACL metadata via `acl(aux)` or `CLUSTER_AUX`"
                 );
 
                 return Err(ErrorCode::Invalid.into());
@@ -735,32 +772,36 @@ impl ClusterHandler for GroupcastHandler {
                 .is_none();
 
             if is_new {
-                // Capacity: per-fabric first, then node-wide
+                // Membership capacity: per-fabric first, then node-wide
                 if state.fabrics.fabric(fab_idx)?.groups().group_count() >= MAX_GROUPS_PER_FABRIC
                     || Self::total_group_count(&state.fabrics) >= MAX_MEMBERSHIP_COUNT as usize
                 {
                     return Err(ErrorCode::ResourceExhausted.into());
                 }
+            }
 
-                // Multicast address capacity: a new `PerGroup` group needs a
-                // new address; a new IANA-policy group needs one only if the
-                // IANA address is not in use yet
-                let used = Self::used_mcast_addrs(&state.fabrics);
-                let needs_addr =
-                    match mcast_addr_policy.unwrap_or(MulticastAddrPolicyEnum::IanaAddr) {
-                        MulticastAddrPolicyEnum::PerGroup => true,
-                        MulticastAddrPolicyEnum::IanaAddr => !state.fabrics.iter().any(|fabric| {
-                            fabric.groups().iter().any(|e| {
-                                matches!(
-                                    e.effective_mcast_policy(),
-                                    MulticastAddrPolicyEnum::IanaAddr
-                                )
-                            })
-                        }),
-                    };
-                if needs_addr && used >= MAX_MCAST_ADDR_COUNT {
-                    return Err(ErrorCode::ResourceExhausted.into());
-                }
+            // Multicast address capacity, computed against the policy this
+            // group would end up with - covering both new groups and policy
+            // changes of existing ones (a `PerGroup` flip of an existing
+            // IANA-policy group needs a new address too; the reference
+            // implementation misses that case, but the spec is clear that
+            // `UsedMcastAddrCount` SHALL NOT exceed `MaxMcastAddrCount`)
+            let target_policy = match mcast_addr_policy {
+                Some(policy) => policy,
+                None => state
+                    .fabrics
+                    .fabric(fab_idx)?
+                    .groups()
+                    .get(group_id)
+                    // Mirrors `groupcast_join`: an existing entry keeps its
+                    // effective policy; a new one defaults to `IanaAddr`
+                    .map(|entry| entry.effective_mcast_policy())
+                    .unwrap_or(MulticastAddrPolicyEnum::IanaAddr),
+            };
+            if Self::used_mcast_addrs_with(&state.fabrics, fab_idx, group_id, target_policy)
+                > MAX_MCAST_ADDR_COUNT
+            {
+                return Err(ErrorCode::ResourceExhausted.into());
             }
 
             let fabric = state.fabrics.fabric_mut(fab_idx)?;
@@ -884,9 +925,20 @@ impl ClusterHandler for GroupcastHandler {
                         // A membership left with no endpoints is removed
                         // entirely - unless the device is (also) a Sender,
                         // where it lives on as a sender-only membership
-                        if empty && !sender {
-                            fabric.groups_mut().groupcast_remove(group_id);
-                            fabric.groups_mut().key_map_remove_group(group_id);
+                        if empty {
+                            if sender {
+                                // A retained empty membership must be marked
+                                // Groupcast-managed: legacy Groups-cluster
+                                // entries may not exist without endpoints
+                                // (the legacy cleanup would reap them)
+                                let entry = unwrap!(fabric.groups_mut().get_mut(group_id));
+                                if entry.mcast_policy.is_none() {
+                                    entry.mcast_policy = Some(MulticastAddrPolicyEnum::PerGroup);
+                                }
+                            } else {
+                                fabric.groups_mut().groupcast_remove(group_id);
+                                fabric.groups_mut().key_map_remove_group(group_id);
+                            }
                         }
                     }
                     None => {
@@ -1008,11 +1060,6 @@ impl ClusterHandler for GroupcastHandler {
         request: GroupcastTestingRequest<'_>,
     ) -> Result<(), Error> {
         let operation = request.test_operation()?;
-        let duration_secs = request.duration_seconds()?.unwrap_or(TESTING_SECS_FALLBACK);
-
-        if !(TESTING_SECS_MIN..=TESTING_SECS_MAX).contains(&duration_secs) {
-            return Err(ErrorCode::ConstraintError.into());
-        }
 
         let bridge = ctx.exchange().matter().groupcast_testing();
 
@@ -1025,6 +1072,13 @@ impl ClusterHandler for GroupcastHandler {
                     _ => self.sender(),
                 };
                 if !feature_ok {
+                    return Err(ErrorCode::ConstraintError.into());
+                }
+
+                // Per the Matter Core spec, `DurationSeconds` is ignored
+                // (and hence not validated) for `DisableTesting`
+                let duration_secs = request.duration_seconds()?.unwrap_or(TESTING_SECS_FALLBACK);
+                if !(TESTING_SECS_MIN..=TESTING_SECS_MAX).contains(&duration_secs) {
                     return Err(ErrorCode::ConstraintError.into());
                 }
 

--- a/rs-matter/src/dm/clusters/groupcast.rs
+++ b/rs-matter/src/dm/clusters/groupcast.rs
@@ -1,0 +1,847 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! This module contains the implementation of the Groupcast cluster (provisional
+//! in Matter 1.6) and its handler.
+//!
+//! The Groupcast cluster is the unified replacement of the legacy Groups +
+//! Group Key Management flow. It deliberately owns NO state of its own:
+//! - group memberships live in the per-fabric group table (shared with the
+//!   legacy Groups cluster, so legacy- and Groupcast-managed groups coexist
+//!   and group-addressed RX processing needs no changes);
+//! - group keys are ordinary Group Key Management key sets (`KeySetID` ==
+//!   `GroupKeySetID`), so key sets created via [`JoinGroup`] are visible to -
+//!   and manageable by - the Group Key Management cluster, and vice versa;
+//! - the `Membership` attribute is a live join of the group table and the
+//!   group-key map: a membership whose group has no key-set mapping reports
+//!   [`KEY_SET_ID_INVALID`];
+//! - `UsedMcastAddrCount` is a live count of the distinct multicast addresses
+//!   implied by the memberships' address policies.
+
+use core::num::NonZeroU8;
+
+use embassy_futures::select::select;
+use embassy_time::{Duration, Instant, Timer};
+
+use crate::acl::AccessReq;
+use crate::dm::clusters::acl::notify_auxiliary_access_updated;
+use crate::dm::{
+    Access, ArrayAttributeRead, Cluster, Dataver, EndptId, HandlerContext, InvokeContext,
+    LifecycleOp, Metadata, ReadContext,
+};
+use crate::error::{Error, ErrorCode};
+use crate::fabric::{Fabric, FabricPersist, Fabrics, MAX_GROUPS_PER_FABRIC};
+use crate::group_keys::{GroupEpochKeyEntry, GroupKeySet};
+use crate::im::{FabricIndex, GenericPath};
+use crate::tlv::TLVBuilderParent;
+use crate::utils::cell::RefCell;
+use crate::utils::storage::Vec;
+use crate::utils::sync::blocking::Mutex;
+use crate::utils::sync::Notification;
+use crate::with;
+
+pub use crate::dm::clusters::decl::groupcast::*;
+
+use super::decl::group_key_management::GroupKeySecurityPolicyEnum;
+
+/// The value the `Membership` attribute's `KeySetID` field reports for a
+/// group that currently has no key-set mapping (e.g. after the Group Key
+/// Management cluster's `GroupKeyMap` was rewritten without it).
+pub const KEY_SET_ID_INVALID: u16 = 0xFFFF;
+
+/// The value of the `MaxMembershipCount` attribute: the node-wide maximum
+/// number of distinct group IDs across all fabrics.
+///
+/// Per the Matter Core spec, the per-fabric limit is half of this - which is
+/// exactly the per-fabric group-table capacity - and the spec minimum for
+/// this attribute is 10, so a Groupcast-enabled node should be built with
+/// `max-groups-per-fabric-5` or larger.
+pub const MAX_MEMBERSHIP_COUNT: u16 = (2 * MAX_GROUPS_PER_FABRIC) as u16;
+
+/// The value of the `MaxMcastAddrCount` attribute.
+///
+/// Per the Matter Core spec, when the `PerGroup` feature is supported this
+/// SHOULD equal `MaxMembershipCount` (and SHALL be at least 4).
+pub const MAX_MCAST_ADDR_COUNT: u16 = MAX_MEMBERSHIP_COUNT;
+
+/// Max endpoints in a single `JoinGroup` / `LeaveGroup` command (Matter Core
+/// spec constraint).
+const MAX_CMD_ENDPOINTS: usize = 20;
+
+/// `GroupcastTesting` duration bounds and fallback (Matter Core spec).
+const TESTING_SECS_MIN: u16 = 10;
+const TESTING_SECS_MAX: u16 = 1200;
+const TESTING_SECS_FALLBACK: u16 = 60;
+
+/// Return the `Groupcast` cluster metadata for the given feature combination.
+///
+/// Note that the command set is served in full; on a composition without the
+/// `Listener` feature, `ConfigureAuxiliaryACL` (conformance `LN`) should be
+/// excluded by the application via a custom `with_cmds` filter.
+pub const fn cluster(features: Feature) -> Cluster<'static> {
+    FULL_CLUSTER
+        .with_attrs(with!(required))
+        .with_cmds(with!(all))
+        .with_features(features.bits())
+}
+
+/// The state of an ongoing `GroupcastTesting` test session.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+struct Testing {
+    /// The fabric that armed the testing mode (`FabricUnderTest`).
+    fab_idx: NonZeroU8,
+    /// The test operation being executed.
+    #[allow(unused)]
+    operation: GroupcastTestingEnum,
+    /// When the testing mode auto-expires.
+    deadline: Instant,
+}
+
+/// The system implementation of a handler for the Groupcast Matter cluster.
+pub struct GroupcastHandler {
+    dataver: Dataver,
+    features: Feature,
+    testing: Mutex<RefCell<Option<Testing>>>,
+    testing_changed: Notification,
+}
+
+impl GroupcastHandler {
+    /// Create a new instance of `GroupcastHandler` with the given `Dataver`
+    /// and feature combination.
+    ///
+    /// `features` must match the features advertised by the cluster metadata
+    /// this handler is composed with (see [`cluster`]) - it drives the
+    /// feature-conditional command validation.
+    pub const fn new(dataver: Dataver, features: Feature) -> Self {
+        Self {
+            dataver,
+            features,
+            testing: Mutex::new(RefCell::new(None)),
+            testing_changed: Notification::new(),
+        }
+    }
+
+    /// Adapt the handler instance to the generic `rs-matter` `Handler` trait
+    pub const fn adapt(self) -> HandlerAdaptor<Self> {
+        HandlerAdaptor(self)
+    }
+
+    fn listener(&self) -> bool {
+        self.features.contains(Feature::LISTENER)
+    }
+
+    fn sender(&self) -> bool {
+        self.features.contains(Feature::SENDER)
+    }
+
+    fn per_group(&self) -> bool {
+        self.features.contains(Feature::PER_GROUP)
+    }
+
+    /// The number of distinct multicast addresses used by the group
+    /// memberships across all fabrics: one per `PerGroup`-policy group
+    /// (including legacy Groups-cluster entries, which behave as `PerGroup`),
+    /// plus the IANA-assigned address if at least one group uses it.
+    fn used_mcast_addrs(fabrics: &Fabrics) -> u16 {
+        let mut iana = false;
+        let mut count = 0;
+
+        for fabric in fabrics.iter() {
+            for entry in fabric.groups().iter() {
+                match entry.effective_mcast_policy() {
+                    MulticastAddrPolicyEnum::IanaAddr => iana = true,
+                    MulticastAddrPolicyEnum::PerGroup => count += 1,
+                }
+            }
+        }
+
+        count + iana as u16
+    }
+
+    /// The number of distinct group IDs across all fabrics.
+    fn total_group_count(fabrics: &Fabrics) -> usize {
+        fabrics
+            .iter()
+            .map(|fabric| fabric.groups().group_count())
+            .sum()
+    }
+
+    /// Whether the invoking client has been granted the `Administer`
+    /// privilege on this cluster (required for the `UseAuxiliaryACL` field
+    /// of `JoinGroup`, which is otherwise a `Manage`-privilege command).
+    fn accessor_is_admin(&self, ctx: &impl InvokeContext) -> Result<bool, Error> {
+        let accessor = ctx.exchange().accessor()?;
+        let cmd = ctx.cmd();
+
+        let path = GenericPath::new(
+            Some(cmd.endpoint_id),
+            Some(cmd.cluster_id),
+            Some(cmd.cmd_id),
+        );
+
+        let mut req = AccessReq::new(&accessor, path, Access::WRITE);
+        req.set_target_perms(Access::WRITE | Access::NEED_ADMIN);
+
+        Ok(req.allow())
+    }
+
+    /// The node ID of the invoking peer (for the `AuxiliaryAccessUpdated`
+    /// event's `AdminNodeID` field).
+    fn peer_node_id(ctx: &impl InvokeContext) -> Option<u64> {
+        ctx.exchange()
+            .with_state(|state| {
+                Ok::<_, Error>(
+                    ctx.exchange()
+                        .id()
+                        .session(&mut state.sessions)
+                        .get_peer_node_id(),
+                )
+            })
+            .unwrap_or(None)
+    }
+
+    /// Validate that every endpoint in `endpoints` exists on the node and is
+    /// not the root endpoint.
+    fn check_endpoints(ctx: &impl InvokeContext, endpoints: &[EndptId]) -> Result<(), Error> {
+        ctx.metadata().access(|node| {
+            for endpoint in endpoints {
+                if *endpoint == 0 || node.endpoint(*endpoint).is_none() {
+                    return Err(ErrorCode::EndpointNotFound.into());
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    /// Create the Group Key Management key set which `JoinGroup` /
+    /// `UpdateGroupKey` auto-create when their `Key` field is provided:
+    /// `TrustFirst` policy, `EpochKey0` = the input key, `EpochStartTime0` = 1.
+    fn make_key_set(key_set_id: u16, key: &[u8]) -> Result<GroupKeySet, Error> {
+        let mut key0 = GroupEpochKeyEntry {
+            epoch_key: Default::default(),
+            epoch_start_time: 1,
+        };
+        key0.epoch_key
+            .try_load_from_slice(key)
+            .map_err(|_| ErrorCode::ConstraintError)?;
+
+        let mut entry = GroupKeySet {
+            group_key_set_id: key_set_id,
+            group_key_security_policy: GroupKeySecurityPolicyEnum::TrustFirst as u8,
+            ..Default::default()
+        };
+        unwrap!(entry.epoch_keys.push(key0).map_err(|_| ()));
+
+        Ok(entry)
+    }
+
+    /// Bind `key_set_id` (creating it from `key` if provided) to `group_id`
+    /// on the given fabric, per the shared key rules of `JoinGroup` and
+    /// `UpdateGroupKey`:
+    /// - `key` provided + key set exists -> `AlreadyExists`;
+    /// - `key` omitted + key set missing -> `NotFound`.
+    fn bind_key_set(
+        fabric: &mut Fabric,
+        group_id: u16,
+        key_set_id: u16,
+        key: Option<&[u8]>,
+    ) -> Result<(), Error> {
+        if let Some(key) = key {
+            if fabric.groups().key_set_get(key_set_id).is_some() {
+                return Err(ErrorCode::AlreadyExists.into());
+            }
+
+            fabric
+                .groups_mut()
+                .key_set_add(Self::make_key_set(key_set_id, key)?)?;
+        } else if fabric.groups().key_set_get(key_set_id).is_none() {
+            return Err(ErrorCode::NotFound.into());
+        }
+
+        fabric.groups_mut().key_map_set_group(group_id, key_set_id)
+    }
+
+    /// Serialize one `Membership` list entry.
+    fn build_membership<P: TLVBuilderParent>(
+        listener: bool,
+        fabric: &Fabric,
+        entry: &crate::fabric::GroupEndpointMapping,
+        builder: MembershipStructBuilder<P>,
+    ) -> Result<P, Error> {
+        let key_set_id = fabric
+            .groups()
+            .key_map_get(entry.group_id)
+            .unwrap_or(KEY_SET_ID_INVALID);
+
+        builder
+            .group_id(entry.group_id)?
+            .endpoints()?
+            .with_some_if(listener, |mut builder| {
+                for endpoint in &entry.endpoints {
+                    builder = builder.push(endpoint)?;
+                }
+
+                builder.end()
+            })?
+            .key_set_id(Some(key_set_id))?
+            .has_auxiliary_acl(listener.then(|| entry.has_aux_acl()))?
+            .mcast_addr_policy(entry.effective_mcast_policy())?
+            .fabric_index(Some(fabric.fab_idx().get()))?
+            .end()
+    }
+
+    /// Common tail of the state-mutating commands: persist the fabric
+    /// (unless the failsafe is armed for it, in which case the commissioning
+    /// completion persists), bump the dataver and notify subscribers.
+    fn changed(&self, ctx: &impl InvokeContext, fab_idx: NonZeroU8) -> Result<(), Error> {
+        let mut persist = FabricPersist::new(ctx.kv());
+
+        ctx.exchange().with_state(|state| {
+            if !state.failsafe.is_armed_for(fab_idx.get()) {
+                let fabric = state.fabrics.fabric(fab_idx)?;
+                persist.store(fabric)?;
+            }
+
+            Ok::<_, Error>(())
+        })?;
+
+        persist.run()?;
+
+        // Reconcile the joined multicast addresses with the new memberships
+        ctx.exchange().matter().transport().notify_groups_changed();
+
+        self.dataver_changed();
+        ctx.notify_own_endpoint_changed();
+
+        Ok(())
+    }
+}
+
+impl ClusterHandler for GroupcastHandler {
+    const CLUSTER: Cluster<'static> = cluster(
+        Feature::LISTENER
+            .union(Feature::SENDER)
+            .union(Feature::PER_GROUP),
+    );
+
+    fn dataver(&self) -> u32 {
+        self.dataver.get()
+    }
+
+    fn dataver_changed(&self) {
+        self.dataver.changed();
+    }
+
+    fn lifecycle(&self, _ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
+        if matches!(op, LifecycleOp::Startup) {
+            // Per the Matter Core spec, `FabricUnderTest` is zero when the
+            // server initializes - testing mode does not survive a reboot.
+            self.testing.lock(|testing| *testing.borrow_mut() = None);
+        }
+
+        Ok(())
+    }
+
+    async fn run(&self, ctx: impl HandlerContext) -> Result<(), Error> {
+        // Expire the `GroupcastTesting` mode when its deadline passes,
+        // reporting the `FabricUnderTest` change to subscribers.
+        loop {
+            let deadline = self
+                .testing
+                .lock(|testing| testing.borrow().as_ref().map(|t| t.deadline));
+
+            match deadline {
+                Some(deadline) => {
+                    if Instant::now() >= deadline {
+                        self.testing.lock(|testing| *testing.borrow_mut() = None);
+
+                        self.dataver_changed();
+                        ctx.notify_attr_changed(
+                            crate::dm::endpoints::ROOT_ENDPOINT_ID,
+                            Self::CLUSTER.id,
+                            AttributeId::FabricUnderTest as _,
+                        );
+                    } else {
+                        select(Timer::at(deadline), self.testing_changed.wait()).await;
+                    }
+                }
+                None => self.testing_changed.wait().await,
+            }
+        }
+    }
+
+    fn membership<P: TLVBuilderParent>(
+        &self,
+        ctx: impl ReadContext,
+        builder: ArrayAttributeRead<MembershipStructArrayBuilder<P>, MembershipStructBuilder<P>>,
+    ) -> Result<P, Error> {
+        let listener = self.listener();
+
+        ctx.exchange().with_state(|state| {
+            let attr = ctx.attr();
+
+            let mut entries = state
+                .fabrics
+                .iter()
+                .filter(|fabric| !attr.fab_filter || fabric.fab_idx().get() == attr.fab_idx)
+                .flat_map(|fabric| fabric.groups().iter().map(move |entry| (fabric, entry)));
+
+            match builder {
+                ArrayAttributeRead::ReadAll(mut builder) => {
+                    for (fabric, entry) in entries {
+                        builder = Self::build_membership(listener, fabric, entry, builder.push()?)?;
+                    }
+
+                    builder.end()
+                }
+                ArrayAttributeRead::ReadOne(index, builder) => {
+                    let Some((fabric, entry)) = entries.nth(index as usize) else {
+                        return Err(ErrorCode::ConstraintError.into());
+                    };
+
+                    Self::build_membership(listener, fabric, entry, builder)
+                }
+                ArrayAttributeRead::ReadNone(builder) => builder.end(),
+            }
+        })
+    }
+
+    fn max_membership_count(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
+        Ok(MAX_MEMBERSHIP_COUNT)
+    }
+
+    fn max_mcast_addr_count(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
+        Ok(MAX_MCAST_ADDR_COUNT)
+    }
+
+    fn used_mcast_addr_count(&self, ctx: impl ReadContext) -> Result<u16, Error> {
+        ctx.exchange()
+            .with_state(|state| Ok(Self::used_mcast_addrs(&state.fabrics)))
+    }
+
+    fn fabric_under_test(&self, _ctx: impl ReadContext) -> Result<FabricIndex, Error> {
+        Ok(self.testing.lock(|testing| {
+            testing
+                .borrow()
+                .as_ref()
+                // Lazily treat an expired-but-not-yet-swept testing mode as
+                // disabled (the `run` loop sweeps and notifies shortly after)
+                .filter(|t| Instant::now() < t.deadline)
+                .map(|t| t.fab_idx.get())
+                .unwrap_or(0)
+        }))
+    }
+
+    fn handle_join_group(
+        &self,
+        ctx: impl InvokeContext,
+        request: JoinGroupRequest<'_>,
+    ) -> Result<(), Error> {
+        let group_id = request.group_id()?;
+        if group_id == 0 {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+
+        let key_set_id = request.key_set_id()?;
+        if key_set_id == 0 {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+
+        let key = request.key()?;
+        if let Some(key) = &key {
+            if key.0.len() != 16 {
+                return Err(ErrorCode::ConstraintError.into());
+            }
+        }
+
+        let mut endpoints = Vec::<EndptId, MAX_CMD_ENDPOINTS>::new();
+        for endpoint in &request.endpoints()? {
+            endpoints
+                .push(endpoint?)
+                .map_err(|_| ErrorCode::ConstraintError)?;
+        }
+
+        let use_auxiliary_acl = request.use_auxiliary_acl()?;
+        let replace_endpoints = request.replace_endpoints()?;
+        let mcast_addr_policy = request.mcast_addr_policy()?;
+
+        if endpoints.is_empty() {
+            // A sender-only join needs the Sender feature
+            if !self.sender() {
+                return Err(ErrorCode::ConstraintError.into());
+            }
+        } else {
+            // A listener join needs the Listener feature
+            if !self.listener() {
+                return Err(ErrorCode::ConstraintError.into());
+            }
+
+            Self::check_endpoints(&ctx, &endpoints)?;
+        }
+
+        // `UseAuxiliaryACL` and `ReplaceEndpoints` are Listener-conformant
+        // fields
+        if !self.listener() && (use_auxiliary_acl.is_some() || replace_endpoints.is_some()) {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+
+        if matches!(mcast_addr_policy, Some(MulticastAddrPolicyEnum::PerGroup)) && !self.per_group()
+        {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+
+        // The `UseAuxiliaryACL` field requires the `Administer` privilege
+        // (the command itself needs just `Manage`)
+        if use_auxiliary_acl.is_some() && !self.accessor_is_admin(&ctx)? {
+            return Err(ErrorCode::UnsupportedAccess.into());
+        }
+
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let peer_node_id = Self::peer_node_id(&ctx);
+
+        let aux_changed = ctx.exchange().with_state(|state| {
+            let is_new = state
+                .fabrics
+                .fabric(fab_idx)?
+                .groups()
+                .get(group_id)
+                .is_none();
+
+            if is_new {
+                // Capacity: per-fabric first, then node-wide
+                if state.fabrics.fabric(fab_idx)?.groups().group_count() >= MAX_GROUPS_PER_FABRIC
+                    || Self::total_group_count(&state.fabrics) >= MAX_MEMBERSHIP_COUNT as usize
+                {
+                    return Err(ErrorCode::ResourceExhausted.into());
+                }
+
+                // Multicast address capacity: a new `PerGroup` group needs a
+                // new address; a new IANA-policy group needs one only if the
+                // IANA address is not in use yet
+                let used = Self::used_mcast_addrs(&state.fabrics);
+                let needs_addr =
+                    match mcast_addr_policy.unwrap_or(MulticastAddrPolicyEnum::IanaAddr) {
+                        MulticastAddrPolicyEnum::PerGroup => true,
+                        MulticastAddrPolicyEnum::IanaAddr => !state.fabrics.iter().any(|fabric| {
+                            fabric.groups().iter().any(|e| {
+                                matches!(
+                                    e.effective_mcast_policy(),
+                                    MulticastAddrPolicyEnum::IanaAddr
+                                )
+                            })
+                        }),
+                    };
+                if needs_addr && used >= MAX_MCAST_ADDR_COUNT {
+                    return Err(ErrorCode::ResourceExhausted.into());
+                }
+            }
+
+            let fabric = state.fabrics.fabric_mut(fab_idx)?;
+
+            Self::bind_key_set(fabric, group_id, key_set_id, key.as_ref().map(|k| k.0))?;
+
+            fabric.groups_mut().groupcast_join(
+                group_id,
+                &endpoints,
+                replace_endpoints.unwrap_or(false),
+                mcast_addr_policy,
+            )?;
+
+            // Apply the `ConfigureAuxiliaryACL` effect, if requested. Per the
+            // Matter Core spec, failures here are ignored, leaving the effect
+            // of the prior successful steps unchanged.
+            let mut aux_changed = false;
+            if let Some(use_auxiliary_acl) = use_auxiliary_acl {
+                let groups = fabric.groups_mut();
+                if groups.set_has_aux_acl(group_id, use_auxiliary_acl) {
+                    aux_changed = !groups
+                        .get(group_id)
+                        .map(|e| e.endpoints.is_empty())
+                        .unwrap_or(true);
+                }
+            }
+
+            Ok::<_, Error>(aux_changed)
+        })?;
+
+        self.changed(&ctx, fab_idx)?;
+
+        if aux_changed {
+            // Best-effort: the join has already been committed
+            if let Err(e) = notify_auxiliary_access_updated(&ctx, peer_node_id, fab_idx) {
+                warn!("Failed to notify the auxiliary ACL change: {:?}", e);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn handle_leave_group<P: TLVBuilderParent>(
+        &self,
+        ctx: impl InvokeContext,
+        request: LeaveGroupRequest<'_>,
+        response: LeaveGroupResponseBuilder<P>,
+    ) -> Result<P, Error> {
+        let group_id = request.group_id()?;
+
+        let mut endpoints = None;
+        if let Some(req_endpoints) = request.endpoints()? {
+            let mut list = Vec::<EndptId, MAX_CMD_ENDPOINTS>::new();
+            for endpoint in &req_endpoints {
+                list.push(endpoint?)
+                    .map_err(|_| ErrorCode::ConstraintError)?;
+            }
+
+            endpoints = Some(list);
+        }
+
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let peer_node_id = Self::peer_node_id(&ctx);
+        let sender = self.sender();
+
+        // The endpoints that were actually removed, reported via the
+        // response (empty for the leave-all form)
+        let mut removed = Vec::<EndptId, MAX_CMD_ENDPOINTS>::new();
+
+        let aux_changed = ctx.exchange().with_state(|state| {
+            let fabric = state.fabrics.fabric_mut(fab_idx)?;
+
+            let mut aux_changed = false;
+
+            let mut remove_group = |groups: &mut crate::fabric::Groups, group_id: u16| {
+                if let Some(entry) = groups.get(group_id) {
+                    aux_changed |= entry.has_aux_acl() && !entry.endpoints.is_empty();
+                }
+
+                groups.groupcast_remove(group_id);
+                groups.key_map_remove_group(group_id);
+            };
+
+            if group_id == 0 {
+                // Leave all groups of the fabric
+                if fabric.groups().group_count() == 0 {
+                    return Err(ErrorCode::NotFound.into());
+                }
+
+                let mut group_ids = Vec::<u16, MAX_GROUPS_PER_FABRIC>::new();
+                for entry in fabric.groups().iter() {
+                    unwrap!(group_ids.push(entry.group_id).map_err(|_| ()));
+                }
+
+                for group_id in group_ids {
+                    remove_group(fabric.groups_mut(), group_id);
+                }
+            } else {
+                if fabric.groups().get(group_id).is_none() {
+                    return Err(ErrorCode::NotFound.into());
+                }
+
+                match &endpoints {
+                    Some(endpoints) => {
+                        // Partial leave: remove the listed endpoints
+                        let entry = unwrap!(fabric.groups_mut().get_mut(group_id));
+
+                        for endpoint in endpoints {
+                            let before = entry.endpoints.len();
+                            entry.endpoints.retain(|ep| ep != endpoint);
+                            if entry.endpoints.len() < before {
+                                unwrap!(removed.push(*endpoint).map_err(|_| ()));
+                            }
+                        }
+
+                        let empty = entry.endpoints.is_empty();
+                        if !removed.is_empty() && entry.has_aux_acl() {
+                            aux_changed = true;
+                        }
+
+                        // A membership left with no endpoints is removed
+                        // entirely - unless the device is (also) a Sender,
+                        // where it lives on as a sender-only membership
+                        if empty && !sender {
+                            fabric.groups_mut().groupcast_remove(group_id);
+                            fabric.groups_mut().key_map_remove_group(group_id);
+                        }
+                    }
+                    None => {
+                        // Full leave
+                        if let Some(entry) = fabric.groups().get(group_id) {
+                            for endpoint in &entry.endpoints {
+                                unwrap!(removed.push(*endpoint).map_err(|_| ()));
+                            }
+                        }
+
+                        remove_group(fabric.groups_mut(), group_id);
+                    }
+                }
+            }
+
+            Ok::<_, Error>(aux_changed)
+        })?;
+
+        self.changed(&ctx, fab_idx)?;
+
+        if aux_changed {
+            if let Err(e) = notify_auxiliary_access_updated(&ctx, peer_node_id, fab_idx) {
+                warn!("Failed to notify the auxiliary ACL change: {:?}", e);
+            }
+        }
+
+        let mut builder = response.group_id(group_id)?.endpoints()?;
+        for endpoint in &removed {
+            builder = builder.push(endpoint)?;
+        }
+
+        builder.end()?.end()
+    }
+
+    fn handle_update_group_key(
+        &self,
+        ctx: impl InvokeContext,
+        request: UpdateGroupKeyRequest<'_>,
+    ) -> Result<(), Error> {
+        let group_id = request.group_id()?;
+        if group_id == 0 {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+
+        let key_set_id = request.key_set_id()?;
+        if key_set_id == 0 {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+
+        let key = request.key()?;
+        if let Some(key) = &key {
+            if key.0.len() != 16 {
+                return Err(ErrorCode::ConstraintError.into());
+            }
+        }
+
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+
+        ctx.exchange().with_state(|state| {
+            let fabric = state.fabrics.fabric_mut(fab_idx)?;
+
+            if fabric.groups().get(group_id).is_none() {
+                return Err(ErrorCode::NotFound.into());
+            }
+
+            Self::bind_key_set(fabric, group_id, key_set_id, key.as_ref().map(|k| k.0))
+        })?;
+
+        self.changed(&ctx, fab_idx)
+    }
+
+    fn handle_configure_auxiliary_acl(
+        &self,
+        ctx: impl InvokeContext,
+        request: ConfigureAuxiliaryACLRequest<'_>,
+    ) -> Result<(), Error> {
+        let group_id = request.group_id()?;
+        let use_auxiliary_acl = request.use_auxiliary_acl()?;
+
+        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let peer_node_id = Self::peer_node_id(&ctx);
+
+        let aux_changed = ctx.exchange().with_state(|state| {
+            let fabric = state.fabrics.fabric_mut(fab_idx)?;
+
+            if fabric.groups().get(group_id).is_none() {
+                return Err(ErrorCode::NotFound.into());
+            }
+
+            let groups = fabric.groups_mut();
+            let changed = groups.set_has_aux_acl(group_id, use_auxiliary_acl);
+
+            // The `AuxiliaryACL` attribute only changes if the group has
+            // endpoints to grant access to (a sender-only membership
+            // generates no entries)
+            Ok::<_, Error>(
+                changed
+                    && !groups
+                        .get(group_id)
+                        .map(|e| e.endpoints.is_empty())
+                        .unwrap_or(true),
+            )
+        })?;
+
+        self.changed(&ctx, fab_idx)?;
+
+        if aux_changed {
+            if let Err(e) = notify_auxiliary_access_updated(&ctx, peer_node_id, fab_idx) {
+                warn!("Failed to notify the auxiliary ACL change: {:?}", e);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn handle_groupcast_testing(
+        &self,
+        ctx: impl InvokeContext,
+        request: GroupcastTestingRequest<'_>,
+    ) -> Result<(), Error> {
+        let operation = request.test_operation()?;
+        let duration_secs = request.duration_seconds()?.unwrap_or(TESTING_SECS_FALLBACK);
+
+        if !(TESTING_SECS_MIN..=TESTING_SECS_MAX).contains(&duration_secs) {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+
+        match operation {
+            GroupcastTestingEnum::DisableTesting => {
+                self.testing.lock(|testing| *testing.borrow_mut() = None);
+            }
+            GroupcastTestingEnum::EnableListenerTesting => {
+                if !self.listener() {
+                    return Err(ErrorCode::ConstraintError.into());
+                }
+
+                let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+                self.testing.lock(|testing| {
+                    *testing.borrow_mut() = Some(Testing {
+                        fab_idx,
+                        operation,
+                        deadline: Instant::now() + Duration::from_secs(duration_secs as _),
+                    })
+                });
+            }
+            GroupcastTestingEnum::EnableSenderTesting => {
+                if !self.sender() {
+                    return Err(ErrorCode::ConstraintError.into());
+                }
+
+                let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+                self.testing.lock(|testing| {
+                    *testing.borrow_mut() = Some(Testing {
+                        fab_idx,
+                        operation,
+                        deadline: Instant::now() + Duration::from_secs(duration_secs as _),
+                    })
+                });
+            }
+        }
+
+        // Rearm the expiry timer in `run` and report `FabricUnderTest`
+        self.testing_changed.notify();
+        self.dataver_changed();
+        ctx.notify_own_endpoint_changed();
+
+        Ok(())
+    }
+}

--- a/rs-matter/src/dm/clusters/groups.rs
+++ b/rs-matter/src/dm/clusters/groups.rs
@@ -68,6 +68,58 @@ impl GroupsHandler {
     }
 }
 
+impl GroupsHandler {
+    /// Whether the given (aux-flagged) group's auxiliary ACL coverage of
+    /// `endpoint_id` would change by adding/removing that endpoint - i.e.
+    /// whether an `AuxiliaryAccessUpdated` notification is due.
+    ///
+    /// `group_id` of `None` means "any group" (the `RemoveAllGroups` case).
+    fn aux_coverage_touched(
+        state: &crate::MatterState,
+        fab_idx: core::num::NonZeroU8,
+        endpoint_id: u16,
+        group_id: Option<u16>,
+        member: bool,
+    ) -> bool {
+        let Some(fabric) = state.fabrics.get(fab_idx) else {
+            return false;
+        };
+
+        fabric.groups().iter().any(|entry| {
+            group_id.is_none_or(|id| id == entry.group_id)
+                && entry.has_aux_acl()
+                && entry.endpoints.contains(&endpoint_id) == member
+        })
+    }
+
+    /// The node ID of the invoking peer (for the `AuxiliaryAccessUpdated`
+    /// event's `AdminNodeID` field).
+    fn peer_node_id(ctx: &impl InvokeContext) -> Option<u64> {
+        ctx.exchange()
+            .with_state(|state| {
+                Ok::<_, Error>(
+                    ctx.exchange()
+                        .id()
+                        .session(&mut state.sessions)
+                        .get_peer_node_id(),
+                )
+            })
+            .unwrap_or(None)
+    }
+
+    /// Emit the auxiliary-ACL change notification, best-effort (the group
+    /// mutation has already been committed).
+    fn notify_aux(ctx: &impl InvokeContext, fab_idx: core::num::NonZeroU8) {
+        let peer_node_id = Self::peer_node_id(ctx);
+
+        if let Err(e) =
+            crate::dm::clusters::acl::notify_auxiliary_access_updated(ctx, peer_node_id, fab_idx)
+        {
+            warn!("Failed to notify the auxiliary ACL change: {:?}", e);
+        }
+    }
+}
+
 impl ClusterHandler for GroupsHandler {
     const CLUSTER: Cluster<'static> = FULL_CLUSTER
         .with_features(Feature::GROUP_NAMES.bits())
@@ -109,11 +161,18 @@ impl ClusterHandler for GroupsHandler {
         let status = ctx.exchange().with_state(|state| {
             // Check if group security material is available
             if !Self::has_group_material(state, fab_idx, group_id)? {
-                return Ok(IMStatusCode::UnsupportedAccess);
+                return Ok((IMStatusCode::UnsupportedAccess, false));
             }
 
             // Add or update group membership
             let endpoint_id = ctx.cmd().endpoint_id;
+
+            // Joining an endpoint to a group with auxiliary ACL generation
+            // enabled (via the Groupcast cluster) extends the synthesized
+            // `AuxiliaryACL` coverage - which must be notified
+            let aux_touched =
+                Self::aux_coverage_touched(state, fab_idx, endpoint_id, Some(group_id), false);
+
             let fabric = state.fabrics.fabric_mut(fab_idx)?;
 
             match fabric.groups_mut().add(endpoint_id, group_id, group_name) {
@@ -127,16 +186,21 @@ impl ClusterHandler for GroupsHandler {
 
                     ctx.exchange().matter().transport().notify_groups_changed();
 
-                    Ok(IMStatusCode::Success)
+                    Ok((IMStatusCode::Success, aux_touched))
                 }
                 Err(e) if e.code() == ErrorCode::ResourceExhausted => {
-                    Ok(IMStatusCode::ResourceExhausted)
+                    Ok((IMStatusCode::ResourceExhausted, false))
                 }
                 Err(e) => Err(e)?,
             }
         })?;
 
         persist.run()?;
+
+        let (status, aux_touched) = status;
+        if aux_touched && matches!(status, IMStatusCode::Success) {
+            Self::notify_aux(&ctx, fab_idx);
+        }
 
         response.status(status as u8)?.group_id(group_id)?.end()
     }
@@ -237,8 +301,14 @@ impl ClusterHandler for GroupsHandler {
         let status = ctx.exchange().with_state(|state| {
             // Step 1: Validate constraints
             if group_id == 0 {
-                return Ok(IMStatusCode::ConstraintError);
+                return Ok((IMStatusCode::ConstraintError, false));
             }
+
+            // Removing an endpoint from a group with auxiliary ACL
+            // generation enabled shrinks the synthesized `AuxiliaryACL`
+            // coverage - which must be notified
+            let aux_touched =
+                Self::aux_coverage_touched(state, fab_idx, endpoint_id, Some(group_id), true);
 
             let fabric = state.fabrics.fabric_mut(fab_idx)?;
 
@@ -253,13 +323,18 @@ impl ClusterHandler for GroupsHandler {
 
                 ctx.exchange().matter().transport().notify_groups_changed();
 
-                Ok(IMStatusCode::Success)
+                Ok((IMStatusCode::Success, aux_touched))
             } else {
-                Ok(IMStatusCode::NotFound)
+                Ok((IMStatusCode::NotFound, false))
             }
         })?;
 
         persist.run()?;
+
+        let (status, aux_touched) = status;
+        if aux_touched && matches!(status, IMStatusCode::Success) {
+            Self::notify_aux(&ctx, fab_idx);
+        }
 
         response.status(status as u8)?.group_id(group_id)?.end()
     }
@@ -270,7 +345,9 @@ impl ClusterHandler for GroupsHandler {
 
         let mut persist = FabricPersist::new(ctx.kv());
 
-        ctx.exchange().with_state(|state| {
+        let aux_touched = ctx.exchange().with_state(|state| {
+            let aux_touched = Self::aux_coverage_touched(state, fab_idx, endpoint_id, None, true);
+
             let fabric = state.fabrics.fabric_mut(fab_idx)?;
 
             fabric.groups_mut().remove(endpoint_id, None);
@@ -284,10 +361,14 @@ impl ClusterHandler for GroupsHandler {
 
             ctx.exchange().matter().transport().notify_groups_changed();
 
-            Ok(())
+            Ok(aux_touched)
         })?;
 
         persist.run()?;
+
+        if aux_touched {
+            Self::notify_aux(&ctx, fab_idx);
+        }
 
         Ok(())
     }

--- a/rs-matter/src/dm/clusters/groups.rs
+++ b/rs-matter/src/dm/clusters/groups.rs
@@ -19,6 +19,7 @@
 
 use core::num::NonZeroU8;
 
+use crate::dm::clusters::acl::notify_auxiliary_access_updated;
 use crate::dm::{Cluster, Dataver, InvokeContext, ReadContext};
 use crate::error::{Error, ErrorCode};
 use crate::fabric::FabricPersist;
@@ -112,9 +113,7 @@ impl GroupsHandler {
     fn notify_aux(ctx: &impl InvokeContext, fab_idx: core::num::NonZeroU8) {
         let peer_node_id = Self::peer_node_id(ctx);
 
-        if let Err(e) =
-            crate::dm::clusters::acl::notify_auxiliary_access_updated(ctx, peer_node_id, fab_idx)
-        {
+        if let Err(e) = notify_auxiliary_access_updated(ctx, peer_node_id, fab_idx) {
             warn!("Failed to notify the auxiliary ACL change: {:?}", e);
         }
     }

--- a/rs-matter/src/dm/clusters/groups.rs
+++ b/rs-matter/src/dm/clusters/groups.rs
@@ -143,7 +143,7 @@ impl ClusterHandler for GroupsHandler {
         request: AddGroupRequest<'_>,
         response: AddGroupResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let group_id = request.group_id()?;
         let group_name: &str = request.group_name()?;
 
@@ -210,7 +210,7 @@ impl ClusterHandler for GroupsHandler {
         request: ViewGroupRequest<'_>,
         response: ViewGroupResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let group_id = request.group_id()?;
 
         // Validate constraints
@@ -251,7 +251,7 @@ impl ClusterHandler for GroupsHandler {
         request: GetGroupMembershipRequest<'_>,
         response: GetGroupMembershipResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let request_group_list = request.group_list()?;
 
         ctx.exchange().with_state(|state| {
@@ -291,7 +291,7 @@ impl ClusterHandler for GroupsHandler {
         request: RemoveGroupRequest<'_>,
         response: RemoveGroupResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let group_id = request.group_id()?;
         let endpoint_id = ctx.cmd().endpoint_id;
 
@@ -339,7 +339,7 @@ impl ClusterHandler for GroupsHandler {
     }
 
     fn handle_remove_all_groups(&self, ctx: impl InvokeContext) -> Result<(), Error> {
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let endpoint_id = ctx.cmd().endpoint_id;
 
         let mut persist = FabricPersist::new(ctx.kv());

--- a/rs-matter/src/dm/clusters/grp_key_mgmt.rs
+++ b/rs-matter/src/dm/clusters/grp_key_mgmt.rs
@@ -260,7 +260,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         ctx: impl InvokeContext,
         request: KeySetWriteRequest<'_>,
     ) -> Result<(), Error> {
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let key_set = request.group_key_set()?;
 
         let group_key_set_id = key_set.group_key_set_id()?;
@@ -426,7 +426,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         request: KeySetReadRequest<'_>,
         response: KeySetReadResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let group_key_set_id = request.group_key_set_id()?;
 
         ctx.exchange().with_state(|state| {
@@ -503,7 +503,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         ctx: impl InvokeContext,
         request: KeySetRemoveRequest<'_>,
     ) -> Result<(), Error> {
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
         let group_key_set_id = request.group_key_set_id()?;
 
         // KeySetRemove of ID 0 (IPK) is not allowed
@@ -540,7 +540,7 @@ impl ClusterHandler for GrpKeyMgmtHandler {
         ctx: impl InvokeContext,
         response: KeySetReadAllIndicesResponseBuilder<P>,
     ) -> Result<P, Error> {
-        let fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let fab_idx = ctx.accessor()?.fab_idx()?;
 
         ctx.exchange().with_state(|state| {
             let fabric = state.fabrics.fabric(fab_idx)?;

--- a/rs-matter/src/dm/clusters/icd_mgmt.rs
+++ b/rs-matter/src/dm/clusters/icd_mgmt.rs
@@ -643,7 +643,7 @@ impl<'a> IcdMgmtHandler<'a> {
             Some(cmd.cmd_id),
         );
 
-        let mut req = AccessReq::new(&accessor, path, Access::WRITE);
+        let mut req = AccessReq::new(&accessor, path, Access::WRITE, &[]);
         req.set_target_perms(Access::WRITE | Access::NEED_ADMIN);
 
         Ok(req.allow())

--- a/rs-matter/src/dm/clusters/icd_mgmt.rs
+++ b/rs-matter/src/dm/clusters/icd_mgmt.rs
@@ -627,7 +627,7 @@ impl<'a> IcdMgmtHandler<'a> {
 
     /// The accessing fabric of the current command.
     fn cmd_fabric(ctx: &impl InvokeContext) -> Result<NonZeroU8, Error> {
-        ctx.exchange().accessor()?.fab_idx()
+        ctx.accessor()?.fab_idx()
     }
 
     /// Whether the caller holds Administer privilege on this command's path.
@@ -635,7 +635,7 @@ impl<'a> IcdMgmtHandler<'a> {
     /// Administrators may register/unregister any client; everyone else must
     /// prove ownership of an existing entry with its verification key.
     fn caller_is_admin(ctx: &impl InvokeContext) -> Result<bool, Error> {
-        let accessor = ctx.exchange().accessor()?;
+        let accessor = ctx.accessor()?;
         let cmd = ctx.cmd();
         let path = GenericPath::new(
             Some(cmd.endpoint_id),

--- a/rs-matter/src/dm/clusters/scenes.rs
+++ b/rs-matter/src/dm/clusters/scenes.rs
@@ -682,7 +682,7 @@ where
     }
 
     fn fab_idx<C: InvokeContext>(ctx: &C) -> Result<NonZeroU8, Error> {
-        ctx.exchange().accessor()?.fab_idx()
+        ctx.accessor()?.fab_idx()
     }
 
     /// Per-fabric `RemainingCapacity` for `GetSceneMembership` and
@@ -920,7 +920,7 @@ where
         builder: ArrayAttributeRead<SceneInfoStructArrayBuilder<P>, SceneInfoStructBuilder<P>>,
     ) -> Result<P, Error> {
         let endpoint_id = ctx.attr().endpoint_id;
-        let accessor_fab_idx = ctx.exchange().accessor()?.fab_idx()?;
+        let accessor_fab_idx = ctx.accessor()?.fab_idx()?;
 
         // Snapshot the relevant scalars under a single lock, then
         // build the response outside the lock. A fabric gets a row

--- a/rs-matter/src/dm/endpoints.rs
+++ b/rs-matter/src/dm/endpoints.rs
@@ -45,6 +45,9 @@ use super::types::{Async, ChainedHandler, Dataver, EndptId, EpClMatcher};
 /// as the corresponding tokens on the [`crate::clusters!`] macro.
 ///
 /// Optional cluster-shape modifiers (in order):
+/// - `acl(aux)` — makes the Access Control cluster advertise the provisional
+///   `AUXILIARY` feature and `AuxiliaryACL` attribute (e.g. for nodes hosting
+///   the Groupcast cluster).
 /// - `sw_diag(heap | watermarks | thread, …)` — shapes the Software
 ///   Diagnostics cluster.
 /// - `time_sync(time_zone | ntp_client | ntp_server | time_sync_client, …)` —
@@ -60,6 +63,7 @@ use super::types::{Async, ChainedHandler, Dataver, EndptId, EpClMatcher};
 #[macro_export]
 macro_rules! root_endpoint {
     ($t:ident
+        $(, acl($($acl_opt:ident),* $(,)?))?
         $(, sw_diag($($sw_opt:ident),* $(,)?))?
         $(, time_sync($($ts_opt:ident),* $(,)?))?
     ) => {
@@ -68,6 +72,7 @@ macro_rules! root_endpoint {
             device_types: $crate::devices!($crate::dm::devices::DEV_TYPE_ROOT_NODE),
             clusters: $crate::clusters!(
                 $t
+                $(, acl($($acl_opt),*))?
                 $(, sw_diag($($sw_opt),*))?
                 $(, time_sync($($ts_opt),*))?
                 ;

--- a/rs-matter/src/dm/types/cluster.rs
+++ b/rs-matter/src/dm/types/cluster.rs
@@ -609,13 +609,14 @@ impl defmt::Format for Cluster<'_> {
 #[macro_export]
 macro_rules! clusters {
     (sys
+        $(, acl($($acl_opt:ident),* $(,)?))?
         $(, sw_diag($($sw_opt:ident),* $(,)?))?
         $(, time_sync($($ts_opt:ident),* $(,)?))?
         ; $($cluster:expr $(,)?)*
     ) => {
         $crate::clusters!(
             <$crate::dm::clusters::desc::DescHandler as $crate::dm::clusters::desc::ClusterHandler>::CLUSTER,
-            <$crate::dm::clusters::acl::AclHandler as $crate::dm::clusters::acl::ClusterHandler>::CLUSTER,
+            $crate::__acl_cluster!( $($($acl_opt),*)? ),
             <$crate::dm::clusters::basic_info::BasicInfoHandler as $crate::dm::clusters::basic_info::ClusterHandler>::CLUSTER,
             <$crate::dm::clusters::gen_comm::GenCommHandler as $crate::dm::clusters::gen_comm::ClusterHandler>::CLUSTER,
             <$crate::dm::clusters::gen_diag::GenDiagHandler as $crate::dm::clusters::gen_diag::ClusterHandler>::CLUSTER,
@@ -632,12 +633,14 @@ macro_rules! clusters {
         )
     };
     (eth
+        $(, acl($($acl_opt:ident),* $(,)?))?
         $(, sw_diag($($sw_opt:ident),* $(,)?))?
         $(, time_sync($($ts_opt:ident),* $(,)?))?
         ; $($cluster:expr $(,)?)*
     ) => {
         $crate::clusters!(
             sys
+            $(, acl($($acl_opt),*))?
             $(, sw_diag($($sw_opt),*))?
             $(, time_sync($($ts_opt),*))?
             ;
@@ -647,12 +650,14 @@ macro_rules! clusters {
         )
     };
     (thread
+        $(, acl($($acl_opt:ident),* $(,)?))?
         $(, sw_diag($($sw_opt:ident),* $(,)?))?
         $(, time_sync($($ts_opt:ident),* $(,)?))?
         ; $($cluster:expr $(,)?)*
     ) => {
         $crate::clusters!(
             sys
+            $(, acl($($acl_opt),*))?
             $(, sw_diag($($sw_opt),*))?
             $(, time_sync($($ts_opt),*))?
             ;
@@ -662,12 +667,14 @@ macro_rules! clusters {
         )
     };
     (wifi
+        $(, acl($($acl_opt:ident),* $(,)?))?
         $(, sw_diag($($sw_opt:ident),* $(,)?))?
         $(, time_sync($($ts_opt:ident),* $(,)?))?
         ; $($cluster:expr $(,)?)*
     ) => {
         $crate::clusters!(
             sys
+            $(, acl($($acl_opt),*))?
             $(, sw_diag($($sw_opt),*))?
             $(, time_sync($($ts_opt),*))?
             ;
@@ -681,6 +688,24 @@ macro_rules! clusters {
             $($cluster,)*
         ]
     }
+}
+
+/// Internal helper: map the `acl(...)` option token to the matching Access
+/// Control cluster metadata: no token → the default
+/// [`crate::dm::clusters::acl::AclHandler::CLUSTER`]; `aux` →
+/// [`crate::dm::clusters::acl::CLUSTER_AUX`] (advertising the provisional
+/// `AUXILIARY` feature and `AuxiliaryACL` attribute, e.g. for nodes hosting
+/// the Groupcast cluster).
+#[allow(unused_macros)]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __acl_cluster {
+    () => {
+        <$crate::dm::clusters::acl::AclHandler as $crate::dm::clusters::acl::ClusterHandler>::CLUSTER
+    };
+    (aux) => {
+        $crate::dm::clusters::acl::CLUSTER_AUX
+    };
 }
 
 /// Internal helper: turn a comma-separated list of `sw_diag(...)` lowercase

--- a/rs-matter/src/dm/types/cluster.rs
+++ b/rs-matter/src/dm/types/cluster.rs
@@ -153,7 +153,7 @@ impl<'a> Cluster<'a> {
         write: bool,
         attr_id: AttrId,
     ) -> Result<(), IMStatusCode> {
-        let mut access_req = AccessReq::new_with_device_types(
+        let mut access_req = AccessReq::new(
             accessor,
             path,
             if write { Access::WRITE } else { Access::READ },
@@ -198,8 +198,7 @@ impl<'a> Cluster<'a> {
         device_types: &[DeviceType],
         cmd_id: CmdId,
     ) -> Result<(), IMStatusCode> {
-        let mut access_req =
-            AccessReq::new_with_device_types(accessor, path, Access::WRITE, device_types);
+        let mut access_req = AccessReq::new(accessor, path, Access::WRITE, device_types);
 
         let target_perms = self
             .commands
@@ -240,8 +239,7 @@ impl<'a> Cluster<'a> {
         device_types: &[DeviceType],
         event_id: EventId,
     ) -> Result<(), IMStatusCode> {
-        let mut access_req =
-            AccessReq::new_with_device_types(accessor, path, Access::READ, device_types);
+        let mut access_req = AccessReq::new(accessor, path, Access::READ, device_types);
 
         let target_perms = self
             .events

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -21,6 +21,7 @@ use core::pin::pin;
 
 use embassy_futures::select::select;
 
+use crate::acl::Accessor;
 use crate::crypto::Crypto;
 use crate::dm::clusters::net_comm::NetworksAccess;
 use crate::dm::{EventId, EventNumber, Metadata};
@@ -377,6 +378,11 @@ pub trait OperationContext:
 {
     /// Return the exchange object that is associated with this operation.
     fn exchange(&self) -> &Exchange<'_>;
+
+    /// Return the accessor object that is associated with this operation.
+    fn accessor(&self) -> Result<Accessor<'_>, Error> {
+        self.exchange().accessor(self.metadata())
+    }
 }
 
 impl<T> OperationContext for &T
@@ -385,6 +391,10 @@ where
 {
     fn exchange(&self) -> &Exchange<'_> {
         (**self).exchange()
+    }
+
+    fn accessor(&self) -> Result<Accessor<'_>, Error> {
+        (**self).accessor()
     }
 }
 

--- a/rs-matter/src/dm/types/node.rs
+++ b/rs-matter/src/dm/types/node.rs
@@ -18,7 +18,8 @@
 use core::fmt;
 
 use crate::acl::Accessor;
-use crate::dm::{Cluster, Endpoint};
+use crate::dm::endpoints::ROOT_ENDPOINT_ID;
+use crate::dm::{Cluster, Endpoint, Metadata};
 use crate::im::encoding::{AttrPath, EventPath, GenericPath, IMStatusCode};
 use crate::utils::init::{init, Init};
 use crate::utils::storage::Vec;
@@ -197,6 +198,22 @@ impl<'a> Node<'a> {
 
         false
     }
+
+    /// Return true if the node metadata advertises the `AUXILIARY` feature, which
+    /// indicates that the node has a feature (e.g. a Groupcast cluster) that
+    /// synthesizes auxiliary ACL entries and requires the special access-control
+    /// behavior mandated by the Matter Core spec for nodes with the feature.
+    pub(crate) fn aux_acl_enabled(&self) -> bool {
+        self.endpoint(ROOT_ENDPOINT_ID)
+            .and_then(|endpoint| {
+                endpoint.cluster(crate::dm::clusters::decl::access_control::FULL_CLUSTER.id)
+            })
+            .is_some_and(|cluster| {
+                cluster.feature_map
+                    & crate::dm::clusters::decl::access_control::Feature::AUXILIARY.bits()
+                    != 0
+            })
+    }
 }
 
 impl core::fmt::Display for Node<'_> {
@@ -270,5 +287,22 @@ impl<const N: usize> core::fmt::Display for DynamicNode<'_, N> {
 impl<'a, const N: usize> Default for DynamicNode<'a, N> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub(crate) trait AuxAclCheck {
+    /// Return true if the metadata advertises the `AUXILIARY` feature, which
+    /// indicates that the node has a feature (e.g. a Groupcast cluster) that
+    /// synthesizes auxiliary ACL entries and requires the special access-control
+    /// behavior mandated by the Matter Core spec for nodes with the feature.
+    fn aux_acl_enabled(&self) -> bool;
+}
+
+impl<T> AuxAclCheck for T
+where
+    T: Metadata,
+{
+    fn aux_acl_enabled(&self) -> bool {
+        self.access(|node| node.aux_acl_enabled())
     }
 }

--- a/rs-matter/src/error.rs
+++ b/rs-matter/src/error.rs
@@ -31,6 +31,7 @@ use alloc::{boxed::Box, string::ToString};
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ErrorCode {
+    AlreadyExists,
     AttributeNotFound,
     AttributeIsCustom,
     BufferTooSmall,

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -852,9 +852,11 @@ impl Fabric {
     /// Check if the fabric allows the given access request
     ///
     /// Note that the fabric index in the access request needs to be checked before that.
-    fn allow(&self, req: &AccessReq) -> bool {
+    /// `aux_feature` conveys whether the node advertises the Access Control
+    /// cluster's `AUXILIARY` feature - see `AclEntry::allow`.
+    fn allow(&self, req: &AccessReq, aux_feature: bool) -> bool {
         for e in &self.acl {
-            if e.allow(req) {
+            if e.allow(req, aux_feature) {
                 return true;
             }
         }
@@ -1174,7 +1176,10 @@ impl Fabrics {
 
     /// Check if the given access request should be allowed, based on all operational fabrics
     /// and their ACLs
-    pub fn allow(&self, req: &AccessReq) -> bool {
+    ///
+    /// `aux_feature` conveys whether the node advertises the Access Control
+    /// cluster's `AUXILIARY` feature - see `AclEntry::allow`.
+    pub fn allow(&self, req: &AccessReq, aux_feature: bool) -> bool {
         // PASE Sessions with no fabric index have implicit access grant,
         // but only as long as the ACL list is empty
         //
@@ -1208,7 +1213,7 @@ impl Fabrics {
             return false;
         };
 
-        fabric.allow(req)
+        fabric.allow(req, aux_feature)
     }
 }
 

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -148,10 +148,6 @@ mod groups {
         /// of the Access Control cluster.
         ///
         /// `None` (in blobs persisted before the field existed) means `false`.
-        ///
-        /// NOTE: keep this field and the one below *last* - the
-        /// persisted-blob TLV tags are positional, and appending preserves
-        /// compatibility with blobs written before the fields existed.
         pub has_aux_acl: Option<bool>,
         /// The multicast-address policy of the group, when it is managed by
         /// the Groupcast cluster.
@@ -1101,6 +1097,20 @@ cfg_if! {
 /// All fabrics
 pub struct Fabrics {
     fabrics: Vec<Fabric, MAX_FABRICS>,
+    /// Whether the node advertises the Access Control cluster's `AUXILIARY`
+    /// feature (auxiliary ACL entries, synthesized by features like a future
+    /// Groupcast cluster)
+    ///
+    /// Derived from the node metadata by `AclHandler` at startup (see
+    /// `dm::clusters::acl::CLUSTER_AUX`). When set, the access-control
+    /// evaluation of wildcard-target Group-auth entries excludes the root
+    /// endpoint, as the Matter Core spec mandates.
+    ///
+    /// Note that there is - deliberately - no accompanying storage for the
+    /// auxiliary entries themselves: they are derived state, to be computed
+    /// on the fly from the producing feature's own state, both when serving
+    /// the `AuxiliaryACL` attribute and during access-control evaluation.
+    pub(crate) aux_acl_enabled: bool,
 }
 
 impl Default for Fabrics {
@@ -1115,6 +1125,7 @@ impl Fabrics {
     pub const fn new() -> Self {
         Self {
             fabrics: Vec::new(),
+            aux_acl_enabled: false,
         }
     }
 
@@ -1122,6 +1133,7 @@ impl Fabrics {
     pub fn init() -> impl Init<Self> {
         init!(Self {
             fabrics <- Vec::init(),
+            aux_acl_enabled: false,
         })
     }
 
@@ -1362,7 +1374,7 @@ impl Fabrics {
     ///
     /// `aux_feature` conveys whether the node advertises the Access Control
     /// cluster's `AUXILIARY` feature - see `AclEntry::allow`.
-    pub fn allow(&self, req: &AccessReq, aux_feature: bool) -> bool {
+    pub fn allow(&self, req: &AccessReq) -> bool {
         // PASE Sessions with no fabric index have implicit access grant,
         // but only as long as the ACL list is empty
         //
@@ -1396,7 +1408,7 @@ impl Fabrics {
             return false;
         };
 
-        fabric.allow(req, aux_feature)
+        fabric.allow(req, self.aux_acl_enabled)
     }
 }
 

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -53,6 +53,7 @@ mod groups {
 
     use heapless::String;
 
+    use crate::dm::clusters::decl::groupcast::MulticastAddrPolicyEnum;
     use crate::error::{Error, ErrorCode};
     use crate::group_keys::GroupKeySet;
     use crate::tlv::{FromTLV, ToTLV};
@@ -141,6 +142,46 @@ mod groups {
         pub group_id: u16,
         pub endpoints: Vec<u16, GROUP_ENDPOINTS_PER_FABRIC>,
         pub group_name: String<MAX_GROUP_NAME_LEN>,
+        /// Whether the (Groupcast-managed) group has auxiliary ACL entries
+        /// generated for its endpoints - see the Groupcast cluster's
+        /// `ConfigureAuxiliaryACL` command and the `AuxiliaryACL` attribute
+        /// of the Access Control cluster.
+        ///
+        /// `None` (in blobs persisted before the field existed) means `false`.
+        ///
+        /// NOTE: keep this field and the one below *last* - the
+        /// persisted-blob TLV tags are positional, and appending preserves
+        /// compatibility with blobs written before the fields existed.
+        pub has_aux_acl: Option<bool>,
+        /// The multicast-address policy of the group, when it is managed by
+        /// the Groupcast cluster.
+        ///
+        /// `None` means the group was created via the legacy Groups cluster,
+        /// which behaves like the `PerGroup` policy (such nodes join the
+        /// fabric+group-scoped multicast address) - the `PerGroup` policy
+        /// exists precisely for interop with them.
+        pub mcast_policy: Option<MulticastAddrPolicyEnum>,
+    }
+
+    impl GroupEndpointMapping {
+        /// Whether the group has auxiliary ACL entries generated for its
+        /// endpoints.
+        pub fn has_aux_acl(&self) -> bool {
+            self.has_aux_acl.unwrap_or(false)
+        }
+
+        /// The effective multicast-address policy of the group (legacy
+        /// Groups-cluster entries behave as `PerGroup`).
+        pub fn effective_mcast_policy(&self) -> MulticastAddrPolicyEnum {
+            self.mcast_policy
+                .unwrap_or(MulticastAddrPolicyEnum::PerGroup)
+        }
+
+        /// Whether the group is managed by the Groupcast cluster (as opposed
+        /// to the legacy Groups cluster).
+        pub fn groupcast_managed(&self) -> bool {
+            self.mcast_policy.is_some()
+        }
     }
 
     /// A stored group key map entry (maps group ID to key set).
@@ -263,6 +304,13 @@ mod groups {
                 .find(|e| e.group_id == group_id)
         }
 
+        /// Look up a group by ID, mutably
+        pub fn get_mut(&mut self, group_id: u16) -> Option<&mut GroupEndpointMapping> {
+            self.endpoint_mapping
+                .iter_mut()
+                .find(|e| e.group_id == group_id)
+        }
+
         /// Add an endpoint to a group.
         /// Returns true if the endpoint was already a member (name still updated per spec).
         pub fn add(
@@ -284,6 +332,8 @@ mod groups {
                         endpoints: Vec::new(),
                         group_name: String::from_str(group_name)
                             .map_err(|_| ErrorCode::ConstraintError)?,
+                        has_aux_acl: None,
+                        mcast_policy: None,
                     })
                     .map_err(|_| ErrorCode::ResourceExhausted)?;
                 unwrap!(self.endpoint_mapping.last_mut())
@@ -324,10 +374,143 @@ mod groups {
                 }
             }
 
-            // Remove entries with no endpoints left
-            self.endpoint_mapping.retain(|e| !e.endpoints.is_empty());
+            // Remove entries with no endpoints left - except Groupcast-managed
+            // ones, which may legitimately exist with no endpoints (a
+            // sender-only membership); the Groupcast cluster removes those
+            // explicitly via its `LeaveGroup` command.
+            self.endpoint_mapping
+                .retain(|e| !e.endpoints.is_empty() || e.groupcast_managed());
 
             removed
+        }
+
+        /// Join endpoints to a group on behalf of the Groupcast cluster,
+        /// creating the membership if it does not exist.
+        ///
+        /// - `endpoints`: the endpoints to add (may be empty for a
+        ///   sender-only membership); duplicates are omitted;
+        /// - `replace`: when `true`, the given endpoints replace the
+        ///   existing list instead of being appended;
+        /// - `mcast_policy`: the multicast-address policy; applied on
+        ///   creation, or updated when `Some` on an existing membership.
+        ///
+        /// Errors with `ResourceExhausted` when the membership or endpoint
+        /// capacity is exceeded; the membership is left unchanged in that
+        /// case, except that a possibly-performed `replace` clearing is
+        /// rolled back by restoring nothing (the caller re-checks capacity
+        /// upfront via [`Self::group_count`] and the endpoint capacity).
+        pub fn groupcast_join(
+            &mut self,
+            group_id: u16,
+            endpoints: &[u16],
+            replace: bool,
+            mcast_policy: Option<MulticastAddrPolicyEnum>,
+        ) -> Result<(), Error> {
+            let entry = if let Some(entry) = self
+                .endpoint_mapping
+                .iter_mut()
+                .find(|e| e.group_id == group_id)
+            {
+                entry
+            } else {
+                self.endpoint_mapping
+                    .push(GroupEndpointMapping {
+                        group_id,
+                        endpoints: Vec::new(),
+                        group_name: String::new(),
+                        has_aux_acl: Some(false),
+                        mcast_policy: Some(
+                            mcast_policy.unwrap_or(MulticastAddrPolicyEnum::IanaAddr),
+                        ),
+                    })
+                    .map_err(|_| ErrorCode::ResourceExhausted)?;
+                unwrap!(self.endpoint_mapping.last_mut())
+            };
+
+            // Joining via Groupcast upgrades a legacy entry to
+            // Groupcast-managed (the default policy matches the legacy
+            // behavior)
+            if entry.mcast_policy.is_none() {
+                entry.mcast_policy = Some(MulticastAddrPolicyEnum::PerGroup);
+            }
+
+            if let Some(mcast_policy) = mcast_policy {
+                entry.mcast_policy = Some(mcast_policy);
+            }
+
+            if replace {
+                entry.endpoints.clear();
+            }
+
+            for endpoint in endpoints {
+                if !entry.endpoints.contains(endpoint) {
+                    entry
+                        .endpoints
+                        .push(*endpoint)
+                        .map_err(|_| ErrorCode::ResourceExhausted)?;
+                }
+            }
+
+            Ok(())
+        }
+
+        /// Remove a whole group membership. Returns `true` if it existed.
+        pub fn groupcast_remove(&mut self, group_id: u16) -> bool {
+            let before = self.endpoint_mapping.len();
+            self.endpoint_mapping.retain(|e| e.group_id != group_id);
+
+            before != self.endpoint_mapping.len()
+        }
+
+        /// Set the `has_aux_acl` flag of a group membership.
+        /// Returns `true` if the flag changed.
+        pub fn set_has_aux_acl(&mut self, group_id: u16, has_aux_acl: bool) -> bool {
+            let Some(entry) = self
+                .endpoint_mapping
+                .iter_mut()
+                .find(|e| e.group_id == group_id)
+            else {
+                return false;
+            };
+
+            let changed = entry.has_aux_acl() != has_aux_acl;
+            entry.has_aux_acl = Some(has_aux_acl);
+
+            changed
+        }
+
+        /// The number of group memberships of this fabric.
+        pub fn group_count(&self) -> usize {
+            self.endpoint_mapping.len()
+        }
+
+        /// Look up the key set ID mapped to a group, if any.
+        pub fn key_map_get(&self, group_id: u16) -> Option<u16> {
+            self.key_map
+                .iter()
+                .find(|e| e.group_id == group_id)
+                .map(|e| e.group_key_set_id)
+        }
+
+        /// Map a group to a key set, replacing any previous mapping of that
+        /// group.
+        pub fn key_map_set_group(&mut self, group_id: u16, key_set_id: u16) -> Result<(), Error> {
+            if let Some(entry) = self.key_map.iter_mut().find(|e| e.group_id == group_id) {
+                entry.group_key_set_id = key_set_id;
+                return Ok(());
+            }
+
+            self.key_map
+                .push(GroupKeyMapping {
+                    group_id,
+                    group_key_set_id: key_set_id,
+                })
+                .map_err(|_| ErrorCode::ResourceExhausted.into())
+        }
+
+        /// Remove all key-set mappings of the given group.
+        pub fn key_map_remove_group(&mut self, group_id: u16) {
+            self.key_map.retain(|e| e.group_id != group_id);
         }
     }
 

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -1031,11 +1031,11 @@ impl Fabric {
     /// Check if the fabric allows the given access request
     ///
     /// Note that the fabric index in the access request needs to be checked before that.
-    /// `aux_feature` conveys whether the node advertises the Access Control
+    /// `aux_acl_enabled` conveys whether the node advertises the Access Control
     /// cluster's `AUXILIARY` feature - see `AclEntry::allow`.
-    fn allow(&self, req: &AccessReq, aux_feature: bool) -> bool {
+    fn allow(&self, req: &AccessReq, aux_acl_enabled: bool) -> bool {
         for e in &self.acl {
-            if e.allow(req, aux_feature) {
+            if e.allow(req, aux_acl_enabled) {
                 return true;
             }
         }
@@ -1097,20 +1097,6 @@ cfg_if! {
 /// All fabrics
 pub struct Fabrics {
     fabrics: Vec<Fabric, MAX_FABRICS>,
-    /// Whether the node advertises the Access Control cluster's `AUXILIARY`
-    /// feature (auxiliary ACL entries, synthesized by features like a future
-    /// Groupcast cluster)
-    ///
-    /// Derived from the node metadata by `AclHandler` at startup (see
-    /// `dm::clusters::acl::CLUSTER_AUX`). When set, the access-control
-    /// evaluation of wildcard-target Group-auth entries excludes the root
-    /// endpoint, as the Matter Core spec mandates.
-    ///
-    /// Note that there is - deliberately - no accompanying storage for the
-    /// auxiliary entries themselves: they are derived state, to be computed
-    /// on the fly from the producing feature's own state, both when serving
-    /// the `AuxiliaryACL` attribute and during access-control evaluation.
-    pub(crate) aux_acl_enabled: bool,
 }
 
 impl Default for Fabrics {
@@ -1125,7 +1111,6 @@ impl Fabrics {
     pub const fn new() -> Self {
         Self {
             fabrics: Vec::new(),
-            aux_acl_enabled: false,
         }
     }
 
@@ -1133,7 +1118,6 @@ impl Fabrics {
     pub fn init() -> impl Init<Self> {
         init!(Self {
             fabrics <- Vec::init(),
-            aux_acl_enabled: false,
         })
     }
 
@@ -1372,9 +1356,9 @@ impl Fabrics {
     /// Check if the given access request should be allowed, based on all operational fabrics
     /// and their ACLs
     ///
-    /// `aux_feature` conveys whether the node advertises the Access Control
+    /// `aux_acl_enabled` conveys whether the node advertises the Access Control
     /// cluster's `AUXILIARY` feature - see `AclEntry::allow`.
-    pub fn allow(&self, req: &AccessReq) -> bool {
+    pub fn allow(&self, req: &AccessReq, aux_acl_enabled: bool) -> bool {
         // PASE Sessions with no fabric index have implicit access grant,
         // but only as long as the ACL list is empty
         //
@@ -1408,7 +1392,7 @@ impl Fabrics {
             return false;
         };
 
-        fabric.allow(req, self.aux_acl_enabled)
+        fabric.allow(req, aux_acl_enabled)
     }
 }
 

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -2430,8 +2430,109 @@ where
 
         let accessor = self.invoker.exchange().accessor()?;
 
+        // When the Groupcast testing mode is armed for listener testing by
+        // this group session's fabric, record an observation per processed
+        // path (turned into `GroupcastTesting` events by the Groupcast
+        // handler): a success per invoked concrete path, or - when nothing
+        // was invocable at all (typically: access denied on every group
+        // endpoint) - a single failed-auth observation.
+        // (For invokes, `suppress_resp` is set exactly for group-addressed
+        // requests - see the `respond` callers.)
+        #[cfg(feature = "groups")]
+        let group_testing = if suppress_resp {
+            let exchange = self.invoker.exchange();
+
+            exchange
+                .matter()
+                .groupcast_testing()
+                .armed(crate::dm::clusters::groupcast::GroupcastTestingEnum::EnableListenerTesting)
+                .and_then(|mode| {
+                    exchange
+                        .with_state(|state| {
+                            let sess = exchange.id().session(&mut state.sessions);
+
+                            let crate::transport::session::SessionMode::Group {
+                                fab_idx,
+                                group_id,
+                            } = sess.get_session_mode()
+                            else {
+                                return Ok(None);
+                            };
+
+                            if *fab_idx != mode.fab_idx {
+                                return Ok(None);
+                            }
+
+                            let src_ip =
+                                crate::dm::clusters::groupcast::addr_ip(&sess.get_peer_addr());
+                            let group_id = *group_id;
+                            let fab_idx = *fab_idx;
+                            let dst_ip = crate::dm::clusters::groupcast::group_dst_ip(
+                                &state.fabrics,
+                                fab_idx,
+                                group_id,
+                            );
+
+                            Ok(Some((group_id, src_ip, dst_ip)))
+                        })
+                        .unwrap_or(None)
+                })
+        } else {
+            None
+        };
+
+        #[cfg(feature = "groups")]
+        let mut any_invoked = false;
+
         for item in expand_invoke(metadata, self.req, &accessor)? {
-            self.invoker.process_invoke(&item?, &mut *wb).await?;
+            let item = item?;
+            let invoked = self.invoker.process_invoke(&item, &mut *wb).await?;
+
+            #[cfg(feature = "groups")]
+            if invoked {
+                any_invoked = true;
+
+                if let (Some((group_id, src_ip, dst_ip)), Ok((cmd, _))) = (&group_testing, &item) {
+                    self.invoker
+                        .exchange()
+                        .matter()
+                        .groupcast_testing()
+                        .observe(crate::dm::clusters::groupcast::TestingObservation {
+                            src_ip: *src_ip,
+                            dst_ip: Some(*dst_ip),
+                            group_id: Some(*group_id),
+                            endpoint_id: Some(cmd.endpoint_id),
+                            cluster_id: Some(cmd.cluster_id),
+                            element_id: Some(cmd.cmd_id),
+                            access_allowed: Some(true),
+                            result:
+                                crate::dm::clusters::groupcast::GroupcastTestResultEnum::Success,
+                        });
+                }
+            }
+        }
+
+        #[cfg(feature = "groups")]
+        if let Some((group_id, src_ip, dst_ip)) = group_testing {
+            if !any_invoked {
+                // Nothing was invocable for this group message - report it
+                // as access-denied (the dominant cause: no ACL grant covers
+                // the group's endpoints)
+                self.invoker
+                    .exchange()
+                    .matter()
+                    .groupcast_testing()
+                    .observe(crate::dm::clusters::groupcast::TestingObservation {
+                        src_ip,
+                        dst_ip: Some(dst_ip),
+                        group_id: Some(group_id),
+                        endpoint_id: None,
+                        cluster_id: None,
+                        element_id: None,
+                        access_allowed: Some(false),
+                        result: crate::dm::clusters::groupcast::GroupcastTestResultEnum::FailedAuth,
+                    });
+            }
         }
 
         if suppress_resp {

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -973,7 +973,7 @@ where
         let req = SubscribeReq::new(TLVElement::new(&rx));
         debug!("IM: Subscribe request: {:?}", req);
 
-        let accessor = exchange.accessor()?;
+        let accessor = exchange.accessor(&self.handler)?;
 
         if let Err(err) = self.validate_subscribe(&req, &accessor) {
             error!("Invalid subscribe request: {:?}", err);
@@ -1938,7 +1938,7 @@ where
         M: Metadata,
         F: FnMut(EndptId, ClusterId, u32) -> bool,
     {
-        let accessor = self.invoker.exchange().accessor()?;
+        let accessor = self.invoker.exchange().accessor(&metadata)?;
 
         if self.req.attr_requests()?.is_some() {
             wb.start_array(&TLVTag::Context(ReportDataRespTag::AttributeReports as u8))?;
@@ -1997,7 +1997,7 @@ where
     where
         M: Metadata,
     {
-        let accessor = self.invoker.exchange().accessor()?;
+        let accessor = self.invoker.exchange().accessor(&metadata)?;
 
         if let Some(event_reqs) = self.req.event_requests()? {
             wb.start_array(&TLVTag::Context(ReportDataRespTag::EventReports as _))?;
@@ -2346,7 +2346,7 @@ where
     where
         M: Metadata,
     {
-        let accessor = self.invoker.exchange().accessor()?;
+        let accessor = self.invoker.exchange().accessor(&metadata)?;
 
         wb.reset();
 
@@ -2428,7 +2428,7 @@ where
             wb.start_array(&TLVTag::Context(InvRespTag::InvokeResponses as u8))?;
         }
 
-        let accessor = self.invoker.exchange().accessor()?;
+        let accessor = self.invoker.exchange().accessor(&metadata)?;
 
         // When the Groupcast testing mode is armed for listener testing by
         // this group session's fabric, record an observation per processed

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -2486,6 +2486,7 @@ where
 
         for item in expand_invoke(metadata, self.req, &accessor)? {
             let item = item?;
+            #[cfg_attr(not(feature = "groups"), allow(unused_variables))]
             let invoked = self.invoker.process_invoke(&item, &mut *wb).await?;
 
             #[cfg(feature = "groups")]

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -2463,11 +2463,10 @@ where
                                 return Ok(None);
                             }
 
-                            let src_ip =
-                                crate::dm::clusters::groupcast::addr_ip(&sess.get_peer_addr());
+                            let src_ip = crate::dm::clusters::groupcast::TestingObservation::addr_ip(&sess.get_peer_addr());
                             let group_id = *group_id;
                             let fab_idx = *fab_idx;
-                            let dst_ip = crate::dm::clusters::groupcast::group_dst_ip(
+                            let dst_ip = crate::dm::clusters::groupcast::TestingObservation::group_dst_ip(
                                 &state.fabrics,
                                 fab_idx,
                                 group_id,
@@ -2516,7 +2515,7 @@ where
         #[cfg(feature = "groups")]
         if let Some((group_id, src_ip, dst_ip)) = group_testing {
             if !any_invoked {
-                // Nothing was invocable for this group message - report it
+                // Nothing was invokable for this group message - report it
                 // as access-denied (the dominant cause: no ACL grant covers
                 // the group's endpoints)
                 self.invoker

--- a/rs-matter/src/im/encoding.rs
+++ b/rs-matter/src/im/encoding.rs
@@ -108,6 +108,7 @@ pub enum IMStatusCode {
     InvalidInState = 0xcb,
     NoCommandResponse = 0xcc,
     DynamicConstraintError = 0xcf,
+    AlreadyExists = 0xd0,
 }
 
 impl From<ErrorCode> for IMStatusCode {
@@ -131,6 +132,7 @@ impl From<ErrorCode> for IMStatusCode {
             ErrorCode::ConstraintError => IMStatusCode::ConstraintError,
             ErrorCode::DynamicConstraintError => IMStatusCode::DynamicConstraintError,
             ErrorCode::NotFound => IMStatusCode::NotFound,
+            ErrorCode::AlreadyExists => IMStatusCode::AlreadyExists,
             ErrorCode::Failure => IMStatusCode::Failure,
             _ => IMStatusCode::Failure,
         }

--- a/rs-matter/src/im/expand.rs
+++ b/rs-matter/src/im/expand.rs
@@ -834,7 +834,13 @@ mod test {
         expected: &[Result<Result<GenericPath, IMStatusCode>, ErrorCode>],
     ) {
         let matter = test_matter();
-        let accessor = Accessor::new(0, AccessorSubjects::new(0), Some(AuthMode::Pase), &matter);
+        let accessor = Accessor::new(
+            0,
+            false,
+            AccessorSubjects::new(0),
+            Some(AuthMode::Pase),
+            &matter,
+        );
 
         let expander = PathExpanderIterator::new(
             node,
@@ -1247,7 +1253,13 @@ mod test {
         expected: &[Result<Result<GenericPath, IMStatusCode>, ErrorCode>],
     ) {
         let matter = test_matter();
-        let accessor = Accessor::new(0, AccessorSubjects::new(0), Some(AuthMode::Pase), &matter);
+        let accessor = Accessor::new(
+            0,
+            false,
+            AccessorSubjects::new(0),
+            Some(AuthMode::Pase),
+            &matter,
+        );
 
         let metadata = SwappableMetadata::new(initial);
 

--- a/rs-matter/src/im/invoker.rs
+++ b/rs-matter/src/im/invoker.rs
@@ -191,11 +191,15 @@ where
             .await
     }
 
+    /// Process one expanded invoke item.
+    ///
+    /// Returns whether the item was successfully invoked on its handler
+    /// (used by the Groupcast testing mode to report group-invoke outcomes).
     pub async fn process_invoke(
         &mut self,
         item: &Result<(CmdDetails, TLVElement<'_>), CmdStatus>,
         tw: &mut WriteBuf<'_>,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         let tail = tw.get_tail();
 
         let result = self.do_process_invoke(item, &mut *tw).await;
@@ -212,8 +216,8 @@ where
         &mut self,
         item: &Result<(CmdDetails, TLVElement<'_>), CmdStatus>,
         tw: &mut WriteBuf<'_>,
-    ) -> Result<(), Error> {
-        let result = match item {
+    ) -> Result<bool, Error> {
+        let (result, invoked) = match item {
             Ok((cmd, data)) => {
                 let pos = tw.get_tail();
 
@@ -222,9 +226,9 @@ where
                 match result {
                     Ok(()) => {
                         if pos == tw.get_tail() {
-                            Ok(cmd.status(IMStatusCode::Success))
+                            (Ok(cmd.status(IMStatusCode::Success)), true)
                         } else {
-                            Ok(None)
+                            (Ok(None), true)
                         }
                     }
                     Err(err) if err.code() != ErrorCode::NoSpace => {
@@ -232,20 +236,23 @@ where
 
                         tw.rewind_to(pos);
 
-                        Ok(cmd.status(err.into()))
+                        (Ok(cmd.status(err.into())), false)
                     }
-                    Err(err) => Err(err),
+                    Err(err) => (Err(err), false),
                 }
             }
             Err(status) => {
                 error!("Error processing command: {:?}", status);
-                Ok(Some(status.clone()))
+                (Ok(Some(status.clone())), false)
             }
         };
 
         match result {
-            Ok(Some(status)) => CmdResp::Status(status).to_tlv(&TagType::Anonymous, tw),
-            Ok(None) => Ok(()),
+            Ok(Some(status)) => {
+                CmdResp::Status(status).to_tlv(&TagType::Anonymous, tw)?;
+                Ok(invoked)
+            }
+            Ok(None) => Ok(invoked),
             Err(err) => Err(err),
         }
     }

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -725,6 +725,20 @@ pub struct MatterState {
     ///
     /// Public for unit tests
     pub fabrics: Fabrics,
+    /// Whether the node advertises the Access Control cluster's `AUXILIARY`
+    /// feature (auxiliary ACL entries, synthesized by features like a future
+    /// Groupcast cluster)
+    ///
+    /// Derived from the node metadata by `AclHandler` at startup (see
+    /// `dm::clusters::acl::CLUSTER_AUX`). When set, the access-control
+    /// evaluation of wildcard-target Group-auth entries excludes the root
+    /// endpoint, as the Matter Core spec mandates.
+    ///
+    /// Note that there is - deliberately - no accompanying storage for the
+    /// auxiliary entries themselves: they are derived state, to be computed
+    /// on the fly from the producing feature's own state, both when serving
+    /// the `AuxiliaryACL` attribute and during access-control evaluation.
+    aux_acl_enabled: bool,
     /// All sessions
     sessions: Sessions,
     /// CASE session resumption cache
@@ -751,6 +765,7 @@ impl MatterState {
     const fn new() -> Self {
         Self {
             fabrics: Fabrics::new(),
+            aux_acl_enabled: false,
             sessions: Sessions::new(),
             #[cfg(feature = "case-resumption")]
             resumption: ResumableSessions::new(),
@@ -769,6 +784,7 @@ impl MatterState {
     fn init() -> impl Init<Self> {
         init!(Self {
             fabrics <- Fabrics::init(),
+            aux_acl_enabled: false,
             sessions <- Sessions::init(),
             resumption <- crate::sc::case::ResumableSessions::init(),
             pase <- Pase::init(),
@@ -784,6 +800,7 @@ impl MatterState {
     fn init() -> impl Init<Self> {
         init!(Self {
             fabrics <- Fabrics::init(),
+            aux_acl_enabled: false,
             sessions <- Sessions::init(),
             pase <- Pase::init(),
             failsafe <- FailSafe::init(),

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -145,6 +145,11 @@ pub struct Matter<'a> {
     dev_att: &'a dyn DeviceAttestation,
     /// The port number on which the Matter stack will listen for incoming connections
     port: u16,
+    /// The Groupcast testing-mode bridge - shared between the transport RX
+    /// path, the Interaction Model's invoke processing and the Groupcast
+    /// cluster handler. See `dm::clusters::groupcast::TestingBridge`.
+    #[cfg(feature = "groups")]
+    groupcast_testing: crate::dm::clusters::groupcast::TestingBridge,
     /// The scratch buffer used by the key-value persistence machinery for
     /// (de)serializing BLOBs. Behind a blocking mutex so [`Matter::kv`] can
     /// recombine it with the user's raw [`KvBlobStore`](crate::persist::KvBlobStore)
@@ -179,6 +184,8 @@ impl<'a> Matter<'a> {
             dev_comm,
             dev_att,
             port,
+            #[cfg(feature = "groups")]
+            groupcast_testing: crate::dm::clusters::groupcast::TestingBridge::new(),
             kv_buf: Mutex::new(RefCell::new([0; crate::persist::KV_BUF_SIZE])),
         }
     }
@@ -199,17 +206,38 @@ impl<'a> Matter<'a> {
         dev_att: &'a dyn DeviceAttestation,
         port: u16,
     ) -> impl Init<Self> {
-        init!(
-            Self {
-                state <- Mutex::init(RefCell::init(MatterState::init())),
-                transport <- Transport::init(dev_det),
-                dev_det,
-                dev_comm,
-                dev_att,
-                port,
-                kv_buf <- Mutex::init(RefCell::init(crate::utils::init::zeroed())),
-            }
-        )
+        // Two variants because the `init!` macro does not accept `#[cfg]`
+        // on fields
+        #[cfg(feature = "groups")]
+        {
+            init!(
+                Self {
+                    state <- Mutex::init(RefCell::init(MatterState::init())),
+                    transport <- Transport::init(dev_det),
+                    dev_det,
+                    dev_comm,
+                    dev_att,
+                    port,
+                    groupcast_testing: crate::dm::clusters::groupcast::TestingBridge::new(),
+                    kv_buf <- Mutex::init(RefCell::init(crate::utils::init::zeroed())),
+                }
+            )
+        }
+
+        #[cfg(not(feature = "groups"))]
+        {
+            init!(
+                Self {
+                    state <- Mutex::init(RefCell::init(MatterState::init())),
+                    transport <- Transport::init(dev_det),
+                    dev_det,
+                    dev_comm,
+                    dev_att,
+                    port,
+                    kv_buf <- Mutex::init(RefCell::init(crate::utils::init::zeroed())),
+                }
+            )
+        }
     }
 
     pub fn dev_det(&self) -> &BasicInfoConfig<'_> {
@@ -549,6 +577,12 @@ impl<'a> Matter<'a> {
             let mut state = state.borrow_mut();
             f(&mut state)
         })
+    }
+
+    /// Return the Groupcast testing-mode bridge.
+    #[cfg(feature = "groups")]
+    pub(crate) fn groupcast_testing(&self) -> &crate::dm::clusters::groupcast::TestingBridge {
+        &self.groupcast_testing
     }
 
     /// Access the Real-Time-clock by invoking a closure with a mutable reference to it.

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -218,7 +218,7 @@ impl<'a> Matter<'a> {
                     dev_comm,
                     dev_att,
                     port,
-                    groupcast_testing: crate::dm::clusters::groupcast::TestingBridge::new(),
+                    groupcast_testing <- crate::dm::clusters::groupcast::TestingBridge::init(),
                     kv_buf <- Mutex::init(RefCell::init(crate::utils::init::zeroed())),
                 }
             )
@@ -759,20 +759,6 @@ pub struct MatterState {
     ///
     /// Public for unit tests
     pub fabrics: Fabrics,
-    /// Whether the node advertises the Access Control cluster's `AUXILIARY`
-    /// feature (auxiliary ACL entries, synthesized by features like a future
-    /// Groupcast cluster)
-    ///
-    /// Derived from the node metadata by `AclHandler` at startup (see
-    /// `dm::clusters::acl::CLUSTER_AUX`). When set, the access-control
-    /// evaluation of wildcard-target Group-auth entries excludes the root
-    /// endpoint, as the Matter Core spec mandates.
-    ///
-    /// Note that there is - deliberately - no accompanying storage for the
-    /// auxiliary entries themselves: they are derived state, to be computed
-    /// on the fly from the producing feature's own state, both when serving
-    /// the `AuxiliaryACL` attribute and during access-control evaluation.
-    aux_acl_enabled: bool,
     /// All sessions
     sessions: Sessions,
     /// CASE session resumption cache
@@ -799,7 +785,6 @@ impl MatterState {
     const fn new() -> Self {
         Self {
             fabrics: Fabrics::new(),
-            aux_acl_enabled: false,
             sessions: Sessions::new(),
             #[cfg(feature = "case-resumption")]
             resumption: ResumableSessions::new(),
@@ -818,7 +803,6 @@ impl MatterState {
     fn init() -> impl Init<Self> {
         init!(Self {
             fabrics <- Fabrics::init(),
-            aux_acl_enabled: false,
             sessions <- Sessions::init(),
             resumption <- crate::sc::case::ResumableSessions::init(),
             pase <- Pase::init(),
@@ -834,7 +818,6 @@ impl MatterState {
     fn init() -> impl Init<Self> {
         init!(Self {
             fabrics <- Fabrics::init(),
-            aux_acl_enabled: false,
             sessions <- Sessions::init(),
             pase <- Pase::init(),
             failsafe <- FailSafe::init(),

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -1155,6 +1155,60 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
         }
     }
 
+    /// Record a `GroupcastTesting` observation for a multicast group data
+    /// message that failed decode/decryption, when the Groupcast listener
+    /// testing mode is armed. See the Matter Core spec's `GroupcastTesting`
+    /// command for the result classification.
+    #[cfg(feature = "groups")]
+    fn observe_group_rx_failure<const N: usize>(
+        &self,
+        packet: &Packet<N>,
+        fabrics: &crate::fabric::Fabrics,
+        e: &Error,
+    ) {
+        use crate::dm::clusters::groupcast;
+
+        // Only multicast group *data* messages participate (not unicast
+        // group-encrypted MCSP control messages)
+        let Some(group_id) = packet.header.plain.get_dst_groupcast_nodeid() else {
+            return;
+        };
+
+        let Some(mode) = self
+            .matter
+            .groupcast_testing()
+            .armed(groupcast::GroupcastTestingEnum::EnableListenerTesting)
+        else {
+            return;
+        };
+
+        let (result, authenticated) = match e.code() {
+            // No candidate key was available to even attempt decryption
+            ErrorCode::NoSession => (groupcast::GroupcastTestResultEnum::NoAvailableKey, false),
+            // Candidate key(s) were tried, none authenticated the message
+            ErrorCode::InvalidSignature => (groupcast::GroupcastTestResultEnum::FailedAuth, false),
+            // Authenticated, but a duplicate of an already-received message
+            ErrorCode::Duplicate => (groupcast::GroupcastTestResultEnum::MessageReplay, true),
+            _ => (groupcast::GroupcastTestResultEnum::GeneralError, false),
+        };
+
+        self.matter
+            .groupcast_testing()
+            .observe(groupcast::TestingObservation {
+                src_ip: groupcast::addr_ip(&packet.peer),
+                dst_ip: Some(groupcast::group_dst_ip(fabrics, mode.fab_idx, group_id)),
+                // Per the Matter Core spec, the `GroupID` field is filled
+                // from the request only when the message was properly
+                // authenticated for the fabric under test
+                group_id: authenticated.then_some(group_id),
+                endpoint_id: None,
+                cluster_id: None,
+                element_id: None,
+                access_allowed: None,
+                result,
+            });
+    }
+
     #[cfg(feature = "groups")]
     async fn process_groups<M>(
         &self,
@@ -1847,12 +1901,26 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                 #[cfg(feature = "groups")]
                 if packet.header.plain.is_group_session() {
                     // Group (multicast) message — derive keys on-the-fly and decrypt
-                    let (session, payload_range) = state.sessions.get_or_create_for_group_rx(
+                    let result = state.sessions.get_or_create_for_group_rx(
                         &self.crypto,
                         &state.fabrics,
                         packet,
                         self.matter.dev_det(),
-                    )?;
+                    );
+
+                    let (session, payload_range) = match result {
+                        Ok(ok) => ok,
+                        Err(e) => {
+                            // When the Groupcast listener testing mode is
+                            // armed, report failed multicast group messages
+                            // as `GroupcastTesting` observations (turned
+                            // into events by the Groupcast handler)
+                            self.observe_group_rx_failure(packet, &state.fabrics, &e);
+
+                            return Err(e);
+                        }
+                    };
+
                     set_payload(packet, payload_range);
 
                     return session.post_recv(&packet.header);

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -1195,8 +1195,12 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
         self.matter
             .groupcast_testing()
             .observe(groupcast::TestingObservation {
-                src_ip: groupcast::addr_ip(&packet.peer),
-                dst_ip: Some(groupcast::group_dst_ip(fabrics, mode.fab_idx, group_id)),
+                src_ip: groupcast::TestingObservation::addr_ip(&packet.peer),
+                dst_ip: Some(groupcast::TestingObservation::group_dst_ip(
+                    fabrics,
+                    mode.fab_idx,
+                    group_id,
+                )),
                 // Per the Matter Core spec, the `GroupID` field is filled
                 // from the request only when the message was properly
                 // authenticated for the fabric under test

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -84,7 +84,7 @@ pub const MATTER_SOCKET_BIND_ADDR: SocketAddr =
     SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, MATTER_PORT, 0, 0));
 
 #[cfg(feature = "groups")]
-const MAX_GROUP_ADDRS: usize = MAX_FABRICS * MAX_GROUPS_PER_FABRIC;
+const MAX_GROUP_ADDRS: usize = MAX_FABRICS * MAX_GROUPS_PER_FABRIC + 1; // +1 for the IANA-assigned Groupcast address
 /// Without multicast group support no group addresses are ever joined, so the
 /// join-list is zero-capacity. Keeping the field (rather than gating it) avoids
 /// splitting the in-place `Transport` initializer, and a `Vec<_, 0>` costs no
@@ -1171,7 +1171,23 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
                 let group_addrs = || {
                     state.fabrics.iter().flat_map(|fabric| {
                         fabric.groups().iter().map(|group| {
-                            compute_group_multicast_addr(fabric.fabric_id(), group.group_id)
+                            // Groups with the `IanaAddr` Groupcast policy all
+                            // share the IANA-assigned address; `PerGroup` ones
+                            // (and legacy Groups-cluster entries, which behave
+                            // as `PerGroup`) each use a fabric+group-scoped
+                            // address. Duplicate enumeration of the shared
+                            // address is fine - the join/leave reconciliation
+                            // below is idempotent per address.
+                            use crate::dm::clusters::decl::groupcast::MulticastAddrPolicyEnum;
+
+                            match group.effective_mcast_policy() {
+                                MulticastAddrPolicyEnum::IanaAddr => {
+                                    crate::utils::ipv6::IANA_GROUPCAST_MULTICAST_ADDR
+                                }
+                                MulticastAddrPolicyEnum::PerGroup => {
+                                    compute_group_multicast_addr(fabric.fabric_id(), group.group_id)
+                                }
+                            }
                         })
                     })
                 };

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -26,7 +26,7 @@ use embassy_time::{Duration, Instant, Timer};
 use crate::acl::Accessor;
 use crate::bdx::{self, PROTO_ID_BDX};
 use crate::crypto::Crypto;
-use crate::dm::NodeId;
+use crate::dm::{AuxAclCheck, Metadata, NodeId};
 use crate::error::{Error, ErrorCode};
 use crate::im::{self, PROTO_ID_INTERACTION_MODEL};
 use crate::sc::{self, PROTO_ID_SECURE_CHANNEL};
@@ -249,11 +249,15 @@ impl ExchangeId {
         }
     }
 
-    fn accessor<'a>(&self, matter: &'a Matter<'a>) -> Result<Accessor<'a>, Error> {
+    fn accessor<'a>(
+        &self,
+        matter: &'a Matter<'a>,
+        aux_acl_enabled: bool,
+    ) -> Result<Accessor<'a>, Error> {
         self.with_state(matter, |state| {
             let sess = self.session(&mut state.sessions);
 
-            Ok(Accessor::for_session(sess, matter))
+            Ok(Accessor::for_session(sess, matter, aux_acl_enabled))
         })
     }
 
@@ -1485,8 +1489,11 @@ impl<'a> Exchange<'a> {
         .await
     }
 
-    pub(crate) fn accessor(&self) -> Result<Accessor<'a>, Error> {
-        self.id.accessor(self.matter)
+    pub(crate) fn accessor<M>(&self, metadata: M) -> Result<Accessor<'a>, Error>
+    where
+        M: Metadata,
+    {
+        self.id.accessor(self.matter, metadata.aux_acl_enabled())
     }
 
     pub fn is_groupcast(&self) -> Result<bool, Error> {

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -1100,6 +1100,11 @@ impl Sessions {
             payload_range: (usize, usize),
         }
         let mut group_key_found: Option<GroupKeyFound> = None;
+        // Whether at least one candidate key matched the message's group
+        // session ID (and was therefore actually tried for decryption) -
+        // distinguishes "authentication failed" from "no key available"
+        // for Groupcast testing-mode diagnostics.
+        let mut key_attempted = false;
 
         'outer: for fabric in fabrics.iter() {
             // For unicast (MCSP) messages the destination Node ID must
@@ -1153,6 +1158,8 @@ impl Sessions {
                         continue;
                     }
 
+                    key_attempted = true;
+
                     if let Some(payload_range) = Self::try_group_decrypt(
                         &crypto,
                         packet,
@@ -1185,13 +1192,22 @@ impl Sessions {
             );
         }
 
+        // `NoSession` = no candidate key was available for this message;
+        // `InvalidSignature` = candidate key(s) matched the group session ID
+        // but none authenticated the message. The distinction feeds the
+        // `GroupcastTesting` event's result field (`NoAvailableKey` vs
+        // `FailedAuth`).
         let GroupKeyFound {
             fab_idx,
             group_id,
             fabric_node_id,
             op_key,
             payload_range,
-        } = group_key_found.ok_or(ErrorCode::NoSession)?;
+        } = group_key_found.ok_or(if key_attempted {
+            ErrorCode::InvalidSignature
+        } else {
+            ErrorCode::NoSession
+        })?;
 
         // Only data messages participate in this dedup: control
         // messages (`C = 1`) live on a separate control-counter space

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -1050,9 +1050,11 @@ impl Sessions {
         // Anything else is malformed.
         let dst_group_id = packet.header.plain.get_dst_groupcast_nodeid();
         let dst_unicast_nodeid = packet.header.plain.get_dst_unicast_nodeid();
+
         if dst_group_id.is_none() && dst_unicast_nodeid.is_none() {
             return Err(ErrorCode::InvalidData.into());
         }
+
         let expected_sess_id = packet.header.plain.sess_id;
         let msg_ctr = packet.header.plain.ctr;
         let is_control = packet.header.plain.is_control_msg();
@@ -1076,9 +1078,11 @@ impl Sessions {
         let encrypted_offset = pb.read_off();
         let encrypted_len = pb.as_slice().len();
         let mut saved_encrypted = [0u8; 1280];
+
         if encrypted_len > saved_encrypted.len() {
             return Err(ErrorCode::BufferTooSmall.into());
         }
+
         saved_encrypted[..encrypted_len].copy_from_slice(pb.as_slice());
 
         // Derive keys on-the-fly and try each one. When a key decrypts,
@@ -1099,6 +1103,7 @@ impl Sessions {
             op_key: CanonAeadKey,
             payload_range: (usize, usize),
         }
+
         let mut group_key_found: Option<GroupKeyFound> = None;
         // Whether at least one candidate key matched the message's group
         // session ID (and was therefore actually tried for decryption) -
@@ -1138,6 +1143,7 @@ impl Sessions {
 
                 for epoch_key_entry in key_set_entry.epoch_keys.iter() {
                     let mut temp_key_set = KeySet::new();
+
                     if temp_key_set
                         .update(
                             &crypto,
@@ -1150,6 +1156,7 @@ impl Sessions {
                     }
 
                     let op_key_ref = temp_key_set.op_key();
+
                     let Ok(session_id) = derive_group_session_id(&crypto, op_key_ref) else {
                         continue;
                     };
@@ -1179,6 +1186,7 @@ impl Sessions {
                             op_key: op_key_owned,
                             payload_range,
                         });
+
                         break 'outer;
                     }
                 }
@@ -1221,12 +1229,14 @@ impl Sessions {
                 "Group: Duplicate message counter {} from node 0x{:016x} fab_idx={}",
                 msg_ctr, src_nodeid, fab_idx
             );
+
             return Err(ErrorCode::Duplicate.into());
         }
 
         // Create ephemeral group session
         let peer = packet.peer;
         let mut rand = crypto.weak_rand()?;
+
         let session = match self.add(rand.next_u32(), false, peer, Some(src_nodeid), dev_det) {
             Ok(session) => session,
             Err(_) => {
@@ -1240,6 +1250,7 @@ impl Sessions {
                 }
             }
         };
+
         session.set_session_mode(SessionMode::Group { fab_idx, group_id });
         session.local_sess_id = expected_sess_id;
         // Mirror the group session id onto the peer side so `pre_send`

--- a/rs-matter/src/utils/ipv6.rs
+++ b/rs-matter/src/utils/ipv6.rs
@@ -34,6 +34,11 @@ pub fn create_link_local_ipv6(mac: &[u8; 6]) -> Ipv6Addr {
     )
 }
 
+/// The IANA-assigned IPv6 multicast address (`ff05::fa`) shared by all
+/// Groupcast groups using the `IanaAddr` multicast-address policy
+/// (Matter Core spec).
+pub const IANA_GROUPCAST_MULTICAST_ADDR: Ipv6Addr = Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 0x00fa);
+
 /// Compute the Matter IPv6 multicast address for a given fabric and group.
 ///
 /// Per Matter Core Specification Section 4.3.1 and RFC 3306:

--- a/rs-matter/tests/data_model/aux_acl.rs
+++ b/rs-matter/tests/data_model/aux_acl.rs
@@ -1,0 +1,189 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Tests for the opt-in `AuxiliaryACL` support of the Access Control cluster
+//! ([`acl::CLUSTER_AUX`]): serving the attribute (an empty list until a
+//! producing feature such as Groupcast exists - entries are derived on the
+//! fly, never stored), and rejecting `AuxiliaryType` in writable-`ACL`
+//! writes.
+//!
+//! The root-endpoint exclusion for wildcard-target Group-auth entries is
+//! covered by the unit tests in `rs-matter/src/acl.rs`.
+
+use rs_matter::tlv::Nullable;
+use rs_matter::dm::clusters::acl::{self, AclHandler};
+use rs_matter::dm::devices::DEV_TYPE_ROOT_NODE;
+use rs_matter::dm::{
+    Async, ChainedHandler, Cluster, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
+};
+use rs_matter::im::{AttrPath, AttrStatus, GenericPath, IMStatusCode};
+use rs_matter::tlv::ToTLV;
+
+use crate::common::e2e::im::attributes::TestAttrData;
+use crate::common::e2e::new_default_runner;
+use crate::common::init_env_logger;
+use crate::{attr_data, attr_data_path};
+
+const GROUP_ID: u64 = 0x12AB;
+
+const CLUSTERS_EP0: &[Cluster<'static>] = &[acl::CLUSTER_AUX];
+
+const NODE: Node<'static> = Node {
+    endpoints: &[Endpoint::new(0, &[DEV_TYPE_ROOT_NODE], CLUSTERS_EP0)],
+};
+
+/// A data model over [`NODE`] serving the Access Control cluster (with the
+/// `AUXILIARY` feature) on EP0.
+fn dm_handler() -> impl DataModel {
+    (
+        NODE,
+        ChainedHandler::new(
+            EpClMatcher::new(Some(0), Some(acl::CLUSTER_AUX.id)),
+            Async(AclHandler::new(Dataver::new(1)).adapt()),
+            EmptyHandler,
+        ),
+    )
+}
+
+/// TLV mirror of the `AccessControlTargetStruct`: positional context tags
+/// 0..=2, with TLV `Null` for the null fields (which the `Option`-based
+/// [`Target`] would instead omit).
+#[derive(Debug, Clone, PartialEq, ToTLV)]
+struct TestTarget {
+    cluster: Nullable<u32>,
+    endpoint: Nullable<u16>,
+    device_type: Nullable<u32>,
+}
+
+impl TestTarget {
+    fn endpoint(endpoint: u16) -> Self {
+        Self {
+            cluster: Nullable::none(),
+            endpoint: Nullable::some(endpoint),
+            device_type: Nullable::none(),
+        }
+    }
+}
+
+/// The shape of a legal client-written `ACL` list entry: positional context
+/// tags 1..=4.
+#[derive(Debug, Clone, PartialEq, ToTLV)]
+#[tlvargs(start = 1)]
+struct TestAclEntry<'a> {
+    privilege: u8,
+    auth_mode: u8,
+    subjects: &'a [u64],
+    targets: &'a [TestTarget],
+}
+
+/// Same as [`TestAclEntry`], but carrying the (server-only) `AuxiliaryType`
+/// field - the shape of an *illegal* client-written `ACL` list entry.
+#[derive(Debug, Clone, PartialEq, ToTLV)]
+#[tlvargs(start = 1)]
+struct TestAuxEntryWrite<'a> {
+    privilege: u8,
+    auth_mode: u8,
+    subjects: &'a [u64],
+    targets: &'a [TestTarget],
+    auxiliary_type: u8,
+}
+
+const PRIVILEGE_OPERATE: u8 = 3;
+const AUTH_MODE_GROUP: u8 = 3;
+const AUX_TYPE_GROUPCAST: u8 = 1;
+
+
+#[test]
+fn test_auxiliary_acl_read() {
+    init_env_logger();
+
+    let path = GenericPath::new(
+        Some(0),
+        Some(acl::CLUSTER_AUX.id),
+        Some(acl::AttributeId::AuxiliaryACL as u32),
+    );
+    let input = &[AttrPath::from_gp(&path)];
+
+    let im = new_default_runner();
+    im.add_default_acl();
+    let dm = dm_handler();
+
+    // Nothing synthesized yet: the attribute reads as an empty list.
+    let no_entries: &[TestAclEntry] = &[];
+    im.handle_read_reqs(
+        &dm,
+        input,
+        &[attr_data!(
+            0,
+            31,
+            acl::AttributeId::AuxiliaryACL,
+            Some(&no_entries)
+        )],
+    );
+}
+
+#[test]
+fn test_acl_write_rejects_auxiliary_type() {
+    init_env_logger();
+
+    let path = GenericPath::new(
+        Some(0),
+        Some(acl::CLUSTER_AUX.id),
+        Some(acl::AttributeId::Acl as u32),
+    );
+
+    let im = new_default_runner();
+    im.add_default_acl();
+    let dm = dm_handler();
+
+    // A write of an `ACL` list entry carrying the (server-only)
+    // `AuxiliaryType` field must be rejected with `ConstraintError`.
+    let targets = [TestTarget::endpoint(1)];
+    let bad = &[TestAuxEntryWrite {
+        privilege: PRIVILEGE_OPERATE,
+        auth_mode: AUTH_MODE_GROUP,
+        subjects: &[GROUP_ID],
+        targets: &targets,
+        auxiliary_type: AUX_TYPE_GROUPCAST,
+    }][..];
+    im.handle_write_reqs(
+        &dm,
+        &[TestAttrData::new(None, AttrPath::from_gp(&path), &bad as _)],
+        &[AttrStatus::from_gp(
+            &path,
+            IMStatusCode::ConstraintError,
+            None,
+        )],
+    );
+
+    // The same entry without `AuxiliaryType` is accepted.
+    let good = &[TestAclEntry {
+        privilege: PRIVILEGE_OPERATE,
+        auth_mode: AUTH_MODE_GROUP,
+        subjects: &[GROUP_ID],
+        targets: &targets,
+    }][..];
+    im.handle_write_reqs(
+        &dm,
+        &[TestAttrData::new(None, AttrPath::from_gp(&path), &good as _)],
+        &[AttrStatus::from_gp(&path, IMStatusCode::Success, None)],
+    );
+}
+
+// Silence unused-import lint (used only via macro expansion)
+#[allow(unused)]
+use attr_data_path as _;

--- a/rs-matter/tests/data_model/aux_acl.rs
+++ b/rs-matter/tests/data_model/aux_acl.rs
@@ -24,13 +24,13 @@
 //! The root-endpoint exclusion for wildcard-target Group-auth entries is
 //! covered by the unit tests in `rs-matter/src/acl.rs`.
 
-use rs_matter::tlv::Nullable;
 use rs_matter::dm::clusters::acl::{self, AclHandler};
 use rs_matter::dm::devices::DEV_TYPE_ROOT_NODE;
 use rs_matter::dm::{
     Async, ChainedHandler, Cluster, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter::im::{AttrPath, AttrStatus, GenericPath, IMStatusCode};
+use rs_matter::tlv::Nullable;
 use rs_matter::tlv::ToTLV;
 
 use crate::common::e2e::im::attributes::TestAttrData;
@@ -106,7 +106,6 @@ const PRIVILEGE_OPERATE: u8 = 3;
 const AUTH_MODE_GROUP: u8 = 3;
 const AUX_TYPE_GROUPCAST: u8 = 1;
 
-
 #[test]
 fn test_auxiliary_acl_read() {
     init_env_logger();
@@ -179,7 +178,11 @@ fn test_acl_write_rejects_auxiliary_type() {
     }][..];
     im.handle_write_reqs(
         &dm,
-        &[TestAttrData::new(None, AttrPath::from_gp(&path), &good as _)],
+        &[TestAttrData::new(
+            None,
+            AttrPath::from_gp(&path),
+            &good as _,
+        )],
         &[AttrStatus::from_gp(&path, IMStatusCode::Success, None)],
     );
 }

--- a/rs-matter/tests/data_model/mod.rs
+++ b/rs-matter/tests/data_model/mod.rs
@@ -16,6 +16,7 @@
  */
 
 mod acl_and_dataver;
+mod aux_acl;
 mod attribute_lists;
 mod attributes;
 mod commands;

--- a/rs-matter/tests/data_model/mod.rs
+++ b/rs-matter/tests/data_model/mod.rs
@@ -16,9 +16,9 @@
  */
 
 mod acl_and_dataver;
-mod aux_acl;
 mod attribute_lists;
 mod attributes;
+mod aux_acl;
 mod commands;
 mod events;
 mod long_reads;

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -281,6 +281,22 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     //
     "TC_G_2_2",
     //
+    // Python tests — Groupcast (system cluster, provisional in Matter 1.6)
+    //
+    // The whole `TC_GC_2_x` suite is driven over unicast IM (JoinGroup /
+    // LeaveGroup / UpdateGroupKey / ConfigureAuxiliaryACL /
+    // GroupcastTesting commands plus attribute and event subscriptions);
+    // no real multicast traffic is involved. `TC_GC_2_6` and `TC_GC_2_7`
+    // commission (and later remove) a second test fabric.
+    "TC_GC_2_1",
+    "TC_GC_2_2",
+    "TC_GC_2_3",
+    "TC_GC_2_4",
+    "TC_GC_2_5",
+    "TC_GC_2_6",
+    "TC_GC_2_7",
+    "TC_GC_2_8",
+    //
     // Python tests — Network Commissioning (system cluster)
     //
     "TC_CNET_1_4",
@@ -1754,6 +1770,17 @@ impl ITests {
             // is fixed upstream, the steps skip here too, and the attribute
             // is covered by rs-matter's own e2e test instead.
             "TC_BINFO_3_2" => Some("--app-pipe /tmp/rs_matter_bin_info_3_2_fifo"),
+            // The `TC_GC_*` suite runs against the Groupcast-enabled app
+            // composition (`NODE_GROUPCAST` in `system_tests`): the
+            // Groupcast cluster on EP0 plus the aux-ACL-enabled Access
+            // Control metadata. Deliberately NOT the default composition:
+            // with `AUXILIARY` advertised, wildcard-target Group-auth ACL
+            // entries no longer cover EP0 (Matter Core spec), which would
+            // break `TestGroupMessaging`'s legacy group-addressed writes to
+            // root-endpoint attributes - upstream likewise runs that suite
+            // against a non-groupcast app variant.
+            "TC_GC_2_1" | "TC_GC_2_2" | "TC_GC_2_3" | "TC_GC_2_4" | "TC_GC_2_5" | "TC_GC_2_6"
+            | "TC_GC_2_7" | "TC_GC_2_8" => Some("--groupcast"),
             // TC_TestEventTrigger validates `GeneralDiagnostics::TestEventTrigger`
             // key/trigger handling — needs the canonical CHIP enable-key
             // 000102030405060708090a0b0c0d0e0f plumbed through to the device's
@@ -1975,6 +2002,9 @@ impl ITests {
             // `system_tests.rs`); Groups now lives on EP1/EP2 under the
             // On/Off Light device type, so target EP1.
             "TC_G_2_2" => "--endpoint 1",
+            // The Groupcast cluster lives on the root endpoint.
+            "TC_GC_2_1" | "TC_GC_2_2" | "TC_GC_2_3" | "TC_GC_2_4" | "TC_GC_2_5" | "TC_GC_2_6"
+            | "TC_GC_2_7" | "TC_GC_2_8" => "--endpoint 0",
             // TC_DA_1_7 ("device attestation: distinct keys per DUT") normally
             // requires two distinct DUTs with different DAC keys. The test
             // also supports a single-DUT mode for CI when `allow_sdk_dac:true`

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -134,6 +134,13 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TC_ACE_1_3",
     "TC_ACE_1_4",
     "TC_ACE_1_5",
+    // Group-auth access enforcement over REAL multicast: the TH sends
+    // group-addressed invokes at the DUT and asserts the
+    // `Groupcast.GroupcastTesting` events the (armed) DUT emits about them
+    // — including access grants coming solely from the Groupcast-synthesized
+    // `AuxiliaryACL`. Runs against the `NODE_GROUPCAST` app composition
+    // (see `app_args_override`).
+    "TC_ACE_1_6",
     "TC_ACL_2_2",
     // "TC_ACL_2_3", // Skipped: tests the optional `AccessControlExtension` feature (Extension attribute), not implemented by rs-matter.
     "TC_ACL_2_4",
@@ -1565,6 +1572,9 @@ impl ITests {
             // so this whole-process ceiling must cover both, each with the
             // per-method budget in `per_test_framework_timeout_secs`.
             "TC_CADMIN_1_3_4" => Some(600),
+            // Sends several real multicast group commands with fixed 3s
+            // settling sleeps in between, plus event-report awaits.
+            "TC_ACE_1_6" => Some(360),
             "TC_CADMIN_1_5" | "TC_CADMIN_1_9" | "TC_CADMIN_1_11" | "TC_CADMIN_1_15"
             | "TC_CADMIN_1_22" | "TC_CADMIN_1_25" => Some(360),
             // TC_OPCREDS_3_8 exercises the VID-Verification feature (Matter
@@ -1780,7 +1790,7 @@ impl ITests {
             // root-endpoint attributes - upstream likewise runs that suite
             // against a non-groupcast app variant.
             "TC_GC_2_1" | "TC_GC_2_2" | "TC_GC_2_3" | "TC_GC_2_4" | "TC_GC_2_5" | "TC_GC_2_6"
-            | "TC_GC_2_7" | "TC_GC_2_8" => Some("--groupcast"),
+            | "TC_GC_2_7" | "TC_GC_2_8" | "TC_ACE_1_6" => Some("--groupcast"),
             // TC_TestEventTrigger validates `GeneralDiagnostics::TestEventTrigger`
             // key/trigger handling — needs the canonical CHIP enable-key
             // 000102030405060708090a0b0c0d0e0f plumbed through to the device's
@@ -1868,6 +1878,9 @@ impl ITests {
                  --PICS src/app/tests/suites/certification/ci-pics-values"
             }
             "TC_CGEN_2_4" => "--endpoint 0",
+            // Gates on `MCORE.ROLE.COMMISSIONEE` + `G.S`; `--endpoint 1` is
+            // `PIXIT.G.ENDPOINT` (the default script args already carry it).
+            "TC_ACE_1_6" => "--PICS src/app/tests/suites/certification/ci-pics-values",
             // TC_CGEN_2_5..2_11 verify the General Commissioning
             // *Terms-and-Conditions* (TC, Matter 1.4+, `CGEN.S.F00`)
             // feature. rs-matter does not implement TC, and each test body


### PR DESCRIPTION
This PR is implementing the Matter 1.6-compliant Groupcast support. Namely:
- The Groupcast cluster handler
- The AUX ACL support

A bunch of extra Python tests are now enabled (all TC_GC_* ones, i.e. the Groupcast cluster handler tests).