### PR TITLE
Network recovery utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Network Recovery data-model support - provisional in Matter 1.6 (#523)
 * Groupcast cluster handler support (Matter 1.6) - available when the `groups` feature is enabled (#521)
 * Fix CASE Sigma2 retransmissions with randomized ECDSA (#520)
 * (Breaking) Optional Time Zones support in the Time Sync Cluster Handler, trait `TimeSync` split into `TimeZones`, `NtpClient` and `NtpServer`

--- a/rs-matter/src/dm/clusters/basic_info.rs
+++ b/rs-matter/src/dm/clusters/basic_info.rs
@@ -416,11 +416,15 @@ pub struct BasicInfoSettings {
     pub configuration_version: u32,
     /// `BasicInformation::DeviceLocation` (provisional in the Matter 1.6
     /// IDL): where the device is installed, admin-writable.
+    pub device_location: Option<Nullable<DeviceLocation>>,
+    /// `GeneralCommissioning::RecoveryIdentifier` (provisional in Matter 1.6):
+    /// a random 64-bit value that identifies this node during the
+    /// Network Recovery flow without revealing its Node ID.
     ///
     /// NOTE: keep this field *last* - the persisted-blob TLV tags are
     /// positional, and appending preserves compatibility with blobs written
     /// before the field existed.
-    pub device_location: Option<Nullable<DeviceLocation>>,
+    pub recovery_identifier: Option<u64>,
 }
 
 impl BasicInfoSettings {
@@ -435,6 +439,7 @@ impl BasicInfoSettings {
             // Core Spec).
             configuration_version: 1,
             device_location: None,
+            recovery_identifier: None,
         }
     }
 
@@ -447,6 +452,7 @@ impl BasicInfoSettings {
             local_config_disabled: false,
             configuration_version: 1,
             device_location: None,
+            recovery_identifier: None,
         })
     }
 
@@ -461,6 +467,7 @@ impl BasicInfoSettings {
         self.local_config_disabled = false;
         self.configuration_version = 1;
         self.device_location = None;
+        self.recovery_identifier = None;
     }
 
     /// Bump `ConfigurationVersion` by one and return the new value.
@@ -512,6 +519,7 @@ impl BasicInfoSettings {
         self.local_config_disabled = info.local_config_disabled;
         self.configuration_version = info.configuration_version;
         self.device_location = info.device_location;
+        self.recovery_identifier = info.recovery_identifier;
 
         Ok(())
     }
@@ -1032,6 +1040,29 @@ mod tests {
         assert!(settings.location.is_none());
         assert!(settings.location_type.is_none());
         assert!(settings.device_location.is_none());
+    }
+
+    /// The `GeneralCommissioning::RecoveryIdentifier` value must survive the
+    /// persisted-blob round-trip (stable across reboots, per Matter Core Spec
+    /// 11.10.6.11), load as "never minted" from a blob that predates the field,
+    /// and be cleared by `reset()` so a factory reset regenerates it.
+    #[test]
+    fn recovery_identifier_survives_persistence_and_resets() {
+        // Factory-fresh (and blobs predating the field) load as "never minted".
+        let mut settings = BasicInfoSettings::new();
+        assert!(settings.recovery_identifier.is_none());
+        assert!(round_trip(&settings).recovery_identifier.is_none());
+
+        // A minted value round-trips verbatim.
+        settings.recovery_identifier = Some(0x1122_3344_5566_7788);
+        assert_eq!(
+            round_trip(&settings).recovery_identifier,
+            Some(0x1122_3344_5566_7788)
+        );
+
+        // Factory reset clears it so the next read mints a fresh one.
+        settings.reset();
+        assert!(settings.recovery_identifier.is_none());
     }
 
     // Silence unused-import lint on no-test builds

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -21,13 +21,16 @@ use core::fmt::Debug;
 
 use either::Either;
 
+use rand_core::RngCore;
+
+use crate::crypto::Crypto;
 use crate::dm::clusters::net_comm::NetworksAccess;
 use crate::dm::{Cluster, Dataver, InvokeContext, OperationContext, ReadContext, WriteContext};
 use crate::error::{Error, ErrorCode};
 use crate::fabric::FabricPersist;
 use crate::persist::{Persist, NETWORKS_KEY};
 use crate::sc::pase::MAX_COMM_WINDOW_TIMEOUT_SECS;
-use crate::tlv::TLVBuilderParent;
+use crate::tlv::{Nullable, Octets, OctetsBuilder, TLVBuilderParent};
 use crate::transport::session::SessionMode;
 use crate::utils::sync::DynBase;
 use crate::{except, with, MatterState};
@@ -203,7 +206,60 @@ impl<'a> GenCommHandler<'a> {
             f(state, &mut notify_mdns)
         })
     }
+
+    /// Return the node's `RecoveryIdentifier`, minting and persisting a stable
+    /// random 64-bit value on first access.
+    fn recovery_identifier_value(ctx: &impl ReadContext) -> Result<u64, Error> {
+        // Fast path: the value has already been minted (this read, a prior
+        // read, or a reload from persistence).
+        if let Some(id) = ctx
+            .exchange()
+            .with_state(|state| Ok(state.basic_info_settings.recovery_identifier))?
+        {
+            return Ok(id);
+        }
+
+        // Mint a fresh 64-bit value from the CSPRNG.
+        let fresh = ctx.crypto().rand()?.next_u64();
+
+        let mut persist = Persist::new(ctx.kv());
+
+        let id = ctx.exchange().with_state(|state| {
+            // Re-check under the state borrow: a concurrent read may have
+            // minted the value first, in which case we keep the stored one.
+            let id = *state
+                .basic_info_settings
+                .recovery_identifier
+                .get_or_insert(fresh);
+
+            state.basic_info_settings.store_persist(&mut persist)?;
+
+            Ok(id)
+        })?;
+
+        persist.run()?;
+
+        Ok(id)
+    }
 }
+
+/// Opt-in General Commissioning metadata that additionally advertises the
+/// **Network Recovery** feature (Matter 1.6, provisional): the `NR` FeatureMap
+/// bit plus the `RecoveryIdentifier` and `NetworkRecoveryReason` attributes.
+///
+/// This mirrors [`GenCommHandler::CLUSTER`] but exposes those two provisional
+/// attributes and sets the feature bit. The runtime [`GenCommHandler`] always
+/// implements both reads, so - exactly like
+/// [`basic_info::CLUSTER_DEVICE_LOCATION`](crate::dm::clusters::basic_info::CLUSTER_DEVICE_LOCATION) -
+/// an application opts in purely by substituting this metadata for
+/// [`GenCommHandler::CLUSTER`] in its endpoint's cluster list; nothing else in
+/// the wiring changes.
+pub const CLUSTER_NETWORK_RECOVERY: Cluster<'static> = FULL_CLUSTER
+    .with_attrs(
+        with!(required; AttributeId::RecoveryIdentifier | AttributeId::NetworkRecoveryReason),
+    )
+    .with_cmds(except!(CommandId::SetTCAcknowledgements))
+    .with_features(Feature::NETWORK_RECOVERY.bits());
 
 impl ClusterHandler for GenCommHandler<'_> {
     const CLUSTER: Cluster<'static> = FULL_CLUSTER
@@ -266,6 +322,30 @@ impl ClusterHandler for GenCommHandler<'_> {
 
     fn supports_concurrent_connection(&self, _ctx: impl ReadContext) -> Result<bool, Error> {
         Ok(self.commissioning_policy.concurrent_connection_supported())
+    }
+
+    fn recovery_identifier<P: TLVBuilderParent>(
+        &self,
+        ctx: impl ReadContext,
+        builder: OctetsBuilder<P>,
+    ) -> Result<P, Error> {
+        // The 8-byte, big-endian encoding of the stable random identifier.
+        // The same byte sequence is what a Recovery Node would carry in its
+        // BLE Network-Recovery advertisement (see `RecoveryAdvData`).
+        let id = Self::recovery_identifier_value(&ctx)?;
+
+        builder.set(Octets::new(&id.to_be_bytes()))
+    }
+
+    fn network_recovery_reason(
+        &self,
+        _ctx: impl ReadContext,
+    ) -> Result<Nullable<NetworkRecoveryReasonEnum>, Error> {
+        // Matter Core Spec 11.10.6.12: this attribute is null whenever the
+        // node is not undergoing a Network Recovery flow. rs-matter core never
+        // autonomously enters recovery mode (the flow is a platform-layer
+        // concern), so the reason is always null.
+        Ok(Nullable::none())
     }
 
     fn handle_arm_fail_safe<P: TLVBuilderParent>(

--- a/rs-matter/src/transport/network/btp/gatt.rs
+++ b/rs-matter/src/transport/network/btp/gatt.rs
@@ -30,6 +30,15 @@ const AD_TYPE_SERVICE_DATA_UUID16: u8 = 0x16;
 const MATTER_SERVICE_DATA_PAYLOAD_LEN: usize = 8;
 /// The Matter BLE advertisement OpCode designating a commissionable device.
 const MATTER_ADV_OPCODE_COMMISSIONABLE: u8 = 0x00;
+/// The Matter BLE advertisement OpCode designating a node in Network Recovery mode.
+const MATTER_ADV_OPCODE_NETWORK_RECOVERY: u8 = 0x01;
+/// The length, in bytes, of the Matter Network-Recovery service-data payload
+/// (the bytes _following_ the 2-byte service UUID16 in the AD2 record), as per
+/// the Matter Core spec.
+const MATTER_RECOVERY_SERVICE_DATA_PAYLOAD_LEN: usize = 11;
+/// The length, in bytes, of the Recovery ID carried in a Network-Recovery
+/// advertisement / stored as `GeneralCommissioning::RecoveryIdentifier`.
+pub const RECOVERY_ID_LEN: usize = 8;
 
 #[cfg(all(feature = "os", feature = "bluer", target_os = "linux"))]
 pub mod bluer;
@@ -187,25 +196,7 @@ impl AdvData {
     /// you (as BlueZ and `bluer` do), use [`AdvData::parse_service_data`] with
     /// the `0xFFF6` service-data value directly.
     pub fn parse_adv(adv: &[u8]) -> Option<Self> {
-        for (ad_type, ad_payload) in AdStructures::new(adv) {
-            if ad_type != AD_TYPE_SERVICE_DATA_UUID16 {
-                continue;
-            }
-
-            // The service-data payload starts with the 2-byte (LE) UUID16. A
-            // structure too short to hold one is malformed - skip it and keep
-            // looking, rather than giving up on the whole advertisement: the Matter
-            // record may well be further along.
-            let Some((uuid16, service_data)) = ad_payload.split_first_chunk::<2>() else {
-                continue;
-            };
-
-            if u16::from_le_bytes(*uuid16) == MATTER_BLE_SERVICE_UUID16 {
-                return Self::parse_service_data(service_data);
-            }
-        }
-
-        None
+        matter_service_data(adv).and_then(Self::parse_service_data)
     }
 
     /// Parse the advertising data out of the Matter service-data payload - i.e.
@@ -300,6 +291,197 @@ impl AdvData {
     }
 }
 
+/// Advertising data for a node in Matter Network Recovery mode (BLE Device
+/// OpCode `0x01`), per the Matter 1.6 Core spec.
+///
+/// The Recovery ID is the 8-byte `GeneralCommissioning::RecoveryIdentifier`
+/// attribute value; it lets an Administrator identify the node without learning
+/// its Node ID. Unlike the commissionable advertisement, a Network Recovery
+/// advertisement carries no VID / PID / discriminator.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct RecoveryAdvData {
+    /// The 8-byte Recovery ID (`GeneralCommissioning::RecoveryIdentifier`).
+    recovery_id: [u8; RECOVERY_ID_LEN],
+    /// Whether the device signals that it carries additional (BLE) advertising
+    /// data (bit 0 of the last byte of the service-data payload).
+    ///
+    /// Always `false` for advertisements produced by this stack; decoded from
+    /// the wire when parsing a peer's advertisement.
+    additional_data: bool,
+}
+
+impl RecoveryAdvData {
+    /// Create a new instance carrying the given 8-byte Recovery ID.
+    ///
+    /// The bytes are the `GeneralCommissioning::RecoveryIdentifier` attribute
+    /// value, copied verbatim onto the wire (Matter 1.6 Core spec, Table 75).
+    pub const fn new(recovery_id: [u8; RECOVERY_ID_LEN]) -> Self {
+        Self {
+            recovery_id,
+            additional_data: false,
+        }
+    }
+
+    /// The 8-byte Recovery ID carried by this advertising data.
+    pub const fn recovery_id(&self) -> [u8; RECOVERY_ID_LEN] {
+        self.recovery_id
+    }
+
+    /// Whether the advertised device signals that it carries additional (BLE)
+    /// advertising data. See the field of the same name.
+    pub const fn additional_data(&self) -> bool {
+        self.additional_data
+    }
+
+    /// Return an iterator over the binary representation of the advertising data
+    /// (the AD1 Flags record followed by the AD2 UUID16+Service Data record).
+    pub fn iter(&self) -> impl Iterator<Item = u8> + '_ {
+        self.flags_iter().chain(self.service_iter())
+    }
+
+    /// Return an iterator over the binary representation of the AD1 advertising
+    /// data (Flags). Useful with GATT stacks that require the advertising data
+    /// to be reported as separate AD records.
+    pub fn flags_iter(&self) -> impl Iterator<Item = u8> + '_ {
+        empty()
+            .chain(once(self.flags_payload_iter().count() as u8 + 1)) // 1-byte type
+            .chain(once(self.flags_adv_type()))
+            .chain(self.flags_payload_iter())
+    }
+
+    /// The AD1 advertising data type (Flags).
+    pub const fn flags_adv_type(&self) -> u8 {
+        0x01
+    }
+
+    /// Return an iterator over the binary representation of the AD1 advertising
+    /// data _payload_.
+    ///
+    /// Per the Matter 1.6 Core spec (Table 75) a Recovery Node advertises
+    /// `0x05`: LE Limited Discoverable Mode (bit 0) set, LE General Discoverable
+    /// Mode (bit 1) clear, BR/EDR Not Supported (bit 2) set. (A commissionable
+    /// device instead advertises `0x06` - General, not Limited.)
+    pub fn flags_payload_iter(&self) -> impl Iterator<Item = u8> + '_ {
+        once(0x05)
+    }
+
+    /// Return an iterator over the binary representation of the AD2 advertising
+    /// data (UUID16+Service Data).
+    pub fn service_iter(&self) -> impl Iterator<Item = u8> + '_ {
+        empty()
+            .chain(once(self.service_payload_iter().count() as u8 + 3)) // + 1-byte type and 2-bytes Matter UUID16 Service
+            .chain(once(self.service_adv_type()))
+            .chain(MATTER_BLE_SERVICE_UUID16.to_le_bytes())
+            .chain(self.service_payload_iter())
+    }
+
+    /// The AD2 advertising data type (UUID16+Service Data).
+    pub const fn service_adv_type(&self) -> u8 {
+        0x16
+    }
+
+    /// Return an iterator over the binary representation of the AD2 advertising
+    /// data _payload_ (the Matter Network-Recovery service-data payload).
+    pub fn service_payload_iter(&self) -> impl Iterator<Item = u8> + '_ {
+        empty()
+            .chain(once(MATTER_ADV_OPCODE_NETWORK_RECOVERY))
+            .chain(once(0x00)) // Bits[7:4] advertisement version == 0, Bits[3:0] reserved == 0
+            .chain(self.recovery_id) // Recovery ID, copied verbatim
+            .chain(once(self.additional_data as u8)) // Additional-data flag (bit 0)
+    }
+
+    /// Parse a Network-Recovery advertisement out of a full, raw BLE
+    /// advertising-data blob (a sequence of `length`-prefixed AD structures).
+    ///
+    /// Walks the AD structures, finds the Matter service-data structure
+    /// (`0xFFF6`) and decodes it as a Network-Recovery payload. Returns `None`
+    /// if the blob carries no (valid) Matter Network-Recovery service data.
+    ///
+    /// Use this when the OS/GATT stack hands you the raw advertising bytes; if
+    /// it instead de-multiplexes service data by UUID, use
+    /// [`RecoveryAdvData::parse_service_data`] with the `0xFFF6` value directly.
+    pub fn parse_adv(adv: &[u8]) -> Option<Self> {
+        matter_service_data(adv).and_then(Self::parse_service_data)
+    }
+
+    /// Parse a Network-Recovery advertisement out of the Matter service-data
+    /// payload - i.e. the bytes of the `0xFFF6` service-data structure that
+    /// _follow_ the 2-byte service UUID.
+    ///
+    /// This is the layout produced by [`RecoveryAdvData::service_payload_iter`].
+    /// Returns `None` if the payload is not a valid Matter Network-Recovery
+    /// service-data payload (e.g. it is a commissionable payload instead).
+    pub fn parse_service_data(payload: &[u8]) -> Option<Self> {
+        // As per spec the payload is exactly 11 bytes. Be lenient and accept a
+        // longer payload (future extensions), but never a shorter one.
+        if payload.len() < MATTER_RECOVERY_SERVICE_DATA_PAYLOAD_LEN {
+            return None;
+        }
+
+        // Byte 0 is the Matter BLE OpCode; only "Network Recovery" (1) applies.
+        if payload[0] != MATTER_ADV_OPCODE_NETWORK_RECOVERY {
+            return None;
+        }
+
+        // Byte 1 high nibble is the advertisement version (currently 0); the low
+        // nibble is reserved. We do not reject a non-zero version so that a
+        // future minor revision keeps parsing, mirroring the commissionable path
+        // which tolerates the version bits.
+
+        // Bytes 2..=9 are the Recovery ID, copied verbatim. The slice is
+        // exactly `RECOVERY_ID_LEN` long (guaranteed by the length check above),
+        // so the `try_into` never fails.
+        let recovery_id: [u8; RECOVERY_ID_LEN] =
+            payload[2..2 + RECOVERY_ID_LEN].try_into().unwrap();
+        let additional_data = payload[2 + RECOVERY_ID_LEN] & 0x01 != 0;
+
+        Some(Self {
+            recovery_id,
+            additional_data,
+        })
+    }
+
+    /// Whether this advertised Recovery Node carries the given Recovery ID.
+    ///
+    /// This is the Network-Recovery analogue of [`AdvData::matches`]: an
+    /// Administrator that retrieved the `RecoveryIdentifier` before the node
+    /// lost connectivity uses it to pick out that specific node among any
+    /// Recovery Nodes it scans.
+    pub fn matches(&self, recovery_id: &[u8; RECOVERY_ID_LEN]) -> bool {
+        self.recovery_id == *recovery_id
+    }
+}
+
+/// Walk the AD structures of a raw BLE advertising-data blob and return the
+/// Matter service-data payload - the bytes of the `0xFFF6` "Service Data -
+/// 16-bit UUID" structure that _follow_ the 2-byte service UUID - or `None` if
+/// there is no such structure.
+///
+/// Shared by [`AdvData::parse_adv`] and [`RecoveryAdvData::parse_adv`], which
+/// differ only in how they interpret the returned payload (by its OpCode byte).
+fn matter_service_data(adv: &[u8]) -> Option<&[u8]> {
+    for (ad_type, ad_payload) in AdStructures::new(adv) {
+        if ad_type != AD_TYPE_SERVICE_DATA_UUID16 {
+            continue;
+        }
+
+        // The service-data payload starts with the 2-byte (LE) UUID16. A
+        // structure too short to hold one is malformed - skip it and keep
+        // looking, rather than giving up on the whole advertisement: the Matter
+        // record may well be further along.
+        let Some((uuid16, service_data)) = ad_payload.split_first_chunk::<2>() else {
+            continue;
+        };
+
+        if u16::from_le_bytes(*uuid16) == MATTER_BLE_SERVICE_UUID16 {
+            return Some(service_data);
+        }
+    }
+
+    None
+}
+
 /// An iterator over the individual AD structures of a raw BLE advertising-data
 /// blob, yielding `(ad_type, ad_payload)` for each well-formed
 /// `[length, type, ..payload..]` structure and stopping at the first malformed
@@ -343,7 +525,7 @@ impl<'a> Iterator for AdStructures<'a> {
 mod test {
     use crate::transport::network::mdns::CommissionableFilter;
 
-    use super::AdvData;
+    use super::{AdvData, RecoveryAdvData};
 
     /// A sample `AdvData` with a 12-bit discriminator that exercises the
     /// version-nibble masking on parse.
@@ -462,6 +644,102 @@ mod test {
 
         // The Matter record precedes the malformed one, so it's still found.
         assert!(AdvData::parse_adv(&blob).is_some());
+    }
+
+    // ---- Network Recovery advertisement (BLE Device OpCode 0x01) -----------
+
+    /// The exemplary Recovery ID from Matter 1.6 Core spec Table 75.
+    const SPEC_RECOVERY_ID: [u8; 8] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+
+    /// The full advertising PDU payload from Matter 1.6 Core spec Table 75
+    /// ("Advertising PDU payload when CHIP BLE OpCode indicates Node is in
+    /// Network Recovery mode"), for `SPEC_RECOVERY_ID` with the additional-data
+    /// flag clear.
+    const SPEC_RECOVERY_ADV: [u8; 18] = [
+        0x02, 0x01, 0x05, // AD1: Flags (Limited Discoverable + BR/EDR not supported)
+        0x0E, 0x16, 0xF6, 0xFF, // AD2: len 14, Service Data - UUID16 == 0xFFF6
+        0x01, // OpCode == Network Recovery
+        0x00, // advertisement version 0 / reserved
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, // Recovery ID
+        0x00, // additional-data flag clear
+    ];
+
+    #[test]
+    fn recovery_serialize_matches_spec_example() {
+        let adv = RecoveryAdvData::new(SPEC_RECOVERY_ID);
+        let blob: heapless::Vec<u8, 32> = adv.iter().collect();
+
+        assert_eq!(&blob[..], &SPEC_RECOVERY_ADV[..]);
+    }
+
+    #[test]
+    fn recovery_parse_service_data_round_trips() {
+        let adv = RecoveryAdvData::new(SPEC_RECOVERY_ID);
+        let payload: heapless::Vec<u8, 16> = adv.service_payload_iter().collect();
+
+        let parsed = RecoveryAdvData::parse_service_data(&payload).unwrap();
+
+        assert_eq!(parsed, adv);
+        assert_eq!(parsed.recovery_id(), SPEC_RECOVERY_ID);
+        assert!(!parsed.additional_data());
+    }
+
+    #[test]
+    fn recovery_parse_full_spec_adv() {
+        let parsed = RecoveryAdvData::parse_adv(&SPEC_RECOVERY_ADV).unwrap();
+
+        assert_eq!(parsed.recovery_id(), SPEC_RECOVERY_ID);
+        assert!(!parsed.additional_data());
+    }
+
+    #[test]
+    fn recovery_additional_data_flag_round_trips() {
+        let adv = RecoveryAdvData {
+            additional_data: true,
+            ..RecoveryAdvData::new(SPEC_RECOVERY_ID)
+        };
+        let payload: heapless::Vec<u8, 16> = adv.service_payload_iter().collect();
+
+        let parsed = RecoveryAdvData::parse_service_data(&payload).unwrap();
+
+        assert!(parsed.additional_data());
+        assert_eq!(parsed, adv);
+    }
+
+    #[test]
+    fn recovery_matches_only_its_own_id() {
+        let adv = RecoveryAdvData::new(SPEC_RECOVERY_ID);
+
+        assert!(adv.matches(&SPEC_RECOVERY_ID));
+
+        let mut other = SPEC_RECOVERY_ID;
+        other[0] ^= 0xFF;
+        assert!(!adv.matches(&other));
+    }
+
+    #[test]
+    fn recovery_parse_rejects_short_payload() {
+        // 10 bytes: one short of the 11-byte minimum.
+        assert!(RecoveryAdvData::parse_service_data(&[1, 0, 1, 2, 3, 4, 5, 6, 7, 8]).is_none());
+    }
+
+    #[test]
+    fn recovery_and_commissionable_payloads_are_disjoint() {
+        // A commissionable payload (OpCode 0) is not a Recovery advertisement...
+        let comm: heapless::Vec<u8, 16> = sample().service_payload_iter().collect();
+        assert!(RecoveryAdvData::parse_service_data(&comm).is_none());
+
+        // ...and a Recovery payload (OpCode 1) is not a commissionable one.
+        let recovery: heapless::Vec<u8, 16> = RecoveryAdvData::new(SPEC_RECOVERY_ID)
+            .service_payload_iter()
+            .collect();
+        assert!(AdvData::parse_service_data(&recovery).is_none());
+    }
+
+    #[test]
+    fn recovery_parse_adv_returns_none_without_matter_service_data() {
+        // Just a Flags record - no Matter service data.
+        assert!(RecoveryAdvData::parse_adv(&[0x02, 0x01, 0x05]).is_none());
     }
 
     #[test]

--- a/rs-matter/tests/data_model/provisional.rs
+++ b/rs-matter/tests/data_model/provisional.rs
@@ -32,6 +32,7 @@ use rs_matter::dm::clusters::basic_info::{
     self, BasicInfoConfig, BasicInfoHandler, DeviceLocationConfig,
 };
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _, DescHandler};
+use rs_matter::dm::clusters::gen_comm::{self, ClusterHandler as _, GenCommHandler};
 use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ROOT_NODE};
 use rs_matter::dm::{
     Async, ChainedHandler, Cluster, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
@@ -389,4 +390,134 @@ fn test_config_factory_defaults() {
             Some(&written)
         )],
     );
+}
+
+// ---- General Commissioning: Network Recovery (provisional 1.6) -------------
+//
+// `RecoveryIdentifier` (0x000A) and `NetworkRecoveryReason` (0x000B) plus the
+// `NetworkRecovery` (`NR`) FeatureMap bit are advertised only via the opt-in
+// `gen_comm::CLUSTER_NETWORK_RECOVERY` metadata; the default
+// `GenCommHandler::CLUSTER` keeps them hidden (provisional, and no upstream
+// test references them). The runtime `GenCommHandler` always implements both
+// reads, so - as with `DeviceLocation` - the choice is purely a metadata swap.
+//
+// NOTE: `RecoveryIdentifier` is minted lazily on first read from the CSPRNG, so
+// its value is not deterministic here; its persistence and factory-reset
+// semantics are covered by the `BasicInfoSettings` unit tests. These e2e tests
+// therefore assert the deterministic surface: the feature bit, the always-null
+// `NetworkRecoveryReason`, and that both attributes are gated off by default.
+
+/// EP0 metadata exposing General Commissioning with Network Recovery enabled.
+const CLUSTERS_EP0_NR: &[Cluster<'static>] = &[gen_comm::CLUSTER_NETWORK_RECOVERY];
+
+const NODE_NR: Node<'static> = Node {
+    endpoints: &[Endpoint::new(0, &[DEV_TYPE_ROOT_NODE], CLUSTERS_EP0_NR)],
+};
+
+/// A data model over [`NODE_NR`] serving General Commissioning with the Network
+/// Recovery feature (and its two provisional attributes) exposed. `&true` is
+/// the no-op `CommPolicy` (concurrent-connection, indoor/outdoor, default
+/// fail-safe timings) - none of which the recovery reads consult.
+fn nr_dm_handler() -> impl DataModel {
+    (
+        NODE_NR,
+        ChainedHandler::new(
+            EpClMatcher::new(Some(0), Some(gen_comm::CLUSTER_NETWORK_RECOVERY.id)),
+            Async(GenCommHandler::new(Dataver::new(1), &true).adapt()),
+            EmptyHandler,
+        ),
+    )
+}
+
+/// EP0 metadata using the *default* General Commissioning cluster (Network
+/// Recovery not advertised).
+const CLUSTERS_EP0_GC: &[Cluster<'static>] = &[GenCommHandler::CLUSTER];
+
+const NODE_GC: Node<'static> = Node {
+    endpoints: &[Endpoint::new(0, &[DEV_TYPE_ROOT_NODE], CLUSTERS_EP0_GC)],
+};
+
+/// A data model over [`NODE_GC`] - the same `GenCommHandler`, but with the
+/// default metadata that hides the provisional Network Recovery attributes.
+fn gc_dm_handler() -> impl DataModel {
+    (
+        NODE_GC,
+        ChainedHandler::new(
+            EpClMatcher::new(Some(0), Some(GenCommHandler::CLUSTER.id)),
+            Async(GenCommHandler::new(Dataver::new(1), &true).adapt()),
+            EmptyHandler,
+        ),
+    )
+}
+
+fn nr_attr_path(attr: gen_comm::AttributeId) -> GenericPath {
+    GenericPath::new(
+        Some(0),
+        Some(gen_comm::CLUSTER_NETWORK_RECOVERY.id),
+        Some(attr as u32),
+    )
+}
+
+#[test]
+fn test_network_recovery_feature_and_reason() {
+    init_env_logger();
+
+    let im = new_default_runner();
+    im.add_default_acl();
+    let dm = nr_dm_handler();
+
+    // The Network Recovery feature bit (`NR` == 0x2) is advertised in FeatureMap.
+    let feature_map_path = nr_attr_path(gen_comm::AttributeId::FeatureMap);
+    im.handle_read_reqs(
+        &dm,
+        &[AttrPath::from_gp(&feature_map_path)],
+        &[attr_data!(
+            0,
+            48,
+            gen_comm::AttributeId::FeatureMap,
+            Some(&2u32)
+        )],
+    );
+
+    // `NetworkRecoveryReason` is exposed and reads as Null - the node never
+    // autonomously enters recovery mode (Matter Core Spec 11.10.6.12).
+    let reason_path = nr_attr_path(gen_comm::AttributeId::NetworkRecoveryReason);
+    let null: Nullable<u8> = Nullable::none();
+    im.handle_read_reqs(
+        &dm,
+        &[AttrPath::from_gp(&reason_path)],
+        &[attr_data!(
+            0,
+            48,
+            gen_comm::AttributeId::NetworkRecoveryReason,
+            Some(&null)
+        )],
+    );
+}
+
+#[test]
+fn test_network_recovery_attributes_gated_by_default() {
+    init_env_logger();
+
+    let im = new_default_runner();
+    im.add_default_acl();
+    let dm = gc_dm_handler();
+
+    // With the default metadata, both provisional attributes are absent from
+    // the cluster and read back `UnsupportedAttribute` - even though the same
+    // handler type implements them for a Network-Recovery-enabled node.
+    for attr in [
+        gen_comm::AttributeId::RecoveryIdentifier,
+        gen_comm::AttributeId::NetworkRecoveryReason,
+    ] {
+        let path = GenericPath::new(Some(0), Some(GenCommHandler::CLUSTER.id), Some(attr as u32));
+        im.handle_read_reqs(
+            &dm,
+            &[AttrPath::from_gp(&path)],
+            &[attr_read_status_resp!(
+                &path,
+                IMStatusCode::UnsupportedAttribute
+            )],
+        );
+    }
 }


### PR DESCRIPTION
While it is likely that `rs-matter` would never get end-to-end network recovery support (because this requires BLE stack startup/teardown which typically sits outside of `rs-matter` and down in `rs-matter-stack`/`rs-matter-embassy`/`esp-idf-matter`), this PR contains the "utility" code that would allow the end-to-end implementation in downstream crates - when the need arises.