### PR TITLE
An indicator for the commissioning window being opened

### DIFF
--- a/.github/workflows/chiptool-tests.yml
+++ b/.github/workflows/chiptool-tests.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
 
+# Pushing a new commit to a pull request supersedes the run already in flight for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   RUST_TOOLCHAIN: stable
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
     - cron: "50 6 * * *"
   workflow_dispatch:
 
+# Pushing a new commit to a pull request supersedes the run already in flight for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   RUST_TOOLCHAIN: stable
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -9,6 +9,15 @@ on:
     - cron: "50 6 * * *"
   workflow_dispatch:
 
+# Pushing a new commit to a pull request supersedes the run already in flight for it.
+#
+# The trade-off is that commits pushed in quick succession onto a pull request do not each get
+# a size report; only the newest one does. The report for the final state of the branch is the
+# one that matters for review, so that is accepted.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # Pinned (rather than floating `stable`) so that size reports stay
   # comparable across runs: a compiler upgrade can move codegen by whole

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 * (Breaking) `Matter::is_commissioned` renamed to `Matter::has_fabrics` (#525)
-* New `Matter::comm_window_state` method (#525)
+* New `Matter::comm_window_state` method useful downstream for figuring out if the commissioning transport should be enabled (#525)
 * Network Recovery data-model support - provisional in Matter 1.6 (#523)
 * Groupcast cluster handler support (Matter 1.6) - available when the `groups` feature is enabled (#521)
 * Fix CASE Sigma2 retransmissions with randomized ECDSA (#520)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* (Breaking) `Matter::is_commissioned` renamed to `Matter::has_fabrics` (#525)
+* New `Matter::is_comm_window_open` method (#525)
 * Network Recovery data-model support - provisional in Matter 1.6 (#523)
 * Groupcast cluster handler support (Matter 1.6) - available when the `groups` feature is enabled (#521)
 * Fix CASE Sigma2 retransmissions with randomized ECDSA (#520)
-* (Breaking) Optional Time Zones support in the Time Sync Cluster Handler, trait `TimeSync` split into `TimeZones`, `NtpClient` and `NtpServer`
-* (Breaking) Handler lifecycle hook - cluster handlers can now participate in the node's persistence lifecycle
-* (Breaking) The code-generated (sync) `ClusterHandler` trait now also carries a defaulted `run` method, mirroring `ClusterAsyncHandler`
+* (Breaking) Optional Time Zones support in the Time Sync Cluster Handler, trait `TimeSync` split into `TimeZones`, `NtpClient` and `NtpServer` (#517)
+* (Breaking) Handler lifecycle hook - cluster handlers can now participate in the node's persistence lifecycle (#516)
+* (Breaking) The code-generated (sync) `ClusterHandler` trait now also carries a defaulted `run` method, mirroring `ClusterAsyncHandler` (#517)
 * (Breaking) Supported Matter Spec Version is now 1.6.0 (#510)
 * Exchange initiators - use a random exchange ID (#509)
 * Support for commissioning over BTP (#507)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 * (Breaking) `Matter::is_commissioned` renamed to `Matter::has_fabrics` (#525)
-* New `Matter::is_comm_window_open` method (#525)
+* New `Matter::comm_window_state` method (#525)
 * Network Recovery data-model support - provisional in Matter 1.6 (#523)
 * Groupcast cluster handler support (Matter 1.6) - available when the `groups` feature is enabled (#521)
 * Fix CASE Sigma2 retransmissions with randomized ECDSA (#520)

--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -442,7 +442,7 @@ fn main() -> ! {
 
     info!("===================================================");
 
-    if !stack.matter.is_commissioned() {
+    if !stack.matter.has_fabrics() {
         // If the device is not commissioned yet, print the QR text and code to the console
         // and enable basic commissioning
 

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -132,7 +132,7 @@ fn main() -> Result<(), Error> {
     let mut mdns = pin!(mdns::run_mdns(&matter, &crypto));
     let mut transport = pin!(matter.run(&crypto, &socket, &socket, &socket));
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         // If the device is not commissioned yet, print the QR text and code to the console
         // and enable basic commissioning
 

--- a/examples/src/bin/camera_tests.rs
+++ b/examples/src/bin/camera_tests.rs
@@ -603,7 +603,7 @@ fn main() -> Result<(), Error> {
 
     matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
         matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
     }

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -146,7 +146,7 @@ fn main() -> Result<(), Error> {
     // even if the device is already commissioned
     matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         // If the device is not commissioned yet, print the QR code to the console
         // and enable basic commissioning
 

--- a/examples/src/bin/light_tests.rs
+++ b/examples/src/bin/light_tests.rs
@@ -177,7 +177,7 @@ fn run() -> Result<(), Error> {
 
     matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
         matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;
     }

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -144,7 +144,7 @@ fn main() -> Result<(), Error> {
     let mut mdns = pin!(mdns::run_mdns(&matter, &crypto));
     let mut transport = pin!(matter.run(&crypto, &socket, &socket, &socket));
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         // If the device is not commissioned yet, print the QR text and code to the console
         // and enable basic commissioning
 

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -118,7 +118,7 @@ fn main() -> Result<(), Error> {
     let mut mdns = pin!(mdns::run_mdns(&matter, &crypto));
     let mut transport = pin!(matter.run(&crypto, &socket, &socket, &socket));
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         // If the device is not commissioned yet, print the QR text and code to the console
         // and enable basic commissioning
 

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -188,7 +188,7 @@ fn run<N: NetCtl + WifiDiag + NetChangeNotif>(
     // Create and run the mDNS responder
     let mut mdns = pin!(mdns::run_mdns(&matter, &crypto));
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         // Not commissioned yet, start commissioning first
 
         // Print the QR text and code to the console

--- a/examples/src/bin/onoff_light_switch.rs
+++ b/examples/src/bin/onoff_light_switch.rs
@@ -144,7 +144,7 @@ fn main() -> Result<(), Error> {
     let mut mdns = pin!(mdns::run_mdns(&matter, &crypto));
     let mut transport = pin!(matter.run(&crypto, &socket, &socket, &socket));
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
         matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;

--- a/examples/src/bin/onoff_light_work_stealing.rs
+++ b/examples/src/bin/onoff_light_work_stealing.rs
@@ -141,7 +141,7 @@ fn main() -> Result<(), Error> {
     let mdns = mdns::run_mdns(matter, crypto);
     let transport = matter.run(crypto, &socket, &socket, &socket);
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         // If the device is not commissioned yet, print the QR text and code to the console
         // and enable basic commissioning
 

--- a/examples/src/bin/ota_requestor.rs
+++ b/examples/src/bin/ota_requestor.rs
@@ -140,7 +140,7 @@ fn main() -> Result<(), Error> {
     // its own CASE exchanges to the provider.
     let ota_job = pin!(run_ota(&matter, &crypto, &providers, &ota_state, &im));
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
 

--- a/examples/src/bin/scenes_tests.rs
+++ b/examples/src/bin/scenes_tests.rs
@@ -224,7 +224,7 @@ fn run() -> Result<(), Error> {
     // even if the device is already commissioned
     matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         // If the device is not commissioned yet, print the QR code to the console
         // and enable basic commissioning
 

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -143,7 +143,7 @@ fn main() -> Result<(), Error> {
     let mut mdns = pin!(mdns::run_mdns(&matter, &crypto));
     let mut transport = pin!(matter.run(&crypto, &socket, &socket, &socket));
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         // If the device is not commissioned yet, print the QR text and code to the console
         // and enable basic commissioning
 

--- a/examples/src/bin/system_tests.rs
+++ b/examples/src/bin/system_tests.rs
@@ -480,7 +480,7 @@ fn main() -> Result<(), Error> {
     // even if the device is already commissioned
     matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         // If the device is not commissioned yet, print the QR code to the console
         // and enable basic commissioning
 

--- a/examples/src/bin/webrtc_camera.rs
+++ b/examples/src/bin/webrtc_camera.rs
@@ -1336,7 +1336,7 @@ fn main() -> Result<(), Error> {
     let mut transport = pin!(matter.run(&crypto, &mut net_send, &mut net_recv, &mut net_multicast));
     let mut driver = pin!(shared.drive());
 
-    if !matter.is_commissioned() {
+    if !matter.has_fabrics() {
         matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;
         matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, &())?;

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -49,7 +49,7 @@ use crate::persist::{KvBlobStore, KvBlobStoreAccess, Persist};
 #[cfg(feature = "case-resumption")]
 use crate::sc::case::ResumableSessions;
 use crate::sc::pase::spake2p::{Spake2pVerifierPassword, SPAKE2P_VERIFIER_SALT_ZEROED};
-use crate::sc::pase::Pase;
+use crate::sc::pase::{CommWindowState, Pase};
 use crate::transport::network::MatterLocalService;
 use crate::transport::network::{NetworkMulticast, NetworkReceive, NetworkSend};
 use crate::transport::session::Sessions;
@@ -424,17 +424,10 @@ impl<'a> Matter<'a> {
         self.with_state(|state| state.fabrics.iter().next().is_some())
     }
 
-    /// Return `true` if a commissioning window (basic or enhanced) is currently open.
-    ///
-    /// This is the condition under which the device is discoverable as commissionable and will
-    /// accept PASE - and therefore also the condition under which a BLE (BTP) transport, if any,
-    /// should be advertising.
-    ///
-    /// A window that has lapsed by timeout rather than being closed explicitly is only reported
-    /// as closed once the expiry is swept, which [`crate::im::InteractionModel::run`] does every
-    /// second, so the answer can trail such a window by about that long.
-    pub fn is_comm_window_open(&self) -> bool {
-        self.with_state(|state| state.pase.comm_window().is_some())
+    /// Return the state of the commissioning window - whether one is open, and if so who
+    /// opened it. See [`CommWindowState`] for what the answer is good for.
+    pub fn comm_window_state(&self) -> CommWindowState {
+        self.with_state(|state| state.pase.comm_window_state())
     }
 
     /// Open a basic commissioning window

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -412,19 +412,29 @@ impl<'a> Matter<'a> {
         Ok(payload)
     }
 
-    /// Return `true` if there is at least one commissioned fabric
-    //
-    // TODO:
-    // The implementation of this method needs to change in future,
-    // because the current implementation does not really track whether
-    // `CommissioningComplete` had been actually received for the fabric.
-    //
-    // The fabric is created once we receive `AddNoc`, but that's just
-    // not enough. The fabric should NOT be considered commissioned until
-    // after we receive `CommissioningComplete` on behalf of a Case session
-    // for the fabric in question.
-    pub fn is_commissioned(&self) -> bool {
+    /// Return `true` if there is at least one fabric.
+    ///
+    /// Note that this is emphatically *not* "the device is commissioned": a fabric is created
+    /// as soon as `AddNOC` is received, which is well before the commissioner has established a
+    /// CASE session over the operational network and sent `CommissioningComplete`. Code that
+    /// needs to know whether commissioning is still in progress should use
+    /// [`Matter::is_comm_window_open`] instead, as the commissioning window stays open for exactly
+    /// that long.
+    pub fn has_fabrics(&self) -> bool {
         self.with_state(|state| state.fabrics.iter().count() > 0)
+    }
+
+    /// Return `true` if a commissioning window (basic or enhanced) is currently open.
+    ///
+    /// This is the condition under which the device is discoverable as commissionable and will
+    /// accept PASE - and therefore also the condition under which a BLE (BTP) transport, if any,
+    /// should be advertising.
+    ///
+    /// A window that has lapsed by timeout rather than being closed explicitly is only reported
+    /// as closed once the expiry is swept, which [`crate::im::InteractionModel::run`] does every
+    /// second, so the answer can trail such a window by about that long.
+    pub fn is_comm_window_open(&self) -> bool {
+        self.with_state(|state| state.pase.comm_window().is_some())
     }
 
     /// Open a basic commissioning window

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -421,7 +421,7 @@ impl<'a> Matter<'a> {
     /// [`Matter::is_comm_window_open`] instead, as the commissioning window stays open for exactly
     /// that long.
     pub fn has_fabrics(&self) -> bool {
-        self.with_state(|state| state.fabrics.iter().count() > 0)
+        self.with_state(|state| state.fabrics.iter().next().is_some())
     }
 
     /// Return `true` if a commissioning window (basic or enhanced) is currently open.

--- a/rs-matter/src/sc/pase.rs
+++ b/rs-matter/src/sc/pase.rs
@@ -84,6 +84,36 @@ pub struct CommWindowOpener {
     pub vendor_id: u16,
 }
 
+/// Whether a PASE commissioning window is open, and - if so - who opened it
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CommWindowState {
+    /// No commissioning window is open
+    Closed,
+    /// A commissioning window is open
+    Open {
+        /// The administrator that opened the window over a CASE session, or `None` when the
+        /// device opened it itself, which is the case for initial commissioning
+        opener: Option<CommWindowOpener>,
+    },
+}
+
+impl CommWindowState {
+    /// Return `true` if a commissioning window is open.
+    ///
+    /// This is the condition under which the device is discoverable as commissionable and will
+    /// accept PASE.
+    pub const fn is_open(&self) -> bool {
+        matches!(self, Self::Open { .. })
+    }
+
+    /// Return `true` if a commissioning window is open and should be advertised on every
+    /// supported transport, rather than on the operational IP network alone.
+    pub const fn is_open_on_all_transports(&self) -> bool {
+        matches!(self, Self::Open { opener: None })
+    }
+}
+
 /// A PASE commissioning window
 pub struct CommWindow {
     /// The mDNS identifier
@@ -249,6 +279,17 @@ impl Pase {
         }
 
         Ok(())
+    }
+
+    /// Return the state of the commissioning window - whether one is open, and if so who
+    /// opened it. See [`CommWindowState`] for what the answer is good for.
+    pub fn comm_window_state(&self) -> CommWindowState {
+        match self.comm_window() {
+            Some(comm_window) => CommWindowState::Open {
+                opener: comm_window.opener(),
+            },
+            None => CommWindowState::Closed,
+        }
     }
 
     /// Open a basic commissioning window using a passcode


### PR DESCRIPTION
Subject says it all. Also `Matter::is_commissioned` now renamed to `Matter::has_fabrics` which is what it really is.

The new indicator is useful in downstream crates and _should_ be useful to the user as an indicator when the BLE stack should run. That is, during the commissioning window being open.