### PR TITLE
Groups, Bind and Switch tests

### DIFF
--- a/rs-matter-codegen/src/idl/handler.rs
+++ b/rs-matter-codegen/src/idl/handler.rs
@@ -79,27 +79,15 @@ pub fn handler(
         .map(|cmd| handler_command(cmd, asynch, delegate, entities, &krate));
 
     if delegate {
-        let lifecycle_run = if asynch {
-            quote!(
-                fn lifecycle(&self, ctx: impl #krate::dm::HandlerContext, op: #krate::dm::LifecycleOp) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                    (**self).lifecycle(ctx, op)
-                }
+        let lifecycle_run = quote!(
+            fn lifecycle(&self, ctx: impl #krate::dm::HandlerContext, op: #krate::dm::LifecycleOp) -> Result<(), #krate::error::Error> {
+                T::lifecycle(self, ctx, op)
+            }
 
-                fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                    (**self).run(ctx)
-                }
-            )
-        } else {
-            quote!(
-                fn lifecycle(&self, ctx: impl #krate::dm::HandlerContext, op: #krate::dm::LifecycleOp) -> Result<(), #krate::error::Error> {
-                    T::lifecycle(self, ctx, op)
-                }
-
-                fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                    (**self).run(ctx)
-                }
-            )
-        };
+            fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                (**self).run(ctx)
+            }
+        );
 
         quote!(
             impl<T> #handler_name for &T
@@ -121,27 +109,17 @@ pub fn handler(
             }
         )
     } else {
-        let lifecycle_run = if asynch {
-            quote!(
-                fn lifecycle(&self, _ctx: impl #krate::dm::HandlerContext, _op: #krate::dm::LifecycleOp) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                    core::future::ready(Ok(()))
-                }
+        // `lifecycle` is deliberately synchronous even on the async handler
+        // trait (like `bump_dataver`) - see `AsyncHandler::lifecycle`.
+        let lifecycle_run = quote!(
+            fn lifecycle(&self, _ctx: impl #krate::dm::HandlerContext, _op: #krate::dm::LifecycleOp) -> Result<(), #krate::error::Error> {
+                Ok(())
+            }
 
-                fn run(&self, _ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                    core::future::pending::<Result::<(), #krate::error::Error>>()
-                }
-            )
-        } else {
-            quote!(
-                fn lifecycle(&self, _ctx: impl #krate::dm::HandlerContext, _op: #krate::dm::LifecycleOp) -> Result<(), #krate::error::Error> {
-                    Ok(())
-                }
-
-                fn run(&self, _ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                    core::future::pending::<Result::<(), #krate::error::Error>>()
-                }
-            )
-        };
+            fn run(&self, _ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+                core::future::pending::<Result::<(), #krate::error::Error>>()
+            }
+        );
 
         quote!(
             #[doc = "The handler trait for the cluster."]
@@ -298,27 +276,15 @@ pub fn handler_adaptor(
         )
     };
 
-    let lifecycle_run = if asynch {
-        quote!(
-            fn lifecycle(&self, ctx: impl #krate::dm::HandlerContext, op: #krate::dm::LifecycleOp) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                self.0.lifecycle(ctx, op)
-            }
+    let lifecycle_run = quote!(
+        fn lifecycle(&self, ctx: impl #krate::dm::HandlerContext, op: #krate::dm::LifecycleOp) -> Result<(), #krate::error::Error> {
+            self.0.lifecycle(ctx, op)
+        }
 
-            fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                self.0.run(ctx)
-            }
-        )
-    } else {
-        quote!(
-            fn lifecycle(&self, ctx: impl #krate::dm::HandlerContext, op: #krate::dm::LifecycleOp) -> Result<(), #krate::error::Error> {
-                self.0.lifecycle(ctx, op)
-            }
-
-            fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
-                self.0.run(ctx)
-            }
-        )
-    };
+        fn run(&self, ctx: impl #krate::dm::HandlerContext) -> impl core::future::Future<Output = Result<(), #krate::error::Error>> {
+            self.0.run(ctx)
+        }
+    );
 
     let pasync = if asynch { quote!(async) } else { quote!() };
 

--- a/rs-matter/src/dm/clusters/adm_comm.rs
+++ b/rs-matter/src/dm/clusters/adm_comm.rs
@@ -275,7 +275,7 @@ impl ClusterHandler for AdminCommHandler {
         //     we do it explicitly here so accumulated dangling PASE sessions
         //     don't confuse the commissioner across multiple rounds (see
         //     TC_CGEN_2_4, which iterates open / commission / revoke 8x).
-        ctx.exchange().with_state(|state| {
+        let removed_fabric = ctx.exchange().with_state(|state| {
             // If RevokeCommissioning came in over a PASE session, don't
             // drop it before we've sent the response — mark it as expired
             // instead so it lingers just long enough for the in-flight
@@ -288,7 +288,7 @@ impl ClusterHandler for AdminCommHandler {
             )
             .then(|| sess.id());
 
-            state.failsafe.expire(
+            let removed_fabric = state.failsafe.expire(
                 &mut state.fabrics,
                 &mut state.sessions,
                 expire_sess_id,
@@ -299,8 +299,17 @@ impl ClusterHandler for AdminCommHandler {
             )?;
 
             ctx.exchange().matter().transport().notify_session_removed();
-            Ok::<_, Error>(())
+
+            Ok::<_, Error>(removed_fabric)
         })?;
+
+        // Broadcast for a fabric the expiry dropped (a not-yet-committed
+        // `AddNOC` one; an `UpdateNOC`-mutated fabric is resurrected instead
+        // and not reported). Outside `with_state`, since the broadcast runs
+        // the handlers inline.
+        if let Some(fab_idx) = removed_fabric {
+            ctx.notify_fabric_removed(fab_idx);
+        }
 
         ctx.exchange().with_state(|state| {
             state

--- a/rs-matter/src/dm/clusters/binding.rs
+++ b/rs-matter/src/dm/clusters/binding.rs
@@ -175,8 +175,24 @@ impl<const N: usize> Bindings<N> {
         store.remove(BINDINGS_KEY, buf)
     }
 
+    /// Drop every binding belonging to `fab_idx`, returning whether anything
+    /// was removed.
+    ///
+    /// Called on fabric removal via the [`LifecycleOp::FabricRemoval`]
+    /// lifecycle operation delivered to the [`BindingHandler`] instance(s)
+    /// borrowing this registry. Idempotent, since each borrowing handler
+    /// instance receives the (broadcast) lifecycle operation.
+    pub fn remove_for_fabric(&self, fab_idx: NonZeroU8) -> bool {
+        self.state.lock(|cell| {
+            let mut state = cell.borrow_mut();
+            let before = state.len();
+            state.retain(|binding| binding.fab_idx != fab_idx);
+            state.len() < before
+        })
+    }
+
     /// Serialise the registry to `ctx.kv()` under [`BINDINGS_KEY`].
-    fn store_persist<C: WriteContext>(&self, ctx: &C) -> Result<(), Error> {
+    fn store_persist<C: HandlerContext>(&self, ctx: &C) -> Result<(), Error> {
         let mut persist = Persist::new(ctx.kv());
 
         self.state.lock(|cell| {
@@ -427,10 +443,21 @@ impl<const N: usize> ClusterHandler for BindingHandler<'_, N> {
     }
 
     fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
-        ctx.kv().access(|store, buf| match op {
-            LifecycleOp::Startup => self.bindings.load_persist(store, buf),
-            LifecycleOp::FactoryReset => self.bindings.reset_persist(store, buf),
-        })
+        match op {
+            LifecycleOp::Startup => ctx
+                .kv()
+                .access(|store, buf| self.bindings.load_persist(store, buf)),
+            LifecycleOp::FactoryReset => ctx
+                .kv()
+                .access(|store, buf| self.bindings.reset_persist(store, buf)),
+            LifecycleOp::FabricRemoval { fab_idx } => {
+                if self.bindings.remove_for_fabric(fab_idx) {
+                    self.bindings.store_persist(&ctx)?;
+                }
+
+                Ok(())
+            }
+        }
     }
 
     fn binding<P: TLVBuilderParent>(

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -368,6 +368,8 @@ impl ClusterHandler for GenCommHandler<'_> {
         // in-flight `AddNOC` / `SetRegulatoryConfig` changes are reverted —
         // the bare `failsafe.arm(0, ...)` path only flips the state to
         // `Idle` and would leave the staged fabric committed.
+        let mut removed_fabric = None;
+
         let status = if expiry_length_seconds == 0 {
             let notify_mdns = || ctx.exchange().matter().transport().notify_mdns_changed();
             let notify_change = |endpt_id, clust_id| ctx.notify_cluster_changed(endpt_id, clust_id);
@@ -377,7 +379,7 @@ impl ClusterHandler for GenCommHandler<'_> {
                 let pase_sess_id =
                     matches!(sess.get_session_mode(), SessionMode::Pase { .. }).then(|| sess.id());
 
-                state.failsafe.expire(
+                removed_fabric = state.failsafe.expire(
                     &mut state.fabrics,
                     &mut state.sessions,
                     pase_sess_id,
@@ -401,6 +403,14 @@ impl ClusterHandler for GenCommHandler<'_> {
                 )
             }))?
         };
+
+        // Broadcast for a fabric the expiry dropped (a not-yet-committed
+        // `AddNOC` one; an `UpdateNOC`-mutated fabric is resurrected instead
+        // and not reported). Outside `with_state`, since the broadcast runs
+        // the handlers inline.
+        if let Some(fab_idx) = removed_fabric {
+            ctx.notify_fabric_removed(fab_idx);
+        }
 
         // Breadcrumb (and possibly failsafe-arm state) may have changed
         ctx.notify_own_cluster_changed();

--- a/rs-matter/src/dm/clusters/groups.rs
+++ b/rs-matter/src/dm/clusters/groups.rs
@@ -20,6 +20,7 @@
 use core::num::NonZeroU8;
 
 use crate::dm::clusters::acl::notify_auxiliary_access_updated;
+use crate::dm::clusters::identify::IdentifyStatus;
 use crate::dm::{Cluster, Dataver, InvokeContext, ReadContext};
 use crate::error::{Error, ErrorCode};
 use crate::fabric::FabricPersist;
@@ -32,19 +33,41 @@ pub use crate::dm::clusters::decl::groups::*;
 /// The handler for the Groups Matter cluster.
 ///
 /// This handler manages per-endpoint group membership in the node-wide Group Table.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct GroupsHandler {
+#[derive(Clone)]
+pub struct GroupsHandler<'a> {
     dataver: Dataver,
+    /// Identification state of the endpoint this instance serves.
+    /// `AddGroupIfIdentifying` is a successful no-op when absent — an
+    /// endpoint without an Identify coupling is never identifying.
+    identify: Option<&'a dyn IdentifyStatus>,
 }
 
-impl GroupsHandler {
+impl<'a> GroupsHandler<'a> {
     /// Creates a new instance of the `GroupsHandler`.
     ///
     /// # Arguments
     /// * `dataver` - The data version tracker
     pub const fn new(dataver: Dataver) -> Self {
-        Self { dataver }
+        Self {
+            dataver,
+            identify: None,
+        }
+    }
+
+    /// Creates a new instance of the `GroupsHandler` coupled to the
+    /// Identify cluster handler serving the same endpoint, so that
+    /// `AddGroupIfIdentifying` can take effect while the endpoint is
+    /// identifying.
+    ///
+    /// # Arguments
+    /// * `dataver` - The data version tracker
+    /// * `identify` - The Identify handler (or any [`IdentifyStatus`] impl)
+    ///   of the endpoint this `GroupsHandler` instance is matched to
+    pub const fn new_with_identify(dataver: Dataver, identify: &'a dyn IdentifyStatus) -> Self {
+        Self {
+            dataver,
+            identify: Some(identify),
+        }
     }
 
     /// Adapt the handler instance to the generic `rs-matter` `Handler` trait
@@ -69,7 +92,7 @@ impl GroupsHandler {
     }
 }
 
-impl GroupsHandler {
+impl GroupsHandler<'_> {
     /// Whether the given (aux-flagged) group's auxiliary ACL coverage of
     /// `endpoint_id` would change by adding/removing that endpoint - i.e.
     /// whether an `AuxiliaryAccessUpdated` notification is due.
@@ -117,44 +140,22 @@ impl GroupsHandler {
             warn!("Failed to notify the auxiliary ACL change: {:?}", e);
         }
     }
-}
 
-impl ClusterHandler for GroupsHandler {
-    const CLUSTER: Cluster<'static> = FULL_CLUSTER
-        .with_features(Feature::GROUP_NAMES.bits())
-        .with_attrs(with!(required));
-
-    fn dataver(&self) -> u32 {
-        self.dataver.get()
-    }
-
-    fn dataver_changed(&self) {
-        self.dataver.changed();
-    }
-
-    fn name_support(&self, _ctx: impl ReadContext) -> Result<NameSupportBitmap, Error> {
-        // Bit 7 (GroupNames) = 1 when GN feature is supported
-        Ok(NameSupportBitmap::GROUP_NAMES)
-    }
-
-    fn handle_add_group<P: TLVBuilderParent>(
+    /// Add the invoked endpoint to `group_id` for the invoking fabric —
+    /// the shared core of `AddGroup` and `AddGroupIfIdentifying` (which
+    /// differ only in how the outcome is reported back).
+    ///
+    /// Returns the IM status of the operation: `UnsupportedAccess` when
+    /// the fabric has no group key material for the group,
+    /// `ResourceExhausted` when the group table is full, `Success`
+    /// otherwise. Emits the auxiliary-ACL change notification when due.
+    fn add_group(
         &self,
-        ctx: impl InvokeContext,
-        request: AddGroupRequest<'_>,
-        response: AddGroupResponseBuilder<P>,
-    ) -> Result<P, Error> {
-        let fab_idx = ctx.accessor()?.fab_idx()?;
-        let group_id = request.group_id()?;
-        let group_name: &str = request.group_name()?;
-
-        // Validate constraints
-        if (group_id == 0) || (group_name.len() > 16) {
-            return response
-                .status(IMStatusCode::ConstraintError as u8)?
-                .group_id(group_id)?
-                .end();
-        }
-
+        ctx: &impl InvokeContext,
+        fab_idx: NonZeroU8,
+        group_id: u16,
+        group_name: &str,
+    ) -> Result<IMStatusCode, Error> {
         let mut persist = FabricPersist::new(ctx.kv());
 
         let status = ctx.exchange().with_state(|state| {
@@ -198,8 +199,50 @@ impl ClusterHandler for GroupsHandler {
 
         let (status, aux_touched) = status;
         if aux_touched && matches!(status, IMStatusCode::Success) {
-            Self::notify_aux(&ctx, fab_idx);
+            Self::notify_aux(ctx, fab_idx);
         }
+
+        Ok(status)
+    }
+}
+
+impl ClusterHandler for GroupsHandler<'_> {
+    const CLUSTER: Cluster<'static> = FULL_CLUSTER
+        .with_features(Feature::GROUP_NAMES.bits())
+        .with_attrs(with!(required));
+
+    fn dataver(&self) -> u32 {
+        self.dataver.get()
+    }
+
+    fn dataver_changed(&self) {
+        self.dataver.changed();
+    }
+
+    fn name_support(&self, _ctx: impl ReadContext) -> Result<NameSupportBitmap, Error> {
+        // Bit 7 (GroupNames) = 1 when GN feature is supported
+        Ok(NameSupportBitmap::GROUP_NAMES)
+    }
+
+    fn handle_add_group<P: TLVBuilderParent>(
+        &self,
+        ctx: impl InvokeContext,
+        request: AddGroupRequest<'_>,
+        response: AddGroupResponseBuilder<P>,
+    ) -> Result<P, Error> {
+        let fab_idx = ctx.accessor()?.fab_idx()?;
+        let group_id = request.group_id()?;
+        let group_name: &str = request.group_name()?;
+
+        // Validate constraints
+        if (group_id == 0) || (group_name.len() > 16) {
+            return response
+                .status(IMStatusCode::ConstraintError as u8)?
+                .group_id(group_id)?
+                .end();
+        }
+
+        let status = self.add_group(&ctx, fab_idx, group_id, group_name)?;
 
         response.status(status as u8)?.group_id(group_id)?.end()
     }
@@ -374,10 +417,35 @@ impl ClusterHandler for GroupsHandler {
 
     fn handle_add_group_if_identifying(
         &self,
-        _ctx: impl InvokeContext,
-        _request: AddGroupIfIdentifyingRequest<'_>,
+        ctx: impl InvokeContext,
+        request: AddGroupIfIdentifyingRequest<'_>,
     ) -> Result<(), Error> {
-        // TODO: implement with Identity Cluster
-        todo!()
+        // Per App Cluster spec, the command is accepted (SUCCESS) but has
+        // no effect unless the endpoint is currently identifying
+        if !self
+            .identify
+            .is_some_and(|identify| identify.is_identifying())
+        {
+            return Ok(());
+        }
+
+        let fab_idx = ctx.accessor()?.fab_idx()?;
+        let group_id = request.group_id()?;
+        let group_name: &str = request.group_name()?;
+
+        // Validate constraints
+        if (group_id == 0) || (group_name.len() > 16) {
+            return Err(ErrorCode::ConstraintError.into());
+        }
+
+        // Unlike `AddGroup`, this command responds with a plain status
+        // rather than an `AddGroupResponse` - so a non-success outcome
+        // is reported by erroring out
+        let status = self.add_group(&ctx, fab_idx, group_id, group_name)?;
+        if let Some(code) = status.to_error_code() {
+            return Err(code.into());
+        }
+
+        Ok(())
     }
 }

--- a/rs-matter/src/dm/clusters/icd_mgmt.rs
+++ b/rs-matter/src/dm/clusters/icd_mgmt.rs
@@ -36,8 +36,10 @@ use embassy_time::{Duration, Instant};
 
 use crate::acl::AccessReq;
 use crate::crypto::{CanonAeadKey, Crypto};
+use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::dm::{
-    Access, ArrayAttributeRead, Cluster, Dataver, HandlerContext, InvokeContext, ReadContext,
+    Access, ArrayAttributeRead, Cluster, Dataver, HandlerContext, InvokeContext, LifecycleOp,
+    ReadContext,
 };
 use crate::error::{Error, ErrorCode};
 use crate::fabric::MAX_FABRICS;
@@ -652,7 +654,7 @@ impl<'a> IcdMgmtHandler<'a> {
     /// Publish the current operating mode to the mDNS layer. This handler serves
     /// the LITS feature, so the device is always ICD-capable — the mode flips
     /// between SIT and LIT as the registration set empties and fills.
-    fn sync_icd_mode(&self, ctx: &impl InvokeContext) {
+    fn sync_icd_mode(&self, ctx: &impl HandlerContext) {
         ctx.matter().set_icd_mode(Some(self.icd.operating_mode()));
     }
 }
@@ -687,6 +689,39 @@ impl ClusterHandler for IcdMgmtHandler<'_> {
 
     fn dataver_changed(&self) {
         self.dataver.changed();
+    }
+
+    fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
+        match op {
+            // Registration re-hydration and factory reset are app-driven
+            // (`Icd::load_registrations` / KV wipe), since the `Icd` state is
+            // owned by the application and shared with the Check-In machinery.
+            LifecycleOp::Startup | LifecycleOp::FactoryReset => Ok(()),
+            LifecycleOp::FabricRemoval { fab_idx } => {
+                let mode_before = self.icd.operating_mode();
+
+                if self.icd.remove_fabric(fab_idx) {
+                    self.icd.store_registrations(&ctx)?;
+
+                    // Dropping the last LIT registration flips the operating
+                    // mode to SIT - a global (not fabric-scoped) observable,
+                    // so subscribers and the mDNS layer must learn about it.
+                    // ICD Management is a root-node cluster, hence the fixed
+                    // endpoint.
+                    if self.icd.operating_mode() != mode_before {
+                        ctx.notify_attr_changed(
+                            ROOT_ENDPOINT_ID,
+                            Self::CLUSTER.id,
+                            AttributeId::OperatingMode as _,
+                        );
+                    }
+
+                    self.sync_icd_mode(&ctx);
+                }
+
+                Ok(())
+            }
+        }
     }
 
     fn idle_mode_duration(&self, _ctx: impl ReadContext) -> Result<u32, Error> {

--- a/rs-matter/src/dm/clusters/identify.rs
+++ b/rs-matter/src/dm/clusters/identify.rs
@@ -127,6 +127,27 @@ impl IdentifyHooks for () {
     }
 }
 
+/// Read-only view over an endpoint's identification state, for sibling
+/// clusters whose behavior depends on it — notably the Groups cluster,
+/// whose `AddGroupIfIdentifying` command only takes effect while the
+/// endpoint is identifying (App Cluster spec).
+///
+/// Implemented by [`IdentifyHandler`]; couple it to the sibling handler
+/// serving the *same* endpoint (identification state is per-endpoint).
+pub trait IdentifyStatus {
+    /// Whether the endpoint is currently identifying (`IdentifyTime > 0`).
+    fn is_identifying(&self) -> bool;
+}
+
+impl<T> IdentifyStatus for &T
+where
+    T: IdentifyStatus + ?Sized,
+{
+    fn is_identifying(&self) -> bool {
+        (*self).is_identifying()
+    }
+}
+
 /// The captured identify session. Reads of `IdentifyTime` compute
 /// `duration.saturating_sub(elapsed)` from this on-demand; the run task
 /// uses `endpoint_id` to target its `notify_attr_changed` at the right
@@ -269,6 +290,15 @@ where
         } else {
             IdentifyAction::Time(value)
         });
+    }
+}
+
+impl<H> IdentifyStatus for IdentifyHandler<H>
+where
+    H: IdentifyHooks,
+{
+    fn is_identifying(&self) -> bool {
+        self.remaining() > 0
     }
 }
 

--- a/rs-matter/src/dm/clusters/noc.rs
+++ b/rs-matter/src/dm/clusters/noc.rs
@@ -495,6 +495,9 @@ impl ClusterHandler for NocHandler {
         // for the auto-created admin ACL entry *after* the failsafe-armed
         // closure unwinds successfully (Matter Core spec).
         let mut admin_acl_entry: Option<AclEntry> = None;
+        // Set by the rollback scopeguard; the `LifecycleOp::FabricRemoval`
+        // broadcast happens below, once the state lock is released.
+        let rolled_back_fab_idx = Cell::new(None);
 
         let buf = response.writer().available_space();
 
@@ -532,6 +535,8 @@ impl ClusterHandler for NocHandler {
                         unwrap!(state.fabrics.remove(fab_idx));
 
                         notify_mdns();
+
+                        rolled_back_fab_idx.set(Some(fab_idx));
                     }
                 });
 
@@ -545,7 +550,17 @@ impl ClusterHandler for NocHandler {
 
                 Ok(())
             },
-        ))?;
+        ));
+
+        // Broadcast `LifecycleOp::FabricRemoval` for a fabric the rollback
+        // scopeguard just removed - on both the mapped-status and the
+        // propagated-error paths. Outside `with_state`, since the broadcast
+        // runs the handlers inline.
+        if let Some(fab_idx) = rolled_back_fab_idx.get() {
+            ctx.notify_fabric_removed(fab_idx);
+        }
+
+        let status = status?;
 
         // AddNOC mutates NOCs, Fabrics, CommissionedFabrics, TrustedRootCerts, etc.
         ctx.notify_own_cluster_changed();
@@ -774,6 +789,12 @@ impl ClusterHandler for NocHandler {
             if let Err(e) = emitted {
                 warn!("Failed to emit the Leave event: {:?}", e);
             }
+
+            // Broadcast `LifecycleOp::FabricRemoval`, so handlers owning
+            // fabric-scoped state outside the fabric table (bindings, scenes,
+            // ...) drop the removed fabric's entries. Outside `with_state`,
+            // since the broadcast runs the handlers inline.
+            ctx.notify_fabric_removed(fab_idx);
         }
 
         // RemoveFabric mutates NOCs, Fabrics, CommissionedFabrics, TrustedRootCerts

--- a/rs-matter/src/dm/clusters/ota_req.rs
+++ b/rs-matter/src/dm/clusters/ota_req.rs
@@ -317,8 +317,35 @@ impl Providers {
         store.remove(OTA_PROVIDERS_KEY, buf)
     }
 
+    /// Drop the default and announced providers belonging to `fab_idx`,
+    /// returning whether anything was removed. Signals
+    /// [`wait_changed`](Self::wait_changed) when so.
+    ///
+    /// Called on fabric removal via the [`LifecycleOp::FabricRemoval`]
+    /// lifecycle operation delivered to the [`OtaRequestorHandler`] borrowing
+    /// this registry. Idempotent.
+    pub fn remove_for_fabric(&self, fab_idx: NonZeroU8) -> bool {
+        let removed = self.state.lock(|cell| {
+            let mut state = cell.borrow_mut();
+            let before = state.default.len() + state.announced.len();
+
+            state.default.retain(|provider| provider.fab_idx != fab_idx);
+            state
+                .announced
+                .retain(|provider| provider.fab_idx != fab_idx);
+
+            state.default.len() + state.announced.len() < before
+        });
+
+        if removed {
+            self.changed.notify();
+        }
+
+        removed
+    }
+
     /// Persist the default provider list to `ctx.kv()`.
-    fn store_persist<C: WriteContext>(&self, ctx: &C) -> Result<(), Error> {
+    fn store_persist<C: HandlerContext>(&self, ctx: &C) -> Result<(), Error> {
         let mut persist = Persist::new(ctx.kv());
 
         self.state.lock(|cell| {
@@ -685,10 +712,21 @@ impl ClusterHandler for OtaRequestorHandler<'_> {
     }
 
     fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
-        ctx.kv().access(|store, buf| match op {
-            LifecycleOp::Startup => self.providers.load_persist(store, buf),
-            LifecycleOp::FactoryReset => self.providers.reset_persist(store, buf),
-        })
+        match op {
+            LifecycleOp::Startup => ctx
+                .kv()
+                .access(|store, buf| self.providers.load_persist(store, buf)),
+            LifecycleOp::FactoryReset => ctx
+                .kv()
+                .access(|store, buf| self.providers.reset_persist(store, buf)),
+            LifecycleOp::FabricRemoval { fab_idx } => {
+                if self.providers.remove_for_fabric(fab_idx) {
+                    self.providers.store_persist(&ctx)?;
+                }
+
+                Ok(())
+            }
+        }
     }
 
     fn default_ota_providers<P: TLVBuilderParent>(

--- a/rs-matter/src/dm/clusters/scenes.rs
+++ b/rs-matter/src/dm/clusters/scenes.rs
@@ -624,6 +624,29 @@ impl<const N: usize, const M: usize> ScenesState<N, M> {
         store.remove(SCENES_KEY, buf)
     }
 
+    /// Drop every scene-table row and `CurrentScene` slot belonging to
+    /// `fab_idx`, returning whether anything was removed.
+    ///
+    /// Called on fabric removal via the [`LifecycleOp::FabricRemoval`]
+    /// lifecycle operation delivered to the [`ScenesHandler`] instance(s)
+    /// borrowing this state. Idempotent, since each borrowing handler
+    /// instance receives the (broadcast) lifecycle operation.
+    pub fn remove_for_fabric(&self, fab_idx: NonZeroU8) -> bool {
+        self.with(|inner| {
+            let before = inner.table.len() + inner.current_per_fabric.len();
+
+            inner.table.retain(|entry| entry.fab_idx != fab_idx);
+            inner.current_per_fabric.retain(|c| c.fab_idx != fab_idx);
+
+            let removed = inner.table.len() + inner.current_per_fabric.len() < before;
+            if removed {
+                inner.bump_info_dataver();
+            }
+
+            removed
+        })
+    }
+
     /// Persist the current state under [`SCENES_KEY`]. Called from
     /// every mutating handler path after the in-memory change is
     /// committed.
@@ -1626,15 +1649,22 @@ where
         self.dataver.changed();
     }
 
-    fn lifecycle(
-        &self,
-        ctx: impl HandlerContext,
-        op: LifecycleOp,
-    ) -> impl Future<Output = Result<(), Error>> {
-        ready(ctx.kv().access(|store, buf| match op {
-            LifecycleOp::Startup => self.state.load_persist(store, buf),
-            LifecycleOp::FactoryReset => self.state.reset_persist(store, buf),
-        }))
+    fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
+        match op {
+            LifecycleOp::Startup => ctx
+                .kv()
+                .access(|store, buf| self.state.load_persist(store, buf)),
+            LifecycleOp::FactoryReset => ctx
+                .kv()
+                .access(|store, buf| self.state.reset_persist(store, buf)),
+            LifecycleOp::FabricRemoval { fab_idx } => {
+                if self.state.remove_for_fabric(fab_idx) {
+                    self.state.store_persist(&ctx)
+                } else {
+                    Ok(())
+                }
+            }
+        }
     }
 
     fn scene_table_size(&self, _ctx: impl ReadContext) -> impl Future<Output = Result<u16, Error>> {

--- a/rs-matter/src/dm/clusters/user_label.rs
+++ b/rs-matter/src/dm/clusters/user_label.rs
@@ -406,6 +406,7 @@ impl<const E: usize, const N: usize> ClusterHandler for UserLabelHandler<'_, E, 
         ctx.kv().access(|store, buf| match op {
             LifecycleOp::Startup => self.labels.load_persist(store, buf),
             LifecycleOp::FactoryReset => self.labels.reset_persist(store, buf),
+            LifecycleOp::FabricRemoval { .. } => Ok(()),
         })
     }
 

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -287,6 +287,19 @@ pub trait HandlerContext: AttrChangeNotifier + EventEmitter {
     /// Lets a handler read IM-internal figures it cannot otherwise reach - the
     /// General Diagnostics handler uses it for `DeviceLoadStatus`.
     fn im_stats(&self) -> impl ImStats + '_;
+
+    /// Notify that the fabric with the given local index has been removed
+    /// from the fabric table, by synchronously broadcasting
+    /// [`LifecycleOp::FabricRemoval`] to every handler in the data model.
+    ///
+    /// Two caveats for callers:
+    /// - The broadcast runs the handlers' `lifecycle` methods inline, so this
+    ///   must NOT be called while holding the Matter state lock (i.e. from
+    ///   within a `with_state` closure) - handlers are free to access the
+    ///   Matter instance themselves.
+    /// - For the same reason, a handler must not call this from its own
+    ///   `lifecycle` implementation (infinite recursion).
+    fn notify_fabric_removed(&self, fab_idx: NonZeroU8);
 }
 
 impl<T> HandlerContext for &T
@@ -323,6 +336,10 @@ where
 
     fn im_stats(&self) -> impl ImStats + '_ {
         (**self).im_stats()
+    }
+
+    fn notify_fabric_removed(&self, fab_idx: NonZeroU8) {
+        (**self).notify_fabric_removed(fab_idx);
     }
 }
 
@@ -578,6 +595,10 @@ where
     fn im_stats(&self) -> impl ImStats + '_ {
         self.context.im_stats()
     }
+
+    fn notify_fabric_removed(&self, fab_idx: NonZeroU8) {
+        self.context.notify_fabric_removed(fab_idx);
+    }
 }
 
 impl<C> AttrChangeNotifier for ReadContextInstance<'_, C>
@@ -754,6 +775,10 @@ where
     fn im_stats(&self) -> impl ImStats + '_ {
         self.context.im_stats()
     }
+
+    fn notify_fabric_removed(&self, fab_idx: NonZeroU8) {
+        self.context.notify_fabric_removed(fab_idx);
+    }
 }
 
 impl<C> AttrChangeNotifier for ReportContextInstance<'_, C>
@@ -875,6 +900,10 @@ where
 
     fn im_stats(&self) -> impl ImStats + '_ {
         self.context.im_stats()
+    }
+
+    fn notify_fabric_removed(&self, fab_idx: NonZeroU8) {
+        self.context.notify_fabric_removed(fab_idx);
     }
 }
 
@@ -1060,6 +1089,10 @@ where
     fn im_stats(&self) -> impl ImStats + '_ {
         self.context.im_stats()
     }
+
+    fn notify_fabric_removed(&self, fab_idx: NonZeroU8) {
+        self.context.notify_fabric_removed(fab_idx);
+    }
 }
 
 impl<C> AttrChangeNotifier for InvokeContextInstance<'_, C>
@@ -1205,6 +1238,28 @@ pub enum LifecycleOp {
     /// The typical reaction is to reset the handler's in-memory state to factory
     /// defaults and remove the handler's persisted data from [`HandlerContext::kv`].
     FactoryReset,
+    /// The fabric with the given local index has been removed from the node.
+    ///
+    /// Delivered synchronously (via [`HandlerContext::notify_fabric_removed`])
+    /// right after the fabric is gone from the fabric table - via the
+    /// `RemoveFabric` command, an `AddNOC` rollback, or a fail-safe expiry
+    /// that did not resurrect a persisted (pre-`UpdateNOC`) copy of the
+    /// fabric. NOT delivered when a fail-safe expiry reverts an in-progress
+    /// `UpdateNOC` - the fabric is still commissioned in that case.
+    ///
+    /// The typical reaction is to drop the removed fabric's entries from any
+    /// fabric-scoped state the handler owns *outside* the fabric table (a
+    /// bindings registry, a scene table, provider lists, ...) and re-persist.
+    /// State stored inside the `Fabric` object itself (ACLs, group keys)
+    /// needs no reaction - it is dropped with the fabric.
+    ///
+    /// Like every lifecycle operation this is a broadcast, so multiple
+    /// handler instances borrowing one shared registry each receive it -
+    /// reactions must be idempotent (a `retain`-style purge naturally is).
+    FabricRemoval {
+        /// The local index the removed fabric had
+        fab_idx: NonZeroU8,
+    },
 }
 
 /// A version of the `AsyncHandler` trait that never awaits any operation.
@@ -1691,13 +1746,14 @@ mod asynch {
         /// Unlike read/write/invoke - which are routed to the single handler matching the
         /// operation path - this method is invoked on every handler in the handler chain.
         ///
+        /// Deliberately synchronous - like [`AsyncHandler::bump_dataver`] -
+        /// even on the async handler trait, so that lifecycle broadcasts can
+        /// be dispatched eagerly from synchronous call sites (see
+        /// [`HandlerContext::notify_fabric_removed`]).
+        ///
         /// The default implementation does nothing.
-        fn lifecycle(
-            &self,
-            _ctx: impl HandlerContext,
-            _op: LifecycleOp,
-        ) -> impl Future<Output = Result<(), Error>> {
-            ready(Ok(()))
+        fn lifecycle(&self, _ctx: impl HandlerContext, _op: LifecycleOp) -> Result<(), Error> {
+            Ok(())
         }
 
         /// A hook (a scheduling facility) for placing handler-impl-specific code that needs to run
@@ -1749,11 +1805,7 @@ mod asynch {
             (**self).bump_dataver(ctx)
         }
 
-        fn lifecycle(
-            &self,
-            ctx: impl HandlerContext,
-            op: LifecycleOp,
-        ) -> impl Future<Output = Result<(), Error>> {
+        fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
             (**self).lifecycle(ctx, op)
         }
 
@@ -1802,11 +1854,7 @@ mod asynch {
             (**self).bump_dataver(ctx)
         }
 
-        fn lifecycle(
-            &self,
-            ctx: impl HandlerContext,
-            op: LifecycleOp,
-        ) -> impl Future<Output = Result<(), Error>> {
+        fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
             (**self).lifecycle(ctx, op)
         }
 
@@ -1938,11 +1986,7 @@ mod asynch {
             self.1.bump_dataver(ctx)
         }
 
-        fn lifecycle(
-            &self,
-            ctx: impl HandlerContext,
-            op: LifecycleOp,
-        ) -> impl Future<Output = Result<(), Error>> {
+        fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
             self.1.lifecycle(ctx, op)
         }
 
@@ -1991,12 +2035,8 @@ mod asynch {
             Handler::bump_dataver(&self.0, ctx)
         }
 
-        fn lifecycle(
-            &self,
-            ctx: impl HandlerContext,
-            op: LifecycleOp,
-        ) -> impl Future<Output = Result<(), Error>> {
-            ready(Handler::lifecycle(&self.0, ctx, op))
+        fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
+            Handler::lifecycle(&self.0, ctx, op)
         }
 
         fn run(&self, ctx: impl HandlerContext) -> impl Future<Output = Result<(), Error>> {
@@ -2116,11 +2156,11 @@ mod asynch {
             self.next.bump_dataver(ctx)
         }
 
-        async fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
+        fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
             // Lifecycle ops are a broadcast: every handler in the chain gets them,
             // regardless of the matcher.
-            self.handler.lifecycle(&ctx, op).await?;
-            self.next.lifecycle(ctx, op).await
+            self.handler.lifecycle(&ctx, op)?;
+            self.next.lifecycle(ctx, op)
         }
 
         async fn run(&self, ctx: impl HandlerContext) -> Result<(), Error> {

--- a/rs-matter/src/failsafe.rs
+++ b/rs-matter/src/failsafe.rs
@@ -120,6 +120,11 @@ impl FailSafe {
     ///
     /// This should be called periodically to ensure that the fail-safe state is updated in a timely manner.
     /// Ideally, it should also be called at the beginning of any API that requires the fail-safe to be armed to ensure that the state is up to date.
+    ///
+    /// Returns the local index of the fabric that ended up removed by the
+    /// rollback (see [`Failsafe::expire`]), if any - the caller must follow
+    /// up with a `HandlerContext::notify_fabric_removed` broadcast once the
+    /// Matter state lock is released.
     #[allow(clippy::too_many_arguments)]
     pub fn check_failsafe_timeout<S, N>(
         &mut self,
@@ -130,7 +135,7 @@ impl FailSafe {
         expire_sess_id: Option<u32>,
         mdns_notif: impl FnMut(),
         notify_change: impl FnMut(EndptId, ClusterId),
-    ) -> Result<bool, Error>
+    ) -> Result<Option<NonZeroU8>, Error>
     where
         S: KvBlobStoreAccess,
         N: NetworksAccess,
@@ -145,7 +150,7 @@ impl FailSafe {
                 // Timeout path: no caller exchange to preserve, so wipe
                 // every PASE session along with the fabric / networks
                 // rollback.
-                self.expire(
+                return self.expire(
                     fabrics,
                     sessions,
                     expire_sess_id,
@@ -153,12 +158,11 @@ impl FailSafe {
                     kv,
                     mdns_notif,
                     notify_change,
-                )?;
-                return Ok(true);
+                );
             }
         }
 
-        Ok(false)
+        Ok(None)
     }
 
     /// Force the fail-safe context to expire immediately, rolling back any
@@ -170,6 +174,14 @@ impl FailSafe {
     /// over PASE, so the response can still be sent before the slot is
     /// reclaimed. `None` for the timeout-driven path or when the trigger
     /// arrived over CASE.
+    ///
+    /// Returns the local index of the fabric the rollback ended up removing,
+    /// if any: a fabric added by the in-flight `AddNOC` has no persisted copy
+    /// yet and is simply dropped, whereas a pre-existing fabric mutated by
+    /// `UpdateNOC` is resurrected from its persisted copy (and is thus NOT
+    /// reported as removed). The caller must follow up with a
+    /// `HandlerContext::notify_fabric_removed` broadcast for a reported
+    /// removal, once the Matter state lock is released.
     #[allow(clippy::too_many_arguments)]
     pub fn expire<S, N>(
         &mut self,
@@ -180,13 +192,13 @@ impl FailSafe {
         kv: S,
         mut mdns_notif: impl FnMut(),
         mut notify_change: impl FnMut(EndptId, ClusterId),
-    ) -> Result<bool, Error>
+    ) -> Result<Option<NonZeroU8>, Error>
     where
         S: KvBlobStoreAccess,
         N: NetworksAccess,
     {
         let State::Armed(ctx) = &self.state else {
-            return Ok(false);
+            return Ok(None);
         };
 
         warn!(
@@ -195,11 +207,14 @@ impl FailSafe {
         );
 
         let fab_idx_raw = ctx.fab_idx;
+        let mut removed_fabric = None;
 
         kv.access(|mut kv, buf| {
             if let Some(fab_idx) = NonZeroU8::new(fab_idx_raw) {
                 fabrics.remove(fab_idx)?;
                 fabrics.add_load(fab_idx.get(), &mut kv, buf)?;
+
+                removed_fabric = fabrics.get(fab_idx).is_none().then_some(fab_idx);
             }
 
             networks.access(|networks| {
@@ -247,7 +262,7 @@ impl FailSafe {
             crate::dm::clusters::decl::network_commissioning::FULL_CLUSTER.id,
         );
 
-        Ok(true)
+        Ok(removed_fabric)
     }
 
     pub fn arm(

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -562,7 +562,7 @@ where
         // Needs the events watermark loaded just above.
         self.resume_subscriptions()?;
 
-        self.handler.lifecycle(self, LifecycleOp::Startup).await
+        self.handler.lifecycle(self, LifecycleOp::Startup)
     }
 
     /// Factory-reset the Data Model persistable state.
@@ -580,9 +580,7 @@ where
     pub async fn factory_reset(&self) -> Result<(), Error> {
         self.state.reset_persist(&self.kv)?;
 
-        self.handler
-            .lifecycle(self, LifecycleOp::FactoryReset)
-            .await
+        self.handler.lifecycle(self, LifecycleOp::FactoryReset)
     }
 
     /// Run the Data Model instance.
@@ -691,7 +689,7 @@ where
         let mut notify_change =
             |endpt_id, clust_id| self.notify_cluster_changed(endpt_id, clust_id);
 
-        self.matter.with_state(|state| {
+        let removed_fabric = self.matter.with_state(|state| {
             let expire_sess_id = exch_id.and_then(|exch_id| {
                 state
                     .sessions
@@ -700,7 +698,7 @@ where
             });
 
             // Disarm the failsafe on timeout
-            state.failsafe.check_failsafe_timeout(
+            let removed_fabric = state.failsafe.check_failsafe_timeout(
                 &mut state.fabrics,
                 &mut state.sessions,
                 &self.state.networks,
@@ -715,8 +713,16 @@ where
                 .pase
                 .check_comm_window_timeout(&mut notify_mdns, &mut notify_change)?;
 
-            Ok(())
-        })
+            Ok::<_, Error>(removed_fabric)
+        })?;
+
+        // Outside `with_state`, since the broadcast runs the handlers inline
+        // and they are free to access the Matter state themselves
+        if let Some(fab_idx) = removed_fabric {
+            self.notify_fabric_removed(fab_idx);
+        }
+
+        Ok(())
     }
 
     /// Answer a responding exchange using the `DataModel` instance wrapped by this exchange handler.
@@ -1755,6 +1761,21 @@ where
 
     fn im_stats(&self) -> impl ImStats + '_ {
         self
+    }
+
+    fn notify_fabric_removed(&self, fab_idx: NonZeroU8) {
+        if let Err(e) = self
+            .handler
+            .lifecycle(self, LifecycleOp::FabricRemoval { fab_idx })
+        {
+            warn!(
+                "Failed to broadcast the removal of fabric {}: {:?}",
+                fab_idx, e
+            );
+        }
+
+        #[cfg(feature = "groups")]
+        self.matter.transport().notify_groups_changed();
     }
 }
 

--- a/rs-matter/tests/binding.rs
+++ b/rs-matter/tests/binding.rs
@@ -1,0 +1,725 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! In-process device-to-device binding integration test — the automated
+//! equivalent of the certification test plan's (manual) TC-BIND-2.1
+//! "DUT as controller" procedure.
+//!
+//! Three in-process Matter stacks over loopback UDP:
+//! - Device A: an **On/Off Light Switch** (`0x0103`) — OnOff in its *client*
+//!   list plus a Binding cluster (its address book);
+//! - Device B: an On/Off **Light** — the OnOff server;
+//! - A controller, which commissions both onto one fabric.
+//!
+//! The flow:
+//! 1. Commission A and B (PASE → AddNOC → CASE → CommissioningComplete);
+//! 2. Controller replaces B's ACL with `[admin(controller), operate(A)]` —
+//!    granting A's *node identity* operate-access on B;
+//! 3. Controller writes a Binding entry on A's switch endpoint pointing at
+//!    B's light endpoint, scoped to the OnOff cluster;
+//! 4. A "switch press" is simulated: A walks its binding registry and — like
+//!    the `onoff_light_switch` example — opens CASE to the bound peer and
+//!    invokes `OnOff::Toggle`;
+//! 5. The controller reads B's OnOff attribute and asserts it flipped.
+//!
+//! mDNS is skipped like in `commissioning.rs` (shared host `:5353` is
+//! unreliable for multicast loopback): the commissioner is given the two
+//! devices' addresses directly, and A's switch press CASEs to the bound
+//! node at its (test-known) address via `Exchange::initiate_plaintext` +
+//! `CaseInitiator::perform` — the same building blocks
+//! `Transport::initiate_new_case` composes after an mDNS resolve.
+
+#![cfg(all(feature = "std", feature = "async-io", target_os = "linux"))]
+
+use core::num::NonZeroU8;
+use core::pin::pin;
+
+use std::net::UdpSocket;
+
+use embassy_futures::select::{select, select3, Either};
+use embassy_time::{Duration, Timer};
+
+use log::info;
+
+use rand_core::RngCore;
+
+use rs_matter::cert::gen::VALID_FOREVER;
+use rs_matter::cert::{MAX_CERT_TLV_AND_ASN1_LEN, MAX_CERT_TLV_LEN};
+use rs_matter::crypto::{
+    test_only_crypto, CanonAeadKey, CanonPkcSecretKey, Crypto, SecretKey, SigningSecretKey,
+};
+use rs_matter::dm::clusters::app::on_off::{self, test::TestOnOffDeviceLogic, OnOffHooks};
+use rs_matter::dm::clusters::binding::{self, BindingHandler, Bindings};
+use rs_matter::dm::clusters::decl::access_control::{
+    AccessControlEntryAuthModeEnum, AccessControlEntryPrivilegeEnum,
+};
+use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
+use rs_matter::dm::clusters::net_comm::DummyNetworks;
+use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
+use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ON_OFF_LIGHT_SWITCH};
+use rs_matter::dm::networks::unix::UnixNetifs;
+use rs_matter::dm::{endpoints, Async, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::error::Error;
+use rs_matter::im::client::ImClient;
+use rs_matter::im::subscriptions::DEFAULT_MAX_SUBSCRIPTIONS;
+use rs_matter::im::{InteractionModel, InteractionModelState};
+use rs_matter::onboard::cac::{IcacGenerator, RcacGenerator};
+use rs_matter::onboard::noc::NocGenerator;
+use rs_matter::onboard::{CommissionOptions, Commissioner};
+use rs_matter::persist::DummyKvBlobStore;
+use rs_matter::respond::DefaultResponder;
+use rs_matter::sc::case::CaseInitiator;
+use rs_matter::sc::pase::MAX_COMM_WINDOW_TIMEOUT_SECS;
+use rs_matter::transport::exchange::{Exchange, MatterBuffers};
+use rs_matter::transport::network::{Address, NoNetwork, SocketAddr, SocketAddrV6};
+use rs_matter::utils::init::InitMaybeUninit;
+use rs_matter::utils::select::Coalesce;
+use rs_matter::{clusters, devices, root_endpoint, Matter};
+
+// IM-client extension traits: `.on_off()` on `Exchange`, and the
+// `.access_control_write()` / `.binding_write()` views on the write-request
+// entries array.
+use rs_matter::dm::clusters::app::on_off::OnOffClient as _;
+use rs_matter::dm::clusters::decl::access_control::AccessControlAttrWrites as _;
+use rs_matter::dm::clusters::decl::binding::BindingAttrWrites as _;
+
+use static_cell::StaticCell;
+
+use crate::common::{init_env_logger, run_device_controller, run_with_transport};
+
+#[allow(dead_code)]
+mod common;
+
+/// Passcode used by `TEST_DEV_COMM`
+const TEST_PASSCODE: u32 = 20202021;
+
+/// Ports for the two devices. Off `MATTER_PORT` (5540), which the
+/// concurrently-running `commissioning` test binary occupies.
+const PORT_A: u16 = 5580;
+const PORT_B: u16 = 5581;
+
+/// Operational node ids the controller assigns during commissioning.
+const NODE_ID_A: u64 = 0x11;
+const NODE_ID_B: u64 = 0x22;
+/// The controller's own node id (also the CaseAdminSubject seeded into each
+/// device's ACL by AddNOC) — chip-tool's conventional admin node id.
+const CONTROLLER_NODE_ID: u64 = 112233;
+
+/// The endpoint hosting the switch role on device A.
+const SWITCH_ENDPOINT: u16 = 1;
+/// The endpoint hosting the light on device B.
+const LIGHT_ENDPOINT: u16 = 1;
+
+/// How many binding entries device A can hold.
+const MAX_BINDINGS: usize = 4;
+
+/// Timeout for the whole driven flow.
+const FLOW_TIMEOUT_SECS: u64 = 60;
+
+/// A device's data model state: a dummy (no-op) network store, default
+/// subscription count, no events.
+type DeviceDmState = InteractionModelState<DummyNetworks, DEFAULT_MAX_SUBSCRIPTIONS, 0>;
+
+static A_MATTER: StaticCell<Matter> = StaticCell::new();
+static A_BUFFERS: StaticCell<MatterBuffers> = StaticCell::new();
+static A_STATE: StaticCell<DeviceDmState> = StaticCell::new();
+static B_MATTER: StaticCell<Matter> = StaticCell::new();
+static B_BUFFERS: StaticCell<MatterBuffers> = StaticCell::new();
+static B_STATE: StaticCell<DeviceDmState> = StaticCell::new();
+static CTRL_MATTER: StaticCell<Matter> = StaticCell::new();
+
+// ============================================================================
+// Device A: the switch — Binding server + OnOff client on `SWITCH_ENDPOINT`
+// ============================================================================
+
+const SWITCH_NODE: Node<'static> = Node {
+    endpoints: &[
+        root_endpoint!(eth),
+        Endpoint::new_with_clients(
+            SWITCH_ENDPOINT,
+            devices!(DEV_TYPE_ON_OFF_LIGHT_SWITCH),
+            clusters!(desc::DescHandler::CLUSTER, binding::CLUSTER),
+            &[on_off::FULL_CLUSTER.id],
+        ),
+    ],
+};
+
+fn switch_data_model<'a>(
+    mut rand: impl RngCore + Copy,
+    bindings: &'a Bindings<MAX_BINDINGS>,
+) -> impl DataModel + 'a {
+    (
+        SWITCH_NODE,
+        endpoints::EthSysHandlerBuilder::new()
+            .netif_diag(&UnixNetifs)
+            .build(rand)
+            .chain(
+                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(desc::DescHandler::CLUSTER.id)),
+                Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+            )
+            .chain(
+                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(binding::CLUSTER.id)),
+                Async(
+                    BindingHandler::new(Dataver::new_rand(&mut rand), SWITCH_ENDPOINT, bindings)
+                        .adapt(),
+                ),
+            ),
+    )
+}
+
+// ============================================================================
+// Device B: the light — OnOff server on `LIGHT_ENDPOINT`
+// ============================================================================
+
+const LIGHT_NODE: Node<'static> = Node {
+    endpoints: &[
+        root_endpoint!(eth),
+        Endpoint::new(
+            LIGHT_ENDPOINT,
+            devices!(DEV_TYPE_ON_OFF_LIGHT),
+            clusters!(desc::DescHandler::CLUSTER, TestOnOffDeviceLogic::CLUSTER),
+        ),
+    ],
+};
+
+fn light_data_model<'a, OH: OnOffHooks>(
+    mut rand: impl RngCore + Copy,
+    on_off: &'a on_off::OnOffHandler<'a, OH, on_off::NoLevelControl>,
+) -> impl DataModel + 'a {
+    (
+        LIGHT_NODE,
+        endpoints::EthSysHandlerBuilder::new()
+            .netif_diag(&UnixNetifs)
+            .build(rand)
+            .chain(
+                EpClMatcher::new(Some(LIGHT_ENDPOINT), Some(desc::DescHandler::CLUSTER.id)),
+                Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+            )
+            .chain(
+                EpClMatcher::new(Some(LIGHT_ENDPOINT), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                on_off::HandlerAsyncAdaptor(on_off),
+            ),
+    )
+}
+
+// ============================================================================
+// The test
+// ============================================================================
+
+#[test]
+fn test_switch_binding() {
+    // Three in-process Matter stacks' worth of future state-machines don't
+    // fit the default 2 MiB test-thread stack.
+    let thread = std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            init_env_logger();
+            futures_lite::future::block_on(async {
+                run_test().await.unwrap();
+            });
+        })
+        .unwrap();
+    thread.join().unwrap();
+}
+
+async fn run_test() -> Result<(), Error> {
+    // ---- Device A (the switch) ----
+
+    let a_matter = A_MATTER.uninit().init_with(Matter::init(
+        &TEST_DEV_DET,
+        TEST_DEV_COMM,
+        &TEST_DEV_ATT,
+        PORT_A,
+    ));
+    let a_crypto = test_only_crypto();
+    let a_rand = a_crypto.rand()?;
+    let a_buffers = A_BUFFERS.uninit().init_with(MatterBuffers::init());
+    let a_state = A_STATE.init(InteractionModelState::new(DummyNetworks));
+    let a_kv = a_matter.kv(DummyKvBlobStore);
+
+    let bindings = Bindings::<MAX_BINDINGS>::new();
+
+    let a_dm = InteractionModel::new(
+        a_matter,
+        &a_crypto,
+        a_buffers,
+        switch_data_model(a_rand, &bindings),
+        &a_kv,
+        a_state,
+    );
+
+    a_matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &a_crypto, &())?;
+
+    let a_responder = DefaultResponder::new(&a_dm);
+    let a_net = async_io::Async::<UdpSocket>::bind(device_bind_addr(PORT_A))?;
+
+    let a_fut = async {
+        select3(
+            a_matter.run(&a_crypto, &a_net, &a_net, NoNetwork),
+            a_responder.run::<4, 4>(),
+            a_dm.run(),
+        )
+        .coalesce()
+        .await
+    };
+
+    // ---- Device B (the light) ----
+
+    let b_matter = B_MATTER.uninit().init_with(Matter::init(
+        &TEST_DEV_DET,
+        TEST_DEV_COMM,
+        &TEST_DEV_ATT,
+        PORT_B,
+    ));
+    let b_crypto = test_only_crypto();
+    let mut b_rand = b_crypto.rand()?;
+    let b_buffers = B_BUFFERS.uninit().init_with(MatterBuffers::init());
+    let b_state = B_STATE.init(InteractionModelState::new(DummyNetworks));
+    let b_kv = b_matter.kv(DummyKvBlobStore);
+
+    let b_on_off = on_off::OnOffHandler::new_standalone(
+        Dataver::new_rand(&mut b_rand),
+        LIGHT_ENDPOINT,
+        TestOnOffDeviceLogic::new(false),
+    );
+
+    let b_dm = InteractionModel::new(
+        b_matter,
+        &b_crypto,
+        b_buffers,
+        light_data_model(b_rand, &b_on_off),
+        &b_kv,
+        b_state,
+    );
+
+    b_matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &b_crypto, &())?;
+
+    let b_responder = DefaultResponder::new(&b_dm);
+    let b_net = async_io::Async::<UdpSocket>::bind(device_bind_addr(PORT_B))?;
+
+    let b_fut = async {
+        select3(
+            b_matter.run(&b_crypto, &b_net, &b_net, NoNetwork),
+            b_responder.run::<4, 4>(),
+            b_dm.run(),
+        )
+        .coalesce()
+        .await
+    };
+
+    // ---- The controller ----
+
+    let ctrl_matter = CTRL_MATTER.uninit().init_with(Matter::init(
+        &TEST_DEV_DET,
+        TEST_DEV_COMM,
+        &TEST_DEV_ATT,
+        0,
+    ));
+    let ctrl_crypto = test_only_crypto();
+    let ctrl_net = async_io::Async::<UdpSocket>::bind(SocketAddr::V6(SocketAddrV6::new(
+        std::net::Ipv6Addr::UNSPECIFIED,
+        0,
+        0,
+        0,
+    )))?;
+
+    info!("Two devices and the controller initialized; starting the binding test...");
+
+    let controller_fut = run_with_transport(
+        ctrl_matter.run(&ctrl_crypto, &ctrl_net, &ctrl_net, NoNetwork),
+        run_flow_with_timeout(ctrl_matter, &ctrl_crypto, a_matter, &a_crypto, &bindings),
+    );
+
+    let devices_fut = async {
+        let mut a_fut = pin!(a_fut);
+        let mut b_fut = pin!(b_fut);
+        select(&mut a_fut, &mut b_fut).coalesce().await
+    };
+
+    run_device_controller(devices_fut, controller_fut).await
+}
+
+async fn run_flow_with_timeout<C: Crypto, AC: Crypto>(
+    ctrl_matter: &Matter<'_>,
+    ctrl_crypto: &C,
+    a_matter: &Matter<'_>,
+    a_crypto: &AC,
+    bindings: &Bindings<MAX_BINDINGS>,
+) -> Result<(), Error> {
+    let mut flow = pin!(run_flow(
+        ctrl_matter,
+        ctrl_crypto,
+        a_matter,
+        a_crypto,
+        bindings
+    ));
+    let mut timeout = pin!(Timer::after(Duration::from_secs(FLOW_TIMEOUT_SECS)));
+
+    match select(&mut flow, &mut timeout).await {
+        Either::First(result) => result,
+        Either::Second(_) => panic!("binding test flow timed out after {FLOW_TIMEOUT_SECS}s"),
+    }
+}
+
+async fn run_flow<C: Crypto, AC: Crypto>(
+    ctrl_matter: &Matter<'_>,
+    ctrl_crypto: &C,
+    a_matter: &Matter<'_>,
+    a_crypto: &AC,
+    bindings: &Bindings<MAX_BINDINGS>,
+) -> Result<(), Error> {
+    let addr_a = device_addr(PORT_A)?;
+    let addr_b = device_addr(PORT_B)?;
+
+    info!("=== Phase 1: Commission both devices onto one fabric ===");
+    let ctrl_fab_idx = commission_both(ctrl_matter, ctrl_crypto, addr_a, addr_b).await?;
+
+    info!("=== Phase 2: Replace B's ACL with [admin(controller), operate(A)] ===");
+    write_light_acl(ctrl_matter, ctrl_crypto, ctrl_fab_idx).await?;
+
+    info!("=== Phase 3: Write the Binding entry on A's switch endpoint ===");
+    write_switch_binding(ctrl_matter, ctrl_crypto, ctrl_fab_idx).await?;
+
+    let initial = read_light_on_off(ctrl_matter, ctrl_crypto, ctrl_fab_idx).await?;
+    assert!(!initial, "expected the light OFF before the switch press");
+
+    info!("=== Phase 4: Simulate the switch press on A ===");
+    press_switch(a_matter, a_crypto, bindings, addr_b).await?;
+
+    info!("=== Phase 5: Verify the bound light toggled ===");
+    let toggled = read_light_on_off(ctrl_matter, ctrl_crypto, ctrl_fab_idx).await?;
+    assert!(toggled, "expected the light ON after the switch press");
+
+    info!("=== Binding test completed successfully! ===");
+    Ok(())
+}
+
+/// Build the controller's fabric and commission device A, then device B,
+/// onto it. Same offline-CA plumbing as `commissioning.rs`.
+async fn commission_both<C: Crypto>(
+    matter: &Matter<'_>,
+    crypto: &C,
+    addr_a: Address,
+    addr_b: Address,
+) -> Result<NonZeroU8, Error> {
+    const FABRIC_ID: u64 = 1;
+    const ADMIN_VENDOR_ID: u16 = 0xFFF1;
+
+    // ---- Offline CA chain: RCAC then ICAC; RCAC priv discarded ----
+
+    let mut rcac_buf = [0u8; MAX_CERT_TLV_AND_ASN1_LEN];
+    let mut rcac_gen = RcacGenerator::new(&mut rcac_buf);
+    let (rcac_priv, rcac) = rcac_gen.generate(crypto, FABRIC_ID, VALID_FOREVER)?;
+
+    let mut icac_buf = [0u8; MAX_CERT_TLV_AND_ASN1_LEN];
+    let mut icac_gen = IcacGenerator::new(&mut icac_buf);
+    let (icac_priv, icac) =
+        icac_gen.generate(crypto, rcac_priv.reference(), rcac, VALID_FOREVER)?;
+    drop(rcac_priv);
+
+    // ---- Controller operational keypair + NOC ----
+
+    let controller_secret_key = crypto.generate_secret_key()?;
+    let mut controller_csr_buf = [0u8; 256];
+    let controller_csr = controller_secret_key.csr(&mut controller_csr_buf)?;
+    let mut controller_secret_key_canon = CanonPkcSecretKey::new();
+    controller_secret_key.write_canon(&mut controller_secret_key_canon)?;
+
+    let mut noc_buf = [0u8; MAX_CERT_TLV_AND_ASN1_LEN];
+    let mut noc_generator = NocGenerator::create(icac_priv.reference(), rcac, icac, &mut noc_buf)?;
+
+    let controller_noc = noc_generator.generate(
+        crypto,
+        controller_csr,
+        CONTROLLER_NODE_ID,
+        &[],
+        VALID_FOREVER,
+    )?;
+
+    // ---- Fabric IPK + install the controller's fabric ----
+
+    let mut ipk = CanonAeadKey::new();
+    crypto.rand()?.fill_bytes(ipk.access_mut());
+
+    let ctrl_fab_idx = matter.with_state(|state| {
+        state
+            .fabrics
+            .add(
+                crypto,
+                controller_secret_key_canon.reference(),
+                rcac,
+                controller_noc,
+                icac,
+                Some(ipk.reference()),
+                ADMIN_VENDOR_ID,
+                CONTROLLER_NODE_ID,
+            )
+            .map(|f| f.fab_idx())
+    })?;
+
+    // ---- Commission the two devices, sequentially ----
+
+    let mut commissioner_buf = [0u8; MAX_CERT_TLV_LEN];
+    let mut commissioner = Commissioner::new(
+        matter,
+        crypto,
+        ctrl_fab_idx,
+        &mut noc_generator,
+        &mut commissioner_buf,
+    );
+
+    let opts = CommissionOptions {
+        // Test DAC — TEST_DEV_ATT.
+        allow_test_attestation: true,
+        ..CommissionOptions::default()
+    };
+
+    for (addr, node_id, tag) in [
+        (addr_a, NODE_ID_A, "switch-A"),
+        (addr_b, NODE_ID_B, "light-B"),
+    ] {
+        let result = commissioner
+            .commission(addr, TEST_PASSCODE, &opts, node_id, VALID_FOREVER)
+            .await?;
+        commissioner.complete_via_case(addr, &result).await?;
+        info!(
+            "Commissioned {tag} as node 0x{:016x}",
+            result.device_node_id
+        );
+    }
+
+    Ok(ctrl_fab_idx)
+}
+
+/// Replace B's ACL with the admin entry (for the controller) plus an
+/// operate entry for A's node identity — the grant that lets the switch
+/// invoke `OnOff::Toggle` on the light.
+async fn write_light_acl<C: Crypto>(
+    matter: &Matter<'_>,
+    crypto: &C,
+    fab_idx: NonZeroU8,
+) -> Result<(), Error> {
+    let exchange = Exchange::initiate(matter, crypto, fab_idx, NODE_ID_B).await?;
+
+    let handle = exchange
+        .write_with(None, |builder| {
+            let entries = builder.write_requests()?;
+            let acl = entries.access_control_write().acl(0)?;
+
+            // Entry 1: the admin entry AddNOC seeded (CaseAdminSubject) —
+            // a whole-list replace must carry it or the controller locks
+            // itself out.
+            let acl = acl
+                .push()?
+                .privilege(Some(AccessControlEntryPrivilegeEnum::Administer))?
+                .auth_mode(Some(AccessControlEntryAuthModeEnum::CASE))?
+                .subjects()?
+                .some()?
+                .non_null()?
+                .push(&CONTROLLER_NODE_ID)?
+                .end()?
+                .targets()?
+                .some()?
+                .null()?
+                .auxiliary_type(None)?
+                .fabric_index(None)?
+                .end()?;
+
+            // Entry 2: operate for the switch's node identity.
+            let acl = acl
+                .push()?
+                .privilege(Some(AccessControlEntryPrivilegeEnum::Operate))?
+                .auth_mode(Some(AccessControlEntryAuthModeEnum::CASE))?
+                .subjects()?
+                .some()?
+                .non_null()?
+                .push(&NODE_ID_A)?
+                .end()?
+                .targets()?
+                .some()?
+                .null()?
+                .auxiliary_type(None)?
+                .fabric_index(None)?
+                .end()?;
+
+            acl.end()?.end()?.end()?.end()
+        })
+        .await?;
+
+    let resp = handle.response()?;
+    for status in resp.write_responses.iter() {
+        let status = status?;
+        assert_eq!(
+            status.status.status,
+            rs_matter::im::IMStatusCode::Success,
+            "ACL write on the light failed"
+        );
+    }
+
+    Ok(())
+}
+
+/// Write a single Binding entry on A's switch endpoint, pointing at B's
+/// light endpoint and scoped to the OnOff cluster.
+async fn write_switch_binding<C: Crypto>(
+    matter: &Matter<'_>,
+    crypto: &C,
+    fab_idx: NonZeroU8,
+) -> Result<(), Error> {
+    let exchange = Exchange::initiate(matter, crypto, fab_idx, NODE_ID_A).await?;
+
+    let handle = exchange
+        .write_with(None, |builder| {
+            let entries = builder.write_requests()?;
+            let bindings = entries.binding_write().binding(SWITCH_ENDPOINT)?;
+
+            let bindings = bindings
+                .push()?
+                .node(Some(NODE_ID_B))?
+                .group(None)?
+                .endpoint(Some(LIGHT_ENDPOINT))?
+                .cluster(Some(on_off::FULL_CLUSTER.id))?
+                .fabric_index(None)?
+                .end()?;
+
+            bindings.end()?.end()?.end()?.end()
+        })
+        .await?;
+
+    let resp = handle.response()?;
+    for status in resp.write_responses.iter() {
+        let status = status?;
+        assert_eq!(
+            status.status.status,
+            rs_matter::im::IMStatusCode::Success,
+            "Binding write on the switch failed"
+        );
+    }
+
+    Ok(())
+}
+
+/// Simulate a switch press on device A: walk its binding registry and — for
+/// each unicast OnOff target — establish CASE to the bound peer and invoke
+/// `OnOff::Toggle`, exactly like the `onoff_light_switch` example's switch
+/// loop. The bound peer's address comes from the test (mDNS is skipped);
+/// `CaseInitiator::perform` + `Exchange::initiate` compose the same way
+/// `Transport::initiate_new_case` does after an mDNS resolve.
+async fn press_switch<C: Crypto>(
+    a_matter: &Matter<'_>,
+    a_crypto: &C,
+    bindings: &Bindings<MAX_BINDINGS>,
+    peer_addr: Address,
+) -> Result<(), Error> {
+    let mut toggled = 0;
+
+    for i in 0..bindings.len() {
+        let Some(binding) = bindings.get(i) else {
+            break;
+        };
+
+        if binding.local_endpoint != SWITCH_ENDPOINT {
+            continue;
+        }
+
+        let (Some(node), Some(endpoint)) = (binding.node, binding.endpoint) else {
+            continue;
+        };
+
+        if let Some(cluster) = binding.cluster {
+            if cluster != on_off::FULL_CLUSTER.id {
+                continue;
+            }
+        }
+
+        info!(
+            "Switch: toggling fabric {}, node 0x{:016X}, endpoint {}",
+            binding.fab_idx, node, endpoint
+        );
+
+        // CASE to the bound peer at its known address (no mDNS in this test).
+        let case_exchange = Exchange::initiate_plaintext(a_matter, a_crypto, peer_addr).await?;
+        CaseInitiator::perform(case_exchange, a_crypto, binding.fab_idx, node).await?;
+
+        // The CASE session is now in A's session table; `initiate` reuses it.
+        let exchange = Exchange::initiate(a_matter, a_crypto, binding.fab_idx, node).await?;
+        exchange.on_off().toggle(endpoint).await?;
+
+        toggled += 1;
+    }
+
+    assert_eq!(toggled, 1, "expected exactly one bound light to toggle");
+
+    Ok(())
+}
+
+/// Read B's OnOff attribute from the controller (over the CASE session kept
+/// from commissioning).
+async fn read_light_on_off<C: Crypto>(
+    matter: &Matter<'_>,
+    crypto: &C,
+    fab_idx: NonZeroU8,
+) -> Result<bool, Error> {
+    let exchange = Exchange::initiate(matter, crypto, fab_idx, NODE_ID_B).await?;
+
+    exchange.on_off().on_off_read(LIGHT_ENDPOINT).await
+}
+
+/// The `[::]:<port>` address a device binds.
+fn device_bind_addr(port: u16) -> std::net::SocketAddr {
+    std::net::SocketAddr::V6(std::net::SocketAddrV6::new(
+        std::net::Ipv6Addr::UNSPECIFIED,
+        port,
+        0,
+        0,
+    ))
+}
+
+/// The address peers use to reach a device (mDNS skipped): the host's
+/// primary IPv4, v6-mapped — same approach as `commissioning.rs`.
+fn device_addr(port: u16) -> Result<Address, Error> {
+    let ipv4 = find_host_ipv4()?;
+
+    Ok(Address::Udp(SocketAddr::V6(SocketAddrV6::new(
+        ipv4.to_ipv6_mapped(),
+        port,
+        0,
+        0,
+    ))))
+}
+
+/// The host's primary (non-loopback, multicast-capable) IPv4 address.
+fn find_host_ipv4() -> Result<std::net::Ipv4Addr, Error> {
+    use nix::net::if_::InterfaceFlags;
+
+    nix::ifaddrs::getifaddrs()
+        .unwrap()
+        .filter(|ia| {
+            ia.flags.contains(InterfaceFlags::IFF_UP)
+                && ia
+                    .flags
+                    .intersects(InterfaceFlags::IFF_BROADCAST | InterfaceFlags::IFF_MULTICAST)
+                && !ia
+                    .flags
+                    .intersects(InterfaceFlags::IFF_LOOPBACK | InterfaceFlags::IFF_POINTOPOINT)
+        })
+        .find_map(|ia| {
+            ia.address
+                .and_then(|addr| addr.as_sockaddr_in().map(|addr| addr.ip()))
+        })
+        .ok_or_else(|| rs_matter::error::ErrorCode::NoNetworkInterface.into())
+}

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -127,8 +127,8 @@ impl<'a, OH: OnOffHooks, LH: LevelControlHooks> AsyncHandler for E2eTestHandler<
         self.0.bump_dataver(ctx)
     }
 
-    async fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
-        self.0.lifecycle(ctx, op).await
+    fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
+        self.0.lifecycle(ctx, op)
     }
 }
 

--- a/rs-matter/tests/data_model/groups.rs
+++ b/rs-matter/tests/data_model/groups.rs
@@ -1,0 +1,252 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Tests for the Groups cluster's `AddGroupIfIdentifying` command and its
+//! coupling to the Identify cluster via `IdentifyStatus`: the command is a
+//! successful no-op unless the endpoint is currently identifying, and on the
+//! identifying path applies the same validation as `AddGroup` — reported as
+//! a plain IM status, since the command has no response structure.
+
+use rs_matter::dm::clusters::groups::{self, ClusterHandler as _, GroupsHandler};
+use rs_matter::dm::clusters::grp_key_mgmt::{self, ClusterHandler as _, GrpKeyMgmtHandler};
+use rs_matter::dm::clusters::identify::{self, IdentifyHandler};
+use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ROOT_NODE};
+use rs_matter::dm::{
+    Async, ChainedHandler, Cluster, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
+};
+use rs_matter::im::{AttrPath, AttrStatus, CmdPath, CmdStatus, GenericPath, IMStatusCode};
+use rs_matter::tlv::{Nullable, ToTLV};
+
+use crate::common::e2e::im::attributes::TestAttrData;
+use crate::common::e2e::im::commands::{TestCmdData, TestCmdResp};
+use crate::common::e2e::new_default_runner;
+use crate::common::init_env_logger;
+
+const GROUP_ID: u16 = 0x0012;
+const KEY_SET_ID: u16 = 0x01A3;
+
+const CLUSTERS_EP0: &[Cluster<'static>] = &[GrpKeyMgmtHandler::CLUSTER];
+const CLUSTERS_EP1: &[Cluster<'static>] = &[identify::CLUSTER, GroupsHandler::CLUSTER];
+
+const NODE: Node<'static> = Node {
+    endpoints: &[
+        Endpoint::new(0, &[DEV_TYPE_ROOT_NODE], CLUSTERS_EP0),
+        Endpoint::new(1, &[DEV_TYPE_ON_OFF_LIGHT], CLUSTERS_EP1),
+    ],
+};
+
+/// TLV mirror of `AddGroupIfIdentifyingRequest`: positional context tags 0..=1.
+#[derive(Debug, Clone, PartialEq, ToTLV)]
+struct TestAddGroupIfIdentifyingReq<'a> {
+    group_id: u16,
+    group_name: &'a str,
+}
+
+/// TLV mirror of `GetGroupMembershipRequest`: context tag 0.
+#[derive(Debug, Clone, PartialEq, ToTLV)]
+struct TestGetGroupMembershipReq<'a> {
+    group_list: &'a [u16],
+}
+
+/// TLV mirror of `GetGroupMembershipResponse`: positional context tags 0..=1.
+#[derive(Debug, Clone, PartialEq, ToTLV)]
+struct TestGetGroupMembershipResp<'a> {
+    capacity: Nullable<u8>,
+    group_list: &'a [u16],
+}
+
+/// TLV mirror of the `GroupKeyMapStruct`: context tags 1..=2 (the
+/// fabric-index tag 254 is filled in server-side).
+#[derive(Debug, Clone, PartialEq, ToTLV)]
+#[tlvargs(start = 1)]
+struct TestGroupKeyMapEntry {
+    group_id: u16,
+    group_key_set_id: u16,
+}
+
+fn groups_cmd(cmd: groups::CommandId) -> CmdPath {
+    CmdPath::new(Some(1), Some(GroupsHandler::CLUSTER.id), Some(cmd as u32))
+}
+
+fn groups_resp(resp: groups::CommandResponseId) -> CmdPath {
+    CmdPath::new(Some(1), Some(GroupsHandler::CLUSTER.id), Some(resp as u32))
+}
+
+/// Invoke `GetGroupMembership` (empty filter = all groups) and expect
+/// exactly `group_list` back.
+fn expect_membership(
+    im: &crate::common::e2e::E2eRunner<impl rs_matter::crypto::Crypto>,
+    dm: &impl rs_matter::dm::DataModel,
+    group_list: &[u16],
+) {
+    im.handle_commands(
+        dm,
+        &[TestCmdData::new(
+            groups_cmd(groups::CommandId::GetGroupMembership),
+            &TestGetGroupMembershipReq { group_list: &[] },
+        )],
+        &[TestCmdResp::Cmd(TestCmdData::new(
+            groups_resp(groups::CommandResponseId::GetGroupMembershipResponse),
+            &TestGetGroupMembershipResp {
+                capacity: Nullable::none(),
+                group_list,
+            },
+        ))],
+    );
+}
+
+#[test]
+fn test_add_group_if_identifying() {
+    init_env_logger();
+
+    let im = new_default_runner();
+    im.add_default_acl();
+
+    let identify_handler = IdentifyHandler::new(Dataver::new(1));
+
+    let dm = (
+        NODE,
+        ChainedHandler::new(
+            EpClMatcher::new(Some(0), Some(GrpKeyMgmtHandler::CLUSTER.id)),
+            Async(GrpKeyMgmtHandler::new(Dataver::new(2)).adapt()),
+            ChainedHandler::new(
+                EpClMatcher::new(Some(1), Some(identify::CLUSTER.id)),
+                Async(identify::HandlerAdaptor(&identify_handler)),
+                ChainedHandler::new(
+                    EpClMatcher::new(Some(1), Some(GroupsHandler::CLUSTER.id)),
+                    Async(
+                        GroupsHandler::new_with_identify(Dataver::new(3), &identify_handler)
+                            .adapt(),
+                    ),
+                    EmptyHandler,
+                ),
+            ),
+        ),
+    );
+
+    // Provision group key material (a GroupKeyMap entry) for GROUP_ID, so
+    // that the identifying-path additions below pass the key-material check.
+    let map_path = GenericPath::new(
+        Some(0),
+        Some(GrpKeyMgmtHandler::CLUSTER.id),
+        Some(grp_key_mgmt::AttributeId::GroupKeyMap as u32),
+    );
+    let map = &[TestGroupKeyMapEntry {
+        group_id: GROUP_ID,
+        group_key_set_id: KEY_SET_ID,
+    }][..];
+    im.handle_write_reqs(
+        &dm,
+        &[TestAttrData::new(
+            None,
+            AttrPath::from_gp(&map_path),
+            &map as _,
+        )],
+        &[AttrStatus::from_gp(&map_path, IMStatusCode::Success, None)],
+    );
+
+    // Not identifying: the command is accepted (SUCCESS)...
+    let add_req = TestAddGroupIfIdentifyingReq {
+        group_id: GROUP_ID,
+        group_name: "gp1",
+    };
+    im.handle_commands(
+        &dm,
+        &[TestCmdData::new(
+            groups_cmd(groups::CommandId::AddGroupIfIdentifying),
+            &add_req,
+        )],
+        &[TestCmdResp::Status(CmdStatus::new(
+            groups_cmd(groups::CommandId::AddGroupIfIdentifying),
+            IMStatusCode::Success,
+            None,
+            None,
+        ))],
+    );
+
+    // ...but has no effect
+    expect_membership(&im, &dm, &[]);
+
+    // Start identifying via an `IdentifyTime` write
+    let time_path = GenericPath::new(
+        Some(1),
+        Some(identify::CLUSTER.id),
+        Some(identify::AttributeId::IdentifyTime as u32),
+    );
+    im.handle_write_reqs(
+        &dm,
+        &[TestAttrData::new(
+            None,
+            AttrPath::from_gp(&time_path),
+            &60u16 as _,
+        )],
+        &[AttrStatus::from_gp(&time_path, IMStatusCode::Success, None)],
+    );
+
+    // Identifying: constraint validation applies (group ID 0 is invalid)
+    im.handle_commands(
+        &dm,
+        &[TestCmdData::new(
+            groups_cmd(groups::CommandId::AddGroupIfIdentifying),
+            &TestAddGroupIfIdentifyingReq {
+                group_id: 0,
+                group_name: "gp1",
+            },
+        )],
+        &[TestCmdResp::Status(CmdStatus::new(
+            groups_cmd(groups::CommandId::AddGroupIfIdentifying),
+            IMStatusCode::ConstraintError,
+            None,
+            None,
+        ))],
+    );
+
+    // Identifying: a group without key material is rejected
+    im.handle_commands(
+        &dm,
+        &[TestCmdData::new(
+            groups_cmd(groups::CommandId::AddGroupIfIdentifying),
+            &TestAddGroupIfIdentifyingReq {
+                group_id: 0x0034,
+                group_name: "gp2",
+            },
+        )],
+        &[TestCmdResp::Status(CmdStatus::new(
+            groups_cmd(groups::CommandId::AddGroupIfIdentifying),
+            IMStatusCode::UnsupportedAccess,
+            None,
+            None,
+        ))],
+    );
+
+    // Identifying + key material: the group is added
+    im.handle_commands(
+        &dm,
+        &[TestCmdData::new(
+            groups_cmd(groups::CommandId::AddGroupIfIdentifying),
+            &add_req,
+        )],
+        &[TestCmdResp::Status(CmdStatus::new(
+            groups_cmd(groups::CommandId::AddGroupIfIdentifying),
+            IMStatusCode::Success,
+            None,
+            None,
+        ))],
+    );
+
+    expect_membership(&im, &dm, &[GROUP_ID]);
+}

--- a/rs-matter/tests/data_model/mod.rs
+++ b/rs-matter/tests/data_model/mod.rs
@@ -21,6 +21,8 @@ mod attributes;
 mod aux_acl;
 mod commands;
 mod events;
+#[cfg(feature = "groups")]
+mod groups;
 mod long_reads;
 mod provisional;
 mod timed_requests;

--- a/tests/src/bin/light_tests.pics
+++ b/tests/src/bin/light_tests.pics
@@ -56,10 +56,11 @@ OO.S.F01=0
 OO.S.F02=0
 OO.M.ManuallyControlled=1
 
-OO.C=0
+# The On/Off Light Switch endpoint (EP2) sends `Toggle` to its bound lights.
+OO.C=1
 OO.C.C00.Tx=0
 OO.C.C01.Tx=0
-OO.C.C02.Tx=0
+OO.C.C02.Tx=1
 OO.C.C40.Tx=0
 OO.C.C41.Tx=0
 OO.C.C42.Tx=0
@@ -67,6 +68,36 @@ OO.C.AM-READ=0
 OO.C.AM-WRITE=0
 OO.C.AO-READ=0
 OO.C.AO-WRITE=0
+
+# ---- Identify Cluster (on the On/Off Light Switch endpoint, EP2) ----
+I.S=1
+I.S.A0000=1
+I.S.A0001=1
+I.S.C00.Rsp=1
+I.S.C01.Rsp=1
+I.S.C40.Rsp=1
+I.S.C00.Tx=0
+I.S.F00=0
+
+I.C=0
+
+# ---- Binding Cluster (on the On/Off Light Switch endpoint, EP2) ----
+BIND.S=1
+BIND.S.A0000=1
+
+BIND.C=0
+
+# ---- Switch Cluster (on the Generic Switch endpoint, EP3) ----
+# A momentary push-button: MS (F01) + MSR (F02) + MSL (F03); no latching
+# (F00) and no multi-press (F04).
+SWTCH.S=1
+SWTCH.S.F00=0
+SWTCH.S.F01=1
+SWTCH.S.F02=1
+SWTCH.S.F03=1
+SWTCH.S.F04=0
+
+SWTCH.C=0
 
 # ---- Color Control Cluster ----
 CC.S=1

--- a/tests/src/bin/light_tests.rs
+++ b/tests/src/bin/light_tests.rs
@@ -18,9 +18,18 @@
 //! Example Matter device exercising OnOff + LevelControl + ColorControl
 //! over Ethernet. Used to drive the chip-tool `light` itest suite
 //! (`Test_TC_OO_*`, `Test_TC_LVL_*`, `Test_TC_CC_*`).
+//!
+//! Besides the Extended Color Light on endpoint 1, the device hosts an
+//! **On/Off Light Switch** (`0x0103`) on endpoint 2 — OnOff in its *client*
+//! list plus a Binding cluster — so the same binary also exercises the
+//! client role: the `switch` itest suite runs two instances of it, binds one
+//! instance's switch endpoint to the other's light endpoint, and triggers a
+//! "switch press" via the `--app-pipe` command channel, making the first
+//! instance resolve + CASE + `OnOff::Toggle` the second.
 #![allow(clippy::uninlined_format_args)]
 
 use core::cell::Cell;
+use core::num::NonZeroU8;
 use core::pin::pin;
 
 use std::fs;
@@ -28,7 +37,7 @@ use std::io::{Read, Write};
 use std::net::UdpSocket;
 use std::path::PathBuf;
 
-use embassy_futures::select::select3;
+use embassy_futures::select::{select3, select4};
 
 use async_signal::{Signal, Signals};
 use log::{error, info, trace};
@@ -40,18 +49,29 @@ use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::color_control::{self, ColorControlHooks};
 use rs_matter::dm::clusters::app::level_control::{self, LevelControlHooks};
 use rs_matter::dm::clusters::app::on_off::{self, OnOffHooks, StartUpOnOffEnum};
+use rs_matter::dm::clusters::binding::{self, BindingHandler, Bindings};
 use rs_matter::dm::clusters::decl::level_control::{
     AttributeId, CommandId, OptionsBitmap, FULL_CLUSTER as LEVEL_CONTROL_FULL_CLUSTER,
 };
 use rs_matter::dm::clusters::decl::on_off as on_off_cluster;
+use rs_matter::dm::clusters::decl::switch::{
+    self as switch_cluster, ClusterHandler as _, Feature as SwitchFeature, InitialPress, LongPress,
+    LongRelease,
+};
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
 use rs_matter::dm::clusters::groups::{self, ClusterHandler as _};
+use rs_matter::dm::clusters::identify::{self, IdentifyHandler};
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_DET};
-use rs_matter::dm::devices::DEV_TYPE_EXTENDED_COLOR_LIGHT;
+use rs_matter::dm::devices::{
+    DEV_TYPE_EXTENDED_COLOR_LIGHT, DEV_TYPE_GENERIC_SWITCH, DEV_TYPE_ON_OFF_LIGHT_SWITCH,
+};
 use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, Cluster, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{
+    Async, AttrChangeNotifier, Cluster, DataModel, Dataver, Endpoint, EpClMatcher, EventEmitter,
+    Node, ReadContext,
+};
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
 use rs_matter::pairing::qr::QrTextType;
@@ -59,10 +79,14 @@ use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::respond::DefaultResponder;
 use rs_matter::sc::pase::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use rs_matter::tlv::Nullable;
-use rs_matter::transport::exchange::MatterBuffers;
+use rs_matter::transport::exchange::{Exchange, MatterBuffers};
 use rs_matter::utils::init::InitMaybeUninit;
 use rs_matter::utils::select::Coalesce;
+use rs_matter::utils::sync::Notification;
 use rs_matter::{clusters, devices, root_endpoint, with, Matter};
+
+// `OnOffClient` brings the `.on_off()` IM-client method into scope on `Exchange`.
+use rs_matter::dm::clusters::app::on_off::OnOffClient as _;
 
 use static_cell::StaticCell;
 
@@ -71,6 +95,20 @@ mod mdns;
 
 #[path = "../common/args.rs"]
 mod args;
+
+#[path = "../common/pipe.rs"]
+mod pipe;
+
+/// The local endpoint hosting the On/Off Light Switch (OnOff client + Binding).
+const SWITCH_ENDPOINT: u16 = 2;
+
+/// The local endpoint hosting the Generic Switch (`Switch` server cluster,
+/// press events) — exercised by the `TC_SWTCH` Python test via its
+/// `--app-pipe` button simulator.
+const GENERIC_SWITCH_ENDPOINT: u16 = 3;
+
+/// How many binding entries the device can hold (across all fabrics/endpoints).
+const MAX_BINDINGS: usize = 8;
 
 static MATTER: StaticCell<Matter> = StaticCell::new();
 static BUFFERS: StaticCell<MatterBuffers> = StaticCell::new();
@@ -139,6 +177,14 @@ fn main() -> Result<(), Error> {
     );
     color_control_handler.init(Some(&on_off_handler));
 
+    // The Binding registry (the switch endpoint's address book), re-hydrated
+    // from KV by the `Startup` lifecycle op delivered below.
+    let bindings = Bindings::<MAX_BINDINGS>::new();
+
+    // The Generic Switch's current position, shared between its cluster
+    // handler and the button-simulator task.
+    let switch_position = Cell::new(0u8);
+
     let im = InteractionModel::new(
         matter,
         &crypto,
@@ -148,6 +194,8 @@ fn main() -> Result<(), Error> {
             &on_off_handler,
             &level_control_handler,
             &color_control_handler,
+            &bindings,
+            &switch_position,
         ),
         &kv,
         state,
@@ -183,13 +231,120 @@ fn main() -> Result<(), Error> {
         Ok(())
     });
 
+    // The switch-press trigger: the itest orchestration sends
+    // `{"Name": "Toggle"}` over the `--app-pipe` FIFO to simulate a press,
+    // and the switch task reacts by toggling every bound light.
+    let toggle_requested = Notification::new();
+
+    // The Generic Switch button simulator, driven by `TC_SWTCH` over the
+    // same `--app-pipe` FIFO (`SimulateLongPress` / `SimulateSwitchIdle`).
+    let sim = SimChannel::new();
+
+    let mut pipe_job = pin!(pipe::run_app_pipe_actions(
+        args::parse_arg_opt_override("--app-pipe", |s| s.to_string()),
+        |line| {
+            if line.contains("\"Toggle\"") {
+                toggle_requested.notify();
+                Ok(true)
+            } else if line.contains("\"SimulateLongPress\"") {
+                sim.send(SimCommand::LongPress {
+                    button: json_u64(&line, "ButtonId").unwrap_or(1) as u8,
+                    delay_ms: json_u64(&line, "LongPressDelayMillis").unwrap_or(4500),
+                    duration_ms: json_u64(&line, "LongPressDurationMillis").unwrap_or(5000),
+                });
+                Ok(true)
+            } else if line.contains("\"SimulateSwitchIdle\"") {
+                sim.send(SimCommand::Idle);
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+    ));
+
+    let mut switch_job = pin!(run_switch(matter, &crypto, &bindings, &toggle_requested));
+    let mut sim_job = pin!(run_switch_simulation(&im, &switch_position, &sim));
+
     let all = select3(
         &mut transport,
         &mut mdns,
-        select3(&mut respond, &mut im_job, &mut term).coalesce(),
+        select4(
+            &mut respond,
+            &mut im_job,
+            &mut term,
+            select3(&mut pipe_job, &mut switch_job, &mut sim_job).coalesce(),
+        )
+        .coalesce(),
     );
 
     futures_lite::future::block_on(all.coalesce())
+}
+
+/// The switch loop: on every requested "press", walk the binding registry and
+/// send `OnOff::Toggle` to each unicast `(node, endpoint)` target bound on
+/// [`SWITCH_ENDPOINT`]. Each binding carries its own `fab_idx`, and
+/// `Exchange::initiate` performs the operational mDNS resolve + CASE when no
+/// session to the target exists yet.
+async fn run_switch<const N: usize>(
+    matter: &Matter<'_>,
+    crypto: &impl Crypto,
+    bindings: &Bindings<N>,
+    toggle_requested: &Notification,
+) -> Result<(), Error> {
+    loop {
+        toggle_requested.wait().await;
+
+        info!("Switch: toggling all bound lights...");
+
+        // Iterate by index; `get` clones each entry out (lock released per
+        // call) so we can `await` the remote invoke below.
+        for i in 0..bindings.len() {
+            let Some(binding) = bindings.get(i) else {
+                break;
+            };
+
+            // Only this switch's endpoint.
+            if binding.local_endpoint != SWITCH_ENDPOINT {
+                continue;
+            }
+
+            // Only unicast OnOff targets (node + endpoint present).
+            let (Some(node), Some(endpoint)) = (binding.node, binding.endpoint) else {
+                continue;
+            };
+
+            // If a specific cluster is bound, it must be OnOff.
+            if let Some(cluster) = binding.cluster {
+                if cluster != on_off_cluster::FULL_CLUSTER.id {
+                    continue;
+                }
+            }
+
+            info!(
+                "Switch: toggling fabric {}, node 0x{:016X}, endpoint {}",
+                binding.fab_idx, node, endpoint
+            );
+
+            match toggle(matter, crypto, binding.fab_idx, node, endpoint).await {
+                Ok(()) => info!("Switch: toggle ok"),
+                Err(e) => error!("Switch: toggle failed: {:?}", e),
+            }
+        }
+    }
+}
+
+/// Open (or reuse) a CASE session to `(fab_idx, node)` and send `OnOff::Toggle`
+/// to `endpoint`.
+async fn toggle(
+    matter: &Matter<'_>,
+    crypto: &impl Crypto,
+    fab_idx: NonZeroU8,
+    node: u64,
+    endpoint: u16,
+) -> Result<(), Error> {
+    let exchange = Exchange::initiate(matter, crypto, fab_idx, node).await?;
+
+    exchange.on_off().toggle(endpoint).await
 }
 
 const NODE: Node<'static> = Node {
@@ -206,6 +361,28 @@ const NODE: Node<'static> = Node {
                 ColorControlDeviceLogic::CLUSTER,
             ),
         ),
+        // The On/Off Light Switch (`0x0103`): OnOff in the *client* list plus
+        // the Binding cluster (its address book) — the `switch_binding` Rust
+        // integration test and the (manual) TC-BIND certification procedures
+        // drive a bound light through this endpoint.
+        Endpoint::new_with_clients(
+            SWITCH_ENDPOINT,
+            devices!(DEV_TYPE_ON_OFF_LIGHT_SWITCH),
+            clusters!(
+                desc::DescHandler::CLUSTER,
+                identify::CLUSTER,
+                binding::CLUSTER,
+            ),
+            &[on_off_cluster::FULL_CLUSTER.id],
+        ),
+        // The Generic Switch (`0x000F`): a momentary push-button (`Switch`
+        // server cluster) whose presses are simulated over the `--app-pipe`
+        // channel — exercised by the `TC_SWTCH` Python test.
+        Endpoint::new(
+            GENERIC_SWITCH_ENDPOINT,
+            devices!(DEV_TYPE_GENERIC_SWITCH),
+            clusters!(desc::DescHandler::CLUSTER, SwitchHandler::CLUSTER),
+        ),
     ],
 };
 
@@ -214,6 +391,8 @@ fn data_model<'a, LH: LevelControlHooks, OH: OnOffHooks, CH: ColorControlHooks>(
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     level_control: &'a level_control::LevelControlHandler<'a, LH, OH>,
     color_control: &'a color_control::ColorControlHandler<'a, CH, OH, LH>,
+    bindings: &'a Bindings<MAX_BINDINGS>,
+    switch_position: &'a Cell<u8>,
 ) -> impl DataModel + 'a {
     (
         NODE,
@@ -239,8 +418,200 @@ fn data_model<'a, LH: LevelControlHooks, OH: OnOffHooks, CH: ColorControlHooks>(
             .chain(
                 EpClMatcher::new(Some(1), Some(ColorControlDeviceLogic::CLUSTER.id)),
                 color_control::HandlerAsyncAdaptor(color_control),
+            )
+            // Clusters for the switch endpoint
+            .chain(
+                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(desc::DescHandler::CLUSTER.id)),
+                Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+            )
+            .chain(
+                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(identify::CLUSTER.id)),
+                Async(IdentifyHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+            )
+            .chain(
+                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(binding::CLUSTER.id)),
+                Async(
+                    BindingHandler::new(Dataver::new_rand(&mut rand), SWITCH_ENDPOINT, bindings)
+                        .adapt(),
+                ),
+            )
+            // Clusters for the Generic Switch endpoint
+            .chain(
+                EpClMatcher::new(
+                    Some(GENERIC_SWITCH_ENDPOINT),
+                    Some(desc::DescHandler::CLUSTER.id),
+                ),
+                Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+            )
+            .chain(
+                EpClMatcher::new(
+                    Some(GENERIC_SWITCH_ENDPOINT),
+                    Some(SwitchHandler::CLUSTER.id),
+                ),
+                Async(SwitchHandler::new(Dataver::new_rand(&mut rand), switch_position).adapt()),
             ),
     )
+}
+
+// ---- Generic Switch: cluster handler + button simulator ----
+
+/// A momentary Generic Switch cluster handler: `MS | MSR | MSL` — a
+/// push-button reporting `InitialPress` on press and, for the (simulated)
+/// long presses `TC_SWTCH` drives, `LongPress` / `LongRelease`.
+///
+/// The `CurrentPosition` state is shared (by reference) with the button
+/// simulator task, which mutates it and emits the events.
+struct SwitchHandler<'a> {
+    dataver: Dataver,
+    position: &'a Cell<u8>,
+}
+
+impl<'a> SwitchHandler<'a> {
+    const fn new(dataver: Dataver, position: &'a Cell<u8>) -> Self {
+        Self { dataver, position }
+    }
+
+    fn adapt(self) -> switch_cluster::HandlerAdaptor<Self> {
+        switch_cluster::HandlerAdaptor(self)
+    }
+}
+
+impl switch_cluster::ClusterHandler for SwitchHandler<'_> {
+    const CLUSTER: Cluster<'static> = switch_cluster::FULL_CLUSTER
+        .with_features(
+            SwitchFeature::MOMENTARY_SWITCH
+                .union(SwitchFeature::MOMENTARY_SWITCH_RELEASE)
+                .union(SwitchFeature::MOMENTARY_SWITCH_LONG_PRESS)
+                .bits(),
+        )
+        .with_attrs(with!(required));
+
+    fn dataver(&self) -> u32 {
+        self.dataver.get()
+    }
+
+    fn dataver_changed(&self) {
+        self.dataver.changed();
+    }
+
+    fn number_of_positions(&self, _ctx: impl ReadContext) -> Result<u8, Error> {
+        Ok(2)
+    }
+
+    fn current_position(&self, _ctx: impl ReadContext) -> Result<u8, Error> {
+        Ok(self.position.get())
+    }
+}
+
+/// A button-simulator command, parsed off the `--app-pipe` channel.
+#[derive(Copy, Clone, Debug)]
+enum SimCommand {
+    /// `SimulateLongPress`: press `button`, emit `LongPress` after
+    /// `delay_ms`, release (with `LongRelease`) at `duration_ms`.
+    LongPress {
+        button: u8,
+        delay_ms: u64,
+        duration_ms: u64,
+    },
+    /// `SimulateSwitchIdle`: return the button to its resting position.
+    Idle,
+}
+
+/// The single-slot channel from the (sync) app-pipe action closure to the
+/// (async) button-simulator task.
+struct SimChannel {
+    cmd: Cell<Option<SimCommand>>,
+    notify: Notification,
+}
+
+impl SimChannel {
+    const fn new() -> Self {
+        Self {
+            cmd: Cell::new(None),
+            notify: Notification::new(),
+        }
+    }
+
+    fn send(&self, cmd: SimCommand) {
+        self.cmd.set(Some(cmd));
+        self.notify.notify();
+    }
+}
+
+/// The Generic Switch button simulator: play each [`SimCommand`] against the
+/// shared `CurrentPosition` state, notifying subscribers of the position
+/// changes and emitting the press events, with the command's timing.
+async fn run_switch_simulation(
+    notifier: &(impl EventEmitter + AttrChangeNotifier),
+    position: &Cell<u8>,
+    sim: &SimChannel,
+) -> Result<(), Error> {
+    fn set_position(notifier: &impl AttrChangeNotifier, position: &Cell<u8>, value: u8) {
+        if position.replace(value) != value {
+            notifier.notify_attr_changed(
+                GENERIC_SWITCH_ENDPOINT,
+                switch_cluster::FULL_CLUSTER.id,
+                switch_cluster::AttributeId::CurrentPosition as _,
+            );
+        }
+    }
+
+    loop {
+        sim.notify.wait().await;
+
+        let Some(cmd) = sim.cmd.take() else {
+            continue;
+        };
+
+        info!("Switch simulator: {cmd:?}");
+
+        match cmd {
+            SimCommand::Idle => set_position(notifier, position, 0),
+            SimCommand::LongPress {
+                button,
+                delay_ms,
+                duration_ms,
+            } => {
+                set_position(notifier, position, button);
+                if let Err(e) = InitialPress::emit_for(notifier, GENERIC_SWITCH_ENDPOINT, |b| {
+                    b.new_position(button)?.end()
+                }) {
+                    error!("InitialPress emit failed: {e:?}");
+                }
+
+                embassy_time::Timer::after(embassy_time::Duration::from_millis(delay_ms)).await;
+                if let Err(e) = LongPress::emit_for(notifier, GENERIC_SWITCH_ENDPOINT, |b| {
+                    b.new_position(button)?.end()
+                }) {
+                    error!("LongPress emit failed: {e:?}");
+                }
+
+                embassy_time::Timer::after(embassy_time::Duration::from_millis(
+                    duration_ms.saturating_sub(delay_ms),
+                ))
+                .await;
+                set_position(notifier, position, 0);
+                if let Err(e) = LongRelease::emit_for(notifier, GENERIC_SWITCH_ENDPOINT, |b| {
+                    b.previous_position(button)?.end()
+                }) {
+                    error!("LongRelease emit failed: {e:?}");
+                }
+            }
+        }
+    }
+}
+
+/// Extract a `"key": <number>` field from a single-line JSON dict — the
+/// app-pipe protocol is simple enough to not warrant a JSON dependency.
+fn json_u64(line: &str, key: &str) -> Option<u64> {
+    let pos = line.find(&format!("\"{key}\""))?;
+    let rest = &line[pos..];
+    let rest = &rest[rest.find(':')? + 1..];
+    let rest = rest.trim_start();
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    rest[..end].parse().ok()
 }
 
 // ---- ColorControl business logic ----
@@ -375,7 +746,13 @@ const STORAGE_FILE_NAME: &str = "rs-matter-light-tests-on-off-state";
 
 impl OnOffDeviceLogic {
     pub fn new() -> Self {
-        let storage_path = std::env::temp_dir().join(STORAGE_FILE_NAME);
+        // Tie the OnOff state file to the `--KVS` path when one is given, so
+        // multiple simultaneous instances (the two-node `switch` itest suite)
+        // don't clobber each other's persisted OnOff state.
+        let storage_path = match args::kvs_override() {
+            Some(kvs) => PathBuf::from(format!("{kvs}-on-off-state")),
+            None => std::env::temp_dir().join(STORAGE_FILE_NAME),
+        };
         let persisted_state = match fs::File::open(storage_path.as_path()) {
             Ok(mut file) => {
                 let mut buf: [u8; 1] = [0];

--- a/tests/src/bin/system_tests.pics
+++ b/tests/src/bin/system_tests.pics
@@ -722,8 +722,10 @@ S.C.AO-READ=0
 S.C.AO-WRITE=0
 
 # Switch Cluster
-SWTCH.S=1
-SWTCH.S.F00=1
+# No Switch cluster handler exists (the `TC_SWTCH` Python test skips all of
+# its methods) - claiming `SWTCH.S=1` here would be a PICS/device mismatch.
+SWTCH.S=0
+SWTCH.S.F00=0
 SWTCH.S.F01=0
 SWTCH.S.F02=0
 SWTCH.S.F03=0

--- a/tests/src/bin/system_tests.pics
+++ b/tests/src/bin/system_tests.pics
@@ -618,13 +618,16 @@ PRS.C.AO-WRITE=0
 # Groups Cluster
 G.S=1
 G.S.F00=1
-G.S.A0000=0
+G.S.A0000=1
 G.S.C00.Rsp=1
 G.S.C01.Rsp=1
 G.S.C02.Rsp=1
 G.S.C03.Rsp=1
 G.S.C04.Rsp=1
-G.S.C05.Rsp=0
+G.S.C05.Rsp=1
+# Groups cluster present on more than one endpoint (EP0, EP1 and EP2 here),
+# as required by Test_TC_G_2_4
+MCORE.G.MULTIENDPOINT=1
 G.S.C00.Tx=1
 G.S.C01.Tx=1
 G.S.C02.Tx=1
@@ -642,6 +645,8 @@ G.C.C05.Tx=0
 GRPKEY.S=1
 # No support for the CacheAndSync feature so far
 GRPKEY.S.F00=0
+# Malformed spelling of GRPKEY.S.F00 used by a Test_TC_GRPKEY_2_2 step gate
+GRPKEY.F00=0
 # Groupcast (Matter 1.6). Not implemented - the cluster metadata is built with
 # `with!(required)`, so the provisional `GroupcastAdoption` attribute is not
 # advertised either.

--- a/tests/src/bin/system_tests.rs
+++ b/tests/src/bin/system_tests.rs
@@ -283,6 +283,12 @@ fn main() -> Result<(), Error> {
         TimeSyncHandler::new_with_time_zone(Dataver::new_rand(&mut rand), time_zone_store);
     let binding_handler_ep1 = BindingHandler::new(Dataver::new_rand(&mut rand), 1, bindings);
 
+    // Identify handlers for EP1/EP2 — owned by `main` (rather than moved
+    // into the handler chain) because the per-endpoint Groups handlers
+    // borrow them for `AddGroupIfIdentifying`.
+    let identify_handler_ep1 = IdentifyHandler::new(Dataver::new_rand(&mut rand));
+    let identify_handler_ep2 = IdentifyHandler::new(Dataver::new_rand(&mut rand));
+
     // Our unit testing cluster data
     let unit_testing_data = UNIT_TESTING_DATA
         .uninit()
@@ -379,6 +385,8 @@ fn main() -> Result<(), Error> {
             &user_label_handler,
             &binding_handler_ep0,
             &binding_handler_ep1,
+            &identify_handler_ep1,
+            &identify_handler_ep2,
             ota_images,
             &ota_providers,
             &ota_state,
@@ -931,6 +939,8 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     user_label_handler: &'a UserLabelHandler<'a, 1, 4>,
     binding_handler_ep0: &'a BindingHandler<'a, 16>,
     binding_handler_ep1: &'a BindingHandler<'a, 16>,
+    identify_handler_ep1: &'a IdentifyHandler,
+    identify_handler_ep2: &'a IdentifyHandler,
     ota_images: &'a OtaFileImages,
     ota_providers: &'a Providers,
     ota_state: &'a OtaState,
@@ -1009,13 +1019,22 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                 EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
+            // Identify at EP1 — owned by `main`, borrowed by reference into
+            // the chain, because the EP1 Groups handler below also borrows
+            // it for `AddGroupIfIdentifying`.
             .chain(
                 EpClMatcher::new(Some(1), Some(identify::CLUSTER.id)),
-                Async(IdentifyHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+                Async(identify::HandlerAdaptor(identify_handler_ep1)),
             )
             .chain(
                 EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
-                Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+                Async(
+                    groups::GroupsHandler::new_with_identify(
+                        Dataver::new_rand(&mut rand),
+                        identify_handler_ep1,
+                    )
+                    .adapt(),
+                ),
             )
             .chain(
                 EpClMatcher::new(Some(1), Some(fixed_label::CLUSTER.id)),
@@ -1050,13 +1069,20 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                 EpClMatcher::new(Some(2), Some(desc::DescHandler::CLUSTER.id)),
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
+            // Identify + Groups at EP2, coupled the same way as EP1 above.
             .chain(
                 EpClMatcher::new(Some(2), Some(identify::CLUSTER.id)),
-                Async(IdentifyHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+                Async(identify::HandlerAdaptor(identify_handler_ep2)),
             )
             .chain(
                 EpClMatcher::new(Some(2), Some(groups::GroupsHandler::CLUSTER.id)),
-                Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+                Async(
+                    groups::GroupsHandler::new_with_identify(
+                        Dataver::new_rand(&mut rand),
+                        identify_handler_ep2,
+                    )
+                    .adapt(),
+                ),
             )
             .chain(
                 EpClMatcher::new(Some(2), Some(TestOnOffDeviceLogic::CLUSTER.id)),

--- a/tests/src/bin/system_tests.rs
+++ b/tests/src/bin/system_tests.rs
@@ -129,6 +129,11 @@ mod mdns;
 #[path = "../common/args.rs"]
 mod args;
 
+#[path = "../common/pipe.rs"]
+mod pipe;
+
+use pipe::run_app_pipe_actions;
+
 // Statically allocate in BSS the bigger objects
 // `rs-matter` supports efficient initialization of BSS objects (with `init`)
 // as well as just allocating the objects on-stack or on the heap.
@@ -1314,69 +1319,6 @@ async fn persist_icd_counter_on_trigger(
     loop {
         ICD_COUNTER_PERSIST_NOTIFY.wait().await;
         kv.access(|store, buf| icd.persist_counter(store, buf))?;
-    }
-}
-
-/// Read JSON command lines from the named pipe at `path` and dispatch them to
-/// `bump` on the calling task — which is the main thread, so it's free to
-/// touch `&Matter` / `&InteractionModel` directly (neither is `Sync`).
-async fn run_app_pipe_actions(
-    path: Option<String>,
-    mut action: impl FnMut(String) -> Result<bool, Error>,
-) -> Result<(), Error> {
-    let Some(path) = path else {
-        info!("No --app-pipe provided; out-of-band command channel disabled.");
-        core::future::pending::<()>().await;
-        unreachable!()
-    };
-    info!("App pipe enabled at {path}");
-
-    use blocking::{unblock, Unblock};
-    use futures_lite::io::{AsyncBufReadExt, BufReader};
-
-    // Best-effort: create the FIFO if it doesn't already exist. Shell out to
-    // `mkfifo` to avoid pulling in a `libc`/`nix` dep just for this. Errors
-    // here are non-fatal: if the file already exists (or is a regular file
-    // from a prior run) the reader open below will surface a useful error.
-    let _ = std::process::Command::new("mkfifo").arg(&path).status();
-
-    loop {
-        let path_clone = path.clone();
-        let file = match unblock(move || std::fs::File::open(&path_clone)).await {
-            Ok(f) => f,
-            Err(e) => {
-                log::warn!("Failed to open app pipe {}: {}", path, e);
-                embassy_time::Timer::after(embassy_time::Duration::from_secs(1)).await;
-                continue;
-            }
-        };
-
-        let mut reader = BufReader::new(Unblock::new(file));
-        let mut line = String::new();
-
-        loop {
-            line.clear();
-            match reader.read_line(&mut line).await {
-                Ok(0) => break, // writer closed; reopen
-                Ok(_) => {
-                    // Avoid a JSON dep: the framework sends one JSON dict per
-                    // line and we only care about a single command name.
-
-                    let line = line.trim_end();
-                    info!("[app-pipe] received: {line}");
-
-                    match action(line.to_string()) {
-                        Ok(true) => info!("Processed"),
-                        Ok(false) => info!("Skipped"),
-                        Err(e) => warn!("Failed: {}", e),
-                    }
-                }
-                Err(e) => {
-                    log::warn!("Error reading from app pipe: {}", e);
-                    break;
-                }
-            }
-        }
     }
 }
 

--- a/tests/src/common/pipe.rs
+++ b/tests/src/common/pipe.rs
@@ -1,0 +1,97 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! The `--app-pipe <path>` out-of-band command channel shared by the `*_tests`
+//! binaries.
+//!
+//! The CHIP Python test framework (`MatterBaseTest::write_to_app_pipe`) — and
+//! the `xtask` itest orchestration — send JSON command lines to a named FIFO;
+//! the device-under-test reads them and reacts out-of-band (outside the Matter
+//! protocol), e.g. to simulate a physical switch press.
+
+// Each binary includes this module via `#[path = "../common/pipe.rs"]`, so not
+// every item is used by every binary.
+#![allow(dead_code)]
+
+use log::{info, warn};
+
+use rs_matter::error::Error;
+
+/// Read command lines from the `--app-pipe` FIFO (creating it if necessary)
+/// and dispatch each to `action`. Pends forever when no pipe path is given.
+///
+/// `action` runs on the calling task — typically the main thread, so it's
+/// free to touch `&Matter` / `&InteractionModel` directly (neither is `Sync`).
+pub async fn run_app_pipe_actions(
+    path: Option<String>,
+    mut action: impl FnMut(String) -> Result<bool, Error>,
+) -> Result<(), Error> {
+    let Some(path) = path else {
+        info!("No --app-pipe provided; out-of-band command channel disabled.");
+        core::future::pending::<()>().await;
+        unreachable!()
+    };
+    info!("App pipe enabled at {path}");
+
+    use blocking::{unblock, Unblock};
+    use futures_lite::io::{AsyncBufReadExt, BufReader};
+
+    // Best-effort: create the FIFO if it doesn't already exist. Shell out to
+    // `mkfifo` to avoid pulling in a `libc`/`nix` dep just for this. Errors
+    // here are non-fatal: if the file already exists (or is a regular file
+    // from a prior run) the reader open below will surface a useful error.
+    let _ = std::process::Command::new("mkfifo").arg(&path).status();
+
+    loop {
+        let path_clone = path.clone();
+        let file = match unblock(move || std::fs::File::open(&path_clone)).await {
+            Ok(f) => f,
+            Err(e) => {
+                warn!("Failed to open app pipe {}: {}", path, e);
+                embassy_time::Timer::after(embassy_time::Duration::from_secs(1)).await;
+                continue;
+            }
+        };
+
+        let mut reader = BufReader::new(Unblock::new(file));
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            match reader.read_line(&mut line).await {
+                Ok(0) => break, // writer closed; reopen
+                Ok(_) => {
+                    // Avoid a JSON dep: the framework sends one JSON dict per
+                    // line and we only care about a single command name.
+
+                    let line = line.trim_end();
+                    info!("[app-pipe] received: {line}");
+
+                    match action(line.to_string()) {
+                        Ok(true) => info!("Processed"),
+                        Ok(false) => info!("Skipped"),
+                        Err(e) => warn!("Failed: {}", e),
+                    }
+                }
+                Err(e) => {
+                    warn!("Error reading from app pipe: {}", e);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -86,6 +86,17 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TestGroupMessaging",
     "TestGroupsCluster",
     "TestGroupKeyManagementCluster",
+    // Certification variants of the Groups / GroupKeyManagement suites
+    // (the `Test_TC_*` YAMLs the CSA Test Harness runs, stricter than the
+    // functional `Test*Cluster` suites above). The remaining cert YAMLs in
+    // this area - `Test_TC_G_2_3`, `Test_TC_G_3_2`, `Test_TC_GRPKEY_5_4`
+    // and `Test_TC_BIND_2_1/2_2/2_3` - are manual procedures (every step
+    // is `disabled: true`, DUT-as-client or operator-driven), so enabling
+    // them here would only buy a vacuous pass.
+    "Test_TC_G_2_1",
+    "Test_TC_G_2_4",
+    "Test_TC_GRPKEY_2_1",
+    "Test_TC_GRPKEY_2_2",
     "TestIdentifyCluster",
     "TestLogCommands",
     "TestMultiAdmin",

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -517,10 +517,6 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     // "TC_BRBINFO_4_1", // Skipped: rs-matter does not implement bridge devices.
 
     //
-    // Python tests — Switch (optional application cluster)
-    //
-    "TC_SWTCH", // Switch cluster not implemented (Matter spec §1.13); 5 inner test methods, each `@run_if_endpoint_matches(has_feature(Switch, ...))`, all skip cleanly via `no_fail_on_skipped.py`.
-    //
     // Python tests — Device Attestation (commissioning)
     //
     "TC_DA_1_2",
@@ -655,6 +651,11 @@ pub(crate) const LIGHT_TESTS: &[&str] = &[
     "Test_TC_CC_9_1",
     "Test_TC_CC_9_2",
     "Test_TC_CC_9_3",
+    // Generic Switch (Python): runs against the `light_tests` Generic
+    // Switch endpoint (EP3, `MS | MSR | MSL`), with the presses simulated
+    // over the `--app-pipe` channel. The latching (2_2) and multi-press
+    // (2_5 / 2_6) methods skip on the feature gates; 2_3 / 2_4 run.
+    "TC_SWTCH",
 ];
 
 /// Scenes Management YAML tests — run against the `scenes_tests` example.
@@ -2252,7 +2253,10 @@ impl ITests {
                 | "TC_LCFG_2_1"      // has_cluster(LocalizationConfiguration)
                 | "TC_LTIME_3_1"     // has_cluster(TimeFormatLocalization)
                 | "TC_LUNIT_3_1"     // has_cluster(UnitLocalization) and has_attribute(TemperatureUnit)
-                | "TC_SWTCH"         // 5 inner methods, each has_feature(Switch, ...)
+                // The latching (2_2) and multi-press (2_5 / 2_6) methods skip
+                // on their feature gates (`light_tests`' Generic Switch is
+                // `MS | MSR | MSL`); 2_3 / 2_4 run.
+                | "TC_SWTCH"
                 // All three test the optional `AccessControlExtension`
                 // feature (Extension attribute); rs-matter does not implement
                 // it, so `has_attribute(AccessControl.Extension)` skips cleanly.
@@ -2519,6 +2523,10 @@ impl ITests {
             // is fixed upstream, the steps skip here too, and the attribute
             // is covered by rs-matter's own e2e test instead.
             "TC_BINFO_3_2" => Some("--app-pipe /tmp/rs_matter_bin_info_3_2_fifo"),
+            // `TC_SWTCH` simulates the Generic Switch presses via app-pipe
+            // commands (`SimulateLongPress` / `SimulateSwitchIdle`); the
+            // same path is handed to the Python side in `test_args`.
+            "TC_SWTCH" => Some("--app-pipe /tmp/rs_matter_swtch_fifo"),
             // The `TC_GC_*` suite runs against the Groupcast-enabled app
             // composition (`NODE_GROUPCAST` in `system_tests`): the
             // Groupcast cluster on EP0 plus the aux-ACL-enabled Access
@@ -2718,6 +2726,16 @@ impl ITests {
                 "--endpoint 0 \
                  --PICS src/app/tests/suites/certification/ci-pics-values \
                  --app-pipe /tmp/rs_matter_bin_info_3_2_fifo"
+            }
+            // `TC_SWTCH` targets the `light_tests` Generic Switch endpoint
+            // and takes its button-simulator path only when
+            // `PICS_SDK_CI_ONLY` is set (else it prompts an operator). The
+            // `--app-pipe` path is mirrored on the DUT side via
+            // `app_args_override`.
+            "TC_SWTCH" => {
+                "--endpoint 3 \
+                 --PICS src/app/tests/suites/certification/ci-pics-values \
+                 --app-pipe /tmp/rs_matter_swtch_fifo"
             }
             // `test_TC_IDM_10_5` flags every server cluster that is not part of
             // some device type declared on its endpoint. `system_tests` hosts


### PR DESCRIPTION
Turns out a lot of those (their Python flavors) are actually not enabled yet in our `itest` suite.

This PR addresses this.

In addition, the PR introduces a new Lifecycle event - Fabric Removal. Due to the need to emit this event from non-async contexts, the `lifecycle` method is now non-async as well.