### PR TITLE
Groupcast sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Groupcast **sending** APIs (`groups` feature): `Exchange::initiate_group` and `ImClient::group_invoke_with`; the `onoff_light_switch` example and the `light_tests` switch endpoint now act on *group* binding targets
 * (Breaking) `Matter::is_commissioned` renamed to `Matter::has_fabrics` (#525)
 * New `Matter::comm_window_state` method useful downstream for figuring out if the commissioning transport should be enabled (#525)
 * Network Recovery data-model support - provisional in Matter 1.6 (#523)

--- a/examples/src/bin/onoff_light_switch.rs
+++ b/examples/src/bin/onoff_light_switch.rs
@@ -226,17 +226,34 @@ async fn run_switch<const N: usize>(
                 continue;
             }
 
-            // Only unicast OnOff targets (node + endpoint present).
-            let (Some(node), Some(endpoint)) = (binding.node, binding.endpoint) else {
-                continue;
-            };
-
             // If a specific cluster is bound, it must be OnOff.
             if let Some(cluster) = binding.cluster {
                 if cluster != on_off::FULL_CLUSTER.id {
                     continue;
                 }
             }
+
+            // Group targets: multicast an encrypted, fire-and-forget Toggle
+            // to the whole group, with an endpoint-less command path —
+            // receivers apply it to their group-member endpoints.
+            if let Some(group_id) = binding.group {
+                info!(
+                    "Switch: group-toggling fabric {}, group 0x{:04X}",
+                    binding.fab_idx, group_id
+                );
+
+                match group_toggle(matter, crypto, binding.fab_idx, group_id).await {
+                    Ok(()) => info!("Switch: group toggle ok"),
+                    Err(e) => warn!("Switch: group toggle failed: {:?}", e),
+                }
+
+                continue;
+            }
+
+            // Unicast OnOff targets (node + endpoint present).
+            let (Some(node), Some(endpoint)) = (binding.node, binding.endpoint) else {
+                continue;
+            };
 
             info!(
                 "Switch: toggling fabric {}, node 0x{:016X}, endpoint {}",
@@ -265,6 +282,36 @@ async fn toggle(
     let exchange = Exchange::initiate(matter, crypto, fab_idx, node).await?;
 
     exchange.on_off().toggle(endpoint).await
+}
+
+/// Multicast an encrypted, fire-and-forget `OnOff::Toggle` to `group_id`.
+async fn group_toggle(
+    matter: &Matter<'_>,
+    crypto: &impl Crypto,
+    fab_idx: NonZeroU8,
+    group_id: u16,
+) -> Result<(), Error> {
+    use rs_matter::im::client::ImClient as _;
+    use rs_matter::im::{CmdDataTag, CmdPath};
+    use rs_matter::tlv::{TLVTag, TLVWrite};
+
+    let exchange = Exchange::initiate_group(matter, crypto, fab_idx, group_id)?;
+
+    exchange
+        .group_invoke_with(|b| {
+            b.push()?
+                .path_from(&CmdPath::new(
+                    None,
+                    Some(on_off::FULL_CLUSTER.id),
+                    Some(on_off::CommandId::Toggle as u32),
+                ))?
+                .data(|w| {
+                    w.start_struct(&TLVTag::Context(CmdDataTag::Data as u8))?;
+                    w.end_container()
+                })?
+                .end()
+        })
+        .await
 }
 
 /// A minimal **momentary** Generic Switch cluster handler.

--- a/rs-matter/src/im/client.rs
+++ b/rs-matter/src/im/client.rs
@@ -32,8 +32,12 @@ use either::Either;
 pub use super::{AttrId, ClusterId, EndptId};
 
 use crate::error::{Error, ErrorCode};
+#[cfg(feature = "groups")]
+use crate::tlv::TLVWriteParent;
 use crate::tlv::{FromTLV, TLVBuilderParent, TLVElement, TLVTag, TLVWrite, TagType, ToTLV};
 use crate::transport::exchange::{Exchange, OwnedSender, OwnedSenderTx};
+#[cfg(feature = "groups")]
+use crate::utils::storage::WriteBuf;
 
 use super::{
     IMStatusCode, InvReqBuilder, InvokeResp, OpCode, ReadReqBuilder, ReportDataResp, StatusResp,
@@ -299,7 +303,50 @@ pub trait ImClient<'a>: Sized + Into<Exchange<'a>> {
             state: SubscribeSenderState::Ready(sender),
         })
     }
+
+    /// Perform a fire-and-forget IM invoke — for group (multicast) exchanges
+    /// opened with [`Exchange::initiate_group`].
+    ///
+    /// Sends a single `InvokeRequestMessage` with `SuppressResponse = true`
+    /// and completes as soon as the message is out: groupcast invokes elicit
+    /// no responses and group messages carry no MRP, so there is nothing to
+    /// wait for. Push the command entries with endpoint-less paths
+    /// ([`CmdDataBuilder::path_from`] with an endpoint-less
+    /// [`crate::im::CmdPath`]) — receivers apply them to their group-member
+    /// endpoints.
+    #[cfg(feature = "groups")]
+    async fn group_invoke_with<B>(self, mut build: B) -> Result<(), Error>
+    where
+        B: for<'x, 'y> FnMut(
+            GroupInvokeRequestsBuilder<'x, 'y>,
+        ) -> Result<GroupInvokeRequestsBuilder<'x, 'y>, Error>,
+    {
+        let mut exchange: Exchange<'a> = self.into();
+
+        exchange
+            .send_with(|_, wb| {
+                let builder =
+                    InvReqBuilder::new(TLVWriteParent::new("GroupInvoke", wb), &TLVTag::Anonymous)?
+                        .suppress_response(true)?
+                        .invoke_requests()?;
+
+                let builder = build(builder)?;
+
+                builder.end()?.end()?;
+
+                Ok(Some(OpCode::InvokeRequest.meta().reliable(false)))
+            })
+            .await
+    }
 }
+
+/// The builder handed to [`ImClient::group_invoke_with`]'s closure: the
+/// `InvokeRequests` array of a `SuppressResponse` invoke, writing into the
+/// exchange's TX buffer.
+#[cfg(feature = "groups")]
+pub type GroupInvokeRequestsBuilder<'x, 'y> = crate::im::CmdDataArrayBuilder<
+    InvReqBuilder<TLVWriteParent<&'static str, &'x mut WriteBuf<'y>>, 3>,
+>;
 
 /// Blanket impl so any [`Exchange<'a>`] is an [`ImClient<'a>`] when
 /// the trait is `use`d. The default-method bodies do all the work;

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -2036,9 +2036,14 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
         if let Some(session) = &mut session {
             packet.header.plain = Default::default();
 
+            // Group DATA messages are only ever sent through the exchange
+            // path (`ExchangeSender`), which supplies the global group data
+            // counter; this transport-level path serves the remaining
+            // (unicast and group-control) sends.
             let (peer, retransmission) = session.pre_send(
                 exchange_index,
                 &mut packet.header,
+                None,
                 self.transport().device_sai,
                 self.transport().device_sii,
             )?;

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -723,6 +723,35 @@ impl TxMessage<'_> {
         meta.set_into(&mut self.packet.header.proto);
 
         self.matter.with_state(|state| {
+            // An outgoing group DATA message is stamped with the Global Group
+            // Encrypted Data Message Counter, fetched (and advanced) up-front
+            // since the session borrow below aliases the sessions container.
+            let is_group_data = {
+                let session = state
+                    .sessions
+                    .get(self.exchange_id.session_id())
+                    .ok_or(ErrorCode::NoSession)?;
+
+                matches!(session.get_session_mode(), SessionMode::Group { .. })
+                    && !MessageMeta::from(&self.packet.header.proto).is_control_msg()
+            };
+
+            #[cfg(feature = "groups")]
+            let group_data_ctr = is_group_data
+                .then(|| state.sessions.next_global_group_data_ctr())
+                .transpose()?;
+
+            #[cfg(not(feature = "groups"))]
+            let group_data_ctr = {
+                // Group sessions are never created without the `groups`
+                // feature, so this is unreachable in practice.
+                if is_group_data {
+                    return Err(ErrorCode::InvalidState.into());
+                }
+
+                None
+            };
+
             let session = state
                 .sessions
                 .get(self.exchange_id.session_id())
@@ -737,6 +766,7 @@ impl TxMessage<'_> {
             let (peer, retransmission) = session.pre_send(
                 Some(self.exchange_id.exchange_index()),
                 &mut self.packet.header,
+                group_data_ctr,
                 Some(session.get_peer_active_interval_ms()),
                 Some(session.get_peer_idle_interval_ms()),
             )?;
@@ -1150,6 +1180,38 @@ impl<'a> Exchange<'a> {
         matter
             .transport()
             .initiate_for_session(matter, crypto, session_id)
+    }
+
+    /// Create a new initiator exchange for sending group DATA messages to
+    /// `(fab_idx, group_id)` — encrypted with the group's active operational
+    /// key and addressed at the group's multicast address.
+    ///
+    /// Group messages are fire-and-forget: no MRP, no acknowledgements and
+    /// no responses — so the exchange is only good for *sending* (e.g. an
+    /// Interaction Model invoke with `SuppressResponse`); do not wait for
+    /// replies on it. The group's security material (a `GroupKeyMap` entry
+    /// plus its key set) must be provisioned on the fabric, else this fails
+    /// with [`ErrorCode::NotFound`].
+    #[cfg(feature = "groups")]
+    pub fn initiate_group<C: Crypto + Copy>(
+        matter: &'a Matter<'a>,
+        crypto: C,
+        fab_idx: NonZeroU8,
+        group_id: u16,
+    ) -> Result<Self, Error> {
+        let session_id = matter.with_state(|state| {
+            let session = state.sessions.get_or_create_for_group_tx(
+                crypto,
+                &state.fabrics,
+                fab_idx,
+                group_id,
+                matter.dev_det(),
+            )?;
+
+            Ok::<_, Error>(session.id)
+        })?;
+
+        Self::initiate_for_session(matter, crypto, session_id)
     }
 
     /// Create a new initiator exchange on a new plaintext session to

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -1591,8 +1591,15 @@ impl Drop for Exchange<'_> {
 
             let closed = sess.remove_exch(exch_index);
             if closed {
+                // RX group sessions (unicast peer = the sender's address) are
+                // ephemeral, one per received message — remove them with their
+                // last exchange. TX group sessions (multicast peer) stay: the
+                // just-queued outgoing packet still needs the session for
+                // encoding, and subsequent sends to the same group reuse it
+                // (`get_or_create_for_group_tx`); LRU eviction reclaims them.
                 if matches!(sess.get_session_mode(), SessionMode::Group { .. })
                     && sess.exchanges.iter().all(Option::is_none)
+                    && !sess.is_peer_multicast()
                 {
                     // Group session with no remaining exchanges — remove it
                     state.sessions.remove(self.id.session_id());

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -490,6 +490,20 @@ impl Session {
         }
     }
 
+    /// Whether the session's peer address is a multicast address — true only
+    /// for TX group sessions (see [`Sessions::get_or_create_for_group_tx`]).
+    pub(crate) fn is_peer_multicast(&self) -> bool {
+        match &self.peer_addr {
+            Address::Udp(crate::transport::network::SocketAddr::V6(addr)) => {
+                addr.ip().is_multicast()
+            }
+            Address::Udp(crate::transport::network::SocketAddr::V4(addr)) => {
+                addr.ip().is_multicast()
+            }
+            _ => false,
+        }
+    }
+
     pub(crate) fn pre_send(
         &mut self,
         exch_index: Option<usize>,
@@ -567,9 +581,12 @@ impl Session {
 
         tx_header.proto.adjust_reliability(false, &self.peer_addr);
 
-        if is_group {
-            // Group messages never use MRP: no reliability, no piggybacked
-            // (or solicited) acknowledgements.
+        if is_group && !is_control {
+            // Group DATA messages never use MRP: they are multicast
+            // fire-and-forget, so there is nobody to acknowledge them.
+            // Group CONTROL messages (MCSP) are unicast-addressed and stay
+            // reliable - which is also what keeps their (ephemeral) session
+            // alive until the reply has been encoded.
             tx_header.proto.unset_reliable();
             tx_header.proto.set_ack(None);
         }
@@ -951,10 +968,14 @@ pub struct Sessions {
     /// [`Sessions::get_or_init_global_group_data_ctr`] to obtain a valid
     /// non-zero value.
     ///
-    /// Not persisted — the counter is re-randomized on each process
-    /// start. Peers will observe a fresh trust-first sync on their next
-    /// MCSP exchange after we restart, which matches the fallback for
-    /// any lost-sync-state scenario.
+    /// TODO: Not persisted yet — the counter is re-randomized on each
+    /// process start, whereas the spec requires persisting it (with an
+    /// epoch/stride scheme) so it never goes backwards across reboots: a
+    /// receiver tracking our source in its group counter store may
+    /// otherwise reject our post-reboot group data messages as replays
+    /// until the fresh random value exceeds the old one. Follow the
+    /// (equally not-yet-wired) `Matter::run_persist_resumption` pattern
+    /// when addressing this.
     #[cfg(feature = "groups")]
     global_group_data_ctr: u32,
 }

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -494,6 +494,7 @@ impl Session {
         &mut self,
         exch_index: Option<usize>,
         tx_header: &mut PacketHdr,
+        group_data_ctr: Option<u32>,
         session_active_interval_ms: Option<u32>,
         session_idle_interval_ms: Option<u32>,
     ) -> Result<(Address, bool), Error> {
@@ -508,18 +509,29 @@ impl Session {
 
         let is_group = matches!(self.mode, SessionMode::Group { .. });
 
+        // Whether this outbound message is a control-plane message
+        // (only MCSP opcodes today). Used to set the `C` bit, to pick
+        // DSIZ = 1 vs. the groupcast destination, and to pick the
+        // per-session vs. the global group data message counter.
+        let is_control = is_group && MessageMeta::from(&tx_header.proto).is_control_msg();
+
         // For a group session, `local_sess_id == peer_sess_id` — both
         // hold the same Group Session Id derived from the operational
         // group key (see `get_or_create_for_group_rx`) — so this line
         // works uniformly for unicast replies and group control messages.
         tx_header.plain.sess_id = self.get_peer_sess_id();
-        tx_header.plain.ctr = ctr.unwrap_or_else(|| self.get_msg_ctr());
-
-        // Whether this outbound message is a control-plane message
-        // (only MCSP opcodes today). Used both to set the `C` bit and
-        // to decide DSIZ = 1 vs. leaving the caller's groupcast dst
-        // alone.
-        let is_control = is_group && MessageMeta::from(&tx_header.proto).is_control_msg();
+        tx_header.plain.ctr = if let Some(ctr) = ctr {
+            ctr
+        } else if is_group && !is_control {
+            // Group data messages use the Global Group Encrypted Data
+            // Message Counter — one counter across all groups, so the
+            // per-source counter tracking on the receiving side stays
+            // monotonic — supplied by the caller from
+            // `Sessions::next_global_group_data_ctr`.
+            group_data_ctr.ok_or(ErrorCode::InvalidState)?
+        } else {
+            self.get_msg_ctr()
+        };
 
         // Include the Source Node ID for:
         // - Unsecured initiator sessions (spec).
@@ -535,13 +547,15 @@ impl Session {
         // - Plaintext: echo `peer_nodeid` back to the initiator.
         // - Group control (MCSP reply): DSIZ = 1, destination =
         //   originator's Node ID.
-        // - Group data (future group-data-send): destination is a
-        //   groupcast Node ID set on the packet header by the caller;
-        //   leave it alone here so we don't clobber it.
+        // - Group data: DSIZ = 2, destination = the target Group ID
+        //   (carried by the session mode, see `get_or_create_for_group_tx`).
         // - CASE/PASE: no DSIZ; clear.
+        #[allow(irrefutable_let_patterns)]
         if self.mode == SessionMode::PlainText || is_control {
             tx_header.plain.set_dst_unicast_nodeid(self.peer_nodeid);
-        } else if !is_group {
+        } else if let SessionMode::Group { group_id, .. } = self.mode {
+            tx_header.plain.set_dst_groupcast_nodeid(Some(group_id));
+        } else {
             tx_header.plain.set_dst_unicast_nodeid(None);
         }
 
@@ -552,6 +566,13 @@ impl Session {
         }
 
         tx_header.proto.adjust_reliability(false, &self.peer_addr);
+
+        if is_group {
+            // Group messages never use MRP: no reliability, no piggybacked
+            // (or solicited) acknowledgements.
+            tx_header.proto.unset_reliable();
+            tx_header.proto.set_ack(None);
+        }
 
         if let Some(exchange_index) = exch_index {
             let exchange = unwrap!(self.exchanges[exchange_index].as_mut());
@@ -1012,6 +1033,163 @@ impl Sessions {
             self.global_group_data_ctr = if candidate == 0 { 1 } else { candidate };
         }
         Ok(self.global_group_data_ctr)
+    }
+
+    /// Return the current Global Group Encrypted Data Message Counter and
+    /// advance it — one counter across ALL outgoing group data messages, so
+    /// the per-source counter tracking on the receiving side stays monotonic
+    /// regardless of which group a message targets.
+    ///
+    /// Counter-initialization requires randomness, so it is done by
+    /// [`Sessions::get_or_create_for_group_tx`] (which has a crypto instance
+    /// at hand) — erroring out here on an uninitialized counter rather than
+    /// carrying a crypto parameter into the send path.
+    pub(crate) fn next_global_group_data_ctr(&mut self) -> Result<u32, Error> {
+        if self.global_group_data_ctr == 0 {
+            return Err(ErrorCode::InvalidState.into());
+        }
+
+        let ctr = self.global_group_data_ctr;
+
+        // Advance within the counter range, skipping 0 (the "uninitialized"
+        // marker here, and a value peers ignore in `MsgCounterSyncRsp`).
+        let next = ctr.wrapping_add(1) & MATTER_MSG_CTR_RANGE;
+        self.global_group_data_ctr = if next == 0 { 1 } else { next };
+
+        Ok(ctr)
+    }
+
+    /// Get or create a TX group session for sending group data messages to
+    /// `(fab_idx, group_id)`.
+    ///
+    /// The mirror image of [`Sessions::get_or_create_for_group_rx`]: keyed
+    /// with the group's *active* operational key (the epoch key with the
+    /// highest start time — RX tries all of them instead), carrying the
+    /// derived Group Session ID in both session-id slots, and addressed at
+    /// the group's multicast address per its multicast-address policy.
+    ///
+    /// Also seeds the Global Group Encrypted Data Message Counter, which
+    /// [`Session::pre_send`] stamps into every outgoing group data message
+    /// (via [`Sessions::next_global_group_data_ctr`]).
+    pub(crate) fn get_or_create_for_group_tx<C: Crypto>(
+        &mut self,
+        crypto: C,
+        fabrics: &Fabrics,
+        fab_idx: NonZeroU8,
+        group_id: u16,
+        dev_det: &BasicInfoConfig<'_>,
+    ) -> Result<&mut Session, Error> {
+        use crate::dm::clusters::decl::groupcast::MulticastAddrPolicyEnum;
+        use crate::transport::network::{SocketAddr, SocketAddrV6};
+
+        let fabric = fabrics.fabric(fab_idx)?;
+
+        // The group's security material: the first key set mapped to the
+        // group, with its active epoch key.
+        let map_entry = fabric
+            .groups()
+            .key_map_iter()
+            .find(|entry| entry.group_id == group_id)
+            .ok_or(ErrorCode::NotFound)?;
+        let key_set = fabric
+            .groups()
+            .key_set_get(map_entry.group_key_set_id)
+            .ok_or(ErrorCode::NotFound)?;
+        let epoch_key_entry = key_set
+            .epoch_keys
+            .iter()
+            .max_by_key(|entry| entry.epoch_start_time)
+            .ok_or(ErrorCode::NotFound)?;
+
+        let mut derived = KeySet::new();
+        derived.update(
+            &crypto,
+            epoch_key_entry.epoch_key.reference(),
+            &fabric.compressed_fabric_id(),
+        )?;
+        let op_key = derived.op_key();
+        let session_id = derive_group_session_id(&crypto, op_key)?;
+
+        // Destination: the group's multicast address, per its policy. A
+        // group the sender is no member of (a sender-only role) has no
+        // group-table entry and uses the `PerGroup` default.
+        let ip = match fabric
+            .groups()
+            .get(group_id)
+            .map(|entry| entry.effective_mcast_policy())
+            .unwrap_or(MulticastAddrPolicyEnum::PerGroup)
+        {
+            MulticastAddrPolicyEnum::IanaAddr => crate::utils::ipv6::IANA_GROUPCAST_MULTICAST_ADDR,
+            MulticastAddrPolicyEnum::PerGroup => {
+                crate::utils::ipv6::compute_group_multicast_addr(fabric.fabric_id(), group_id)
+            }
+        };
+        let peer = Address::Udp(SocketAddr::V6(SocketAddrV6::new(
+            ip,
+            crate::MATTER_PORT,
+            0,
+            0,
+        )));
+        let fabric_node_id = fabric.node_id();
+
+        // Seed the global data counter while we hold a crypto instance.
+        self.get_or_init_global_group_data_ctr(&crypto)?;
+
+        // Reuse a previously-created TX session for this group: same mode
+        // and the multicast peer address (RX-created group sessions carry
+        // the sender's unicast address instead), still keyed with the
+        // active key — checked via the derived Group Session ID, so a key
+        // rotation transparently rolls onto a fresh session.
+        let existing = self.sessions.iter().position(|sess| {
+            matches!(
+                sess.mode,
+                SessionMode::Group {
+                    fab_idx: f,
+                    group_id: g
+                } if f == fab_idx && g == group_id
+            ) && sess.peer_addr == peer
+                && sess.local_sess_id == session_id
+        });
+
+        if let Some(index) = existing {
+            let session = unwrap!(self.sessions.get_mut(index));
+            session.update_last_used();
+            return Ok(session);
+        }
+
+        let mut rand = crypto.weak_rand()?;
+
+        let session = match self.add(rand.next_u32(), false, peer, None, dev_det) {
+            Ok(session) => session,
+            Err(_) => {
+                // Session table is full; evict the least-recently-used session
+                if let Some(lru_id) = self.get_session_for_eviction().map(|sess| sess.id) {
+                    debug!("Group TX: Evicting session {} to make room", lru_id);
+                    self.remove(lru_id);
+                    self.add(rand.next_u32(), false, peer, None, dev_det)?
+                } else {
+                    return Err(ErrorCode::NoSpaceSessions.into());
+                }
+            }
+        };
+
+        session.set_session_mode(SessionMode::Group { fab_idx, group_id });
+        session.local_sess_id = session_id;
+        session.peer_sess_id = session_id;
+        // Group sessions always emit their Source Node ID.
+        session.set_local_nodeid(fabric_node_id);
+        session.enc_key.load(op_key);
+        session.dec_key.load(op_key);
+
+        debug!(
+            "Group TX: Created group session for fab_idx={}, group_id=0x{:04x}, dst={}",
+            fab_idx, group_id, peer
+        );
+
+        let session = unwrap!(self.sessions.last_mut());
+        session.update_last_used();
+
+        Ok(session)
     }
 
     /// Attempt to decrypt and accept a group-encrypted message.

--- a/rs-matter/tests/binding.rs
+++ b/rs-matter/tests/binding.rs
@@ -67,7 +67,12 @@ use rs_matter::dm::clusters::binding::{self, BindingHandler, Bindings};
 use rs_matter::dm::clusters::decl::access_control::{
     AccessControlEntryAuthModeEnum, AccessControlEntryPrivilegeEnum,
 };
+use rs_matter::dm::clusters::decl::group_key_management::{
+    GroupKeyManagementAttrWrites as _, GroupKeyManagementClient as _, GroupKeySecurityPolicyEnum,
+};
+use rs_matter::dm::clusters::decl::groups::GroupsClient as _;
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _};
+use rs_matter::dm::clusters::groups::{self, ClusterHandler as _, GroupsHandler};
 use rs_matter::dm::clusters::net_comm::DummyNetworks;
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ON_OFF_LIGHT_SWITCH};
@@ -76,7 +81,7 @@ use rs_matter::dm::{endpoints, Async, DataModel, Dataver, Endpoint, EpClMatcher,
 use rs_matter::error::Error;
 use rs_matter::im::client::ImClient;
 use rs_matter::im::subscriptions::DEFAULT_MAX_SUBSCRIPTIONS;
-use rs_matter::im::{InteractionModel, InteractionModelState};
+use rs_matter::im::{CmdDataTag, CmdPath, InteractionModel, InteractionModelState};
 use rs_matter::onboard::cac::{IcacGenerator, RcacGenerator};
 use rs_matter::onboard::noc::NocGenerator;
 use rs_matter::onboard::{CommissionOptions, Commissioner};
@@ -84,11 +89,12 @@ use rs_matter::persist::DummyKvBlobStore;
 use rs_matter::respond::DefaultResponder;
 use rs_matter::sc::case::CaseInitiator;
 use rs_matter::sc::pase::MAX_COMM_WINDOW_TIMEOUT_SECS;
+use rs_matter::tlv::{Nullable, OctetStr, TLVTag, TLVWrite};
 use rs_matter::transport::exchange::{Exchange, MatterBuffers};
 use rs_matter::transport::network::{Address, NoNetwork, SocketAddr, SocketAddrV6};
 use rs_matter::utils::init::InitMaybeUninit;
 use rs_matter::utils::select::Coalesce;
-use rs_matter::{clusters, devices, root_endpoint, Matter};
+use rs_matter::{clusters, devices, root_endpoint, Matter, MATTER_PORT};
 
 // IM-client extension traits: `.on_off()` on `Exchange`, and the
 // `.access_control_write()` / `.binding_write()` views on the write-request
@@ -107,10 +113,21 @@ mod common;
 /// Passcode used by `TEST_DEV_COMM`
 const TEST_PASSCODE: u32 = 20202021;
 
-/// Ports for the two devices. Off `MATTER_PORT` (5540), which the
-/// concurrently-running `commissioning` test binary occupies.
+/// The switch's port — off `MATTER_PORT` so it never clashes with B.
 const PORT_A: u16 = 5580;
-const PORT_B: u16 = 5581;
+/// The light's port MUST be `MATTER_PORT` (5540): group data messages are
+/// multicast to the fixed Matter port. Safe against the `commissioning`
+/// test binary (which also binds 5540): cargo runs test binaries
+/// sequentially.
+const PORT_B: u16 = MATTER_PORT;
+
+/// The group the light joins and the switch multicasts to, with its
+/// security material.
+const GROUP_ID: u16 = 0x002A;
+const GROUP_KEY_SET_ID: u16 = 0x01A3;
+const GROUP_EPOCH_KEY: [u8; 16] = [
+    0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf,
+];
 
 /// Operational node ids the controller assigns during commissioning.
 const NODE_ID_A: u64 = 0x11;
@@ -191,7 +208,11 @@ const LIGHT_NODE: Node<'static> = Node {
         Endpoint::new(
             LIGHT_ENDPOINT,
             devices!(DEV_TYPE_ON_OFF_LIGHT),
-            clusters!(desc::DescHandler::CLUSTER, TestOnOffDeviceLogic::CLUSTER),
+            clusters!(
+                desc::DescHandler::CLUSTER,
+                groups::GroupsHandler::CLUSTER,
+                TestOnOffDeviceLogic::CLUSTER,
+            ),
         ),
     ],
 };
@@ -208,6 +229,13 @@ fn light_data_model<'a, OH: OnOffHooks>(
             .chain(
                 EpClMatcher::new(Some(LIGHT_ENDPOINT), Some(desc::DescHandler::CLUSTER.id)),
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
+            )
+            .chain(
+                EpClMatcher::new(
+                    Some(LIGHT_ENDPOINT),
+                    Some(groups::GroupsHandler::CLUSTER.id),
+                ),
+                Async(GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
                 EpClMatcher::new(Some(LIGHT_ENDPOINT), Some(TestOnOffDeviceLogic::CLUSTER.id)),
@@ -313,7 +341,9 @@ async fn run_test() -> Result<(), Error> {
 
     let b_fut = async {
         select3(
-            b_matter.run(&b_crypto, &b_net, &b_net, NoNetwork),
+            // B's own socket doubles as the multicast impl, so the transport
+            // joins the group multicast address once B is added to the group.
+            b_matter.run(&b_crypto, &b_net, &b_net, &b_net),
             b_responder.run::<4, 4>(),
             b_dm.run(),
         )
@@ -404,7 +434,165 @@ async fn run_flow<C: Crypto, AC: Crypto>(
     let toggled = read_light_on_off(ctrl_matter, ctrl_crypto, ctrl_fab_idx).await?;
     assert!(toggled, "expected the light ON after the switch press");
 
-    info!("=== Binding test completed successfully! ===");
+    info!("=== Phase 6: Provision the group on both devices ===");
+    // Key material on both ends: A encrypts with it, B decrypts with it.
+    provision_group_keys(ctrl_matter, ctrl_crypto, ctrl_fab_idx, NODE_ID_A).await?;
+    provision_group_keys(ctrl_matter, ctrl_crypto, ctrl_fab_idx, NODE_ID_B).await?;
+    // B's light endpoint joins the group (and its transport joins the
+    // group's multicast address).
+    add_light_to_group(ctrl_matter, ctrl_crypto, ctrl_fab_idx).await?;
+
+    info!("=== Phase 7: Re-bind A's switch to the group ===");
+    write_switch_group_binding(ctrl_matter, ctrl_crypto, ctrl_fab_idx).await?;
+
+    // Give B's transport a moment to complete the multicast join.
+    Timer::after(Duration::from_millis(500)).await;
+
+    info!("=== Phase 8: Simulate a switch press — now a groupcast Toggle ===");
+    press_switch(a_matter, a_crypto, bindings, addr_b).await?;
+
+    info!("=== Phase 9: Verify the light toggled via the group message ===");
+    // The groupcast Toggle flips the (currently ON) light OFF. Poll: the
+    // multicast delivery is asynchronous to the (fire-and-forget) send.
+    let deadline = embassy_time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if !read_light_on_off(ctrl_matter, ctrl_crypto, ctrl_fab_idx).await? {
+            break;
+        }
+
+        if embassy_time::Instant::now() > deadline {
+            panic!("light did not toggle OFF on the groupcast Toggle");
+        }
+
+        Timer::after(Duration::from_millis(250)).await;
+    }
+
+    info!("=== Binding test (unicast + groupcast) completed successfully! ===");
+    Ok(())
+}
+
+/// Provision the group's security material on `node_id` via the
+/// GroupKeyManagement cluster: `KeySetWrite` with the shared epoch key,
+/// then a `GroupKeyMap` entry binding [`GROUP_ID`] to the key set.
+async fn provision_group_keys<C: Crypto>(
+    matter: &Matter<'_>,
+    crypto: &C,
+    fab_idx: NonZeroU8,
+    node_id: u64,
+) -> Result<(), Error> {
+    let exchange = Exchange::initiate(matter, crypto, fab_idx, node_id).await?;
+
+    exchange
+        .group_key_management()
+        .key_set_write(0, |b| {
+            b.group_key_set()?
+                .group_key_set_id(GROUP_KEY_SET_ID)?
+                .group_key_security_policy(GroupKeySecurityPolicyEnum::TrustFirst)?
+                .epoch_key_0(Nullable::some(OctetStr::new(&GROUP_EPOCH_KEY)))?
+                .epoch_start_time_0(Nullable::some(1))?
+                .epoch_key_1(Nullable::none())?
+                .epoch_start_time_1(Nullable::none())?
+                .epoch_key_2(Nullable::none())?
+                .epoch_start_time_2(Nullable::none())?
+                .group_key_multicast_policy(
+                    rs_matter::dm::clusters::decl::group_key_management::GroupKeyMulticastPolicyEnum::PerGroupID,
+                )?
+                .end()?
+                .end()
+        })
+        .await?;
+
+    let exchange = Exchange::initiate(matter, crypto, fab_idx, node_id).await?;
+
+    let handle = exchange
+        .write_with(None, |builder| {
+            let entries = builder.write_requests()?;
+            let map = entries.group_key_management_write().group_key_map(0)?;
+
+            let map = map
+                .push()?
+                .group_id(GROUP_ID)?
+                .group_key_set_id(GROUP_KEY_SET_ID)?
+                .fabric_index(None)?
+                .end()?;
+
+            map.end()?.end()?.end()?.end()
+        })
+        .await?;
+
+    let resp = handle.response()?;
+    for status in resp.write_responses.iter() {
+        let status = status?;
+        assert_eq!(
+            status.status.status,
+            rs_matter::im::IMStatusCode::Success,
+            "GroupKeyMap write failed"
+        );
+    }
+
+    Ok(())
+}
+
+/// Add B's light endpoint to [`GROUP_ID`] via the Groups cluster.
+async fn add_light_to_group<C: Crypto>(
+    matter: &Matter<'_>,
+    crypto: &C,
+    fab_idx: NonZeroU8,
+) -> Result<(), Error> {
+    let exchange = Exchange::initiate(matter, crypto, fab_idx, NODE_ID_B).await?;
+
+    let handle = exchange
+        .groups()
+        .add_group(LIGHT_ENDPOINT, |b| {
+            b.group_id(GROUP_ID)?.group_name("")?.end()
+        })
+        .await?;
+
+    {
+        let resp = handle.response()?;
+        assert_eq!(resp.status()?, 0, "AddGroup on the light failed");
+    }
+
+    handle.complete().await
+}
+
+/// Replace A's binding list with a single *group* target — the switch now
+/// multicasts to the group instead of CASE-ing to a node.
+async fn write_switch_group_binding<C: Crypto>(
+    matter: &Matter<'_>,
+    crypto: &C,
+    fab_idx: NonZeroU8,
+) -> Result<(), Error> {
+    let exchange = Exchange::initiate(matter, crypto, fab_idx, NODE_ID_A).await?;
+
+    let handle = exchange
+        .write_with(None, |builder| {
+            let entries = builder.write_requests()?;
+            let bindings = entries.binding_write().binding(SWITCH_ENDPOINT)?;
+
+            let bindings = bindings
+                .push()?
+                .node(None)?
+                .group(Some(GROUP_ID))?
+                .endpoint(None)?
+                .cluster(Some(on_off::FULL_CLUSTER.id))?
+                .fabric_index(None)?
+                .end()?;
+
+            bindings.end()?.end()?.end()?.end()
+        })
+        .await?;
+
+    let resp = handle.response()?;
+    for status in resp.write_responses.iter() {
+        let status = status?;
+        assert_eq!(
+            status.status.status,
+            rs_matter::im::IMStatusCode::Success,
+            "Group binding write on the switch failed"
+        );
+    }
+
     Ok(())
 }
 
@@ -556,6 +744,25 @@ async fn write_light_acl<C: Crypto>(
                 .fabric_index(None)?
                 .end()?;
 
+            // Entry 3: operate for groupcast invokes targeting GROUP_ID —
+            // group messages authenticate via the group key, so their ACL
+            // subject is the Group ID, not the sender's node identity.
+            let acl = acl
+                .push()?
+                .privilege(Some(AccessControlEntryPrivilegeEnum::Operate))?
+                .auth_mode(Some(AccessControlEntryAuthModeEnum::Group))?
+                .subjects()?
+                .some()?
+                .non_null()?
+                .push(&(GROUP_ID as u64))?
+                .end()?
+                .targets()?
+                .some()?
+                .null()?
+                .auxiliary_type(None)?
+                .fabric_index(None)?
+                .end()?;
+
             acl.end()?.end()?.end()?.end()
         })
         .await?;
@@ -636,15 +843,47 @@ async fn press_switch<C: Crypto>(
             continue;
         }
 
-        let (Some(node), Some(endpoint)) = (binding.node, binding.endpoint) else {
-            continue;
-        };
-
         if let Some(cluster) = binding.cluster {
             if cluster != on_off::FULL_CLUSTER.id {
                 continue;
             }
         }
+
+        if let Some(group_id) = binding.group {
+            // Group target: multicast an encrypted, fire-and-forget Toggle
+            // to the whole group, with an endpoint-less command path —
+            // receivers apply it to their group-member endpoints.
+            info!(
+                "Switch: group-toggling fabric {}, group 0x{:04X}",
+                binding.fab_idx, group_id
+            );
+
+            let exchange = Exchange::initiate_group(a_matter, a_crypto, binding.fab_idx, group_id)?;
+
+            exchange
+                .group_invoke_with(|b| {
+                    b.push()?
+                        .path_from(&CmdPath::new(
+                            None,
+                            Some(on_off::FULL_CLUSTER.id),
+                            Some(on_off::CommandId::Toggle as u32),
+                        ))?
+                        .data(|w| {
+                            w.start_struct(&TLVTag::Context(CmdDataTag::Data as u8))?;
+                            w.end_container()
+                        })?
+                        .end()
+                })
+                .await?;
+
+            toggled += 1;
+            continue;
+        }
+
+        // Unicast OnOff targets (node + endpoint present).
+        let (Some(node), Some(endpoint)) = (binding.node, binding.endpoint) else {
+            continue;
+        };
 
         info!(
             "Switch: toggling fabric {}, node 0x{:016X}, endpoint {}",

--- a/tests/src/bin/light_tests.rs
+++ b/tests/src/bin/light_tests.rs
@@ -85,8 +85,10 @@ use rs_matter::utils::select::Coalesce;
 use rs_matter::utils::sync::Notification;
 use rs_matter::{clusters, devices, root_endpoint, with, Matter};
 
-// `OnOffClient` brings the `.on_off()` IM-client method into scope on `Exchange`.
+// `OnOffClient` brings the `.on_off()` IM-client method into scope on
+// `Exchange`; `ImClient` brings `group_invoke_with`.
 use rs_matter::dm::clusters::app::on_off::OnOffClient as _;
+use rs_matter::im::client::ImClient as _;
 
 use static_cell::StaticCell;
 
@@ -308,17 +310,34 @@ async fn run_switch<const N: usize>(
                 continue;
             }
 
-            // Only unicast OnOff targets (node + endpoint present).
-            let (Some(node), Some(endpoint)) = (binding.node, binding.endpoint) else {
-                continue;
-            };
-
             // If a specific cluster is bound, it must be OnOff.
             if let Some(cluster) = binding.cluster {
                 if cluster != on_off_cluster::FULL_CLUSTER.id {
                     continue;
                 }
             }
+
+            // Group target: multicast an encrypted, fire-and-forget Toggle
+            // to the whole group, with an endpoint-less command path —
+            // receivers apply it to their group-member endpoints.
+            if let Some(group_id) = binding.group {
+                info!(
+                    "Switch: group-toggling fabric {}, group 0x{:04X}",
+                    binding.fab_idx, group_id
+                );
+
+                match group_toggle(matter, crypto, binding.fab_idx, group_id).await {
+                    Ok(()) => info!("Switch: group toggle ok"),
+                    Err(e) => error!("Switch: group toggle failed: {:?}", e),
+                }
+
+                continue;
+            }
+
+            // Unicast OnOff targets (node + endpoint present).
+            let (Some(node), Some(endpoint)) = (binding.node, binding.endpoint) else {
+                continue;
+            };
 
             info!(
                 "Switch: toggling fabric {}, node 0x{:016X}, endpoint {}",
@@ -345,6 +364,35 @@ async fn toggle(
     let exchange = Exchange::initiate(matter, crypto, fab_idx, node).await?;
 
     exchange.on_off().toggle(endpoint).await
+}
+
+/// Multicast an encrypted, fire-and-forget `OnOff::Toggle` to `group_id`.
+async fn group_toggle(
+    matter: &Matter<'_>,
+    crypto: &impl Crypto,
+    fab_idx: NonZeroU8,
+    group_id: u16,
+) -> Result<(), Error> {
+    use rs_matter::im::{CmdDataTag, CmdPath};
+    use rs_matter::tlv::{TLVTag, TLVWrite};
+
+    let exchange = Exchange::initiate_group(matter, crypto, fab_idx, group_id)?;
+
+    exchange
+        .group_invoke_with(|b| {
+            b.push()?
+                .path_from(&CmdPath::new(
+                    None,
+                    Some(on_off_cluster::FULL_CLUSTER.id),
+                    Some(on_off_cluster::CommandId::Toggle as u32),
+                ))?
+                .data(|w| {
+                    w.start_struct(&TLVTag::Context(CmdDataTag::Data as u8))?;
+                    w.end_container()
+                })?
+                .end()
+        })
+        .await
 }
 
 const NODE: Node<'static> = Node {


### PR DESCRIPTION
The existing Groupcast support in `rs-matter` was missing a small detail - the capability to **send** messages to a group.

This PR is filling that gap.