### PR TITLE
Support for ULA/GUA ipv6 in mDNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+* Advertise and use **all** of a node's IPv6 addresses rather than just one (#537)
+* (Breaking) Phase 2 of commissioning always goes through operational discovery now (#537)
+
 ## [0.3.0] - 2026-08-20
 * Groupcast **sending** APIs (`groups` feature): `Exchange::initiate_group` and `ImClient::group_invoke_with`; the `onoff_light_switch` example and the `light_tests` switch endpoint now act on *group* binding targets
 * (Breaking) `Matter::is_commissioned` renamed to `Matter::has_fabrics` (#525)

--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -530,7 +530,7 @@ fn mdns_task_fut<'a, C: Crypto + 'a>(
         &Host {
             hostname: "rs-matter-bloat-check",
             ip: Ipv4Addr::LOCALHOST,
-            ipv6: Ipv6Addr::LOCALHOST,
+            ipv6: &[Ipv6Addr::LOCALHOST],
         },
         Some(Ipv4Addr::LOCALHOST),
         Some(0),

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -18,6 +18,7 @@
 //! An example Matter Bridge that bridges two fictitious non-Matter devices as On-Off (Lamp) Matter devices.
 //! The example operates over Ethernet for simplicity, but the concrete network protocol is orthogonal to
 //! the notion of a Matter bridge anyway.
+#![recursion_limit = "256"]
 
 use core::pin::pin;
 

--- a/examples/src/common/mdns.rs
+++ b/examples/src/common/mdns.rs
@@ -79,7 +79,7 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
     // Uses the cross-platform `if-addrs` crate to enumerate interfaces so the
     // examples work on Linux, macOS and Windows.
     #[inline(never)]
-    fn initialize_network() -> Result<(Ipv4Addr, Ipv6Addr, u32), Error> {
+    fn initialize_network() -> Result<(Ipv4Addr, Vec<Ipv6Addr>, u32), Error> {
         use rs_matter::error::ErrorCode;
 
         let all = if_addrs::get_if_addrs().map_err(|_| ErrorCode::StdIoError)?;
@@ -157,12 +157,35 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
 
         let (iname, ip, ipv6, index) = candidate;
 
-        info!("Will use network interface {iname} with {ip}/{ipv6} for mDNS");
+        // Advertise *every* IPv6 address configured on the chosen interface, not
+        // only the one that got the interface selected. A node has to publish an
+        // AAAA record for each address it accepts Matter messages on; publishing
+        // only the link-local one leaves it unreachable to any peer that learns
+        // of it across a subnet boundary (an mDNS reflector, or the DNS-SD proxy
+        // of a Thread border router), because the relayed record then carries
+        // nothing routable.
+        let mut ipv6_addrs: Vec<Ipv6Addr> = Vec::new();
 
-        Ok((ip.octets().into(), ipv6.octets().into(), index))
+        if !ipv6.is_unspecified() {
+            ipv6_addrs.push(ipv6.octets().into());
+        }
+
+        for ia in all.iter().filter(|ia| ia.name == iname) {
+            if let if_addrs::IfAddr::V6(ref v6) = ia.addr {
+                let addr: Ipv6Addr = v6.ip.octets().into();
+
+                if !v6.ip.is_loopback() && !ipv6_addrs.contains(&addr) {
+                    ipv6_addrs.push(addr);
+                }
+            }
+        }
+
+        info!("Will use network interface {iname} with {ip} / {ipv6_addrs:?} for mDNS");
+
+        Ok((ip.octets().into(), ipv6_addrs, index))
     }
 
-    let (ipv4_addr, ipv6_addr, interface) = initialize_network()?;
+    let (ipv4_addr, ipv6_addrs, interface) = initialize_network()?;
 
     use rs_matter::transport::network::mdns::builtin::{BuiltinMdns, Host};
     use rs_matter::transport::network::mdns::{
@@ -192,7 +215,7 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
             &Host {
                 hostname: "001122334455", //"rs-matter-demo",
                 ip: ipv4_addr,
-                ipv6: ipv6_addr,
+                ipv6: &ipv6_addrs,
             },
             Some(ipv4_addr),
             Some(interface),

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -123,6 +123,19 @@ max-btp-sessions-2 = []
 # Default number of BTP sessions (Matter accessories typically need just 1 BTP session).
 max-btp-sessions-1 = []
 
+# Number of candidate peer addresses kept per mDNS resolve, for CASE failover.
+max-resolve-candidates-8 = []
+max-resolve-candidates-6 = []
+max-resolve-candidates-5 = []
+# Default number of resolve candidates: enough to hold the largest address set a
+# conformant peer can advertise on Wi-Fi / Ethernet - its link-local address plus
+# the three routable ones the Matter Core Specification requires it to support.
+max-resolve-candidates-4 = []
+max-resolve-candidates-3 = []
+max-resolve-candidates-2 = []
+# No failover: only the best-scored address is ever tried.
+max-resolve-candidates-1 = []
+
 # Size (in bytes) of the key-value persistence scratch buffer owned by `Matter`.
 kv-blob-store-65536 = []
 kv-blob-store-32768 = []

--- a/rs-matter/src/error.rs
+++ b/rs-matter/src/error.rs
@@ -161,6 +161,11 @@ impl Error {
         self.code
     }
 
+    /// Whether this error means the peer never answered.
+    pub const fn is_peer_unresponsive(&self) -> bool {
+        matches!(self.code, ErrorCode::TxTimeout | ErrorCode::RxTimeout)
+    }
+
     #[cfg(all(feature = "std", feature = "backtrace"))]
     pub const fn backtrace(&self) -> &std::backtrace::Backtrace {
         &self.backtrace

--- a/rs-matter/src/error.rs
+++ b/rs-matter/src/error.rs
@@ -85,6 +85,10 @@ pub enum ErrorCode {
     Invalid,
     InvalidAAD,
     InvalidData,
+    /// An element was received on a transport that cannot carry it - a command
+    /// with the `L` (Large Message) quality over a transport that is not
+    /// large-message capable. Maps to `IMStatusCode::InvalidTransportType`.
+    InvalidTransportType,
     InvalidKeyLength,
     InvalidOpcode,
     InvalidProto,

--- a/rs-matter/src/im/encoding.rs
+++ b/rs-matter/src/im/encoding.rs
@@ -98,6 +98,7 @@ pub enum IMStatusCode {
     Timeout = 0x94,
     UnsupportedNode = 0x9b,
     Busy = 0x9c,
+    AccessRestricted = 0x9d,
     UnsupportedCluster = 0xc3,
     NoUpstreamSubscription = 0xc5,
     NeedsTimedInteraction = 0xc6,
@@ -107,8 +108,11 @@ pub enum IMStatusCode {
     FailSafeRequired = 0xca,
     InvalidInState = 0xcb,
     NoCommandResponse = 0xcc,
+    TermsAndConditionsChanged = 0xcd,
+    MaintenanceRequired = 0xce,
     DynamicConstraintError = 0xcf,
     AlreadyExists = 0xd0,
+    InvalidTransportType = 0xd1,
 }
 
 impl From<ErrorCode> for IMStatusCode {
@@ -133,6 +137,7 @@ impl From<ErrorCode> for IMStatusCode {
             ErrorCode::DynamicConstraintError => IMStatusCode::DynamicConstraintError,
             ErrorCode::NotFound => IMStatusCode::NotFound,
             ErrorCode::AlreadyExists => IMStatusCode::AlreadyExists,
+            ErrorCode::InvalidTransportType => IMStatusCode::InvalidTransportType,
             ErrorCode::Failure => IMStatusCode::Failure,
             _ => IMStatusCode::Failure,
         }
@@ -170,6 +175,7 @@ impl IMStatusCode {
             Self::UnsupportedEvent => Some(ErrorCode::EventNotFound),
             Self::NeedsTimedInteraction => Some(ErrorCode::NeedsTimedInteraction),
             Self::FailSafeRequired => Some(ErrorCode::FailSafeRequired),
+            Self::InvalidTransportType => Some(ErrorCode::InvalidTransportType),
             _ => Some(ErrorCode::Failure),
         }
     }

--- a/rs-matter/src/onboard.rs
+++ b/rs-matter/src/onboard.rs
@@ -68,10 +68,10 @@ use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::dm::NodeId;
 use crate::error::{Error, ErrorCode};
 use crate::onboard::noc::NocGenerator;
-use crate::sc::case::CaseInitiator;
 use crate::tlv::{FromTLV, OctetStr, TLVElement};
 use crate::transport::exchange::Exchange;
 use crate::transport::network::Address;
+use crate::transport::TransportPreference;
 use crate::Matter;
 
 pub mod cac;
@@ -166,6 +166,8 @@ pub struct Commissioner<'a, C: Crypto> {
     fab_idx: NonZeroU8,
     noc_generator: &'a mut NocGenerator<'a>,
     buf: &'a mut [u8],
+    case_attempts: u8,
+    transport: TransportPreference,
 }
 
 impl<'a, C: Crypto> Commissioner<'a, C> {
@@ -194,7 +196,44 @@ impl<'a, C: Crypto> Commissioner<'a, C> {
             fab_idx,
             noc_generator,
             buf,
+            case_attempts: Self::DEFAULT_CASE_ATTEMPTS,
+            transport: TransportPreference::Mrp,
         }
+    }
+
+    /// How many times [`Self::complete_via_case`] drives the whole
+    /// phase-2 sequence before giving up. See [`Self::with_case_attempts`].
+    pub const DEFAULT_CASE_ATTEMPTS: u8 = 3;
+
+    /// Override how many times phase 2 is attempted (default
+    /// [`Self::DEFAULT_CASE_ATTEMPTS`]).
+    ///
+    /// Phase 2 runs immediately after the device has been told to join its
+    /// operational network, so the first attempt regularly races the device: it
+    /// may not have associated yet, or not yet be announcing over mDNS, and the
+    /// resolve simply finds nothing. Retrying the whole sequence - discovery
+    /// included - is what turns that race into a delay instead of a failure.
+    ///
+    /// This is deliberately scoped to commissioning. The CHIP SDK does the same:
+    /// `FindOrEstablishSession` takes an `attemptCount` that defaults to 1, and
+    /// the commissioner is the only caller that raises it (to 3).
+    ///
+    /// A value of 0 is treated as 1 (a single attempt).
+    pub const fn with_case_attempts(mut self, attempts: u8) -> Self {
+        self.case_attempts = attempts;
+        self
+    }
+
+    /// Override the transport phase 2 establishes its CASE session over
+    /// (default [`TransportPreference::Mrp`], i.e. UDP).
+    ///
+    /// Commissioning is a small-payload exchange, so UDP is the right default and
+    /// what the CHIP SDK's commissioner always uses. The knob exists for devices
+    /// that run no UDP transport at all - rs-matter permits a TCP-only node, and
+    /// such a device cannot be finalised over UDP.
+    pub const fn with_transport(mut self, transport: TransportPreference) -> Self {
+        self.transport = transport;
+        self
     }
 
     /// Index of the controller's fabric in `matter.state.fabrics`. The
@@ -326,67 +365,36 @@ impl<'a, C: Crypto> Commissioner<'a, C> {
     /// Phase 2 — establish CASE against the device's freshly-installed
     /// operational identity and invoke `CommissioningComplete` over it.
     ///
-    /// `peer_addr` is the device's operational endpoint. In production
-    /// it's discovered via `_matter._tcp` mDNS; in tests / examples it
-    /// can be the same address PASE used, since the device announces on
-    /// the same UDP port post-AddNOC.
+    /// The device's operational endpoint is discovered via `_matter._tcp` mDNS
+    /// from `(fabric, device_node_id)`.
     ///
-    /// Steps:
-    ///   1. Open a fresh plaintext exchange to `peer_addr` and run
-    ///      [`CaseInitiator::initiate`] (Sigma1 → Sigma2 → Sigma3 →
-    ///      StatusReport). On success the new CASE session is keyed in
-    ///      `matter.state.sessions` at `(fab_idx, device_node_id,
-    ///      secure=true)`.
-    ///   2. Open a CASE-secured exchange on that session and invoke
-    ///      `GeneralCommissioning::CommissioningComplete`. The device
-    ///      disarms its fail-safe and persists the new fabric.
-    pub async fn complete_via_case(
-        &mut self,
-        peer_addr: Address,
-        phase1: &CommissionResult,
-    ) -> Result<(), Error> {
+    /// The sequence is attempted up to [`Self::with_case_attempts`] times: it
+    /// runs immediately after the device was told to join its network, so losing
+    /// the first race against the device coming online is routine.
+    pub async fn complete_via_case(&mut self, phase1: &CommissionResult) -> Result<(), Error> {
         let fab_idx = self.fab_idx;
 
-        let exchange = Exchange::initiate_plaintext(self.matter, &self.crypto, peer_addr).await?;
-        CaseInitiator::perform(exchange, &self.crypto, fab_idx, phase1.device_node_id).await?;
+        let mut last_err = None;
 
-        // CommissioningComplete on the CASE session.
-        self.commissioning_complete(fab_idx, phase1.device_node_id)
-            .await
-    }
+        for attempt in 0..self.case_attempts.max(1) {
+            match self
+                .commissioning_complete(fab_idx, phase1.device_node_id)
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(err) if Self::phase2_worth_retrying(&err) => {
+                    warn!(
+                        "Commissioning phase 2 attempt {} failed: {}; retrying",
+                        attempt + 1,
+                        err
+                    );
+                    last_err = Some(err);
+                }
+                Err(err) => return Err(err),
+            }
+        }
 
-    /// Phase 2, resolving the device's operational address via mDNS.
-    ///
-    /// Identical to [`Self::complete_via_case`] except that, instead of being
-    /// handed a fixed `peer_addr`, it looks up the device's operational endpoint
-    /// via `_matter._tcp` mDNS from `(fabric, device_node_id)` (using
-    /// [`Exchange::initiate_plaintext_operational`]).
-    ///
-    /// This is the production phase-2 path: after phase 1 the device may only be
-    /// reachable at a *different* address than PASE used - most notably when the
-    /// device was commissioned over BLE and has since joined its operational
-    /// (Wi-Fi / Thread) network, where its operational IP is not known until it
-    /// announces itself. It requires the mDNS backend to be running (so the
-    /// resolve request is answered), and the device to have joined the network
-    /// and started announcing operationally.
-    pub async fn complete_via_case_operational(
-        &mut self,
-        phase1: &CommissionResult,
-    ) -> Result<(), Error> {
-        let fab_idx = self.fab_idx;
-
-        let exchange = Exchange::initiate_plaintext_operational(
-            self.matter,
-            &self.crypto,
-            fab_idx,
-            phase1.device_node_id,
-        )
-        .await?;
-        CaseInitiator::perform(exchange, &self.crypto, fab_idx, phase1.device_node_id).await?;
-
-        // CommissioningComplete on the CASE session.
-        self.commissioning_complete(fab_idx, phase1.device_node_id)
-            .await
+        Err(last_err.unwrap_or_else(|| ErrorCode::Failure.into()))
     }
 
     /// `GeneralCommissioning::ArmFailSafe(expiry, breadcrumb=0)`.
@@ -556,18 +564,29 @@ impl<'a, C: Crypto> Commissioner<'a, C> {
             .ok_or_else(|| ErrorCode::InvalidData.into())
     }
 
-    /// `GeneralCommissioning::CommissioningComplete()` over the CASE
-    /// session keyed by `(fab_idx, peer_node_id, secure=true)`.
-    ///
-    /// **Must be invoked over CASE**, not PASE — the device responder
-    /// rejects it over PASE (`Failsafe::disarm` requires a CASE
-    /// `fab_idx`). [`Self::complete_via_case`] is the only caller.
+    /// Whether a failed phase-2 attempt is worth driving the whole sequence
+    /// again.
+    fn phase2_worth_retrying(err: &Error) -> bool {
+        err.is_peer_unresponsive()
+            || matches!(
+                err.code(),
+                ErrorCode::NotFound | ErrorCode::NoSession | ErrorCode::Busy
+            )
+    }
+
     pub(crate) async fn commissioning_complete(
         &self,
         fab_idx: NonZeroU8,
         peer_node_id: NodeId,
     ) -> Result<(), Error> {
-        let exchange = Exchange::initiate(self.matter, &self.crypto, fab_idx, peer_node_id).await?;
+        let exchange = Exchange::initiate_with_transport(
+            self.matter,
+            &self.crypto,
+            fab_idx,
+            peer_node_id,
+            self.transport,
+        )
+        .await?;
 
         let handle = exchange
             .general_commissioning()

--- a/rs-matter/src/sc/checkin.rs
+++ b/rs-matter/src/sc/checkin.rs
@@ -179,8 +179,14 @@ impl<'k> CheckIn<'k> {
     }
 
     /// Build a Check-In message and send it to the node `(fab_idx, node_id)`,
-    /// resolving its operational address over mDNS and sending sessionlessly
+    /// resolving its operational addresses over mDNS and sending sessionlessly
     /// (Secure Channel opcode `CheckIn`, no MRP).
+    ///
+    /// The message is sent to **every** resolved candidate address, not just the
+    /// best-scored one. A Check-In is deliberately not MRP-reliable, so there is
+    /// no acknowledgement to wait for and no retransmission to exhaust.
+    ///
+    /// Succeeds if the message went out to at least one candidate.
     ///
     /// The low-level per-message primitive: it takes the exact `counter` and
     /// `app_data` to use, and depends on nothing but this codec's key. The
@@ -202,10 +208,34 @@ impl<'k> CheckIn<'k> {
         let payload = self.generate(&crypto, counter, app_data, buf)?;
         let len = payload.len();
 
-        let mut exchange =
-            Exchange::initiate_plaintext_operational(matter, &crypto, fab_idx, node_id).await?;
+        let addrs = Exchange::resolve_operational_addrs(matter, fab_idx, node_id).await?;
 
-        exchange.send(OpCode::CheckIn, &buf[..len]).await
+        let mut sent = false;
+        let mut last_err = None;
+
+        for addr in addrs {
+            let result = match Exchange::initiate_plaintext(matter, &crypto, addr).await {
+                Ok(mut exchange) => exchange.send(OpCode::CheckIn, &buf[..len]).await,
+                Err(err) => Err(err),
+            };
+
+            match result {
+                Ok(()) => sent = true,
+                Err(err) => {
+                    // A candidate the local stack cannot even send to (no route
+                    // to a link-local address heard on another interface, say) is
+                    // not fatal while another candidate may still work.
+                    warn!("Check-In to {} failed: {}", addr, err);
+                    last_err = Some(err);
+                }
+            }
+        }
+
+        if sent {
+            Ok(())
+        } else {
+            Err(last_err.unwrap_or_else(|| ErrorCode::NotFound.into()))
+        }
     }
 }
 

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -48,7 +48,7 @@ use crate::tlv::TLVElement;
 use crate::transport::network::mdns::{
     commissionable_instance_id, merge_resolve_candidate, score_ip_address,
     score_ip_address_on_link, BrowseExclude, CommissionableFilter, MdnsBrowseState,
-    MdnsRemoteService, MdnsResolveState, ResolvedAddr, ResolvedNode,
+    MdnsRemoteService, MdnsResolveState, ResolvedAddr, ResolvedNode, MAX_RESOLVE_CANDIDATES,
 };
 use crate::transport::network::{MatterRemoteService, NetworkMulticast};
 use crate::utils::cell::RefCell;
@@ -334,20 +334,20 @@ impl Transport {
             MdnsResolveState::Resolved {
                 addrs,
                 port,
+                tcp_capable,
                 sii,
                 sai,
                 sat,
             } => {
                 let mut node = ResolvedNode {
                     addrs: Vec::new(),
+                    tcp_capable: *tcp_capable,
                     sii: *sii,
                     sai: *sai,
                     sat: *sat,
                 };
 
                 for candidate in addrs.iter() {
-                    // Bounded by the same `MAX_RESOLVE_CANDIDATES`, so this
-                    // cannot overflow.
                     let _ = node.addrs.push(Self::scoped_socket_addr(
                         candidate.ip,
                         *port,
@@ -416,11 +416,6 @@ impl Transport {
     /// [`MdnsRemoteService`] (the builtin lazily over the packet, the others over
     /// their native records).
     ///
-    /// **All** of the answer's addresses are kept, ranked, and bounded to
-    /// [`MAX_RESOLVE_CANDIDATES`], rather than only the best-scored one: the
-    /// top-ranked address is not necessarily the reachable one, so the CASE
-    /// initiator needs alternatives to fall back to.
-    ///
     /// `local_ipv6` are the IPv6 addresses of the interface the responder is
     /// running on; they let an on-link peer address outrank an off-link one of
     /// the same kind (see [`score_ip_address_on_link`]). Pass `&[]` when they are
@@ -441,6 +436,7 @@ impl Transport {
         let scope_id = answer.scope_id;
 
         let (sii, sai, sat) = answer.session_params();
+        let tcp_capable = answer.supports_tcp_server();
 
         let candidates = || {
             answer.addrs.clone().map(move |ip| ResolvedAddr {
@@ -469,6 +465,7 @@ impl Transport {
                 *state = MdnsResolveState::Resolved {
                     addrs,
                     port,
+                    tcp_capable,
                     sii,
                     sai,
                     sat,
@@ -488,12 +485,18 @@ impl Transport {
             // otherwise clobber the good values from the earlier deposit.
             MdnsResolveState::Resolved {
                 addrs,
+                tcp_capable: cur_tcp,
                 sii: cur_sii,
                 sai: cur_sai,
                 sat: cur_sat,
                 ..
             } => {
                 let mut changed = false;
+
+                // A later deposit may be the one carrying the TXT (some backends
+                // surface addresses and TXT on separate callbacks), so an
+                // advertised capability is latched, never cleared.
+                *cur_tcp |= tcp_capable;
 
                 for candidate in candidates() {
                     changed |= merge_resolve_candidate(addrs, candidate);
@@ -761,6 +764,7 @@ impl Transport {
         crypto: C,
         fabric_idx: NonZeroU8,
         peer_node_id: NodeId,
+        transport: TransportPreference,
     ) -> Result<Exchange<'a>, Error> {
         // Reuse an existing CASE session if present.
         let existing = matter.with_state(|state| {
@@ -776,7 +780,7 @@ impl Transport {
             return self.initiate_for_session(matter, crypto, session_id);
         }
 
-        self.initiate_new_case(matter, crypto, fabric_idx, peer_node_id)
+        self.initiate_new_case(matter, crypto, fabric_idx, peer_node_id, transport)
             .await
     }
 
@@ -795,6 +799,7 @@ impl Transport {
         crypto: C,
         fabric_idx: NonZeroU8,
         peer_node_id: NodeId,
+        transport: TransportPreference,
     ) -> Result<Exchange<'a>, Error> {
         // No CASE session: resolve the operational address and establish one.
         let compressed_fabric_id = matter.with_state(|state| {
@@ -812,16 +817,26 @@ impl Transport {
         // resolved address. On success a secure session keyed at
         // `(fabric_idx, peer_node_id)` is recorded in the stack.
         //
-        // The candidates are walked in score order rather than only the best one
-        // being tried, because the best-scored address is not necessarily the
-        // reachable one: an answer relayed across a subnet boundary - by an mDNS
-        // reflector, or by the DNS-SD proxy of a Thread border router - carries a
-        // link-local address that ranks top and cannot be reached. Without the
-        // fallback the peer would be discoverable but unreachable.
+        // The candidates are walked in score order, because the best-scored address is not
+        // necessarily the reachable one.
+        // The peer's advertised TCP support is a veto, not a trigger: a caller
+        // that asked for a large payload gets an error rather than a UDP session
+        // that silently cannot carry it.
+        if matches!(transport, TransportPreference::LargePayload) && !resolved.tcp_capable {
+            error!(
+                "Large-payload session requested for node {:?} but it does not advertise TCP server support",
+                peer_node_id
+            );
+            return Err(ErrorCode::NoNetworkInterface.into());
+        }
+
         let mut last_err = Some(Error::from(ErrorCode::NotFound));
 
         for addr in resolved.addrs.iter().copied() {
-            let peer = Address::Udp(addr);
+            let peer = match transport {
+                TransportPreference::Mrp => Address::Udp(addr),
+                TransportPreference::LargePayload => Address::Tcp(addr),
+            };
 
             match self.initiate_plaintext(matter, &crypto, peer).await {
                 Ok(exchange) => {
@@ -831,9 +846,17 @@ impl Transport {
                             last_err = None;
                             break;
                         }
-                        Err(err) => {
-                            warn!("CASE to {} failed: {}", peer, err);
+                        Err(err) if err.is_peer_unresponsive() => {
+                            warn!("CASE to {} failed: {}; trying the next address", peer, err);
                             last_err = Some(err);
+                        }
+                        Err(err) => {
+                            // The peer answered and rejected us, so it is
+                            // reachable at this address and every remaining
+                            // candidate leads to the same node. Fail now rather
+                            // than replaying the rejection against each one.
+                            warn!("CASE to {} failed: {}", peer, err);
+                            return Err(err);
                         }
                     }
                 }
@@ -885,26 +908,19 @@ impl Transport {
         _crypto: C,
         _fabric_idx: NonZeroU8,
         _peer_node_id: NodeId,
+        _transport: TransportPreference,
     ) -> Result<Exchange<'a>, Error> {
         Err(ErrorCode::NoSession.into())
     }
 
-    /// Open an exchange over a fresh **unsecured** session to an already-
-    /// commissioned node, resolving its operational address over mDNS.
-    ///
-    /// Unlike [`initiate`](Self::initiate) this establishes no secure session; it
-    /// is for sessionless protocols that carry their own security (e.g. the
-    /// Check-In message), and it never reuses or creates a CASE session.
-    ///
-    /// Requires a running mDNS responder to service the resolve; without one the
-    /// resolve times out and this returns [`ErrorCode::NotFound`].
-    pub(crate) async fn initiate_plaintext_operational<'a, C: Crypto>(
+    /// Resolve an already-commissioned node's operational addresses over mDNS,
+    /// returning **every** ranked candidate rather than just the best-scored one.
+    pub(crate) async fn resolve_operational_addrs(
         &self,
-        matter: &'a Matter<'a>,
-        crypto: C,
+        matter: &Matter<'_>,
         fabric_idx: NonZeroU8,
         peer_node_id: NodeId,
-    ) -> Result<Exchange<'a>, Error> {
+    ) -> Result<Vec<Address, MAX_RESOLVE_CANDIDATES>, Error> {
         let compressed_fabric_id = matter.with_state(|state| {
             Ok::<_, Error>(state.fabrics.fabric(fabric_idx)?.compressed_fabric_id())
         })?;
@@ -916,14 +932,15 @@ impl Transport {
 
         let resolved = self.resolve(service, Self::RESOLVE_TIMEOUT_MS).await?;
 
-        // Only the best-scored candidate is used here: unlike CASE, opening a
-        // plaintext session performs no round trip, so there is no failure to
-        // fall back on. A sessionless message sent over it that never reaches an
-        // unreachable candidate simply exhausts its MRP retransmissions.
-        let addr = resolved.addr().ok_or(ErrorCode::NotFound)?;
+        let mut addrs = Vec::new();
 
-        self.initiate_plaintext(matter, crypto, Address::Udp(addr))
-            .await
+        for addr in resolved.addrs.iter() {
+            // Both are bounded by `MAX_RESOLVE_CANDIDATES`, so this cannot
+            // overflow.
+            let _ = addrs.push(Address::Udp(*addr));
+        }
+
+        Ok(addrs)
     }
 
     /// Open an exchange over a PASE session to a not-yet-commissioned node at the
@@ -1129,6 +1146,24 @@ impl Transport {
             _ => SocketAddr::new(ip, port),
         }
     }
+}
+
+/// Which transport a freshly established operational session should run over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TransportPreference {
+    /// UDP carrying MRP - the default operational transport, and the only one
+    /// every Matter node is required to support.
+    #[default]
+    Mrp,
+    /// TCP, for payloads too large to fit MRP.
+    ///
+    /// Requires the peer to have advertised TCP server support
+    /// ([`ResolvedNode::tcp_capable`]). If it has not, establishment fails with
+    /// [`ErrorCode::NoNetworkInterface`] rather than quietly falling back to UDP -
+    /// a silent downgrade would hand the caller a session that cannot carry what
+    /// it asked to send.
+    LargePayload,
 }
 
 /// Resets the mDNS resolve rendezvous to `Idle` on drop, unless disarmed.

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -46,8 +46,9 @@ use crate::sc::SessionParameters;
 use crate::sc::{sc_write, OpCode, SCStatusCodes, StatusReport, PROTO_ID_SECURE_CHANNEL};
 use crate::tlv::TLVElement;
 use crate::transport::network::mdns::{
-    commissionable_instance_id, score_ip_address, BrowseExclude, CommissionableFilter,
-    MdnsBrowseState, MdnsRemoteService, MdnsResolveState, ResolvedNode,
+    commissionable_instance_id, merge_resolve_candidate, score_ip_address,
+    score_ip_address_on_link, BrowseExclude, CommissionableFilter, MdnsBrowseState,
+    MdnsRemoteService, MdnsResolveState, ResolvedAddr, ResolvedNode,
 };
 use crate::transport::network::{MatterRemoteService, NetworkMulticast};
 use crate::utils::cell::RefCell;
@@ -331,19 +332,29 @@ impl Transport {
         // 3. Wait for the responder to deposit our answer, or time out.
         let mut wait = pin!(self.mdns_resolve.wait(|state| match state {
             MdnsResolveState::Resolved {
-                ip,
+                addrs,
                 port,
-                scope_id,
                 sii,
                 sai,
                 sat,
             } => {
-                let node = ResolvedNode {
-                    addr: Self::scoped_socket_addr(*ip, *port, *scope_id),
+                let mut node = ResolvedNode {
+                    addrs: Vec::new(),
                     sii: *sii,
                     sai: *sai,
                     sat: *sat,
                 };
+
+                for candidate in addrs.iter() {
+                    // Bounded by the same `MAX_RESOLVE_CANDIDATES`, so this
+                    // cannot overflow.
+                    let _ = node.addrs.push(Self::scoped_socket_addr(
+                        candidate.ip,
+                        *port,
+                        candidate.scope_id,
+                    ));
+                }
+
                 *state = MdnsResolveState::Idle;
                 Some(node)
             }
@@ -404,15 +415,26 @@ impl Transport {
     /// OS-backed responders, and any third-party responder - all hand it an
     /// [`MdnsRemoteService`] (the builtin lazily over the packet, the others over
     /// their native records).
-    pub fn try_deposit_mdns_resolve<'a, I, A, T>(&self, answer: &MdnsRemoteService<I, A, T>)
-    where
+    ///
+    /// **All** of the answer's addresses are kept, ranked, and bounded to
+    /// [`MAX_RESOLVE_CANDIDATES`], rather than only the best-scored one: the
+    /// top-ranked address is not necessarily the reachable one, so the CASE
+    /// initiator needs alternatives to fall back to.
+    ///
+    /// `local_ipv6` are the IPv6 addresses of the interface the responder is
+    /// running on; they let an on-link peer address outrank an off-link one of
+    /// the same kind (see [`score_ip_address_on_link`]). Pass `&[]` when they are
+    /// not known - the OS-backed responders delegate the host records to a daemon
+    /// and never see them.
+    pub fn try_deposit_mdns_resolve<'a, I, A, T>(
+        &self,
+        answer: &MdnsRemoteService<I, A, T>,
+        local_ipv6: &[Ipv6Addr],
+    ) where
         I: ToLabelIter,
         A: Iterator<Item = IpAddr> + Clone,
         T: Iterator<Item = (&'a str, &'a str)> + Clone,
     {
-        let Some(ip) = answer.addrs.clone().max_by_key(score_ip_address) else {
-            return;
-        };
         let Some(port) = answer.port else {
             return;
         };
@@ -420,14 +442,33 @@ impl Transport {
 
         let (sii, sai, sat) = answer.session_params();
 
+        let candidates = || {
+            answer.addrs.clone().map(move |ip| ResolvedAddr {
+                ip,
+                scope_id,
+                score: score_ip_address_on_link(&ip, local_ipv6),
+            })
+        };
+
         self.mdns_resolve.modify(|state| match state {
             MdnsResolveState::InFlight { service }
                 if service.matches_instance(&answer.instance_name) =>
             {
+                let mut addrs = Vec::new();
+
+                for candidate in candidates() {
+                    merge_resolve_candidate(&mut addrs, candidate);
+                }
+
+                if addrs.is_empty() {
+                    // An address-less answer (e.g. a PTR-only record) leaves the
+                    // request in flight for a later, complete one.
+                    return (false, ());
+                }
+
                 *state = MdnsResolveState::Resolved {
-                    ip,
+                    addrs,
                     port,
-                    scope_id,
                     sii,
                     sai,
                     sat,
@@ -435,9 +476,10 @@ impl Transport {
                 (true, ())
             }
             // Already resolved (same in-flight target — the rendezvous is
-            // single-slot) but not yet consumed: keep the better-scoring address
-            // so a later IPv6 deposit can upgrade an earlier IPv4 one (e.g.
-            // zeroconf surfaces one address per family at a time).
+            // single-slot) but not yet consumed: merge the new addresses into the
+            // ranked list, so a backend that surfaces one address per callback
+            // (zeroconf, Avahi) still ends up with alternatives to fall back to,
+            // and a later IPv6 deposit still outranks an earlier IPv4 one.
             //
             // Preserve any session params already resolved: a per-address deposit
             // may carry no TXT (e.g. zeroconf's `ServiceDiscovery.txt` is
@@ -445,21 +487,23 @@ impl Transport {
             // address), in which case `sii`/`sai`/`sat` are `None` here and would
             // otherwise clobber the good values from the earlier deposit.
             MdnsResolveState::Resolved {
-                ip: cur_ip,
+                addrs,
                 sii: cur_sii,
                 sai: cur_sai,
                 sat: cur_sat,
                 ..
-            } if score_ip_address(&ip) > score_ip_address(cur_ip) => {
-                *state = MdnsResolveState::Resolved {
-                    ip,
-                    port,
-                    scope_id,
-                    sii: sii.or(*cur_sii),
-                    sai: sai.or(*cur_sai),
-                    sat: sat.or(*cur_sat),
-                };
-                (true, ())
+            } => {
+                let mut changed = false;
+
+                for candidate in candidates() {
+                    changed |= merge_resolve_candidate(addrs, candidate);
+                }
+
+                *cur_sii = cur_sii.or(sii);
+                *cur_sai = cur_sai.or(sai);
+                *cur_sat = cur_sat.or(sat);
+
+                (changed, ())
             }
             _ => (false, ()),
         });
@@ -767,11 +811,42 @@ impl Transport {
         // Establish CASE over a fresh, one-shot unsecured exchange to the
         // resolved address. On success a secure session keyed at
         // `(fabric_idx, peer_node_id)` is recorded in the stack.
-        let exchange = self
-            .initiate_plaintext(matter, &crypto, Address::Udp(resolved.addr))
-            .await?;
+        //
+        // The candidates are walked in score order rather than only the best one
+        // being tried, because the best-scored address is not necessarily the
+        // reachable one: an answer relayed across a subnet boundary - by an mDNS
+        // reflector, or by the DNS-SD proxy of a Thread border router - carries a
+        // link-local address that ranks top and cannot be reached. Without the
+        // fallback the peer would be discoverable but unreachable.
+        let mut last_err = Some(Error::from(ErrorCode::NotFound));
 
-        CaseInitiator::perform(exchange, &crypto, fabric_idx, peer_node_id).await?;
+        for addr in resolved.addrs.iter().copied() {
+            let peer = Address::Udp(addr);
+
+            match self.initiate_plaintext(matter, &crypto, peer).await {
+                Ok(exchange) => {
+                    match CaseInitiator::perform(exchange, &crypto, fabric_idx, peer_node_id).await
+                    {
+                        Ok(()) => {
+                            last_err = None;
+                            break;
+                        }
+                        Err(err) => {
+                            warn!("CASE to {} failed: {}", peer, err);
+                            last_err = Some(err);
+                        }
+                    }
+                }
+                Err(err) => {
+                    warn!("Unsecured session to {} failed: {}", peer, err);
+                    last_err = Some(err);
+                }
+            }
+        }
+
+        if let Some(err) = last_err {
+            return Err(err);
+        }
 
         // Seed the new CASE session's peer MRP/session params from the resolve
         // TXT (rs-matter does not yet exchange these in CASE Sigma1/2) and grab
@@ -841,7 +916,13 @@ impl Transport {
 
         let resolved = self.resolve(service, Self::RESOLVE_TIMEOUT_MS).await?;
 
-        self.initiate_plaintext(matter, crypto, Address::Udp(resolved.addr))
+        // Only the best-scored candidate is used here: unlike CASE, opening a
+        // plaintext session performs no round trip, so there is no failure to
+        // fall back on. A sessionless message sent over it that never reaches an
+        // unreachable candidate simply exhausts its MRP retransmissions.
+        let addr = resolved.addr().ok_or(ErrorCode::NotFound)?;
+
+        self.initiate_plaintext(matter, crypto, Address::Udp(addr))
             .await
     }
 
@@ -2643,7 +2724,7 @@ mod tests {
 
 #[cfg(test)]
 mod resolve_tests {
-    use core::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
 
     use futures_lite::future::{block_on, zip};
 
@@ -2685,7 +2766,7 @@ mod resolve_tests {
                     scope_id: 0,
                 };
 
-                matter.transport().try_deposit_mdns_resolve(&answer);
+                matter.transport().try_deposit_mdns_resolve(&answer, &[]);
             };
 
             let (node, ()) = zip(resolver, responder).await;
@@ -2694,13 +2775,129 @@ mod resolve_tests {
         .unwrap();
 
         assert_eq!(
-            resolved.addr,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)), 1234)
+            resolved.addr(),
+            Some(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)),
+                1234
+            ))
         );
         // The peer's MRP/session params are carried out of the resolve TXT.
         assert_eq!(resolved.sii, Some(300));
         assert_eq!(resolved.sai, Some(4000));
         assert_eq!(resolved.sat, Some(5000));
+    }
+
+    /// An answer carrying several addresses yields all of them, ranked best
+    /// first, so the CASE initiator has alternatives to fall back to when the
+    /// top-ranked one turns out to be unreachable.
+    #[test]
+    fn resolve_keeps_all_addresses_ranked() {
+        let matter = test_matter();
+        let service = op_service();
+
+        let link_local = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+        let gua = Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 1);
+        let ipv4 = Ipv4Addr::new(10, 0, 0, 5);
+
+        let resolved = block_on(async {
+            let resolver = matter.transport().resolve(service.clone(), 5_000);
+
+            let responder = async {
+                matter.transport().wait_mdns_resolve_request().await;
+
+                let mut name = heapless::String::<128>::new();
+                service.instance_name(&mut name);
+
+                // Deposited worst-first and in packet order.
+                let answer = MdnsRemoteService {
+                    instance_name: DottedName(name.as_str()),
+                    port: Some(1234),
+                    addrs: [IpAddr::V4(ipv4), IpAddr::V6(gua), IpAddr::V6(link_local)].into_iter(),
+                    txt: core::iter::empty::<(&str, &str)>(),
+                    scope_id: 7,
+                };
+
+                matter.transport().try_deposit_mdns_resolve(&answer, &[]);
+            };
+
+            let (node, ()) = zip(resolver, responder).await;
+            node
+        })
+        .unwrap();
+
+        assert_eq!(
+            resolved.addrs.as_slice(),
+            &[
+                // Only the link-local candidate carries the scope id.
+                SocketAddr::V6(SocketAddrV6::new(link_local, 1234, 0, 7)),
+                SocketAddr::new(IpAddr::V6(gua), 1234),
+                SocketAddr::new(IpAddr::V4(ipv4), 1234),
+            ]
+        );
+    }
+
+    /// A backend that surfaces one address per callback (zeroconf, Avahi) still
+    /// accumulates candidates: successive deposits against the same in-flight
+    /// target merge into the ranked list instead of replacing it, and TXT-less
+    /// deposits do not clobber session params already resolved.
+    #[test]
+    fn resolve_merges_successive_single_address_deposits() {
+        let matter = test_matter();
+        let service = op_service();
+
+        let gua = Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 1);
+        let link_local = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+
+        let resolved = block_on(async {
+            let resolver = matter.transport().resolve(service.clone(), 5_000);
+
+            let responder = async {
+                matter.transport().wait_mdns_resolve_request().await;
+
+                let mut name = heapless::String::<128>::new();
+                service.instance_name(&mut name);
+
+                // First callback: the routable address, carrying the TXT. Both
+                // deposits run back-to-back without an await in between, so they
+                // land before the resolver is polled again.
+                matter.transport().try_deposit_mdns_resolve(
+                    &MdnsRemoteService {
+                        instance_name: DottedName(name.as_str()),
+                        port: Some(1234),
+                        addrs: core::iter::once(IpAddr::V6(gua)),
+                        txt: [("SII", "300")].into_iter(),
+                        scope_id: 0,
+                    },
+                    &[],
+                );
+
+                // Second callback: the link-local address, no TXT.
+                matter.transport().try_deposit_mdns_resolve(
+                    &MdnsRemoteService {
+                        instance_name: DottedName(name.as_str()),
+                        port: Some(1234),
+                        addrs: core::iter::once(IpAddr::V6(link_local)),
+                        txt: core::iter::empty::<(&str, &str)>(),
+                        scope_id: 7,
+                    },
+                    &[],
+                );
+            };
+
+            let (node, ()) = zip(resolver, responder).await;
+            node
+        })
+        .unwrap();
+
+        assert_eq!(
+            resolved.addrs.as_slice(),
+            &[
+                SocketAddr::V6(SocketAddrV6::new(link_local, 1234, 0, 7)),
+                SocketAddr::new(IpAddr::V6(gua), 1234),
+            ]
+        );
+        // The TXT-less second deposit did not clobber the first one's params.
+        assert_eq!(resolved.sii, Some(300));
     }
 
     /// Without a responder, a resolve times out and releases the slot (drop-clean),
@@ -2731,7 +2928,7 @@ mod resolve_tests {
             txt: core::iter::empty::<(&str, &str)>(),
             scope_id: 0,
         };
-        matter.transport().try_deposit_mdns_resolve(&answer);
+        matter.transport().try_deposit_mdns_resolve(&answer, &[]);
 
         let err = block_on(matter.transport().resolve(op_service(), 50)).unwrap_err();
         assert!(matches!(err.code(), ErrorCode::NotFound));

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -2730,7 +2730,7 @@ mod resolve_tests {
 
     use crate::error::ErrorCode;
     use crate::test::test_matter;
-    use crate::transport::network::mdns::{DottedName, MdnsRemoteService};
+    use crate::transport::network::mdns::{DottedName, MdnsRemoteService, MAX_RESOLVE_CANDIDATES};
     use crate::transport::network::MatterRemoteService;
 
     fn op_service() -> MatterRemoteService {
@@ -2825,14 +2825,18 @@ mod resolve_tests {
         })
         .unwrap();
 
+        // Truncated to whatever `MAX_RESOLVE_CANDIDATES` is configured to, so
+        // this holds for every `max-resolve-candidates-*` feature.
+        let expected = [
+            // Only the link-local candidate carries the scope id.
+            SocketAddr::V6(SocketAddrV6::new(link_local, 1234, 0, 7)),
+            SocketAddr::new(IpAddr::V6(gua), 1234),
+            SocketAddr::new(IpAddr::V4(ipv4), 1234),
+        ];
+
         assert_eq!(
             resolved.addrs.as_slice(),
-            &[
-                // Only the link-local candidate carries the scope id.
-                SocketAddr::V6(SocketAddrV6::new(link_local, 1234, 0, 7)),
-                SocketAddr::new(IpAddr::V6(gua), 1234),
-                SocketAddr::new(IpAddr::V4(ipv4), 1234),
-            ]
+            &expected[..expected.len().min(MAX_RESOLVE_CANDIDATES)]
         );
     }
 
@@ -2889,12 +2893,14 @@ mod resolve_tests {
         })
         .unwrap();
 
+        let expected = [
+            SocketAddr::V6(SocketAddrV6::new(link_local, 1234, 0, 7)),
+            SocketAddr::new(IpAddr::V6(gua), 1234),
+        ];
+
         assert_eq!(
             resolved.addrs.as_slice(),
-            &[
-                SocketAddr::V6(SocketAddrV6::new(link_local, 1234, 0, 7)),
-                SocketAddr::new(IpAddr::V6(gua), 1234),
-            ]
+            &expected[..expected.len().min(MAX_RESOLVE_CANDIDATES)]
         );
         // The TXT-less second deposit did not clobber the first one's params.
         assert_eq!(resolved.sii, Some(300));

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -1597,6 +1597,21 @@ impl<'a> Exchange<'a> {
         self.id.accessor(self.matter, metadata.aux_acl_enabled())
     }
 
+    /// Whether this exchange runs over a transport capable of carrying **Large
+    /// Messages**, i.e. payloads that do not fit the MRP MTU.
+    ///
+    /// In practice that means TCP.
+    pub fn supports_large_payload(&self) -> Result<bool, Error> {
+        self.with_state(|state| {
+            let session = self.id().session(&mut state.sessions);
+
+            Ok(
+                !matches!(session.get_session_mode(), SessionMode::Group { .. })
+                    && session.get_peer_addr().is_tcp(),
+            )
+        })
+    }
+
     pub fn is_groupcast(&self) -> Result<bool, Error> {
         self.with_state(|state| {
             Ok(matches!(

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -146,7 +146,7 @@ impl ExchangeId {
             let mut session_removed = pin!(matter.transport().wait_session_removed());
 
             let mut timeout = pin!(Timer::after(Duration::from_millis(
-                RetransEntry::new(matter.dev_det().sai, 0).max_delay_ms() * 3 / 2
+                RetransEntry::new(matter.dev_det().sai, 0).rx_timeout_ms() * 3 / 2
             )));
 
             match select3(&mut recv, &mut session_removed, &mut timeout).await {

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -31,13 +31,14 @@ use crate::error::{Error, ErrorCode};
 use crate::im::{self, PROTO_ID_INTERACTION_MODEL};
 use crate::sc::{self, PROTO_ID_SECURE_CHANNEL};
 use crate::transport::session::Sessions;
-use crate::transport::TxPayloadState;
+use crate::transport::{TransportPreference, TxPayloadState};
 use crate::utils::storage::pooled::{PooledBuffers, DEFAULT_BUFFER_POOL_SIZE};
-use crate::utils::storage::WriteBuf;
+use crate::utils::storage::{Vec, WriteBuf};
 use crate::{Matter, MatterState};
 
 use super::mrp::{ReliableMessage, RetransEntry};
 use super::network;
+use super::network::mdns::MAX_RESOLVE_CANDIDATES;
 use super::packet::PacketHdr;
 use super::plain_hdr::PlainHdr;
 use super::proto_hdr::ProtoHdr;
@@ -1111,9 +1112,34 @@ impl<'a> Exchange<'a> {
         fabric_idx: NonZeroU8,
         peer_node_id: NodeId,
     ) -> Result<Self, Error> {
+        Self::initiate_with_transport(
+            matter,
+            crypto,
+            fabric_idx,
+            peer_node_id,
+            TransportPreference::Mrp,
+        )
+        .await
+    }
+
+    /// [`Self::initiate`], choosing the transport a newly established session
+    /// runs over.
+    ///
+    /// Only matters when no session to the peer exists yet - an existing session
+    /// is reused whatever it runs over. Pass
+    /// [`TransportPreference::LargePayload`] to require TCP; the peer must have
+    /// advertised TCP server support or establishment fails rather than silently
+    /// downgrading. See [`TransportPreference`].
+    pub async fn initiate_with_transport<C: Crypto>(
+        matter: &'a Matter<'a>,
+        crypto: C,
+        fabric_idx: NonZeroU8,
+        peer_node_id: NodeId,
+        transport: TransportPreference,
+    ) -> Result<Self, Error> {
         matter
             .transport
-            .initiate(matter, crypto, fabric_idx, peer_node_id)
+            .initiate(matter, crypto, fabric_idx, peer_node_id, transport)
             .await
     }
 
@@ -1260,27 +1286,17 @@ impl<'a> Exchange<'a> {
             .await
     }
 
-    /// Open an exchange over a fresh plaintext session to an already-
-    /// commissioned node, resolving its operational address over mDNS.
-    ///
-    /// Like [`initiate_plaintext`](Self::initiate_plaintext) but it discovers the
-    /// peer address itself (as [`initiate`](Self::initiate) does for CASE), rather
-    /// than taking a known one. For sessionless protocols that carry their own
-    /// security and must not establish a CASE session — e.g. sending an ICD
-    /// Check-In message to a registered client.
-    ///
-    /// Requires a running mDNS responder to service the resolve; without one the
-    /// resolve times out and this returns [`ErrorCode::NotFound`].
+    /// Resolve an already-commissioned node's operational addresses over mDNS,
+    /// returning **every** ranked candidate (best-scored first).
     #[inline(always)]
-    pub async fn initiate_plaintext_operational<C: Crypto>(
+    pub async fn resolve_operational_addrs(
         matter: &'a Matter<'a>,
-        crypto: C,
         fabric_idx: NonZeroU8,
         peer_node_id: NodeId,
-    ) -> Result<Self, Error> {
+    ) -> Result<Vec<network::Address, MAX_RESOLVE_CANDIDATES>, Error> {
         matter
             .transport
-            .initiate_plaintext_operational(matter, crypto, fabric_idx, peer_node_id)
+            .resolve_operational_addrs(matter, fabric_idx, peer_node_id)
             .await
     }
 

--- a/rs-matter/src/transport/mrp.rs
+++ b/rs-matter/src/transport/mrp.rs
@@ -54,7 +54,7 @@ pub(crate) use mrp_log;
 
 //const MRP_STANDALONE_ACK_TIMEOUT_MS: u64 = 200;   // TODO: Use to pro-actively send ACKs
 const MRP_BASE_RETRY_INTERVAL_MS: u32 = 300;
-const MRP_MAX_TRANSMISSIONS: u16 = 10;
+const MRP_MAX_TRANSMISSIONS: u16 = 5;
 const MRP_BACKOFF_THRESHOLD: u16 = 1;
 const MRP_BACKOFF_BASE: (u64, u64) = (16, 10); // 1.6
 const MRP_BACKOFF_JITTER: (u64, u64) = (25, 100); // 0.25

--- a/rs-matter/src/transport/mrp.rs
+++ b/rs-matter/src/transport/mrp.rs
@@ -55,6 +55,7 @@ pub(crate) use mrp_log;
 //const MRP_STANDALONE_ACK_TIMEOUT_MS: u64 = 200;   // TODO: Use to pro-actively send ACKs
 const MRP_BASE_RETRY_INTERVAL_MS: u32 = 300;
 const MRP_MAX_TRANSMISSIONS: u16 = 5;
+const MRP_RX_TIMEOUT_TRANSMISSIONS: u16 = 10;
 const MRP_BACKOFF_THRESHOLD: u16 = 1;
 const MRP_BACKOFF_BASE: (u64, u64) = (16, 10); // 1.6
 const MRP_BACKOFF_JITTER: (u64, u64) = (25, 100); // 0.25
@@ -133,9 +134,15 @@ impl RetransEntry {
         self.delay_ms_counter(self.counter, jitter_rand)
     }
 
-    /// Maximum delay before giving up on retransmitting the message
-    pub fn max_delay_ms(&self) -> u64 {
-        self.delay_ms_counter(MRP_MAX_TRANSMISSIONS, MRP_JITTER_RAND_MAX)
+    /// How long to wait for the peer's response before giving up with
+    /// [`ErrorCode::RxTimeout`].
+    ///
+    /// Derived from [`MRP_RX_TIMEOUT_TRANSMISSIONS`] rather than
+    /// [`MRP_MAX_TRANSMISSIONS`] - the two answer different questions, and tying
+    /// them together makes our own retransmission budget silently dictate how
+    /// patient we are with a slow peer.
+    pub fn rx_timeout_ms(&self) -> u64 {
+        self.delay_ms_counter(MRP_RX_TIMEOUT_TRANSMISSIONS, MRP_JITTER_RAND_MAX)
     }
 
     /// Return how much to delay before (re)transmitting the message

--- a/rs-matter/src/transport/mrp.rs
+++ b/rs-matter/src/transport/mrp.rs
@@ -141,6 +141,21 @@ impl RetransEntry {
     /// [`MRP_MAX_TRANSMISSIONS`] - the two answer different questions, and tying
     /// them together makes our own retransmission budget silently dictate how
     /// patient we are with a slow peer.
+    ///
+    /// TODO: The second constant has no counterpart in the CHIP SDK, which gets
+    /// the same separation out of a better formula instead. Its
+    /// `Session::ComputeRoundTripTimeout` is a sum of three terms -
+    /// `GetAckTimeout()` (the full retransmit ladder over the *peer's* MRP
+    /// config, i.e. how long until our message reaches it), an explicit
+    /// upper-layer processing allowance, and `GetMessageReceiptTimeout()` (the
+    /// ladder again, over the *local* config, for its answer reaching us). That
+    /// is roughly two ladders plus processing time, so lowering the
+    /// retransmission budget shrinks it proportionally from a base that was
+    /// large enough to begin with, and no second constant is needed. Non-UDP
+    /// transports skip the derivation entirely there (flat 30s for TCP, the BTP
+    /// ack timeout for BLE). Worth adopting that shape - it also stops us using
+    /// our own `sai` for the outbound half, where the peer's advertised value is
+    /// the correct input - at which point this constant goes away.
     pub fn rx_timeout_ms(&self) -> u64 {
         self.delay_ms_counter(MRP_RX_TIMEOUT_TRANSMISSIONS, MRP_JITTER_RAND_MAX)
     }

--- a/rs-matter/src/transport/network/mdns.rs
+++ b/rs-matter/src/transport/network/mdns.rs
@@ -18,6 +18,8 @@
 use core::fmt::Write;
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
 
+use cfg_if::cfg_if;
+
 use domain::base::name::{Label, ToLabelIter};
 
 use crate::dm::clusters::basic_info::BasicInfoConfig;
@@ -724,18 +726,53 @@ impl ResolvedNode {
     }
 }
 
-/// Maximum number of candidate peer addresses kept for a single resolve.
-///
-/// A node advertises an AAAA record for every address it accepts operational
-/// messages on, and the Matter Core Specification requires support for at least
-/// three routable addresses on top of the link-local one, so a single answer can
-/// easily carry several. Keeping a few of them - rather than only the
-/// best-scored one - is what lets the CASE initiator recover when the top
-/// candidate turns out to be unreachable, which is exactly the failure mode of a
-/// link-local address relayed across a subnet boundary. See
-/// [`score_ip_address_on_link`] for why the ranking cannot decide that on its
-/// own.
-pub const MAX_RESOLVE_CANDIDATES: usize = 3;
+cfg_if! {
+    if #[cfg(feature = "max-resolve-candidates-8")] {
+        /// How many candidate peer addresses are kept for a single resolve, i.e. how
+        /// many addresses the CASE initiator can fall back through when the
+        /// best-scored one turns out to be unreachable. Configurable via the
+        /// `max-resolve-candidates-*` features.
+        pub const MAX_RESOLVE_CANDIDATES: usize = 8;
+    } else if #[cfg(feature = "max-resolve-candidates-6")] {
+        /// How many candidate peer addresses are kept for a single resolve, i.e. how
+        /// many addresses the CASE initiator can fall back through when the
+        /// best-scored one turns out to be unreachable. Configurable via the
+        /// `max-resolve-candidates-*` features.
+        pub const MAX_RESOLVE_CANDIDATES: usize = 6;
+    } else if #[cfg(feature = "max-resolve-candidates-5")] {
+        /// How many candidate peer addresses are kept for a single resolve, i.e. how
+        /// many addresses the CASE initiator can fall back through when the
+        /// best-scored one turns out to be unreachable. Configurable via the
+        /// `max-resolve-candidates-*` features.
+        pub const MAX_RESOLVE_CANDIDATES: usize = 5;
+    } else if #[cfg(feature = "max-resolve-candidates-3")] {
+        /// How many candidate peer addresses are kept for a single resolve, i.e. how
+        /// many addresses the CASE initiator can fall back through when the
+        /// best-scored one turns out to be unreachable. Configurable via the
+        /// `max-resolve-candidates-*` features.
+        pub const MAX_RESOLVE_CANDIDATES: usize = 3;
+    } else if #[cfg(feature = "max-resolve-candidates-2")] {
+        /// How many candidate peer addresses are kept for a single resolve, i.e. how
+        /// many addresses the CASE initiator can fall back through when the
+        /// best-scored one turns out to be unreachable. Configurable via the
+        /// `max-resolve-candidates-*` features.
+        pub const MAX_RESOLVE_CANDIDATES: usize = 2;
+    } else if #[cfg(feature = "max-resolve-candidates-1")] {
+        /// How many candidate peer addresses are kept for a single resolve, i.e. how
+        /// many addresses the CASE initiator can fall back through when the
+        /// best-scored one turns out to be unreachable. Configurable via the
+        /// `max-resolve-candidates-*` features.
+        ///
+        /// No failover: only the best-scored address is ever tried.
+        pub const MAX_RESOLVE_CANDIDATES: usize = 1;
+    } else { // Default (`max-resolve-candidates-4`)
+        /// How many candidate peer addresses are kept for a single resolve, i.e. how
+        /// many addresses the CASE initiator can fall back through when the
+        /// best-scored one turns out to be unreachable. Configurable via the
+        /// `max-resolve-candidates-*` features.
+        pub const MAX_RESOLVE_CANDIDATES: usize = 4;
+    }
+}
 
 /// A single ranked candidate address for a resolved peer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1265,53 +1302,54 @@ mod tests {
         );
     }
 
-    /// The candidate list stays sorted by descending score, deduped, and bounded.
+    /// The candidate list stays sorted by descending score, deduped, and bounded
+    /// to [`MAX_RESOLVE_CANDIDATES`], whatever that is configured to.
     #[test]
     fn merge_resolve_candidate_ranks_dedups_and_bounds() {
-        fn candidate(addr: Ipv6Addr) -> ResolvedAddr {
-            let ip = IpAddr::V6(addr);
-
+        /// A candidate with an explicit score and a distinct address.
+        fn candidate(n: u16, score: u8) -> ResolvedAddr {
             ResolvedAddr {
-                ip,
+                ip: IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, n)),
                 scope_id: 0,
-                score: score_ip_address(&ip),
+                score,
             }
         }
 
-        let link_local = candidate(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1));
-        let global = candidate(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
-        let ula = candidate(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1));
-        let ipv4 = ResolvedAddr {
-            ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            scope_id: 0,
-            score: score_ip_address(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
-        };
-
         let mut addrs = Vec::new();
 
-        // Deposited worst-first; the list still comes out best-first.
-        assert!(merge_resolve_candidate(&mut addrs, ula));
-        assert!(merge_resolve_candidate(&mut addrs, global));
-        assert!(merge_resolve_candidate(&mut addrs, link_local));
+        // Deposited worst-first; the list still comes out best-first, and stops
+        // accepting once full.
+        for i in 0..MAX_RESOLVE_CANDIDATES {
+            let accepted = merge_resolve_candidate(&mut addrs, candidate(i as u16, i as u8 + 1));
+            assert!(accepted);
+        }
 
-        assert_eq!(addrs.as_slice(), &[link_local, global, ula]);
+        assert_eq!(addrs.len(), MAX_RESOLVE_CANDIDATES);
+        assert!(addrs.windows(2).all(|w| w[0].score > w[1].score));
 
-        // A duplicate is dropped.
-        assert!(!merge_resolve_candidate(&mut addrs, global));
-        assert_eq!(addrs.len(), 3);
-
-        // The list is full and IPv4 scores below everything in it, so it is
-        // dropped rather than evicting a better candidate.
-        assert!(!merge_resolve_candidate(&mut addrs, ipv4));
-        assert_eq!(addrs.as_slice(), &[link_local, global, ula]);
-
-        // A better candidate evicts the worst one.
-        let on_link_global = ResolvedAddr {
-            score: global.score + 1,
-            ..candidate(Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 1))
+        // A duplicate address is dropped, whatever it scores.
+        let dup = ResolvedAddr {
+            score: u8::MAX,
+            ..addrs[addrs.len() - 1]
         };
-        assert!(merge_resolve_candidate(&mut addrs, on_link_global));
-        assert_eq!(addrs.as_slice(), &[link_local, on_link_global, global]);
+        assert!(!merge_resolve_candidate(&mut addrs, dup));
+        assert_eq!(addrs.len(), MAX_RESOLVE_CANDIDATES);
+
+        // The list is full and this one scores below everything in it, so it is
+        // dropped rather than evicting a better candidate.
+        let worst = *addrs.last().unwrap();
+        assert!(!merge_resolve_candidate(&mut addrs, candidate(0xfffe, 0)));
+        assert_eq!(*addrs.last().unwrap(), worst);
+
+        // A better candidate takes the top slot and evicts the worst one.
+        assert!(merge_resolve_candidate(
+            &mut addrs,
+            candidate(0xffff, u8::MAX)
+        ));
+        assert_eq!(addrs.len(), MAX_RESOLVE_CANDIDATES);
+        assert_eq!(addrs[0].score, u8::MAX);
+        assert!(!addrs.contains(&worst));
+        assert!(addrs.windows(2).all(|w| w[0].score > w[1].score));
     }
 
     #[test]

--- a/rs-matter/src/transport/network/mdns.rs
+++ b/rs-matter/src/transport/network/mdns.rs
@@ -696,16 +696,92 @@ impl ToLabelIter for DottedName<'_> {
 ///
 /// The params are carried out so the CASE initiator can seed the new session's
 /// MRP backoff from the peer's advertised values rather than local defaults.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ResolvedNode {
-    /// The resolved peer address (best-scored address + port).
-    pub addr: SocketAddr,
+    /// The resolved peer addresses, **best-scored first** (see
+    /// [`score_ip_address`]), each already carrying its IPv6 scope where one
+    /// applies. Never empty.
+    ///
+    /// More than one is carried because the best-scored address is not
+    /// necessarily the reachable one, so the CASE initiator walks the list until
+    /// a handshake completes - see [`MAX_RESOLVE_CANDIDATES`].
+    pub addrs: Vec<SocketAddr, MAX_RESOLVE_CANDIDATES>,
     /// Session Idle Interval (`SII`), milliseconds.
     pub sii: Option<u32>,
     /// Session Active Interval (`SAI`), milliseconds.
     pub sai: Option<u32>,
     /// Session Active Threshold (`SAT`), milliseconds.
     pub sat: Option<u16>,
+}
+
+impl ResolvedNode {
+    /// The best-scored candidate address.
+    ///
+    /// [`Self::addrs`] is never empty, so this only returns `None` for a
+    /// hand-constructed value.
+    pub fn addr(&self) -> Option<SocketAddr> {
+        self.addrs.first().copied()
+    }
+}
+
+/// Maximum number of candidate peer addresses kept for a single resolve.
+///
+/// A node advertises an AAAA record for every address it accepts operational
+/// messages on, and the Matter Core Specification requires support for at least
+/// three routable addresses on top of the link-local one, so a single answer can
+/// easily carry several. Keeping a few of them - rather than only the
+/// best-scored one - is what lets the CASE initiator recover when the top
+/// candidate turns out to be unreachable, which is exactly the failure mode of a
+/// link-local address relayed across a subnet boundary. See
+/// [`score_ip_address_on_link`] for why the ranking cannot decide that on its
+/// own.
+pub const MAX_RESOLVE_CANDIDATES: usize = 3;
+
+/// A single ranked candidate address for a resolved peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ResolvedAddr {
+    /// The peer address.
+    pub ip: IpAddr,
+    /// IPv6 scope (zone) id for a link-local `ip`; 0 otherwise. See
+    /// [`MdnsRemoteService::scope_id`].
+    pub scope_id: u32,
+    /// The score `ip` was ranked by (see [`score_ip_address_on_link`]).
+    /// Candidates are kept in descending score order.
+    pub score: u8,
+}
+
+/// Merge one address into a ranked candidate list, keeping it sorted by
+/// descending score, free of duplicates, and bounded to
+/// [`MAX_RESOLVE_CANDIDATES`].
+///
+/// Returns `true` if the list changed. A duplicate, or an address that scores
+/// below every candidate in an already-full list, is dropped.
+pub(crate) fn merge_resolve_candidate(
+    addrs: &mut Vec<ResolvedAddr, MAX_RESOLVE_CANDIDATES>,
+    candidate: ResolvedAddr,
+) -> bool {
+    if addrs.iter().any(|c| c.ip == candidate.ip) {
+        return false;
+    }
+
+    let pos = addrs
+        .iter()
+        .position(|c| c.score < candidate.score)
+        .unwrap_or(addrs.len());
+
+    if pos >= MAX_RESOLVE_CANDIDATES {
+        // Worse than every candidate already kept, and there is no room.
+        return false;
+    }
+
+    if addrs.is_full() {
+        addrs.pop();
+    }
+
+    // `pos <= addrs.len()` and the list has room, so this cannot fail.
+    let _ = addrs.insert(pos, candidate);
+
+    true
 }
 
 /// The state of the single in-flight mDNS resolve "rendezvous" shared between
@@ -722,16 +798,18 @@ pub(crate) enum MdnsResolveState {
     Requested { service: MatterRemoteService },
     /// The responder picked up the request and sent the query; awaiting an answer.
     InFlight { service: MatterRemoteService },
-    /// The responder deposited the resolved address + MRP/session params.
+    /// The responder deposited the resolved addresses + MRP/session params.
     ///
     /// No `service` is carried: the rendezvous is single-slot, so the only waiter
     /// that can observe this is the one whose request the responder resolved.
     Resolved {
-        ip: IpAddr,
+        /// The candidate addresses, best-scored first and never empty. Further
+        /// deposits for the same in-flight target merge into this list, so a
+        /// backend that surfaces one address per callback (Avahi, zeroconf)
+        /// accumulates candidates the same way a backend that hands over a whole
+        /// packet (the builtin responder) does.
+        addrs: Vec<ResolvedAddr, MAX_RESOLVE_CANDIDATES>,
         port: u16,
-        /// IPv6 scope (zone) id for a link-local `ip`; 0 otherwise. See
-        /// [`MdnsRemoteService::scope_id`].
-        scope_id: u32,
         sii: Option<u32>,
         sai: Option<u32>,
         sat: Option<u16>,
@@ -781,40 +859,89 @@ pub(crate) enum MdnsBrowseState {
     },
 }
 
-/// Score an IP address for prioritization.
+/// Score an IP address for prioritization; higher is more preferred.
 ///
-/// Higher scores indicate more preferred addresses. The priority order follows
-/// the Matter specification:
-///
-/// 1. Link-local IPv6 (highest priority) - most likely to work for local discovery
-/// 2. Unique local IPv6 (ULA, fc00::/7) - private network addresses
-/// 3. Global unicast IPv6 - routable addresses
-/// 4. IPv4 (lowest priority)
-///
-/// This prioritization prefers IPv6 over IPv4 and local addresses over global ones,
-/// which aligns with Matter's preference for link-local communication.
+/// Convenience wrapper over [`score_ip_address_on_link`] for callers that have no
+/// knowledge of the local interface addresses.
 pub fn score_ip_address(addr: &IpAddr) -> u8 {
+    score_ip_address_on_link(addr, &[])
+}
+
+/// Score an IP address for prioritization; higher is more preferred.
+///
+/// The Matter Core Specification prescribes no ordering: it accepts a global
+/// unicast, a link-local or a unique local address equally as an operational
+/// address, and the only related requirement is that a peer must not be assumed
+/// reachable at a single address. The ladder below therefore encodes reachability
+/// heuristics rather than a spec rule, and follows the ordering the CHIP SDK
+/// resolves with, so both stacks pick the same address for the same
+/// advertisement:
+///
+/// 1. Link-local IPv6 - reachability is implied by the discovery itself: mDNS is
+///    link-scoped, so an answer received over multicast DNS proves the peer is on
+///    the link. It also never renumbers and depends on no router.
+/// 2. Global unicast sharing a prefix with a local address - provably on-link
+///    too, without depending on the answer having arrived over the link.
+/// 3. Unique local sharing a prefix with a local address - likewise on-link.
+/// 4. Global unicast - routable, but possibly only via a router.
+/// 5. Unique local - routable, but possibly only via a router.
+/// 6. IPv4 - outside the Matter operational addressing model; last resort.
+/// 7. Any other IPv6 (multicast, unspecified, IPv4-mapped) - unusable.
+///
+/// Ranking link-local first is only safe together with the candidate list the
+/// resolver keeps: an answer relayed across a subnet boundary - by an mDNS
+/// reflector, or by the DNS-SD proxy of a Thread border router - carries a
+/// link-local address that scores highest yet cannot be reached, so the initiator
+/// must be able to fall back to the next candidate. See
+/// [`MAX_RESOLVE_CANDIDATES`].
+///
+/// `local_ipv6` are the IPv6 addresses configured on the local interface, used
+/// for the two "shares a prefix" tiers. Pass `&[]` when they are unknown - which
+/// is the case for every OS-backed responder, as those delegate the host records
+/// to a daemon and never see the addresses themselves.
+pub fn score_ip_address_on_link(addr: &IpAddr, local_ipv6: &[Ipv6Addr]) -> u8 {
     match addr {
         IpAddr::V6(ipv6) => {
             if ipv6.is_unicast_link_local() {
-                // Link-local IPv6 (fe80::/10) - highest priority
-                100
-            } else if ipv6.is_unique_local() {
-                // Unique local address (fc00::/7) - second priority
-                80
+                70
             } else if is_ipv6_global_unicast(ipv6) {
-                // Global unicast - third priority
-                60
+                if shares_prefix(ipv6, local_ipv6) {
+                    60
+                } else {
+                    40
+                }
+            } else if ipv6.is_unique_local() {
+                if shares_prefix(ipv6, local_ipv6) {
+                    50
+                } else {
+                    30
+                }
             } else {
-                // Other IPv6 (multicast, etc.)
-                40
+                10
             }
         }
-        IpAddr::V4(_) => {
-            // IPv4 - lowest priority
-            20
-        }
+        IpAddr::V4(_) => 20,
     }
+}
+
+/// Whether `addr` sits in the same /64 as any of `local_ipv6` - i.e. the peer
+/// address belongs to a prefix this node is itself configured on, and is
+/// therefore reachable without traversing a router.
+///
+/// /64 is the only prefix length worth checking: both the on-link prefixes a
+/// Wi-Fi / Ethernet interface autoconfigures from a Router Advertisement and the
+/// on-mesh prefixes carried in the Thread Network Data are /64.
+///
+/// Local link-local addresses are skipped: every link-local address shares the
+/// `fe80::/64` prefix, so matching against them would promote every peer
+/// link-local address into a tier it does not belong to (and link-local is
+/// already the top tier anyway).
+fn shares_prefix(addr: &Ipv6Addr, local_ipv6: &[Ipv6Addr]) -> bool {
+    let prefix = &addr.octets()[..8];
+
+    local_ipv6
+        .iter()
+        .any(|local| !local.is_unicast_link_local() && &local.octets()[..8] == prefix)
 }
 
 /// Check if an IPv6 address is global unicast (2000::/3)
@@ -1084,10 +1211,107 @@ mod tests {
         let ula = IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1));
         let global = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
         let ipv4 = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+        let mapped = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc0a8, 1));
 
-        assert!(score_ip_address(&link_local) > score_ip_address(&ula));
-        assert!(score_ip_address(&ula) > score_ip_address(&global));
-        assert!(score_ip_address(&global) > score_ip_address(&ipv4));
+        // Link-local first: an answer received over (link-scoped) mDNS proves the
+        // peer is on the link. Global unicast outranks unique local, matching how
+        // the CHIP SDK orders the same advertisement.
+        assert!(score_ip_address(&link_local) > score_ip_address(&global));
+        assert!(score_ip_address(&global) > score_ip_address(&ula));
+        assert!(score_ip_address(&ula) > score_ip_address(&ipv4));
+        assert!(score_ip_address(&ipv4) > score_ip_address(&mapped));
+    }
+
+    /// A peer address on a prefix the node is itself configured on is reachable
+    /// without a router, so it outranks one of the same kind that is not - but
+    /// never outranks link-local.
+    #[test]
+    fn score_ip_address_prefers_on_link_prefixes() {
+        let local = [
+            Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0xaa),
+            Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 0xaa),
+            Ipv6Addr::new(0xfd00, 0, 0, 1, 0, 0, 0, 0xaa),
+        ];
+
+        let on_link_gua = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 0xbb));
+        let off_link_gua = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 9, 0, 0, 0, 0xbb));
+        let on_link_ula = IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 1, 0, 0, 0, 0xbb));
+        let off_link_ula = IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 9, 0, 0, 0, 0xbb));
+        let link_local = IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0xbb));
+
+        assert!(
+            score_ip_address_on_link(&on_link_gua, &local)
+                > score_ip_address_on_link(&off_link_gua, &local)
+        );
+        assert!(
+            score_ip_address_on_link(&on_link_ula, &local)
+                > score_ip_address_on_link(&off_link_ula, &local)
+        );
+        // On-link ULA still ranks under any GUA that is also on-link.
+        assert!(
+            score_ip_address_on_link(&on_link_gua, &local)
+                > score_ip_address_on_link(&on_link_ula, &local)
+        );
+        assert!(
+            score_ip_address_on_link(&link_local, &local)
+                > score_ip_address_on_link(&on_link_gua, &local)
+        );
+
+        // Every link-local address shares the `fe80::/64` prefix, so the local
+        // link-local address must not promote an off-link peer ULA/GUA.
+        assert_eq!(
+            score_ip_address_on_link(&off_link_gua, &local),
+            score_ip_address(&off_link_gua)
+        );
+    }
+
+    /// The candidate list stays sorted by descending score, deduped, and bounded.
+    #[test]
+    fn merge_resolve_candidate_ranks_dedups_and_bounds() {
+        fn candidate(addr: Ipv6Addr) -> ResolvedAddr {
+            let ip = IpAddr::V6(addr);
+
+            ResolvedAddr {
+                ip,
+                scope_id: 0,
+                score: score_ip_address(&ip),
+            }
+        }
+
+        let link_local = candidate(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1));
+        let global = candidate(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+        let ula = candidate(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1));
+        let ipv4 = ResolvedAddr {
+            ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            scope_id: 0,
+            score: score_ip_address(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+        };
+
+        let mut addrs = Vec::new();
+
+        // Deposited worst-first; the list still comes out best-first.
+        assert!(merge_resolve_candidate(&mut addrs, ula));
+        assert!(merge_resolve_candidate(&mut addrs, global));
+        assert!(merge_resolve_candidate(&mut addrs, link_local));
+
+        assert_eq!(addrs.as_slice(), &[link_local, global, ula]);
+
+        // A duplicate is dropped.
+        assert!(!merge_resolve_candidate(&mut addrs, global));
+        assert_eq!(addrs.len(), 3);
+
+        // The list is full and IPv4 scores below everything in it, so it is
+        // dropped rather than evicting a better candidate.
+        assert!(!merge_resolve_candidate(&mut addrs, ipv4));
+        assert_eq!(addrs.as_slice(), &[link_local, global, ula]);
+
+        // A better candidate evicts the worst one.
+        let on_link_global = ResolvedAddr {
+            score: global.score + 1,
+            ..candidate(Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 1))
+        };
+        assert!(merge_resolve_candidate(&mut addrs, on_link_global));
+        assert_eq!(addrs.as_slice(), &[link_local, on_link_global, global]);
     }
 
     #[test]

--- a/rs-matter/src/transport/network/mdns.rs
+++ b/rs-matter/src/transport/network/mdns.rs
@@ -463,6 +463,23 @@ where
 
         (sii, sai, sat)
     }
+
+    /// Whether the peer advertises that it accepts **TCP** connections, from the
+    /// `T` TXT key.
+    ///
+    /// `T` is a bitmap: bit 1 (value 2) marks a TCP client, bit 2 (value 4) a TCP
+    /// server. Only the server bit matters to an initiator - it is the peer's
+    /// willingness to be connected *to*. An absent or unparsable `T` means no TCP
+    /// (the key is omitted entirely by nodes without TCP support).
+    pub fn supports_tcp_server(&self) -> bool {
+        for (key, value) in self.txt.clone() {
+            if key.eq_ignore_ascii_case("T") {
+                return value.parse::<u32>().is_ok_and(|t| t & 0x04 != 0);
+            }
+        }
+
+        false
+    }
 }
 
 /// Filter criteria for discovering commissionable devices.
@@ -708,6 +725,8 @@ pub struct ResolvedNode {
     /// necessarily the reachable one, so the CASE initiator walks the list until
     /// a handshake completes - see [`MAX_RESOLVE_CANDIDATES`].
     pub addrs: Vec<SocketAddr, MAX_RESOLVE_CANDIDATES>,
+    /// Whether the peer advertised TCP server support (the `T` TXT key).
+    pub tcp_capable: bool,
     /// Session Idle Interval (`SII`), milliseconds.
     pub sii: Option<u32>,
     /// Session Active Interval (`SAI`), milliseconds.
@@ -847,6 +866,7 @@ pub(crate) enum MdnsResolveState {
         /// packet (the builtin responder) does.
         addrs: Vec<ResolvedAddr, MAX_RESOLVE_CANDIDATES>,
         port: u16,
+        tcp_capable: bool,
         sii: Option<u32>,
         sai: Option<u32>,
         sat: Option<u16>,

--- a/rs-matter/src/transport/network/mdns/astro.rs
+++ b/rs-matter/src/transport/network/mdns/astro.rs
@@ -137,9 +137,8 @@ impl AstroMdns {
                                 }
                             }
                             // Match is by the full instance name we requested.
-                            matter
-                                .transport()
-                                .try_deposit_mdns_resolve(&MdnsRemoteService {
+                            matter.transport().try_deposit_mdns_resolve(
+                                &MdnsRemoteService {
                                     instance_name: DottedName(name_buf.as_str()),
                                     port: Some(svc.port),
                                     addrs: ips.iter().copied(),
@@ -147,7 +146,11 @@ impl AstroMdns {
                                     // DNS-SD reports the interface index; use it
                                     // as the scope id for a link-local result.
                                     scope_id: link_local_scope_id(&ips, svc.interface_index),
-                                });
+                                },
+                                // The DNS-SD daemon owns the host A/AAAA records; this
+                                // backend never sees the local interface addresses.
+                                &[],
+                            );
                         }
                     }
                     Ok(_) => {} // a different instance of the same type

--- a/rs-matter/src/transport/network/mdns/avahi.rs
+++ b/rs-matter/src/transport/network/mdns/avahi.rs
@@ -231,15 +231,18 @@ impl AvahiMdns {
                     let txt_pairs = txt_pairs(&txt);
                     // Deposit under the full requested instance name (the transport
                     // matches on it). `name` from the browser is the bare label.
-                    matter
-                        .transport()
-                        .try_deposit_mdns_resolve(&MdnsRemoteService {
+                    matter.transport().try_deposit_mdns_resolve(
+                        &MdnsRemoteService {
                             instance_name: DottedName(name_buf.as_str()),
                             port: Some(port),
                             addrs: ips.iter().copied(),
                             txt: txt_pairs.iter().copied(),
                             scope_id,
-                        });
+                        },
+                        // The Avahi daemon owns the host A/AAAA records; this backend never
+                        // sees the local interface addresses.
+                        &[],
+                    );
                 }
             }
 

--- a/rs-matter/src/transport/network/mdns/builtin.rs
+++ b/rs-matter/src/transport/network/mdns/builtin.rs
@@ -465,7 +465,9 @@ impl BuiltinMdns {
                     // browse request.
                     match parse_into_answer(packet, ipv6_interface) {
                         Ok(Some(answer)) => {
-                            matter.transport().try_deposit_mdns_resolve(&answer);
+                            matter
+                                .transport()
+                                .try_deposit_mdns_resolve(&answer, host.ipv6);
                             matter.transport().try_deposit_mdns_browse(&answer);
                         }
                         Ok(None) => {}

--- a/rs-matter/src/transport/network/mdns/builtin/query.rs
+++ b/rs-matter/src/transport/network/mdns/builtin/query.rs
@@ -304,7 +304,7 @@ mod tests {
         Host {
             hostname: "myhost",
             ip: Ipv4Addr::new(192, 168, 1, 5),
-            ipv6: Ipv6Addr::UNSPECIFIED,
+            ipv6: &[Ipv6Addr::UNSPECIFIED],
         }
     }
 

--- a/rs-matter/src/transport/network/mdns/builtin/respond.rs
+++ b/rs-matter/src/transport/network/mdns/builtin/respond.rs
@@ -77,8 +77,22 @@ bitflags! {
 
 pub struct Host<'a> {
     pub hostname: &'a str,
+    /// The host's IPv4 address, or [`Ipv4Addr::UNSPECIFIED`] for none.
     pub ip: Ipv4Addr,
-    pub ipv6: Ipv6Addr,
+    /// **Every** IPv6 address the host accepts Matter messages on - a link-local
+    /// one and, where the network provides on-link prefixes, one or more
+    /// routable (GUA / ULA) ones.
+    ///
+    /// The Matter Core Specification requires a node to publish an AAAA record
+    /// for each address it is willing to accept messages on, so all of these are
+    /// answered with. Advertising only the link-local address makes a node
+    /// unreachable to any peer that learns of it across a subnet boundary - an
+    /// mDNS reflector, or the DNS-SD proxy of a Thread border router - since the
+    /// relayed record then carries nothing the peer can route to.
+    ///
+    /// Unspecified entries are skipped, so a fixed-size array with empty slots is
+    /// fine. An empty slice publishes no AAAA record at all.
+    pub ipv6: &'a [Ipv6Addr],
 }
 
 /// How a response prepared by [`Host::respond`] should be sent.
@@ -515,12 +529,16 @@ impl Host<'_> {
         R: RecordSectionBuilder<C>,
         C: Composer,
     {
-        if !self.ipv6.is_unspecified() {
+        for ipv6 in self.ipv6 {
+            if ipv6.is_unspecified() {
+                continue;
+            }
+
             answer.push((
                 Self::host_fqdn(self.hostname),
                 Self::auth_class(flush),
                 ttl_sec,
-                Aaaa::new(self.ipv6.octets().into()),
+                Aaaa::new(ipv6.octets().into()),
             ))?;
         }
 
@@ -755,7 +773,7 @@ mod tests {
         host: Host {
             hostname: "foo",
             ip: Ipv4Addr::new(192, 168, 0, 1),
-            ipv6: Ipv6Addr::UNSPECIFIED,
+            ipv6: &[Ipv6Addr::UNSPECIFIED],
         },
         services: &[],
 
@@ -799,7 +817,7 @@ mod tests {
         host: Host {
             hostname: "foo",
             ip: Ipv4Addr::new(192, 168, 0, 1),
-            ipv6: Ipv6Addr::new(0xfb, 0, 0, 0, 0, 0, 0, 1),
+            ipv6: &[Ipv6Addr::new(0xfb, 0, 0, 0, 0, 0, 0, 1)],
         },
         services: &[
             TestService {
@@ -956,7 +974,7 @@ mod tests {
         let host = Host {
             hostname: "foo",
             ip: Ipv4Addr::new(192, 168, 0, 1),
-            ipv6: Ipv6Addr::new(0xfb, 0, 0, 0, 0, 0, 0, 1),
+            ipv6: &[Ipv6Addr::new(0xfb, 0, 0, 0, 0, 0, 0, 1)],
         };
 
         let services: &[TestService<'_>] = &[TestService {
@@ -1010,13 +1028,57 @@ mod tests {
         run.run();
     }
 
+    /// A host configured with several IPv6 addresses answers an AAAA question
+    /// with one record per address - a node has to publish an AAAA record for
+    /// every address it accepts Matter messages on, not just one, or a peer that
+    /// learns of it across a subnet boundary is left with nothing routable.
+    /// Unspecified entries are skipped.
+    #[test]
+    fn test_all_ipv6_addresses_are_advertised() {
+        let link_local = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+        let gua = Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 1);
+        let ula = Ipv6Addr::new(0xfd00, 0, 0, 1, 0, 0, 0, 1);
+
+        let run = TestRun {
+            host: Host {
+                hostname: "foo",
+                ip: Ipv4Addr::UNSPECIFIED,
+                ipv6: &[link_local, Ipv6Addr::UNSPECIFIED, gua, ula],
+            },
+            services: &[],
+            tests: &[(
+                &[Question {
+                    name: "foo.local",
+                    qtype: Rtype::AAAA,
+                }],
+                &[
+                    Answer {
+                        owner: "foo.local",
+                        details: AnswerDetails::Aaaa(link_local),
+                    },
+                    Answer {
+                        owner: "foo.local",
+                        details: AnswerDetails::Aaaa(gua),
+                    },
+                    Answer {
+                        owner: "foo.local",
+                        details: AnswerDetails::Aaaa(ula),
+                    },
+                ],
+                &[],
+            )],
+        };
+
+        run.run();
+    }
+
     #[test]
     fn test_response_ignored() {
         // Test that mDNS responses (QR=1) are not replied to
         let host = Host {
             hostname: "foo",
             ip: Ipv4Addr::new(192, 168, 0, 1),
-            ipv6: Ipv6Addr::UNSPECIFIED,
+            ipv6: &[Ipv6Addr::UNSPECIFIED],
         };
 
         let test_service = TestService {
@@ -1078,7 +1140,7 @@ mod tests {
         let host = Host {
             hostname: "foo",
             ip: Ipv4Addr::new(192, 168, 0, 1),
-            ipv6: Ipv6Addr::UNSPECIFIED,
+            ipv6: &[Ipv6Addr::UNSPECIFIED],
         };
 
         let test_service = TestService {

--- a/rs-matter/src/transport/network/mdns/builtin/respond.rs
+++ b/rs-matter/src/transport/network/mdns/builtin/respond.rs
@@ -83,15 +83,7 @@ pub struct Host<'a> {
     /// one and, where the network provides on-link prefixes, one or more
     /// routable (GUA / ULA) ones.
     ///
-    /// The Matter Core Specification requires a node to publish an AAAA record
-    /// for each address it is willing to accept messages on, so all of these are
-    /// answered with. Advertising only the link-local address makes a node
-    /// unreachable to any peer that learns of it across a subnet boundary - an
-    /// mDNS reflector, or the DNS-SD proxy of a Thread border router - since the
-    /// relayed record then carries nothing the peer can route to.
-    ///
-    /// Unspecified entries are skipped, so a fixed-size array with empty slots is
-    /// fine. An empty slice publishes no AAAA record at all.
+    /// Unspecified entries are skipped, an empty slice publishes no AAAA record at all.
     pub ipv6: &'a [Ipv6Addr],
 }
 

--- a/rs-matter/src/transport/network/mdns/resolve.rs
+++ b/rs-matter/src/transport/network/mdns/resolve.rs
@@ -237,9 +237,8 @@ impl ResolveMdns {
             let ips = all_addresses(addresses);
             if !ips.is_empty() {
                 let txt = txt_iter(txt_data);
-                matter
-                    .transport()
-                    .try_deposit_mdns_resolve(&MdnsRemoteService {
+                matter.transport().try_deposit_mdns_resolve(
+                    &MdnsRemoteService {
                         instance_name: DottedName(instance_name),
                         port: Some(*port),
                         addrs: ips.iter().copied(),
@@ -248,7 +247,11 @@ impl ResolveMdns {
                         // address; use the link-local IPv6 one as the scope id
                         // so a `fe80::` result is routable.
                         scope_id: link_local_scope_id(addresses),
-                    });
+                    },
+                    // systemd-resolved owns the host A/AAAA records; this backend never
+                    // sees the local interface addresses.
+                    &[],
+                );
             }
         }
     }

--- a/rs-matter/src/transport/network/mdns/zeroconf.rs
+++ b/rs-matter/src/transport/network/mdns/zeroconf.rs
@@ -137,9 +137,8 @@ impl ZeroconfMdns {
                     if let Ok(ip) = svc.address().parse::<IpAddr>() {
                         let pairs = txt_pairs(svc);
                         // Match is by the full instance name we requested.
-                        matter
-                            .transport()
-                            .try_deposit_mdns_resolve(&MdnsRemoteService {
+                        matter.transport().try_deposit_mdns_resolve(
+                            &MdnsRemoteService {
                                 instance_name: DottedName(name_buf.as_str()),
                                 port: Some(*svc.port()),
                                 addrs: core::iter::once(ip),
@@ -150,7 +149,11 @@ impl ZeroconfMdns {
                                 // (`fe80::`) results are unscoped here. Other
                                 // backends (avahi, resolve, astro) thread it.
                                 scope_id: 0,
-                            });
+                            },
+                            // The mDNS daemon owns the host A/AAAA records; this backend
+                            // never sees the local interface addresses.
+                            &[],
+                        );
                     }
                 });
 

--- a/rs-matter/tests/binding.rs
+++ b/rs-matter/tests/binding.rs
@@ -105,6 +105,7 @@ use rs_matter::dm::clusters::decl::binding::BindingAttrWrites as _;
 
 use static_cell::StaticCell;
 
+use crate::common::mdns::stub_mdns_resolver;
 use crate::common::{init_env_logger, run_device_controller, run_with_transport};
 
 #[allow(dead_code)]
@@ -676,18 +677,39 @@ async fn commission_both<C: Crypto>(
         ..CommissionOptions::default()
     };
 
-    for (addr, node_id, tag) in [
-        (addr_a, NODE_ID_A, "switch-A"),
-        (addr_b, NODE_ID_B, "light-B"),
-    ] {
-        let result = commissioner
-            .commission(addr, TEST_PASSCODE, &opts, node_id, VALID_FOREVER)
-            .await?;
-        commissioner.complete_via_case(addr, &result).await?;
-        info!(
-            "Commissioned {tag} as node 0x{:016x}",
-            result.device_node_id
-        );
+    // Phase 2 goes through operational discovery rather than reusing the address
+    // PASE was driven over, so a stub resolver stands in for the mDNS backend
+    // this test does not run. It answers per node id, which is what lets both
+    // devices be commissioned against the same stub.
+    let sock_of = |addr: Address| match addr {
+        Address::Udp(SocketAddr::V6(sock)) | Address::Tcp(SocketAddr::V6(sock)) => sock,
+        _ => panic!("expected an IPv6 device address"),
+    };
+
+    let mdns_table = [(NODE_ID_A, sock_of(addr_a)), (NODE_ID_B, sock_of(addr_b))];
+    let mdns = stub_mdns_resolver(matter, &mdns_table);
+
+    let commission_both = async {
+        for (addr, node_id, tag) in [
+            (addr_a, NODE_ID_A, "switch-A"),
+            (addr_b, NODE_ID_B, "light-B"),
+        ] {
+            let result = commissioner
+                .commission(addr, TEST_PASSCODE, &opts, node_id, VALID_FOREVER)
+                .await?;
+            commissioner.complete_via_case(&result).await?;
+            info!(
+                "Commissioned {tag} as node 0x{:016x}",
+                result.device_node_id
+            );
+        }
+
+        Ok::<_, Error>(())
+    };
+
+    match select(pin!(commission_both), pin!(mdns)).await {
+        Either::First(r) => r?,
+        Either::Second(_) => unreachable!("the stub resolver never returns"),
     }
 
     Ok(ctrl_fab_idx)

--- a/rs-matter/tests/commissioning.rs
+++ b/rs-matter/tests/commissioning.rs
@@ -76,7 +76,7 @@ use rs_matter::transport::exchange::Exchange;
 use rs_matter::transport::exchange::MatterBuffers;
 use rs_matter::transport::network::tcp::TcpNetwork;
 use rs_matter::transport::network::{Address, NoNetwork, SocketAddr, SocketAddrV6};
-use rs_matter::transport::MATTER_SOCKET_BIND_ADDR;
+use rs_matter::transport::{TransportPreference, MATTER_SOCKET_BIND_ADDR};
 use rs_matter::utils::init::InitMaybeUninit;
 use rs_matter::utils::select::Coalesce;
 use rs_matter::{clusters, devices, root_endpoint, Matter, MATTER_PORT};
@@ -85,6 +85,7 @@ use socket2::{Domain, Protocol, Socket, Type};
 
 use static_cell::StaticCell;
 
+use crate::common::mdns::stub_mdns_resolver_txt;
 use crate::common::{init_env_logger, run_device_controller, run_with_transport};
 
 #[allow(dead_code)]
@@ -295,7 +296,8 @@ async fn run_controller_flow<C: Crypto>(
     let peer_addr = discover_and_resolve_device(use_tcp)?;
 
     info!("=== Phase 2: Commissioner — commission() (incl. PASE) + complete_via_case() ===");
-    let (controller_fab_idx, device_node_id) = test_commission(matter, crypto, peer_addr).await?;
+    let (controller_fab_idx, device_node_id) =
+        test_commission(matter, crypto, peer_addr, use_tcp).await?;
 
     // Cherry on top: after `CommissioningComplete` the device has
     // committed our fabric, torn down PASE, and the only authenticated
@@ -326,6 +328,7 @@ async fn test_commission<C: Crypto>(
     matter: &Matter<'_>,
     crypto: &C,
     peer_addr: Address,
+    use_tcp: bool,
 ) -> Result<(core::num::NonZeroU8, u64), Error> {
     const FABRIC_ID: u64 = 1;
     // chip-tool's conventional admin NodeID; matches the
@@ -400,13 +403,22 @@ async fn test_commission<C: Crypto>(
     // RCAC / ICAC bytes across the async on-wire calls. One
     // `MAX_CERT_TLV_LEN` slot is enough; see `Commissioner::new`.
     let mut commissioner_buf = [0u8; MAX_CERT_TLV_LEN];
+    // Phase 2 discovers the device and defaults to UDP, as the CHIP SDK's
+    // commissioner does. This test's TCP device listens on TCP *only*, so it has
+    // to ask for TCP explicitly - which also covers the `tcp_capable` veto path,
+    // since the stub below has to advertise TCP support for this to be allowed.
     let mut commissioner = Commissioner::new(
         matter,
         crypto,
         controller_fab_idx,
         &mut noc_generator,
         &mut commissioner_buf,
-    );
+    )
+    .with_transport(if use_tcp {
+        TransportPreference::LargePayload
+    } else {
+        TransportPreference::Mrp
+    });
 
     let opts = CommissionOptions {
         // Test DAC — system_tests / TEST_DEV_ATT.
@@ -429,13 +441,33 @@ async fn test_commission<C: Crypto>(
         result.fabric_index, result.device_node_id,
     );
 
-    // Phase 2 — establish CASE against the device's operational
-    // identity at the same address we used for PASE (the device
-    // announces on the same UDP/TCP port post-AddNOC), then drive
-    // CommissioningComplete on the new CASE session.
-    commissioner.complete_via_case(peer_addr, &result).await?;
+    // Phase 2 — operational discovery, then CASE against the device's
+    // operational identity, then CommissioningComplete on the new session.
+    //
+    // No mDNS backend runs in this test, so a stub answers the resolve request
+    // with the device's known address. That covers the production path end to
+    // end; it does not exercise the *failover* across several candidates, which
+    // needs an address that times out rather than failing the send outright and
+    // is therefore too environment-dependent to pin down here.
+    let (Address::Udp(SocketAddr::V6(peer_sock)) | Address::Tcp(SocketAddr::V6(peer_sock))) =
+        peer_addr
+    else {
+        panic!("expected an IPv6 device address");
+    };
+
+    let mdns_table = [(result.device_node_id, peer_sock)];
+    // `T=6` = TCP client (bit 1) + TCP server (bit 2), which is what a
+    // TCP-capable node advertises and what the commissioner's TCP request checks
+    // against.
+    let mdns = stub_mdns_resolver_txt(matter, &mdns_table, if use_tcp { "6" } else { "" });
+
+    match select(pin!(commissioner.complete_via_case(&result)), pin!(mdns)).await {
+        Either::First(r) => r?,
+        Either::Second(_) => unreachable!("the stub resolver never returns"),
+    }
+
     info!(
-        "complete_via_case() ok: controller_fab_idx={}, CASE+CommissioningComplete done",
+        "complete_via_case() ok: controller_fab_idx={}, discovery+CASE+CommissioningComplete done",
         controller_fab_idx,
     );
 

--- a/rs-matter/tests/common/mdns.rs
+++ b/rs-matter/tests/common/mdns.rs
@@ -26,6 +26,8 @@
 //!   multicast packets sent by the device are received by the controller on the
 //!   same host.
 
+use rs_matter::transport::network::mdns::{DottedName, MdnsRemoteService};
+use rs_matter::transport::network::{IpAddr, MatterRemoteService, SocketAddrV6};
 use rs_matter::Matter;
 use rs_matter::{crypto::Crypto, error::Error};
 
@@ -173,4 +175,61 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
             crypto,
         )
         .await
+}
+
+/// Answer operational mDNS resolve requests from a fixed `node_id -> address`
+/// table, standing in for a real mDNS backend.
+///
+/// Tests drive commissioning phase 2 (and anything else that resolves a peer)
+/// against devices at addresses they already know, but the production code path
+/// deliberately goes through discovery rather than taking a known address. This
+/// closes that gap without binding port 5353 on a real interface, which would
+/// make the tests depend on the host's network and on no other responder
+/// running.
+///
+/// Never returns - run it concurrently with whatever drives the resolves, e.g.
+/// `select(work, stub_mdns_resolver(matter, &table))`.
+#[allow(unused)]
+pub async fn stub_mdns_resolver(matter: &Matter<'_>, table: &[(u64, SocketAddrV6)]) -> ! {
+    stub_mdns_resolver_txt(matter, table, "").await
+}
+
+/// [`stub_mdns_resolver`], additionally advertising a `T` TXT value.
+///
+/// `T` is the TCP-support bitmap (bit 1 = client, bit 2 = server), so `"6"`
+/// makes the stubbed peer look TCP-capable and `""` omits the key entirely, as a
+/// node without TCP support does. It gates whether a
+/// [`TransportPreference::LargePayload`](rs_matter::transport::TransportPreference)
+/// request is allowed to establish over TCP.
+#[allow(unused)]
+pub async fn stub_mdns_resolver_txt(
+    matter: &Matter<'_>,
+    table: &[(u64, SocketAddrV6)],
+    tcp: &str,
+) -> ! {
+    loop {
+        let service = matter.transport().wait_mdns_resolve_request().await;
+
+        let MatterRemoteService::Operational { node_id, .. } = &service else {
+            continue;
+        };
+
+        let Some((_, sock)) = table.iter().find(|(id, _)| id == node_id) else {
+            continue;
+        };
+
+        let mut name = heapless::String::<128>::new();
+        service.instance_name(&mut name);
+
+        matter.transport().try_deposit_mdns_resolve(
+            &MdnsRemoteService {
+                instance_name: DottedName(name.as_str()),
+                port: Some(sock.port()),
+                addrs: core::iter::once(IpAddr::V6(*sock.ip())),
+                txt: (!tcp.is_empty()).then_some(("T", tcp)).into_iter(),
+                scope_id: 0,
+            },
+            &[],
+        );
+    }
 }

--- a/rs-matter/tests/common/mdns.rs
+++ b/rs-matter/tests/common/mdns.rs
@@ -71,7 +71,7 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
     use rs_matter::transport::network::{Ipv4Addr, Ipv6Addr};
 
     #[inline(never)]
-    fn initialize_network() -> Result<(Ipv4Addr, Ipv6Addr, u32), Error> {
+    fn initialize_network() -> Result<(Ipv4Addr, Vec<Ipv6Addr>, u32), Error> {
         use log::error;
         use nix::{net::if_::InterfaceFlags, sys::socket::SockaddrIn6};
         use rs_matter::error::ErrorCode;
@@ -107,12 +107,30 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
                 ErrorCode::StdIoError
             })?;
 
-        info!("Will use network interface {iname} with {ip}/{ipv6} for mDNS");
+        // Advertise *every* IPv6 address configured on the chosen interface, not
+        // only the one that got the interface selected: a node has to publish an
+        // AAAA record for each address it accepts Matter messages on.
+        let mut ipv6_addrs: Vec<Ipv6Addr> = vec![ipv6.octets().into()];
 
-        Ok((ip.octets().into(), ipv6.octets().into(), 0 as _))
+        for ia in interfaces().filter(|ia| ia.interface_name == iname) {
+            if let Some(other) = ia
+                .address
+                .and_then(|addr| addr.as_sockaddr_in6().map(SockaddrIn6::ip))
+            {
+                let addr: Ipv6Addr = other.octets().into();
+
+                if !ipv6_addrs.contains(&addr) {
+                    ipv6_addrs.push(addr);
+                }
+            }
+        }
+
+        info!("Will use network interface {iname} with {ip} / {ipv6_addrs:?} for mDNS");
+
+        Ok((ip.octets().into(), ipv6_addrs, 0 as _))
     }
 
-    let (ipv4_addr, ipv6_addr, interface) = initialize_network()?;
+    let (ipv4_addr, ipv6_addrs, interface) = initialize_network()?;
 
     use rs_matter::transport::network::mdns::builtin::{BuiltinMdns, Host};
     use rs_matter::transport::network::mdns::{
@@ -147,7 +165,7 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
             &Host {
                 hostname: "rs-matter-test",
                 ip: ipv4_addr,
-                ipv6: ipv6_addr,
+                ipv6: &ipv6_addrs,
             },
             Some(ipv4_addr),
             Some(interface),

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -66,6 +66,7 @@ if-addrs = "0.15"
 async-io = "2"
 blocking = "1"
 futures-lite = "2"
+heapless = "0.9"
 rs-matter = { path = "../rs-matter", features = ["async-io", "groups", "persistent-subscriptions", "max-groups-per-fabric-12", "max-group-keys-per-fabric-3", "max-group-endpoints-per-fabric-3", "max-sessions-32"] }
 rand = { version = "0.8", features = ["std", "std_rng"] }
 async-signal = "0.2"

--- a/tests/src/bin/camera_tests.rs
+++ b/tests/src/bin/camera_tests.rs
@@ -24,6 +24,7 @@
 //! - `PushAvStreamTransport` (0x0555)
 //! - `WebRTCTransportProvider` (0x0553) – stub (no real ICE/DTLS)
 //! - `Chime` (0x0556)
+#![recursion_limit = "256"]
 
 use core::pin::pin;
 

--- a/tests/src/bin/commissioner_tests.rs
+++ b/tests/src/bin/commissioner_tests.rs
@@ -303,11 +303,10 @@ async fn run_commission<C: Crypto>(
             return Err(ErrorCode::InvalidData.into());
         };
 
-        let mdns = stub_mdns_resolver(matter, &[(DEVICE_NODE_ID, peer_sock)]);
-        let mut case_fut = pin!(select(
-            pin!(commissioner.complete_via_case(&phase1)),
-            pin!(mdns),
-        ));
+        let mdns_table = [(DEVICE_NODE_ID, peer_sock)];
+        let mdns = pin!(stub_mdns_resolver(matter, &mdns_table));
+        let case = pin!(commissioner.complete_via_case(&phase1));
+        let mut case_fut = pin!(select(case, mdns));
         let mut timeout = pin!(Timer::after(Duration::from_secs(COMMISSION_TIMEOUT_SECS)));
         match select(&mut case_fut, &mut timeout).await {
             Either::First(Either::First(r)) => r?,

--- a/tests/src/bin/commissioner_tests.rs
+++ b/tests/src/bin/commissioner_tests.rs
@@ -67,6 +67,11 @@ use rs_matter::Matter;
 
 use static_cell::StaticCell;
 
+#[path = "../common/mdns.rs"]
+mod mdns;
+
+use mdns::stub_mdns_resolver;
+
 /// Defaults match rs-matter's `TEST_DEV_COMM`. Override via CLI args
 /// for chip-all-clusters-app or any other peer.
 const DEFAULT_PASSCODE: u32 = 20202021;
@@ -288,13 +293,27 @@ async fn run_commission<C: Crypto>(
         phase1.fabric_index, phase1.device_node_id,
     );
 
-    info!("=== complete_via_case (phase 2 — CASE + CommissioningComplete) ===");
+    info!("=== complete_via_case (phase 2 — discovery + CASE + CommissioningComplete) ===");
     {
-        let peer = Address::Udp(args.peer_addr);
-        let mut case_fut = pin!(commissioner.complete_via_case(peer, &phase1));
+        // Phase 2 discovers the device rather than reusing the PASE address, so a
+        // stub resolver stands in for the mDNS backend this harness does not run,
+        // answering with the address we were given on the command line.
+        let SocketAddr::V6(peer_sock) = args.peer_addr else {
+            error!("expected an IPv6 device address");
+            return Err(ErrorCode::InvalidData.into());
+        };
+
+        let mdns = stub_mdns_resolver(matter, &[(DEVICE_NODE_ID, peer_sock)]);
+        let mut case_fut = pin!(select(
+            pin!(commissioner.complete_via_case(&phase1)),
+            pin!(mdns),
+        ));
         let mut timeout = pin!(Timer::after(Duration::from_secs(COMMISSION_TIMEOUT_SECS)));
         match select(&mut case_fut, &mut timeout).await {
-            Either::First(r) => r?,
+            Either::First(Either::First(r)) => r?,
+            Either::First(Either::Second(_)) => {
+                unreachable!("the stub resolver never returns")
+            }
             Either::Second(_) => {
                 error!("complete_via_case() timed out after {COMMISSION_TIMEOUT_SECS}s");
                 return Err(ErrorCode::RxTimeout.into());

--- a/tests/src/bin/light_tests.rs
+++ b/tests/src/bin/light_tests.rs
@@ -26,6 +26,7 @@
 //! instance's switch endpoint to the other's light endpoint, and triggers a
 //! "switch press" via the `--app-pipe` command channel, making the first
 //! instance resolve + CASE + `OnOff::Toggle` the second.
+#![recursion_limit = "256"]
 #![allow(clippy::uninlined_format_args)]
 
 use core::cell::Cell;

--- a/tests/src/common/mdns.rs
+++ b/tests/src/common/mdns.rs
@@ -79,7 +79,7 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
     // Uses the cross-platform `if-addrs` crate to enumerate interfaces so the
     // examples work on Linux, macOS and Windows.
     #[inline(never)]
-    fn initialize_network() -> Result<(Ipv4Addr, Ipv6Addr, u32), Error> {
+    fn initialize_network() -> Result<(Ipv4Addr, Vec<Ipv6Addr>, u32), Error> {
         use rs_matter::error::ErrorCode;
 
         let all = if_addrs::get_if_addrs().map_err(|_| ErrorCode::StdIoError)?;
@@ -157,12 +157,35 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
 
         let (iname, ip, ipv6, index) = candidate;
 
-        info!("Will use network interface {iname} with {ip}/{ipv6} for mDNS");
+        // Advertise *every* IPv6 address configured on the chosen interface, not
+        // only the one that got the interface selected. A node has to publish an
+        // AAAA record for each address it accepts Matter messages on; publishing
+        // only the link-local one leaves it unreachable to any peer that learns
+        // of it across a subnet boundary (an mDNS reflector, or the DNS-SD proxy
+        // of a Thread border router), because the relayed record then carries
+        // nothing routable.
+        let mut ipv6_addrs: Vec<Ipv6Addr> = Vec::new();
 
-        Ok((ip.octets().into(), ipv6.octets().into(), index))
+        if !ipv6.is_unspecified() {
+            ipv6_addrs.push(ipv6.octets().into());
+        }
+
+        for ia in all.iter().filter(|ia| ia.name == iname) {
+            if let if_addrs::IfAddr::V6(ref v6) = ia.addr {
+                let addr: Ipv6Addr = v6.ip.octets().into();
+
+                if !v6.ip.is_loopback() && !ipv6_addrs.contains(&addr) {
+                    ipv6_addrs.push(addr);
+                }
+            }
+        }
+
+        info!("Will use network interface {iname} with {ip} / {ipv6_addrs:?} for mDNS");
+
+        Ok((ip.octets().into(), ipv6_addrs, index))
     }
 
-    let (ipv4_addr, ipv6_addr, interface) = initialize_network()?;
+    let (ipv4_addr, ipv6_addrs, interface) = initialize_network()?;
 
     use rs_matter::transport::network::mdns::builtin::{BuiltinMdns, Host};
     use rs_matter::transport::network::mdns::{
@@ -192,7 +215,7 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
             &Host {
                 hostname: "001122334455", //"rs-matter-demo",
                 ip: ipv4_addr,
-                ipv6: ipv6_addr,
+                ipv6: &ipv6_addrs,
             },
             Some(ipv4_addr),
             Some(interface),

--- a/tests/src/common/mdns.rs
+++ b/tests/src/common/mdns.rs
@@ -17,6 +17,8 @@
 
 //! A module containing the mDNS code used in the examples
 
+use rs_matter::transport::network::mdns::{DottedName, MdnsRemoteService};
+use rs_matter::transport::network::{IpAddr, MatterRemoteService, SocketAddrV6};
 use rs_matter::Matter;
 use rs_matter::{crypto::Crypto, error::Error};
 
@@ -223,4 +225,61 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
             crypto,
         )
         .await
+}
+
+/// Answer operational mDNS resolve requests from a fixed `node_id -> address`
+/// table, standing in for a real mDNS backend.
+///
+/// Tests drive commissioning phase 2 (and anything else that resolves a peer)
+/// against devices at addresses they already know, but the production code path
+/// deliberately goes through discovery rather than taking a known address. This
+/// closes that gap without binding port 5353 on a real interface, which would
+/// make the tests depend on the host's network and on no other responder
+/// running.
+///
+/// Never returns - run it concurrently with whatever drives the resolves, e.g.
+/// `select(work, stub_mdns_resolver(matter, &table))`.
+#[allow(unused)]
+pub async fn stub_mdns_resolver(matter: &Matter<'_>, table: &[(u64, SocketAddrV6)]) -> ! {
+    stub_mdns_resolver_txt(matter, table, "").await
+}
+
+/// [`stub_mdns_resolver`], additionally advertising a `T` TXT value.
+///
+/// `T` is the TCP-support bitmap (bit 1 = client, bit 2 = server), so `"6"`
+/// makes the stubbed peer look TCP-capable and `""` omits the key entirely, as a
+/// node without TCP support does. It gates whether a
+/// [`TransportPreference::LargePayload`](rs_matter::transport::TransportPreference)
+/// request is allowed to establish over TCP.
+#[allow(unused)]
+pub async fn stub_mdns_resolver_txt(
+    matter: &Matter<'_>,
+    table: &[(u64, SocketAddrV6)],
+    tcp: &str,
+) -> ! {
+    loop {
+        let service = matter.transport().wait_mdns_resolve_request().await;
+
+        let MatterRemoteService::Operational { node_id, .. } = &service else {
+            continue;
+        };
+
+        let Some((_, sock)) = table.iter().find(|(id, _)| id == node_id) else {
+            continue;
+        };
+
+        let mut name = heapless::String::<128>::new();
+        service.instance_name(&mut name);
+
+        matter.transport().try_deposit_mdns_resolve(
+            &MdnsRemoteService {
+                instance_name: DottedName(name.as_str()),
+                port: Some(sock.port()),
+                addrs: core::iter::once(IpAddr::V6(*sock.ip())),
+                txt: (!tcp.is_empty()).then_some(("T", tcp)).into_iter(),
+                scope_id: 0,
+            },
+            &[],
+        );
+    }
 }


### PR DESCRIPTION
Currently the mDNS Responders assume a single ipv6 address. 
Furthermore, the mDNS resolving code does not really re-try connecting in the presence of multiple ipv6 addresses, nor it tries to determine whether a node would be reachable on an ipv6 address advertised by it depending on _our_ ipv6 addresses.

This "single ipv6 address only" status quo is primarily because initially I was concentrated on handling a single (link-local, for Ethernet and Wifi) ipv6 address.

Using only a single link-local ipv6 address is not a compliant behavior and even putting Thread aside (which did work because of reasons), cannot support multi-segment networks where the nodes should reach each other even if they are in separate network segments. This - however - would be quite possible **if** `rs-matter`'s mDNS handling supports ULA and GUA addresses in addition to LLA, **and** the router has an mDNS reflector installed.

See also https://github.com/sysgrok/rs-matter-embassy/issues/74 for a downstream issue. The upstream problem solved here is related to the mDNS handling, as the rest is actually fine in `rs-matter`.

EDIT: The PR also evolved into providing an extra API for the user to initiate a session over a transport that allows for large payloads (TCP). The gap here was uncovered completely accidentally, but since it was a small API surface, and touched the same places in `transport` it was implemented as part of this PR.