### PR TITLE
Fix RX and TX timeouts handling; expire sessions with RX/TX issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 * Advertise and use **all** of a node's IPv6 addresses rather than just one (#537)
 * (Breaking) Phase 2 of commissioning always goes through operational discovery now (#537)
+* Improved handling of RX and TX timeouts (#538)
 
 ## [0.3.0] - 2026-08-20
 * Groupcast **sending** APIs (`groups` feature): `Exchange::initiate_group` and `ImClient::group_invoke_with`; the `onoff_light_switch` example and the `light_tests` switch endpoint now act on *group* binding targets

--- a/rs-matter/src/transport/exchange.rs
+++ b/rs-matter/src/transport/exchange.rs
@@ -36,7 +36,7 @@ use crate::utils::storage::pooled::{PooledBuffers, DEFAULT_BUFFER_POOL_SIZE};
 use crate::utils::storage::{Vec, WriteBuf};
 use crate::{Matter, MatterState};
 
-use super::mrp::{ReliableMessage, RetransEntry};
+use super::mrp::{self, ReliableMessage};
 use super::network;
 use super::network::mdns::MAX_RESOLVE_CANDIDATES;
 use super::packet::PacketHdr;
@@ -145,9 +145,16 @@ impl ExchangeId {
 
             let mut session_removed = pin!(matter.transport().wait_session_removed());
 
-            let mut timeout = pin!(Timer::after(Duration::from_millis(
-                RetransEntry::new(matter.dev_det().sai, 0).rx_timeout_ms() * 3 / 2
-            )));
+            let mut timeout = pin!(Timer::after(Duration::from_millis(self.with_state(
+                matter,
+                |state| {
+                    let sai = matter
+                        .dev_det()
+                        .sai
+                        .unwrap_or(mrp::MRP_BASE_RETRY_INTERVAL_MS);
+                    Ok(self.session(&mut state.sessions).rx_timeout_ms(sai))
+                }
+            )?)));
 
             match select3(&mut recv, &mut session_removed, &mut timeout).await {
                 Either3::First(mut packet) => {

--- a/rs-matter/src/transport/mrp.rs
+++ b/rs-matter/src/transport/mrp.rs
@@ -53,14 +53,17 @@ macro_rules! mrp_log {
 pub(crate) use mrp_log;
 
 //const MRP_STANDALONE_ACK_TIMEOUT_MS: u64 = 200;   // TODO: Use to pro-actively send ACKs
-const MRP_BASE_RETRY_INTERVAL_MS: u32 = 300;
+pub(crate) const MRP_BASE_RETRY_INTERVAL_MS: u32 = 300;
 const MRP_MAX_TRANSMISSIONS: u16 = 5;
-const MRP_RX_TIMEOUT_TRANSMISSIONS: u16 = 10;
 const MRP_BACKOFF_THRESHOLD: u16 = 1;
 const MRP_BACKOFF_BASE: (u64, u64) = (16, 10); // 1.6
 const MRP_BACKOFF_JITTER: (u64, u64) = (25, 100); // 0.25
 const MRP_BACKOFF_MARGIN: (u64, u64) = (11, 10); // 1.1
 const MRP_JITTER_RAND_MAX: u8 = u8::MAX;
+
+/// Allowance for the peer's upper layer to actually process a request, on top of
+/// the time the message spends being retransmitted on the wire.
+pub(crate) const MRP_EXPECTED_PROCESSING_MS: u64 = 30_000;
 
 /// Fallback for `MRP_SESSION_IDLE_INTERVAL` when neither the peer nor our
 /// own `BasicInfoConfig::sii` advertised a value. Matches the docstring
@@ -134,45 +137,10 @@ impl RetransEntry {
         self.delay_ms_counter(self.counter, jitter_rand)
     }
 
-    /// How long to wait for the peer's response before giving up with
-    /// [`ErrorCode::RxTimeout`].
-    ///
-    /// Derived from [`MRP_RX_TIMEOUT_TRANSMISSIONS`] rather than
-    /// [`MRP_MAX_TRANSMISSIONS`] - the two answer different questions, and tying
-    /// them together makes our own retransmission budget silently dictate how
-    /// patient we are with a slow peer.
-    ///
-    /// TODO: The second constant has no counterpart in the CHIP SDK, which gets
-    /// the same separation out of a better formula instead. Its
-    /// `Session::ComputeRoundTripTimeout` is a sum of three terms -
-    /// `GetAckTimeout()` (the full retransmit ladder over the *peer's* MRP
-    /// config, i.e. how long until our message reaches it), an explicit
-    /// upper-layer processing allowance, and `GetMessageReceiptTimeout()` (the
-    /// ladder again, over the *local* config, for its answer reaching us). That
-    /// is roughly two ladders plus processing time, so lowering the
-    /// retransmission budget shrinks it proportionally from a base that was
-    /// large enough to begin with, and no second constant is needed. Non-UDP
-    /// transports skip the derivation entirely there (flat 30s for TCP, the BTP
-    /// ack timeout for BLE). Worth adopting that shape - it also stops us using
-    /// our own `sai` for the outbound half, where the peer's advertised value is
-    /// the correct input - at which point this constant goes away.
-    pub fn rx_timeout_ms(&self) -> u64 {
-        self.delay_ms_counter(MRP_RX_TIMEOUT_TRANSMISSIONS, MRP_JITTER_RAND_MAX)
-    }
-
     /// Return how much to delay before (re)transmitting the message
     /// based on the provided number of re-transmissions so far
     pub fn delay_ms_counter(&self, counter: u16, jitter_rand: u8) -> u64 {
-        let mut delay =
-            self.base_delay_interval_ms as u64 * MRP_BACKOFF_MARGIN.0 / MRP_BACKOFF_MARGIN.1;
-
-        if counter > MRP_BACKOFF_THRESHOLD {
-            for _ in 0..counter - MRP_BACKOFF_THRESHOLD {
-                delay = delay * MRP_BACKOFF_BASE.0 / MRP_BACKOFF_BASE.1;
-            }
-        }
-
-        delay + (delay * jitter_rand as u64 * MRP_BACKOFF_JITTER.0) / (255 * MRP_BACKOFF_JITTER.1)
+        Self::backoff_ms(self.base_delay_interval_ms, counter, jitter_rand)
     }
 
     pub fn pre_send(&mut self, ctr: u32) -> Result<(), Error> {
@@ -187,6 +155,45 @@ impl RetransEntry {
             // This indicates there was some existing entry for same sess-id/exch-id, which shouldn't happen
             panic!("Previous retrans entry for this exchange already exists");
         }
+    }
+
+    /// The delay before the `counter`-th (re)transmission of a message whose base
+    /// retry interval is `base_interval_ms`, per the Matter Core Specification's
+    /// backoff equation.
+    fn backoff_ms(base_interval_ms: u32, counter: u16, jitter_rand: u8) -> u64 {
+        let mut delay = base_interval_ms as u64 * MRP_BACKOFF_MARGIN.0 / MRP_BACKOFF_MARGIN.1;
+
+        if counter > MRP_BACKOFF_THRESHOLD {
+            for _ in 0..counter - MRP_BACKOFF_THRESHOLD {
+                delay = delay * MRP_BACKOFF_BASE.0 / MRP_BACKOFF_BASE.1;
+            }
+        }
+
+        delay + (delay * jitter_rand as u64 * MRP_BACKOFF_JITTER.0) / (255 * MRP_BACKOFF_JITTER.1)
+    }
+
+    /// How long a sender can keep retransmitting a message before it runs out of
+    /// attempts - the *sum* of the whole backoff ladder with maximum jitter, not
+    /// the length of its last step.
+    pub fn retransmission_timeout_ms(
+        active_interval_ms: u32,
+        idle_interval_ms: u32,
+        active_threshold_ms: u16,
+        active_only: bool,
+    ) -> u64 {
+        let mut timeout = 0;
+
+        for counter in 0..MRP_MAX_TRANSMISSIONS {
+            let base_interval_ms = if active_only || timeout < active_threshold_ms as u64 {
+                active_interval_ms
+            } else {
+                idle_interval_ms
+            };
+
+            timeout += Self::backoff_ms(base_interval_ms, counter, MRP_JITTER_RAND_MAX);
+        }
+
+        timeout
     }
 }
 
@@ -273,6 +280,11 @@ impl ReliableMessage {
 
                     self.retrans = None;
                     self.ack = None;
+
+                    // The error is propagated rather than swallowed: clearing
+                    // `retrans` leaves no pending retransmission, which is exactly
+                    // what a peer *acknowledging* the message also looks like.
+                    Err(ErrorCode::TxTimeout)?;
                 }
             } else {
                 self.retrans = Some(RetransEntry::new(session_active_interval_ms, tx_plain.ctr));
@@ -331,5 +343,90 @@ impl ReliableMessage {
         self.received_at = Some(Instant::now());
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A sender gets exactly `MRP_MAX_TRANSMISSIONS` attempts, and the one after
+    /// that fails with `TxTimeout` rather than silently succeeding.
+    ///
+    /// The give-up used to be swallowed, which is indistinguishable from the peer
+    /// having acknowledged: the caller was told the message went out and then
+    /// waited a whole receive timeout for an answer that could never come.
+    #[test]
+    fn retrans_entry_gives_up_after_max_transmissions() {
+        const CTR: u32 = 42;
+
+        let mut entry = RetransEntry::new(Some(300), CTR);
+
+        for attempt in 0..MRP_MAX_TRANSMISSIONS {
+            assert!(
+                entry.pre_send(CTR).is_ok(),
+                "transmission {attempt} should be allowed"
+            );
+        }
+
+        let err = unwrap!(entry.pre_send(CTR).err());
+        assert_eq!(err.code(), ErrorCode::TxTimeout);
+
+        // ... and it keeps failing rather than resetting.
+        assert_eq!(
+            unwrap!(entry.pre_send(CTR).err()).code(),
+            ErrorCode::TxTimeout
+        );
+    }
+
+    /// The backoff grows: linear up to `MRP_BACKOFF_THRESHOLD`, exponential after.
+    #[test]
+    fn backoff_is_linear_then_exponential() {
+        let step = |counter| RetransEntry::backoff_ms(300, counter, MRP_JITTER_RAND_MAX);
+
+        // Up to the threshold the interval does not grow.
+        assert_eq!(step(0), step(MRP_BACKOFF_THRESHOLD));
+
+        // Beyond it, each step grows by the backoff base.
+        for counter in MRP_BACKOFF_THRESHOLD + 1..MRP_MAX_TRANSMISSIONS {
+            assert!(
+                step(counter) > step(counter - 1),
+                "step {counter} should exceed step {}",
+                counter - 1
+            );
+        }
+    }
+
+    /// The retransmission timeout is the *sum* of the ladder, not the length of
+    /// its last step - the distinction the receive timeout is built on.
+    #[test]
+    fn retransmission_timeout_sums_the_whole_ladder() {
+        let expected: u64 = (0..MRP_MAX_TRANSMISSIONS)
+            .map(|counter| RetransEntry::backoff_ms(300, counter, MRP_JITTER_RAND_MAX))
+            .sum();
+
+        let actual = RetransEntry::retransmission_timeout_ms(300, 300, 0, true);
+        assert_eq!(actual, expected);
+
+        // Strictly greater than any single step, which is what a "single step"
+        // regression would collapse it to.
+        let longest = RetransEntry::backoff_ms(300, MRP_MAX_TRANSMISSIONS - 1, MRP_JITTER_RAND_MAX);
+        assert!(actual > longest);
+    }
+
+    /// A sender that may be talking to a sleeping peer paces the ladder by the
+    /// idle interval once the accumulated wait leaves the active threshold, so it
+    /// is more patient than an always-active one.
+    #[test]
+    fn retransmission_timeout_falls_back_to_the_idle_interval() {
+        let active_only = RetransEntry::retransmission_timeout_ms(300, 5000, 4000, true);
+
+        // With a threshold of zero, every step is paced by the idle interval.
+        let idle = RetransEntry::retransmission_timeout_ms(300, 5000, 0, false);
+        assert!(idle > active_only);
+
+        // With a threshold beyond the whole ladder, none of them are.
+        let active = RetransEntry::retransmission_timeout_ms(300, 5000, u16::MAX, false);
+        assert_eq!(active, active_only);
     }
 }

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -55,6 +55,20 @@ use super::proto_hdr::ProtoHdr;
 #[cfg(feature = "groups")]
 use super::Packet;
 
+/// Receive timeout for a TCP-backed session.
+///
+/// TCP handles its own retransmission, so there is no MRP ladder to derive from;
+/// this is a flat upper bound on how long the peer may take to answer. The CHIP
+/// SDK uses the same 30 seconds for `GetAckTimeout` / `GetMessageReceiptTimeout`
+/// on TCP sessions.
+const TCP_RX_TIMEOUT_MS: u64 = 30_000;
+
+/// Receive timeout for a BTP (BLE) session.
+///
+/// BTP runs its own acknowledgement scheme underneath, so the MRP ladder does not
+/// describe it; this matches the BTP layer's own ack timeout.
+const BTP_RX_TIMEOUT_MS: u64 = 5_000;
+
 pub const MAX_CAT_IDS_PER_NOC: usize = 3;
 pub type NocCatIds = [u32; MAX_CAT_IDS_PER_NOC];
 
@@ -140,7 +154,8 @@ pub struct Session {
     /// Peer's effective `MRP_SESSION_ACTIVE_THRESHOLD` (ms).
     peer_active_threshold_ms: u16,
     /// If `true` then the session is considered "expired". Session expiration happens
-    /// for the session on behalf of which a fabric is removed.
+    /// for the session on behalf of which a fabric is removed, and for a CASE session
+    /// whose peer stopped acknowledging (see [`Session::pre_send`]).
     ///
     /// Expired sessions can still process their ongoing exchanges, but do not accept any new ones.
     /// Furthermore, expired sessions are the prime candidates for eviction.
@@ -424,6 +439,59 @@ impl Session {
         self.expired
     }
 
+    /// How long to wait for the peer's answer on this session before giving up
+    /// with [`ErrorCode::RxTimeout`].
+    ///
+    /// Mirrors the CHIP SDK's `Session::ComputeRoundTripTimeout`, which is a sum
+    /// of three terms rather than a single scaled backoff step:
+    ///
+    /// - the time our message may spend being retransmitted before it reaches the
+    ///   peer, paced by the **peer's** advertised retry interval,
+    /// - an allowance for the peer's upper layer to process the request,
+    /// - the time the peer's answer may spend being retransmitted before it
+    ///   reaches us, paced by **our own** retry interval.
+    ///
+    /// The two halves deliberately use different inputs: each direction is paced
+    /// by the retry configuration of whichever side is doing the sending.
+    ///
+    /// The outbound half uses the peer's *idle* interval, because we cannot know
+    /// whether the peer is awake when we first speak to it, while the inbound half
+    /// uses the *active* interval, since the peer is by then answering a message
+    /// it has just received. That is the same asymmetry CHIP encodes through its
+    /// `isFirstMessageOnExchange` flag.
+    ///
+    /// Non-UDP transports derive nothing: TCP is a reliable stream with no MRP
+    /// ladder to account for, and BTP carries its own acknowledgement timeout.
+    pub(crate) fn rx_timeout_ms(&self, local_active_interval_ms: u32) -> u64 {
+        match self.peer_addr {
+            Address::Tcp(_) => TCP_RX_TIMEOUT_MS,
+            Address::Btp(_) => BTP_RX_TIMEOUT_MS,
+            Address::Udp(_) => {
+                // Outbound: our message reaching the peer, paced by the peer's own
+                // retry configuration, and allowed to fall back to its idle
+                // interval since we cannot know whether it is awake.
+                let outbound = mrp::RetransEntry::retransmission_timeout_ms(
+                    self.peer_active_interval_ms,
+                    self.peer_idle_interval_ms,
+                    self.peer_active_threshold_ms,
+                    false,
+                );
+
+                // Inbound: the peer's answer reaching us, paced by our own retry
+                // configuration. Always active - the peer is answering a message
+                // it just received, so it is demonstrably awake.
+                let inbound = mrp::RetransEntry::retransmission_timeout_ms(
+                    local_active_interval_ms,
+                    local_active_interval_ms,
+                    0,
+                    true,
+                );
+
+                outbound + mrp::MRP_EXPECTED_PROCESSING_MS + inbound
+            }
+        }
+    }
+
     pub fn upgrade_fabric_idx(&mut self, fabric_idx: NonZeroU8) -> Result<(), Error> {
         if let SessionMode::Pase { fab_idx } = &mut self.mode {
             if *fab_idx == 0 {
@@ -613,12 +681,41 @@ impl Session {
         if let Some(exchange_index) = exch_index {
             let exchange = unwrap!(self.exchanges[exchange_index].as_mut());
 
-            exchange.pre_send(
+            let result = exchange.pre_send(
                 &tx_header.plain,
                 &mut tx_header.proto,
                 session_active_interval_ms,
                 session_idle_interval_ms,
-            )?;
+            );
+
+            if matches!(
+                result.as_ref().map_err(Error::code),
+                Err(ErrorCode::TxTimeout)
+            ) && matches!(self.mode, SessionMode::Case { .. })
+                && !self.expired
+            {
+                // The peer never acknowledged, which is the strongest evidence we
+                // get that its recorded address no longer reaches it - it may have
+                // renumbered, moved subnet, or the address picked out of the
+                // resolve was never reachable in the first place.
+                //
+                // Expiring keeps the session usable for the exchanges already on
+                // it (they fail on their own) while making `Transport::initiate`
+                // skip it, so the next attempt re-resolves the peer and builds a
+                // fresh session against the current candidate list.
+                //
+                // Only CASE sessions: PASE and plaintext are short-lived and
+                // pinned to an address the caller supplied itself, so there is
+                // nothing to re-resolve.
+                warn!(
+                    "Session {}: Peer did not acknowledge; marking the session as expired",
+                    self.id
+                );
+
+                self.expired = true;
+            }
+
+            result?;
         }
 
         Ok((self.peer_addr, retransmission))
@@ -2037,7 +2134,7 @@ pub fn derive_group_session_id<C: Crypto>(
 mod tests {
     use crate::crypto::{test_only_crypto, AEAD_KEY_ZEROED};
     use crate::dm::clusters::basic_info::BasicInfoConfig;
-    use crate::transport::network::Address;
+    use crate::transport::network::{Address, BtAddr};
 
     use super::*;
 
@@ -2067,6 +2164,66 @@ mod tests {
         assert_eq!(sm.get_next_sess_id(), 65534);
         assert_eq!(sm.get_next_sess_id(), 65535);
         assert_eq!(sm.get_next_sess_id(), 2);
+    }
+
+    /// The receive timeout is derived per transport: only UDP has an MRP ladder
+    /// to account for, while TCP and BTP carry their own reliability underneath.
+    #[test]
+    fn rx_timeout_is_per_transport() {
+        use core::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
+
+        let addr = |f: fn(SocketAddr) -> Address| {
+            f(SocketAddr::V6(SocketAddrV6::new(
+                Ipv6Addr::LOCALHOST,
+                5540,
+                0,
+                0,
+            )))
+        };
+
+        let session = |peer_addr| Session::new(1, 0, false, peer_addr, None, 300, 5000, 4000);
+
+        assert_eq!(
+            session(addr(Address::Tcp)).rx_timeout_ms(300),
+            TCP_RX_TIMEOUT_MS
+        );
+        assert_eq!(
+            session(Address::Btp(BtAddr([0; 6]))).rx_timeout_ms(300),
+            BTP_RX_TIMEOUT_MS
+        );
+
+        // UDP sums both directions of the MRP ladder plus the processing
+        // allowance, and is therefore strictly larger than either ladder alone.
+        let udp = session(addr(Address::Udp)).rx_timeout_ms(300);
+        let one_ladder = mrp::RetransEntry::retransmission_timeout_ms(300, 300, 0, true);
+
+        assert_eq!(
+            udp,
+            one_ladder + mrp::MRP_EXPECTED_PROCESSING_MS + one_ladder
+        );
+        assert!(udp > one_ladder + mrp::MRP_EXPECTED_PROCESSING_MS);
+    }
+
+    /// The receive timeout must outlast the send-side give-up, or a peer that is
+    /// merely slow would be abandoned before its answer could arrive.
+    #[test]
+    fn rx_timeout_outlasts_the_send_side_give_up() {
+        use core::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
+
+        let peer_addr = Address::Udp(SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::LOCALHOST,
+            5540,
+            0,
+            0,
+        )));
+
+        let rx = Session::new(1, 0, false, peer_addr, None, 300, 5000, 4000).rx_timeout_ms(300);
+        let give_up = mrp::RetransEntry::retransmission_timeout_ms(300, 5000, 4000, false);
+
+        assert!(
+            rx > give_up,
+            "receive timeout {rx}ms must exceed the retransmission give-up {give_up}ms"
+        );
     }
 
     #[test]


### PR DESCRIPTION
* A followup from #537 - use RX timeouts which more closely map the ones CHIP uses.
* Expire sessions where an exchange gets a TX/RX failure
