### PR TITLE
Streamline the logging of the E2E test drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Streamline the logging of the E2E test drivers (#542)
 * Commissioning - trying to close a non-open comm window should return an error (#541)
 * Commissioning over PASE - fix a spurious SessionNotFound error (#541)
 * Support for PICS and the TH tool (#541)

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -733,28 +733,16 @@ impl<'a> Matter<'a> {
     where
         F: FnMut(MatterLocalService) -> Result<(), Error>,
     {
-        debug!("=== Currently published mDNS services");
-
         self.with_state(|state| {
             if let Some(comm_window) = state.pase.comm_window() {
-                // Do not remove this logging line or change its formatting.
-                // C++ E2E tests rely on this log line to determine when the mDNS service is published
-                debug!("mDNS service published: {:?}", comm_window.mdns_service());
-
                 f(comm_window.mdns_service())?;
             }
 
             for fabric in state.fabrics.iter() {
                 if let Some(service) = fabric.mdns_service() {
-                    // Do not remove this logging line or change its formatting.
-                    // C++ E2E tests rely on this log line to determine when the mDNS service is published
-                    debug!("mDNS service published: {:?}", service);
-
                     f(service)?;
                 }
             }
-
-            debug!("===");
 
             Ok(())
         })

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -1246,8 +1246,17 @@ impl<'a, C: Crypto> TransportRunner<'a, C> {
         info!("Running Matter transport");
 
         // Do not remove this logging line or change its formatting.
-        // C++ E2E tests rely on this log line to determine when the tested app is ready
-        debug!("APP STATUS: Starting event loop");
+        // C++ E2E tests rely on this log line to determine when the tested app is ready.
+        info!("APP STATUS: Starting event loop");
+
+        // Do not remove this logging line or change its formatting either.
+        //
+        // `waitForApplicationUp` in the harness
+        // (`scripts/tests/chiptest/test_definition.py`) blocks until it has seen
+        // *both* "APP STATUS: Starting event loop" and "mDNS service published:"
+        // on the app's stdout, so the phrase has to appear at least once per
+        // start.
+        info!("mDNS service published: (app started)");
 
         let send = IfMutex::new(send);
 

--- a/tests/src/bin/ble_tests.rs
+++ b/tests/src/bin/ble_tests.rs
@@ -104,6 +104,9 @@ mod mdns;
 #[path = "../common/args.rs"]
 mod args;
 
+#[path = "../common/logging.rs"]
+mod logging;
+
 #[path = "../common/mock_net_ctl.rs"]
 #[allow(dead_code)]
 mod mock_net_ctl;
@@ -129,14 +132,7 @@ fn main() -> Result<(), Error> {
 }
 
 fn run() -> Result<(), Error> {
-    env_logger::builder()
-        .format(|buf, record| {
-            use std::io::Write;
-            writeln!(buf, "{}: {}", record.level(), record.args())
-        })
-        .target(env_logger::Target::Stdout)
-        .filter_level(::log::LevelFilter::Debug)
-        .init();
+    logging::init();
 
     // `--ble-controller <n>` selects `hci<n>`, matching how the CHIP harness
     // keeps the device and the commissioner on separate adapters.

--- a/tests/src/bin/camera_tests.rs
+++ b/tests/src/bin/camera_tests.rs
@@ -101,6 +101,9 @@ mod mdns;
 #[path = "../common/args.rs"]
 mod args;
 
+#[path = "../common/logging.rs"]
+mod logging;
+
 // ---------------------------------------------------------------------------
 // Device type
 // ---------------------------------------------------------------------------
@@ -390,16 +393,7 @@ static PUSH_AV: StaticCell<PushAvStreamHandler<'static, StubPushHooks, PUSH_NC>>
 // ---------------------------------------------------------------------------
 
 fn main() -> Result<(), Error> {
-    std::env::set_var("RUST_BACKTRACE", "1");
-
-    env_logger::builder()
-        .format(|buf, record| {
-            use std::io::Write;
-            writeln!(buf, "{}: {}", record.level(), record.args())
-        })
-        .target(env_logger::Target::Stdout)
-        .filter_level(::log::LevelFilter::Debug)
-        .init();
+    logging::init();
 
     let matter = MATTER.uninit().init_with(Matter::init(
         &BASIC_INFO,

--- a/tests/src/bin/commissioner_tests.rs
+++ b/tests/src/bin/commissioner_tests.rs
@@ -70,6 +70,9 @@ use static_cell::StaticCell;
 #[path = "../common/mdns.rs"]
 mod mdns;
 
+#[path = "../common/logging.rs"]
+mod logging;
+
 use mdns::stub_mdns_resolver;
 
 /// Defaults match rs-matter's `TEST_DEV_COMM`. Override via CLI args
@@ -82,7 +85,7 @@ const COMMISSION_TIMEOUT_SECS: u64 = 60;
 static CTRL_MATTER: StaticCell<Matter> = StaticCell::new();
 
 fn main() -> ExitCode {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    logging::init();
 
     let args = match parse_args() {
         Ok(a) => a,

--- a/tests/src/bin/light_tests.rs
+++ b/tests/src/bin/light_tests.rs
@@ -104,6 +104,9 @@ mod mdns;
 #[path = "../common/args.rs"]
 mod args;
 
+#[path = "../common/logging.rs"]
+mod logging;
+
 #[path = "../common/pipe.rs"]
 mod pipe;
 
@@ -123,14 +126,7 @@ static BUFFERS: StaticCell<MatterBuffers> = StaticCell::new();
 static STATE: StaticCell<EthInteractionModelState> = StaticCell::new();
 
 fn main() -> Result<(), Error> {
-    env_logger::builder()
-        .format(|buf, record| {
-            use std::io::Write;
-            writeln!(buf, "{}: {}", record.level(), record.args())
-        })
-        .target(env_logger::Target::Stdout)
-        .filter_level(::log::LevelFilter::Debug)
-        .init();
+    logging::init();
 
     let matter = MATTER.uninit().init_with(Matter::init(
         &TEST_DEV_DET,

--- a/tests/src/bin/scenes_tests.rs
+++ b/tests/src/bin/scenes_tests.rs
@@ -79,6 +79,9 @@ mod mdns;
 #[path = "../common/args.rs"]
 mod args;
 
+#[path = "../common/logging.rs"]
+mod logging;
+
 // Statically allocate in BSS the bigger objects
 // `rs-matter` supports efficient initialization of BSS objects (with `init`)
 // as well as just allocating the objects on-stack or on the heap.
@@ -94,14 +97,7 @@ static SCENES_STATE: StaticCell<ScenesState<SCENES_CAPACITY>> = StaticCell::new(
 static UNIT_TESTING_DATA: StaticCell<RefCell<UnitTestingHandlerData>> = StaticCell::new();
 
 fn main() -> Result<(), Error> {
-    env_logger::builder()
-        .format(|buf, record| {
-            use std::io::Write;
-            writeln!(buf, "{}: {}", record.level(), record.args())
-        })
-        .target(env_logger::Target::Stdout)
-        .filter_level(::log::LevelFilter::Debug)
-        .init();
+    logging::init();
 
     let matter = MATTER.uninit().init_with(Matter::init(
         &TEST_DEV_DET,

--- a/tests/src/bin/system_tests.rs
+++ b/tests/src/bin/system_tests.rs
@@ -133,6 +133,9 @@ mod mdns;
 #[path = "../common/args.rs"]
 mod args;
 
+#[path = "../common/logging.rs"]
+mod logging;
+
 #[path = "../common/pipe.rs"]
 mod pipe;
 
@@ -174,20 +177,10 @@ static DLOG_BUFFERS: StaticCell<MatterBuffers<2>> = StaticCell::new();
 static SW_FAULT_NOTIFY: Notification<CriticalSectionRawMutex> = Notification::new();
 
 fn main() -> Result<(), Error> {
-    // Enable detailed backtraces for debugging test failures
-    // (Temporarily disabled to keep TC_SC_3_4 traces readable.)
-    // std::env::set_var("RUST_BACKTRACE", "1");
-
-    // Special logging configuration compatible with ConnectedHomeIP YAML tests
-    // Log to stdout with simplified format at debug level as required by chip-tool tests
-    env_logger::builder()
-        .format(|buf, record| {
-            use std::io::Write;
-            writeln!(buf, "{}: {}", record.level(), record.args())
-        })
-        .target(env_logger::Target::Stdout)
-        .filter_level(::log::LevelFilter::Debug)
-        .init();
+    // Logs go to stdout at debug level, which is what the ConnectedHomeIP
+    // harness reads: it waits for a ready pattern in this stream, and a
+    // failing run is diagnosed by reading it beside chip-tool's own log.
+    logging::init();
 
     // Optional `--discriminator <u16>` / `--passcode <u32>` overrides for the
     // hardcoded `TEST_DEV_COMM` defaults. Used by tests like TC-SC-7.1 that

--- a/tests/src/bin/thread_tests.rs
+++ b/tests/src/bin/thread_tests.rs
@@ -76,6 +76,9 @@ mod mdns;
 #[path = "../common/args.rs"]
 mod args;
 
+#[path = "../common/logging.rs"]
+mod logging;
+
 /// The env var carrying the (hex TLV) operational dataset the driver attaches
 /// to at startup. Set by `cargo xtask itest --suite thread`.
 const DATASET_ENV: &str = "RS_MATTER_THREAD_DATASET";
@@ -99,14 +102,7 @@ fn main() -> Result<(), Error> {
 }
 
 fn run() -> Result<(), Error> {
-    env_logger::builder()
-        .format(|buf, record| {
-            use std::io::Write;
-            writeln!(buf, "{}: {}", record.level(), record.args())
-        })
-        .target(env_logger::Target::Stdout)
-        .filter_level(::log::LevelFilter::Debug)
-        .init();
+    logging::init();
 
     // Built before the Thread attach below so that `--pics-json` works
     // without an operational dataset or a running `otbr-agent`: the data

--- a/tests/src/bin/wireless_tests.rs
+++ b/tests/src/bin/wireless_tests.rs
@@ -78,6 +78,9 @@ mod mdns;
 #[path = "../common/args.rs"]
 mod args;
 
+#[path = "../common/logging.rs"]
+mod logging;
+
 #[path = "../common/mock_net_ctl.rs"]
 mod mock_net_ctl;
 
@@ -104,14 +107,7 @@ fn main() -> Result<(), Error> {
 }
 
 fn run() -> Result<(), Error> {
-    env_logger::builder()
-        .format(|buf, record| {
-            use std::io::Write;
-            writeln!(buf, "{}: {}", record.level(), record.args())
-        })
-        .target(env_logger::Target::Stdout)
-        .filter_level(::log::LevelFilter::Debug)
-        .init();
+    logging::init();
 
     // The Wi-Fi and Thread network stores are distinct types, so the node is
     // built out in one of two monomorphisations rather than switched at runtime.

--- a/tests/src/common/logging.rs
+++ b/tests/src/common/logging.rs
@@ -1,0 +1,62 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Shared logging setup for the `*_tests` example binaries.
+
+/// Initialise logging for a test binary.
+///
+/// Defaults to `Debug`, which is the level the integration tests are written
+/// against: a failure is normally diagnosed by reading this log next to the
+/// harness's own, message by message, and anything quieter drops the exchanges
+/// that make that possible.
+///
+/// `RUST_LOG` overrides it when a run wants to be quieter or more targeted -
+/// `RUST_LOG=info`, `RUST_LOG=rs_matter::transport=trace`. The default is
+/// supplied through `Env::default_filter_or`, so the whole of `env_logger`'s
+/// environment handling (`RUST_LOG_STYLE` included) keeps working.
+///
+/// Lines carry a millisecond timestamp. These logs are read alongside the Test
+/// Harness's, which timestamps everything it prints, and lining the two up is
+/// how a failure gets placed in the run.
+pub fn init() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug"))
+        .format(|buf, record| {
+            use std::io::Write;
+
+            writeln!(
+                buf,
+                "[{} {}]: {}",
+                buf.timestamp_millis(),
+                record.level(),
+                record.args()
+            )
+        })
+        .target(env_logger::Target::Stdout)
+        .init();
+
+    // `rs_matter::error::Error` captures a `std::backtrace::Backtrace`, which
+    // is only populated when `RUST_BACKTRACE` is set - otherwise it renders as
+    // "disabled backtrace".
+    //
+    // Tie that to debug logging rather than turning it on unconditionally, so
+    // that quietening a run with `RUST_LOG` also quietens the backtraces. Set
+    // before the first `Error` is constructed, since `Backtrace` caches whether
+    // capture is enabled on first use.
+    if log::max_level() >= log::LevelFilter::Debug && std::env::var_os("RUST_BACKTRACE").is_none() {
+        std::env::set_var("RUST_BACKTRACE", "1");
+    }
+}


### PR DESCRIPTION
* Restore the date-time prefix, or else the logs are difficult to navigate
* Unify the logs initialization, avoid copy-paste and drifts between the various test drivers
* Make the log init respect `RUST_LOG`, and default to `Debug` if the var is not set
* Remove the "published mDNS service" avalanche of logs