### PR TITLE
Add more tests available upstream; small extensions for NFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Add PAF and NTL options to `DiscoveryCapabilities`; `QrPayload::as_ndef` (#543)
 * Streamline the logging of the E2E test drivers (#542)
 * Commissioning - trying to close a non-open comm window should return an error (#541)
 * Commissioning over PASE - fix a spurious SessionNotFound error (#541)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* (Breaking) Retire `GenDiag::reboot_count` and `GenDiag::uptime_ms` as they are now implemented directly in `rs-matter` (#543)
 * Add PAF and NTL options to `DiscoveryCapabilities`; `QrPayload::as_ndef` (#543)
 * Streamline the logging of the E2E test drivers (#542)
 * Commissioning - trying to close a non-open comm window should return an error (#541)

--- a/rs-matter/src/dm/clusters/gen_diag.rs
+++ b/rs-matter/src/dm/clusters/gen_diag.rs
@@ -102,12 +102,6 @@ pub use crate::im::DeviceLoad;
 /// A trait to which the system implementation of the General Diagnostics Matter cluster
 /// delegates for information.
 pub trait GenDiag: DynBase {
-    /// Get the reboot count of the node.
-    fn reboot_count(&self) -> Result<u16, Error>;
-
-    /// Get the uptime of the node in milliseconds.
-    fn uptime_ms(&self) -> Result<u64, Error>;
-
     /// Whether the test event triggers are enabled.
     /// Check the Matter Core spec for more info.
     fn test_event_triggers_enabled(&self) -> Result<bool, Error>;
@@ -121,14 +115,6 @@ impl<T> GenDiag for &T
 where
     T: GenDiag,
 {
-    fn reboot_count(&self) -> Result<u16, Error> {
-        (**self).reboot_count()
-    }
-
-    fn uptime_ms(&self) -> Result<u64, Error> {
-        (**self).uptime_ms()
-    }
-
     fn test_event_triggers_enabled(&self) -> Result<bool, Error> {
         (**self).test_event_triggers_enabled()
     }
@@ -146,14 +132,6 @@ where
 /// semantics the spec asks for, and what `TimeSnapshot::SystemTimeMs` needs
 /// to advance with real wall time between calls.
 impl GenDiag for () {
-    fn reboot_count(&self) -> Result<u16, Error> {
-        Ok(0)
-    }
-
-    fn uptime_ms(&self) -> Result<u64, Error> {
-        Ok(embassy_time::Instant::now().as_millis())
-    }
-
     fn test_event_triggers_enabled(&self) -> Result<bool, Error> {
         Ok(false)
     }
@@ -275,12 +253,12 @@ impl ClusterHandler for GenDiagHandler<'_> {
         }
     }
 
-    fn reboot_count(&self, _ctx: impl ReadContext) -> Result<u16, Error> {
-        self.diag.reboot_count()
+    fn reboot_count(&self, ctx: impl ReadContext) -> Result<u16, Error> {
+        Ok(ctx.exchange().matter().reboot_count())
     }
 
     fn up_time(&self, _ctx: impl ReadContext) -> Result<u64, Error> {
-        self.diag.uptime_ms().map(|uptime| uptime / 1000)
+        Ok(embassy_time::Instant::now().as_secs())
     }
 
     fn device_load_status<P: TLVBuilderParent>(
@@ -324,9 +302,7 @@ impl ClusterHandler for GenDiagHandler<'_> {
         ctx: impl InvokeContext,
         response: TimeSnapshotResponseBuilder<P>,
     ) -> Result<P, Error> {
-        // `SystemTimeMs` is the monotonic since-boot timestamp; we delegate
-        // to `GenDiag::uptime_ms`.
-        let system_time_ms = self.diag.uptime_ms()?;
+        let system_time_ms = embassy_time::Instant::now().as_millis();
 
         // `PosixTimeMs` (Matter Core spec): SHALL be null only
         // when the device doesn't support the TimeSynchronization cluster

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -317,7 +317,7 @@ impl<'a> Matter<'a> {
         self.dev_att = dev_att;
     }
 
-    /// Print the standard QR code text to the console
+    /// Log the standard QR code text.
     ///
     /// The printed QR code text corresponds to the standard commissioning flow (i.e. `CommFlowType::Standard`)
     /// and contains no optional data.
@@ -344,7 +344,48 @@ impl<'a> Matter<'a> {
         Ok(())
     }
 
-    /// Print the standard QR code to the console
+    /// Log the NDEF message an NFC tag should carry for this device.
+    ///
+    /// # Arguments
+    /// - `disc_caps`: The discovery capabilities to be used in the QR code payload
+    pub fn print_standard_nfc_ndef(&self, disc_caps: DiscoveryCapabilities) -> Result<(), Error> {
+        let rx_buf = self.transport().rx_buffer();
+
+        let mut buf = rx_buf.get_immediate().ok_or(ErrorCode::NoMemory)?;
+        let buf = &mut *buf;
+
+        let payload = self.standard_qr_payload(disc_caps)?;
+
+        let (ndef, remaining) = payload.as_ndef(buf)?;
+
+        // Hex, because bytes are what get written to the tag, and as one
+        // contiguous string so it can be compared against a tag reader's dump.
+        // (`fmt::Bytes` pretty-prints across lines, which is unusable here.)
+        // The buffer `as_ndef` hands back is where it goes - two characters per
+        // byte.
+        const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+        let hex_len = ndef.len() * 2;
+        if remaining.len() < hex_len {
+            Err(ErrorCode::BufferTooSmall)?;
+        }
+
+        for (index, byte) in ndef.iter().enumerate() {
+            remaining[index * 2] = HEX[(byte >> 4) as usize];
+            remaining[index * 2 + 1] = HEX[(byte & 0x0f) as usize];
+        }
+
+        // Cannot fail: every byte written above is an ASCII hex digit.
+        let hex = unwrap!(
+            core::str::from_utf8(&remaining[..hex_len]).map_err(|_| ErrorCode::InvalidData)
+        );
+
+        info!("SetupNFCTagNDEF: [{}]", hex);
+
+        Ok(())
+    }
+
+    /// Log the standard QR code text.
     ///
     /// The printed QR code corresponds to the standard commissioning flow (i.e. `CommFlowType::Standard`)
     /// and contains no optional data.

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -385,7 +385,7 @@ impl<'a> Matter<'a> {
         Ok(())
     }
 
-    /// Log the standard QR code text.
+    /// Log the standard QR code.
     ///
     /// The printed QR code corresponds to the standard commissioning flow (i.e. `CommFlowType::Standard`)
     /// and contains no optional data.

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -45,11 +45,12 @@ use crate::pairing::qr::{
     no_optional_data, CommFlowType, NoOptionalData, Qr, QrPayload, QrTextType,
 };
 use crate::pairing::DiscoveryCapabilities;
-use crate::persist::{KvBlobStore, KvBlobStoreAccess, Persist};
+use crate::persist::{KvBlobStore, KvBlobStoreAccess, Persist, REBOOT_COUNT_KEY};
 #[cfg(feature = "case-resumption")]
 use crate::sc::case::ResumableSessions;
 use crate::sc::pase::spake2p::{Spake2pVerifierPassword, SPAKE2P_VERIFIER_SALT_ZEROED};
 use crate::sc::pase::{CommWindowState, Pase};
+use crate::tlv::{TLVElement, TLVTag, ToTLV};
 use crate::transport::network::MatterLocalService;
 use crate::transport::network::{NetworkMulticast, NetworkReceive, NetworkSend};
 use crate::transport::session::Sessions;
@@ -59,6 +60,7 @@ use crate::transport::{
 use crate::utils::cell::RefCell;
 use crate::utils::init::{init, Init};
 use crate::utils::storage::pooled::Buffers;
+use crate::utils::storage::WriteBuf;
 use crate::utils::sync::blocking::Mutex;
 
 use rand_core::RngCore;
@@ -256,6 +258,61 @@ impl<'a> Matter<'a> {
 
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    /// Persist the reboot count established by [`Matter::startup`], so the
+    /// next boot counts from it.
+    ///
+    /// Separate from `startup` on purpose. The counter needs one write per
+    /// boot - there is exactly one increment per boot, so unlike the event
+    /// counter there is nothing to batch - and putting that write in the boot
+    /// path means a device stuck in a boot loop rewrites flash on every
+    /// iteration. Calling this once the boot looks healthy (the transport is
+    /// up, or some device-specific milestone) leaves a boot loop writing
+    /// nothing at all.
+    ///
+    /// The cost of deferring is that a crash before this call leaves that boot
+    /// uncounted, which the spec's "best-effort" wording allows.
+    ///
+    /// Idempotent: a call that would rewrite the value already on record does
+    /// nothing, so it is safe to call repeatedly (per milestone, or on a
+    /// timer).
+    ///
+    /// A device that never calls this reports a plausible count for the current
+    /// boot but never advances across reboots.
+    pub fn persist_reboot_count<K: KvBlobStoreAccess>(&self, kv: K) -> Result<(), Error> {
+        let reboot_count = self.with_state(|state| state.reboot_count);
+
+        kv.access(|store, buf| {
+            let stored = store
+                .load(REBOOT_COUNT_KEY, buf)?
+                .map(|data| TLVElement::new(data).u16())
+                .transpose()?;
+
+            // Nothing to do if this boot's count is already on record, so
+            // calling this more than once per boot costs no writes.
+            if stored == Some(reboot_count) {
+                return Ok(());
+            }
+
+            let mut wb = WriteBuf::new(buf);
+
+            reboot_count.to_tlv(&TLVTag::Anonymous, &mut wb)?;
+
+            let len = wb.get_tail();
+            let (data, buf) = buf.split_at_mut(len);
+
+            store.store(REBOOT_COUNT_KEY, data, buf)
+        })
+    }
+
+    /// The node's reboot count, as reported by
+    /// `GeneralDiagnostics::RebootCount`.
+    ///
+    /// Bumped once per [`Matter::startup`] and persisted, so it survives
+    /// reboots and resets only on a factory reset.
+    pub fn reboot_count(&self) -> u16 {
+        self.with_state(|state| state.reboot_count)
     }
 
     /// The ICD operating mode to advertise in the operational `ICD` DNS-SD TXT
@@ -705,6 +762,27 @@ impl<'a> Matter<'a> {
                 #[cfg(feature = "groups")]
                 state.sessions.load_persist(&mut store, buf)?;
 
+                // `RebootCount` for *this* boot: the persisted value plus one.
+                //
+                // Only loaded here - the matching write is
+                // [`Matter::persist_reboot_count`], which the device calls once
+                // it considers the boot healthy. Writing it here instead would
+                // put one flash write in the boot path, so a device stuck in a
+                // boot loop would churn its write-endurance budget while
+                // already broken.
+                //
+                // Reaching `startup` *is* a boot, so no platform support is
+                // needed to detect one, and the spec asks only for a
+                // "best-effort" count - it deliberately does not distinguish a
+                // crash from a power cut. A wake from sleep does not re-enter
+                // startup, which is the one case the spec excludes.
+                state.reboot_count = store
+                    .load(REBOOT_COUNT_KEY, buf)?
+                    .map(|data| TLVElement::new(data).u16())
+                    .transpose()?
+                    .unwrap_or(0)
+                    .saturating_add(1);
+
                 Ok::<_, Error>(())
             })
         })?;
@@ -816,6 +894,8 @@ pub struct MatterState {
     /// The ICD operating mode advertised in the operational `ICD` DNS-SD TXT key.
     /// The ICD Management handler keeps this in sync with its registration set.
     icd_mode: Option<OperatingModeEnum>,
+    /// The node's reboot counter, bumped and persisted by `Matter::startup`.
+    reboot_count: u16,
 }
 
 impl MatterState {
@@ -832,6 +912,7 @@ impl MatterState {
             basic_info_settings: BasicInfoSettings::new(),
             rtc: Rtc::new(),
             icd_mode: None,
+            reboot_count: 0,
         }
     }
 
@@ -849,6 +930,7 @@ impl MatterState {
             basic_info_settings <- BasicInfoSettings::init(),
             rtc <- Rtc::init(),
             icd_mode: None,
+            reboot_count: 0,
         })
     }
 
@@ -863,6 +945,7 @@ impl MatterState {
             basic_info_settings <- BasicInfoSettings::init(),
             rtc <- Rtc::init(),
             icd_mode: None,
+            reboot_count: 0,
         })
     }
 }

--- a/rs-matter/src/pairing.rs
+++ b/rs-matter/src/pairing.rs
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2023-2025 Project CHIP Authors
+ *    Copyright (c) 2023-2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,10 +28,23 @@ pub mod qr;
 bitflags! {
     #[repr(transparent)]
     #[cfg_attr(not(feature = "defmt"), derive(Debug, Copy, Clone, Eq, PartialEq, Hash))]
+    /// The Discovery Capabilities Bitmask carried in the machine-readable
+    /// onboarding payloads (QR code, NFC tag).
     pub struct DiscoveryCapabilities: u8 {
+        /// Soft Access Point (AP) discovery.
+        ///
+        /// Note bit 0 is reserved and SHALL be zero as of Matter 1.6;
+        /// `SOFT_AP` predates that and is kept only for backwards
+        /// compatibility - do not set it on a 1.6 device.
         const SOFT_AP = 0x01;
+        /// BLE discovery
         const BLE = 0x02;
+        /// IP-based discovery (e.g. mDNS or DNS-SD with Thread)
         const IP = 0x04;
+        /// Wi-Fi Public Action Frame
+        const PAF = 0x08;
+        /// NFC Transport Layer (NTL) commissioning
+        const NTL = 0x10;
     }
 }
 

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -1409,6 +1409,48 @@ mod tests {
         assert_eq!(data_str, QR_CODE)
     }
 
+    /// The bit positions are fixed by the Matter Core spec's Discovery
+    /// Capabilities Bitmask, and a payload carrying PAF or NTL has to survive a
+    /// round-trip: `parse` uses `from_bits_truncate`, so any bit the type does
+    /// not define is silently dropped off a peer's payload.
+    #[test]
+    fn discovery_capability_bits_round_trip() {
+        assert_eq!(DiscoveryCapabilities::BLE.bits(), 1 << 1);
+        assert_eq!(DiscoveryCapabilities::IP.bits(), 1 << 2);
+        assert_eq!(DiscoveryCapabilities::PAF.bits(), 1 << 3);
+        assert_eq!(DiscoveryCapabilities::NTL.bits(), 1 << 4);
+
+        let comm_data = BasicCommData {
+            password: 20202021_u32.to_le_bytes().into(),
+            discriminator: 3840,
+        };
+        let dev_det = BasicInfoConfig {
+            vid: 65521,
+            pid: 32769,
+            ..Default::default()
+        };
+
+        let caps = DiscoveryCapabilities::BLE | DiscoveryCapabilities::NTL;
+
+        let payload = QrPayload::new_from_basic_info(
+            caps,
+            CommFlowType::Standard,
+            comm_data,
+            &dev_det,
+            no_optional_data,
+        );
+
+        let mut buf = [0; 1024];
+        let (text, buf) = unwrap!(payload.as_str(&mut buf), "Failed to encode");
+
+        let mut parse_buf = [0; 1024];
+        let parsed = unwrap!(QrPayload::parse(text, &mut parse_buf), "Failed to parse");
+
+        assert_eq!(parsed.discovery_capabilities, caps);
+
+        let _ = buf;
+    }
+
     /// The NFC tag carries the same onboarding payload as the QR code, wrapped
     /// in the single NDEF URI record the Matter Core spec fixes byte for byte.
     #[test]

--- a/rs-matter/src/pairing/qr.rs
+++ b/rs-matter/src/pairing/qr.rs
@@ -281,6 +281,65 @@ where
         Ok((str, remaining_buf))
     }
 
+    /// Encode this payload as the NDEF message an NFC tag carries, into the
+    /// provided buffer.
+    ///
+    /// An NFC tag is an alternative carrier for the *same* onboarding payload
+    /// as the QR code - "The data contained in the NFC tag SHALL be formatted
+    /// as specified in QR Code Format" - wrapped in a single NDEF URI record.
+    /// This is passive-tag onboarding only: it says nothing about the NFC
+    /// Transport Layer (PASE over NFC), which rs-matter does not implement and
+    /// which needs no payload of this kind.
+    ///
+    /// The record layout is fixed by the Matter Core spec:
+    ///
+    /// ```text
+    /// 0: 0xD1   TNF=0x01 (well-known), SR=1, MB=1, ME=1
+    /// 1: 0x01   length of the record type
+    /// 2: <len>  URI payload size in bytes
+    /// 3: 0x55   record name, "U"
+    /// 4: 0x00   URI identifier code: no abbreviation
+    /// 5: MT:<base-38 content>
+    /// ```
+    ///
+    /// # Arguments
+    /// - `buf` - Buffer to store the NDEF message
+    ///
+    /// # Returns
+    /// - On success, a tuple of the NDEF message and the remaining buffer
+    /// - On failure, an error
+    pub fn as_ndef<'b>(&self, buf: &'b mut [u8]) -> Result<(&'b [u8], &'b mut [u8]), Error> {
+        /// `0xD1`, `0x01`, payload length, `0x55`, `0x00`.
+        const HEADER_LEN: usize = 5;
+
+        let uri_len = self.emit_chars().count();
+
+        // `SR=1` in the header byte makes this a Short Record, whose payload
+        // length is a single byte. The payload is the URI identifier code plus
+        // the text, and `MT:` has no NFC Forum abbreviation, so all of it
+        // counts.
+        let payload_len = uri_len + 1;
+        if payload_len > u8::MAX as usize {
+            Err(ErrorCode::NoSpace)?;
+        }
+
+        if buf.len() < HEADER_LEN + uri_len {
+            Err(ErrorCode::BufferTooSmall)?;
+        }
+
+        let (ndef_buf, remaining_buf) = buf.split_at_mut(HEADER_LEN + uri_len);
+        let (header, uri_buf) = ndef_buf.split_at_mut(HEADER_LEN);
+
+        header.copy_from_slice(&[0xd1, 0x01, payload_len as u8, 0x55, 0x00]);
+
+        let mut wb = WriteBuf::new(uri_buf);
+        for ch in self.emit_chars() {
+            wb.le_u8(ch? as u8)?;
+        }
+
+        Ok((ndef_buf, remaining_buf))
+    }
+
     /// Emit the QR text of this payload as an iterator of characters
     pub fn emit_chars(&self) -> impl Iterator<Item = Result<char, Error>> + '_ {
         struct PackedBitsIterator<I>(I);
@@ -1348,6 +1407,48 @@ mod tests {
         let mut buf = [0; 1024];
         let data_str = unwrap!(qr_code_data.as_str(&mut buf), "Failed to encode").0;
         assert_eq!(data_str, QR_CODE)
+    }
+
+    /// The NFC tag carries the same onboarding payload as the QR code, wrapped
+    /// in the single NDEF URI record the Matter Core spec fixes byte for byte.
+    #[test]
+    fn encodes_the_nfc_ndef_record() {
+        const QR_CODE: &str = "MT:YNJV7VSC00CMVH7SR00";
+
+        let comm_data = BasicCommData {
+            password: 34567890_u32.to_le_bytes().into(),
+            discriminator: 2976,
+        };
+        let dev_det = BasicInfoConfig {
+            vid: 9050,
+            pid: 65279,
+            ..Default::default()
+        };
+
+        let qr_code_data = QrPayload::new_from_basic_info(
+            DiscoveryCapabilities::BLE,
+            CommFlowType::Standard,
+            comm_data,
+            &dev_det,
+            no_optional_data,
+        );
+
+        let mut buf = [0; 1024];
+        let ndef = unwrap!(qr_code_data.as_ndef(&mut buf), "Failed to encode").0;
+
+        // Header, then the URI text verbatim.
+        assert_eq!(
+            ndef,
+            [
+                &[0xd1, 0x01, (QR_CODE.len() + 1) as u8, 0x55, 0x00][..],
+                QR_CODE.as_bytes(),
+            ]
+            .concat()
+        );
+
+        // The URI data is exactly what the QR code carries: one payload, two
+        // carriers.
+        assert_eq!(&ndef[5..], QR_CODE.as_bytes());
     }
 
     #[test]

--- a/rs-matter/src/persist.rs
+++ b/rs-matter/src/persist.rs
@@ -144,13 +144,16 @@ pub const TIME_ZONE_KEY: u16 = CASE_RESUMPTION_KEY + 1;
 /// features it was built with.
 pub const GROUP_DATA_COUNTER_KEY: u16 = TIME_ZONE_KEY + 1;
 
+/// The node's reboot counter, backing `GeneralDiagnostics::RebootCount`.
+pub const REBOOT_COUNT_KEY: u16 = GROUP_DATA_COUNTER_KEY + 1;
+
 /// The first key past the singleton keys above - i.e. the next free slot for
 /// a *new* singleton key.
 ///
 /// Only used by [`SINGLETON_KEYS_FIT`] to prove that the singleton block has
 /// not grown into [`PERSISTENT_SUBSCRIPTIONS_START`]; bump the key it is
 /// derived from whenever a singleton is added.
-const SINGLETON_KEYS_END: u16 = GROUP_DATA_COUNTER_KEY + 1;
+const SINGLETON_KEYS_END: u16 = REBOOT_COUNT_KEY + 1;
 
 /// The first key of the range reserved for persisted subscriptions.
 ///

--- a/tests/src/bin/light_tests.rs
+++ b/tests/src/bin/light_tests.rs
@@ -235,6 +235,7 @@ fn main() -> Result<(), Error> {
     let mut transport = pin!(matter.run(&crypto, &socket, &socket, &socket));
 
     matter.print_standard_qr_text(DiscoveryCapabilities::IP)?;
+    matter.print_standard_nfc_ndef(DiscoveryCapabilities::IP)?;
 
     if !matter.has_fabrics() {
         matter.print_standard_qr_code(QrTextType::Unicode, DiscoveryCapabilities::IP)?;

--- a/tests/src/bin/light_tests.rs
+++ b/tests/src/bin/light_tests.rs
@@ -33,10 +33,7 @@ use core::cell::Cell;
 use core::num::NonZeroU8;
 use core::pin::pin;
 
-use std::fs;
-use std::io::{Read, Write};
 use std::net::UdpSocket;
-use std::path::PathBuf;
 
 use embassy_futures::select::{select3, select4};
 
@@ -98,8 +95,7 @@ use rs_matter::im::client::ImClient as _;
 
 use static_cell::StaticCell;
 
-#[path = "../common/mdns.rs"]
-mod mdns;
+use vendor_kv::VendorKv;
 
 #[path = "../common/args.rs"]
 mod args;
@@ -107,8 +103,14 @@ mod args;
 #[path = "../common/logging.rs"]
 mod logging;
 
+#[path = "../common/mdns.rs"]
+mod mdns;
+
 #[path = "../common/pipe.rs"]
 mod pipe;
+
+#[path = "../common/vendor_kv.rs"]
+mod vendor_kv;
 
 /// The local endpoint hosting the On/Off Light Switch (OnOff client + Binding).
 const SWITCH_ENDPOINT: u16 = 2;
@@ -166,7 +168,7 @@ fn main() -> Result<(), Error> {
     // transition applies `OnMode` (the ModeSelect `ON_OFF` feature) - the
     // behaviour `Test_TC_MOD_3_1` verifies.
     let on_off_handler =
-        on_off::OnOffHandler::new(Dataver::new_rand(&mut rand), 1, OnOffDeviceLogic::new())
+        on_off::OnOffHandler::new(Dataver::new_rand(&mut rand), 1, OnOffDeviceLogic::new(&kv))
             .with_on_mode_applier(&mode_select_handler);
 
     // LevelControl cluster setup
@@ -190,7 +192,7 @@ fn main() -> Result<(), Error> {
     let color_control_handler = color_control::ColorControlHandler::new(
         Dataver::new_rand(&mut rand),
         1,
-        ColorControlDeviceLogic::new(),
+        ColorControlDeviceLogic::new(&kv),
         color_control::AttributeDefaults::default(),
     );
     color_control_handler.init(Some(&on_off_handler));
@@ -710,48 +712,27 @@ fn json_u64(line: &str, key: &str) -> Option<u64> {
 // persisted value to `ColorTemperatureMireds` at power-up - see
 // `ColorControlHandler::init`.)
 
-pub struct ColorControlDeviceLogic {
+pub struct ColorControlDeviceLogic<'a> {
     inner: TestColorControlDeviceLogic,
-    storage_path: PathBuf,
+    kv: &'a dyn VendorKv,
 }
 
-const CT_STORAGE_FILE_NAME: &str = "rs-matter-light-tests-start-up-ct";
-
-impl Default for ColorControlDeviceLogic {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ColorControlDeviceLogic {
-    pub fn new() -> Self {
-        // Tie the state file to `--KVS` when given, so concurrent
-        // instances don't clobber each other (same reasoning as
-        // `OnOffDeviceLogic`).
-        let storage_path = match args::kvs_override() {
-            Some(kvs) => PathBuf::from(format!("{kvs}-start-up-ct")),
-            None => std::env::temp_dir().join(CT_STORAGE_FILE_NAME),
-        };
-
+impl<'a> ColorControlDeviceLogic<'a> {
+    pub fn new(kv: &'a dyn VendorKv) -> Self {
         let inner = TestColorControlDeviceLogic::new();
 
         // Re-hydrate: a 2-byte little-endian value, or absent for null.
-        if let Ok(mut file) = fs::File::open(storage_path.as_path()) {
-            let mut buf = [0u8; 2];
-            if file.read_exact(&mut buf).is_ok() {
-                let value = u16::from_le_bytes(buf);
-                let _ = inner.set_start_up_color_temperature_mireds(Nullable::some(value));
-            }
+        let mut buf = [0u8; 2];
+        if let Ok(Some(2)) = kv.load_blob(vendor_kv::START_UP_CT_KEY, &mut buf) {
+            let value = u16::from_le_bytes(buf);
+            let _ = inner.set_start_up_color_temperature_mireds(Nullable::some(value));
         }
 
-        Self {
-            inner,
-            storage_path,
-        }
+        Self { inner, kv }
     }
 }
 
-impl ColorControlHooks for ColorControlDeviceLogic {
+impl ColorControlHooks for ColorControlDeviceLogic<'_> {
     const CLUSTER: Cluster<'static> = TestColorControlDeviceLogic::CLUSTER;
     const COLOR_CAPABILITIES: color_control::ColorCapabilitiesBitmap =
         TestColorControlDeviceLogic::COLOR_CAPABILITIES;
@@ -776,12 +757,12 @@ impl ColorControlHooks for ColorControlDeviceLogic {
 
         match value.into_option() {
             Some(mireds) => {
-                let mut file = fs::File::create(self.storage_path.as_path())?;
-                file.write_all(&mireds.to_le_bytes())?;
+                self.kv
+                    .store_blob(vendor_kv::START_UP_CT_KEY, &mireds.to_le_bytes())?;
             }
-            // Null: drop the file so the next boot starts with no value.
+            // Null: drop the blob so the next boot starts with no value.
             None => {
-                let _ = fs::remove_file(self.storage_path.as_path());
+                self.kv.remove_blob(vendor_kv::START_UP_CT_KEY)?;
             }
         }
 
@@ -1000,52 +981,42 @@ impl ModeSelectHooks for ModeSelectDeviceLogic {
     }
 }
 
-#[derive(Default)]
-pub struct OnOffDeviceLogic {
+pub struct OnOffDeviceLogic<'a> {
     on_off: Cell<bool>,
     start_up_on_off: Cell<Option<StartUpOnOffEnum>>,
-    storage_path: PathBuf,
+    kv: &'a dyn VendorKv,
 }
 
-const STORAGE_FILE_NAME: &str = "rs-matter-light-tests-on-off-state";
+impl<'a> OnOffDeviceLogic<'a> {
+    pub fn new(kv: &'a dyn VendorKv) -> Self {
+        let mut buf: [u8; 1] = [0];
 
-impl OnOffDeviceLogic {
-    pub fn new() -> Self {
-        // Tie the OnOff state file to the `--KVS` path when one is given, so
-        // multiple simultaneous instances (the two-node `switch` itest suite)
-        // don't clobber each other's persisted OnOff state.
-        let storage_path = match args::kvs_override() {
-            Some(kvs) => PathBuf::from(format!("{kvs}-on-off-state")),
-            None => std::env::temp_dir().join(STORAGE_FILE_NAME),
-        };
-        let persisted_state = match fs::File::open(storage_path.as_path()) {
-            Ok(mut file) => {
-                let mut buf: [u8; 1] = [0];
-                file.read_exact(&mut buf).unwrap();
+        let persisted_state = match kv.load_blob(vendor_kv::ON_OFF_STATE_KEY, &mut buf) {
+            Ok(Some(1)) => {
                 trace!("OnOffDeviceLogic::new: read {:0x}", buf[0]);
                 OnOffPersistentState::from_bytes(buf[0]).unwrap()
             }
-            Err(_) => OnOffPersistentState::default(),
+            _ => OnOffPersistentState::default(),
         };
+
         Self {
             on_off: Cell::new(persisted_state.on_off),
             start_up_on_off: Cell::new(persisted_state.start_up_on_off),
-            storage_path,
+            kv,
         }
     }
 
     fn save_state(&self) -> Result<(), Error> {
-        let mut file = fs::File::create(self.storage_path.as_path())?;
         let value = OnOffPersistentState::to_bytes_from_values(
             self.on_off.get(),
             self.start_up_on_off.get(),
         );
-        file.write_all(&[value])?;
-        Ok(())
+
+        self.kv.store_blob(vendor_kv::ON_OFF_STATE_KEY, &[value])
     }
 }
 
-impl OnOffHooks for OnOffDeviceLogic {
+impl OnOffHooks for OnOffDeviceLogic<'_> {
     const CLUSTER: Cluster<'static> = on_off_cluster::FULL_CLUSTER
         .with_revision(6)
         .with_features(on_off_cluster::Feature::LIGHTING.bits())

--- a/tests/src/bin/scenes_tests.rs
+++ b/tests/src/bin/scenes_tests.rs
@@ -24,10 +24,7 @@
 use core::cell::Cell;
 use core::pin::pin;
 
-use std::fs;
-use std::io::{Read, Write};
 use std::net::UdpSocket;
-use std::path::PathBuf;
 
 use embassy_futures::select::select3;
 
@@ -73,14 +70,19 @@ use rs_matter::{clusters, devices, root_endpoint, with, Matter};
 
 use static_cell::StaticCell;
 
-#[path = "../common/mdns.rs"]
-mod mdns;
+use vendor_kv::VendorKv;
 
 #[path = "../common/args.rs"]
 mod args;
 
 #[path = "../common/logging.rs"]
 mod logging;
+
+#[path = "../common/mdns.rs"]
+mod mdns;
+
+#[path = "../common/vendor_kv.rs"]
+mod vendor_kv;
 
 // Statically allocate in BSS the bigger objects
 // `rs-matter` supports efficient initialization of BSS objects (with `init`)
@@ -141,7 +143,7 @@ fn main() -> Result<(), Error> {
 
     // OnOff cluster setup
     let on_off_handler =
-        on_off::OnOffHandler::new(Dataver::new_rand(&mut rand), 1, OnOffDeviceLogic::new())
+        on_off::OnOffHandler::new(Dataver::new_rand(&mut rand), 1, OnOffDeviceLogic::new(&kv))
             .with_scene_invalidator(scenes_state);
 
     // LevelControl cluster setup
@@ -472,61 +474,45 @@ impl OnOffPersistentState {
     }
 }
 
-#[derive(Default)]
-pub struct OnOffDeviceLogic {
+pub struct OnOffDeviceLogic<'a> {
     on_off: Cell<bool>,
     start_up_on_off: Cell<Option<StartUpOnOffEnum>>,
-    storage_path: PathBuf,
+    kv: &'a dyn VendorKv,
 }
 
-const STORAGE_FILE_NAME: &str = "rs-matter-on-off-state";
+impl<'a> OnOffDeviceLogic<'a> {
+    pub fn new(kv: &'a dyn VendorKv) -> Self {
+        let mut buf: [u8; 1] = [0];
 
-impl OnOffDeviceLogic {
-    pub fn new() -> Self {
-        let storage_path = std::env::temp_dir().join(STORAGE_FILE_NAME);
-        info!(
-            "OnOffDeviceLogic using storage path: {}",
-            storage_path.as_path().to_str().unwrap_or("none")
-        );
-
-        let persisted_state = match fs::File::open(storage_path.as_path()) {
-            Ok(mut file) => {
-                let mut buf: [u8; 1] = [0];
-                file.read_exact(&mut buf).unwrap();
-
+        let persisted_state = match kv.load_blob(vendor_kv::ON_OFF_STATE_KEY, &mut buf) {
+            Ok(Some(1)) => {
                 trace!("OnOffDeviceLogic::new: read from storage: {:0x}", buf[0]);
 
                 OnOffPersistentState::from_bytes(buf[0]).unwrap()
             }
-            Err(_) => OnOffPersistentState::default(),
+            _ => OnOffPersistentState::default(),
         };
 
         Self {
             on_off: Cell::new(persisted_state.on_off),
             start_up_on_off: Cell::new(persisted_state.start_up_on_off),
-            storage_path,
+            kv,
         }
     }
 
     fn save_state(&self) -> Result<(), Error> {
-        let mut file = fs::File::create(self.storage_path.as_path())?;
-
         let value = OnOffPersistentState::to_bytes_from_values(
             self.on_off.get(),
             self.start_up_on_off.get(),
         );
 
-        let buf = &[value];
-
         trace!("save_storage: wrote {:0x}", value);
 
-        file.write_all(buf)?;
-
-        Ok(())
+        self.kv.store_blob(vendor_kv::ON_OFF_STATE_KEY, &[value])
     }
 }
 
-impl OnOffHooks for OnOffDeviceLogic {
+impl OnOffHooks for OnOffDeviceLogic<'_> {
     const CLUSTER: Cluster<'static> = on_off_cluster::FULL_CLUSTER
         .with_revision(6)
         .with_features(on_off_cluster::Feature::LIGHTING.bits())

--- a/tests/src/bin/system_tests.rs
+++ b/tests/src/bin/system_tests.rs
@@ -220,6 +220,12 @@ fn main() -> Result<(), Error> {
     // Re-hydrate the `Matter` instance (fabrics, basic info, RTC).
     matter.startup(&kv)?;
 
+    // Persist the reboot count this boot established. A real product would
+    // defer this until the boot looks healthy, so a boot loop never writes;
+    // a test binary that is about to be driven by the harness has no such
+    // concern.
+    matter.persist_reboot_count(&kv)?;
+
     // Create the crypto instance
     let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
 
@@ -1295,14 +1301,6 @@ static ICD_COUNTER_PERSIST_NOTIFY: Notification<CriticalSectionRawMutex> = Notif
 impl rs_matter::utils::sync::DynBase for TestEventTriggerDiag {}
 
 impl GenDiag for TestEventTriggerDiag {
-    fn reboot_count(&self) -> Result<u16, Error> {
-        ().reboot_count()
-    }
-
-    fn uptime_ms(&self) -> Result<u64, Error> {
-        ().uptime_ms()
-    }
-
     fn test_event_triggers_enabled(&self) -> Result<bool, Error> {
         Ok(true)
     }

--- a/tests/src/common/vendor_kv.rs
+++ b/tests/src/common/vendor_kv.rs
@@ -1,0 +1,88 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#![allow(dead_code)]
+
+//! Device state the test drivers keep across a restart, stored in the Matter
+//! KVS under the vendor key range.
+//!
+//! The drivers model devices whose application state outlives a restart - a
+//! light's OnOff state, its startup color temperature - because several tests
+//! restart the DUT mid-run and then assert on what came back.
+//!
+//! Keeping that state in the same store as the Matter state is what makes a
+//! factory reset mean what the tests assume: the harness unlinks the KVS file
+//! between tests, so the device really does come back with default application
+//! state. State kept in a file of its own would survive that reset and leak
+//! into whichever test ran next.
+
+use rs_matter::error::Error;
+use rs_matter::persist::{KvBlobStoreAccess, VENDOR_KEYS_START};
+
+/// The OnOff state and `StartUpOnOff` of the light, as one byte.
+pub const ON_OFF_STATE_KEY: u16 = VENDOR_KEYS_START;
+
+/// `StartUpColorTemperatureMireds`, as a little-endian `u16`. Absent for null.
+pub const START_UP_CT_KEY: u16 = VENDOR_KEYS_START + 1;
+
+/// An object-safe view of a [`KvBlobStoreAccess`].
+///
+/// [`KvBlobStoreAccess::access`] is generic over its closure, so there is no
+/// `&dyn KvBlobStoreAccess`. The device-logic structs need to hold a handle to
+/// the store without becoming generic themselves - they are named bare in
+/// `EpClMatcher` expressions, as `OnOffDeviceLogic::CLUSTER` - so this narrows
+/// the store down to the three whole-blob operations they actually use.
+pub trait VendorKv {
+    /// Read the blob at `key` into `out`, returning how many bytes were
+    /// written, or `None` if the key holds nothing.
+    ///
+    /// A blob longer than `out` is truncated: every caller here stores a fixed
+    /// small value and reads it back with a buffer of exactly that size.
+    fn load_blob(&self, key: u16, out: &mut [u8]) -> Result<Option<usize>, Error>;
+
+    /// Write `data` to `key`.
+    fn store_blob(&self, key: u16, data: &[u8]) -> Result<(), Error>;
+
+    /// Remove `key`, which need not exist.
+    fn remove_blob(&self, key: u16) -> Result<(), Error>;
+}
+
+impl<K> VendorKv for K
+where
+    K: KvBlobStoreAccess,
+{
+    fn load_blob(&self, key: u16, out: &mut [u8]) -> Result<Option<usize>, Error> {
+        self.access(|store, buf| {
+            let Some(data) = store.load(key, buf)? else {
+                return Ok(None);
+            };
+
+            let len = data.len().min(out.len());
+            out[..len].copy_from_slice(&data[..len]);
+
+            Ok(Some(len))
+        })
+    }
+
+    fn store_blob(&self, key: u16, data: &[u8]) -> Result<(), Error> {
+        self.access(|store, buf| store.store(key, data, buf))
+    }
+
+    fn remove_blob(&self, key: u16) -> Result<(), Error> {
+        self.access(|store, buf| store.remove(key, buf))
+    }
+}

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -16,6 +16,49 @@
  */
 
 //! A module for running Chip integration tests on the `rs-matter` project.
+//!
+//! # Functional YAML suites that are deliberately not listed
+//!
+//! Besides the certification suites, upstream ships a set of functional
+//! YAML suites under `src/app/tests/suites/`. The ones absent from every
+//! list below are absent for one of five reasons:
+//!
+//! - **No rs-matter test node exposes the cluster.** The suites drive
+//!   device types we do not model: `DL_*` (Door Lock),
+//!   `TV_*` (the twelve media clusters), `TestOperationalState` and
+//!   `TestRVCOperationalState`, `TestActivatedCarbonFilterMonitoring`,
+//!   `TestHepaFilterMonitoring`, `TestDishwasherAlarm`, `TestFanControl`,
+//!   `TestTemperatureControl` and `TestThermostat`. Each would need its
+//!   own example binary with a simulated appliance behind it, not just
+//!   the cluster.
+//! - **The suite tests the harness, not a DUT.**
+//!   `TestPurposefulFailureEqualities`,
+//!   `TestPurposefulFailureExtraReportingOnToggle` and
+//!   `TestPurposefulFailureNotNullConstraint` are required to fail —
+//!   upstream keeps them to check that the runner notices a failure.
+//!   `TestExampleCluster` drives a chip-tool-side pseudo-cluster and
+//!   never puts a message on the wire. `TestGroupDemoCommand` and
+//!   `TestGroupDemoConfig` are demo scaffolding, listed in
+//!   `manualTests.json` rather than `ciTests.json`.
+//! - **chip-tool cannot run it.** `TestDiagnosticLogsDownloadCommand`
+//!   pulls the log over BDX with a `Bdx`/`Download` pseudo-command that
+//!   only darwin-framework-tool implements; upstream skips it for
+//!   chip-tool for exactly this reason. The rs-matter side of that
+//!   transfer is covered by `TestDiagnosticLogs`, which is enabled.
+//! - **The suite assumes a DUT state it never establishes.**
+//!   `TestLevelControlWithOnOffDependency` writes `OnLevel`, sends
+//!   `On`, and expects `CurrentLevel` to follow `OnLevel` — but only an
+//!   OFF -> ON edge applies `OnLevel`, and the suite never turns the
+//!   light off first. `light_tests` persists its OnOff state across
+//!   restarts, so whether that edge happens depends on what the previous
+//!   test left behind: the suite passes or fails according to its
+//!   position in the batch. Upstream's app starts off every time, which
+//!   is why the gap does not show there.
+//! - **It duplicates an enabled certification suite.**
+//!   `TestColorControl_9_1` and `TestColorControl_9_2` are copies of
+//!   `Test_TC_CC_9_1` / `Test_TC_CC_9_2` with the PICS gates stripped.
+//!   Our PICS answers `1` to every item those two gate on, so the
+//!   certification versions already execute all of their steps.
 
 use core::iter::once;
 
@@ -746,6 +789,10 @@ pub(crate) const LIGHT_TESTS: &[&str] = &[
     "Test_TC_LVL_5_1",
     "Test_TC_LVL_6_1",
     "Test_TC_LVL_7_1",
+    // Drives a timed `MoveToLevel` and waits for the reported
+    // `CurrentLevel` to reach its target, exercising transition reporting
+    // rather than a single read-back.
+    "Test_WaitForAttributeValue",
     // `Test_TC_LVL_8_1` is a "DUT as Client" test whose single step is
     // `disabled: true` - enabling it would only buy a vacuous pass.
     // `TC_LVL_9_1` is a Scenes-interaction test - see `SCENES_TESTS`.

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -63,6 +63,28 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TestCommandsById",
     "TestCommissionerNodeId",
     "TestCommissioningWindow",
+    "Test_TC_CADMIN_1_6",
+    "Test_TC_CADMIN_1_16",
+    // Every remaining `Test_TC_CADMIN_*` YAML ships with *every* step
+    // `disabled: true` upstream. They are written as procedures for a human to
+    // adapt rather than as runnable suites - "Chip-tool command used below are
+    // an example to verify the functionality. For certification test, we expect
+    // DUT should have a capability or way to run the equivalent command" - so
+    // enabling them here would only buy a vacuous pass.
+    //
+    // They exercise the DUT-as-commissioner role (`CADMIN.C`), which rs-matter
+    // does support - see `TestSuite::Commissioner` and `commissioner_tests`.
+    // Should upstream ever enable their steps, they belong to that suite and
+    // not here: `SYS_TESTS` runs against the commissionee (`system_tests`).
+    // "Test_TC_CADMIN_1_1",
+    // "Test_TC_CADMIN_1_2",
+    // "Test_TC_CADMIN_1_7",
+    // "Test_TC_CADMIN_1_8",
+    // "Test_TC_CADMIN_1_12",
+    // "Test_TC_CADMIN_1_13",
+    // "Test_TC_CADMIN_1_14",
+    // "Test_TC_CADMIN_1_17",
+    // "Test_TC_CADMIN_1_18",
     "TestConfigVariables",
     "TestConstraints",
     "TestDelayCommands",
@@ -1326,7 +1348,11 @@ impl ITests {
                     }
                 }
 
-                self.run_yaml_batch(&batch, test_timeout_secs, profile, target, &chip_env)?;
+                // Every member shares a key, so they share the override too.
+                let batch_timeout_secs =
+                    Self::per_test_timeout_secs(tests[i]).unwrap_or(test_timeout_secs);
+
+                self.run_yaml_batch(&batch, batch_timeout_secs, profile, target, &chip_env)?;
             }
         }
 
@@ -1341,13 +1367,18 @@ impl ITests {
     /// - the `.pics` file and the `RS_MATTER_WIRELESS_THREAD` device-flavour
     ///   selection, both determined by [`WirelessFlavour::of`];
     /// - the OTA app-path wiring, which is role-specific - so `OTA_*` tests
-    ///   stay singleton batches, keyed by their own (role-suffixed) name.
-    fn yaml_batch_key(test_name: &str) -> (Option<WirelessFlavour>, Option<&str>) {
+    ///   stay singleton batches, keyed by their own (role-suffixed) name;
+    /// - the per-test timeout, which `run_test_suite.py` takes once per
+    ///   invocation as `--test-timeout-seconds`. A test needing longer than the
+    ///   suite default therefore batches only with others needing exactly the
+    ///   same, rather than dragging the whole batch's ceiling up with it.
+    fn yaml_batch_key(test_name: &str) -> (Option<WirelessFlavour>, Option<&str>, Option<u32>) {
         let real_name = test_name.strip_suffix("@requestor").unwrap_or(test_name);
 
         (
             WirelessFlavour::of(test_name),
             real_name.starts_with("OTA_").then_some(test_name),
+            Self::per_test_timeout_secs(test_name),
         )
     }
 
@@ -1531,10 +1562,10 @@ impl ITests {
     /// Run a batch of YAML tests in a single `run_test_suite.py` invocation.
     ///
     /// All batch members share one per-invocation configuration - guaranteed
-    /// by [`Self::yaml_batch_key`] - and none of them has a
-    /// [`Self::per_test_timeout_secs`] override (those are all `TC_*` Python
-    /// tests), so the suite default applies to every member, enforced
-    /// per-test by the runner itself via `--test-timeout-seconds`.
+    /// by [`Self::yaml_batch_key`], which folds in
+    /// [`Self::per_test_timeout_secs`] - so `timeout_secs` applies to every
+    /// member, enforced per-test by the runner itself via
+    /// `--test-timeout-seconds`.
     fn run_yaml_batch(
         &self,
         batch: &[&str],
@@ -2330,6 +2361,11 @@ impl ITests {
             "TC_ACE_1_6" => Some(360),
             "TC_CADMIN_1_5" | "TC_CADMIN_1_9" | "TC_CADMIN_1_11" | "TC_CADMIN_1_15"
             | "TC_CADMIN_1_22" | "TC_CADMIN_1_25" => Some(360),
+            // The YAML twin of the above: step 7 is a literal
+            // "Wait for PIXIT.CADMIN.CwDuration + 10" and `CwDuration` defaults
+            // to 180s in the test's own PIXIT block, so the suite's 120s
+            // ceiling cannot fit it. Measured at ~295s end to end.
+            "Test_TC_CADMIN_1_6" => Some(600),
             // TC_OPCREDS_3_8 exercises the VID-Verification feature (Matter
             // 1.4): it sets a 400-byte VVSC and an 85-byte
             // VIDVerificationStatement on a fabric and then issues

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -21,7 +21,7 @@
 //!
 //! Besides the certification suites, upstream ships a set of functional
 //! YAML suites under `src/app/tests/suites/`. The ones absent from every
-//! list below are absent for one of five reasons:
+//! list below are absent for one of four reasons:
 //!
 //! - **No rs-matter test node exposes the cluster.** The suites drive
 //!   device types we do not model: `DL_*` (Door Lock),
@@ -45,15 +45,6 @@
 //!   only darwin-framework-tool implements; upstream skips it for
 //!   chip-tool for exactly this reason. The rs-matter side of that
 //!   transfer is covered by `TestDiagnosticLogs`, which is enabled.
-//! - **The suite assumes a DUT state it never establishes.**
-//!   `TestLevelControlWithOnOffDependency` writes `OnLevel`, sends
-//!   `On`, and expects `CurrentLevel` to follow `OnLevel` — but only an
-//!   OFF -> ON edge applies `OnLevel`, and the suite never turns the
-//!   light off first. `light_tests` persists its OnOff state across
-//!   restarts, so whether that edge happens depends on what the previous
-//!   test left behind: the suite passes or fails according to its
-//!   position in the batch. Upstream's app starts off every time, which
-//!   is why the gap does not show there.
 //! - **It duplicates an enabled certification suite.**
 //!   `TestColorControl_9_1` and `TestColorControl_9_2` are copies of
 //!   `Test_TC_CC_9_1` / `Test_TC_CC_9_2` with the PICS gates stripped.
@@ -789,6 +780,13 @@ pub(crate) const LIGHT_TESTS: &[&str] = &[
     "Test_TC_LVL_5_1",
     "Test_TC_LVL_6_1",
     "Test_TC_LVL_7_1",
+    // LevelControl <-> OnOff coupling: writes `OnLevel`, then checks that
+    // `On` drives `CurrentLevel` to it over `OnOffTransitionTime`. Only an
+    // OFF -> ON edge applies `OnLevel`, and the suite never turns the light
+    // off itself, so it relies on the DUT coming up off - which it does,
+    // because the runner factory-resets it and `light_tests` keeps its OnOff
+    // state in the Matter KVS. No certification suite covers this.
+    "TestLevelControlWithOnOffDependency",
     // Drives a timed `MoveToLevel` and waits for the reported
     // `CurrentLevel` to reach its target, exercising transition reporting
     // rather than a single read-back.

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -381,11 +381,18 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     // "TC_CADMIN_1_28",  // Skipped: requires the CHIP `jfc-server-app` (Joint Fabric Controller); rs-matter does not implement JF.
     // Python system tests upstream that we do not run:
     // "TC_BRBINFO_2_1",  // Skipped: driven against CHIP's `${BRIDGE_APP}`; rs-matter has no bridge DUT.
-    // "TC_BRBINFO_3_1",  // Skipped: same - bridged-device composition behind an Aggregator.
+    // "TC_BRBINFO_3_1",  // Skipped: bridged devices, and it carries no CI runner metadata at all - not wired for automated runs.
     // "TC_DD_1_5",       // Skipped: NFC onboarding. `DiscoveryCapabilities` (see `pairing.rs`) has no NFC/NTL bit.
     // "TC_DD_3_24",      // Skipped: NFC commissioning of an unpowered DUT - needs NFC plus physical power control.
-    // "TC_SC_5_1",       // Skipped: needs `ALL_CLUSTERS_APP` *and* `ALL_CLUSTERS_NO_GROUPCAST_APP` in one run. We
-    // "TC_SC_5_2",       // have both compositions (`system_tests --groupcast`), but one binary per role per run.
+    "TC_SC_5_1",
+    "TC_SC_5_2",
+    // Upstream's `run1` half: the same two tests against the Groupcast-enabled
+    // composition, where `AUXILIARY` is advertised and wildcard-target
+    // Group-auth ACL entries no longer reach the root endpoint - so group
+    // messaging is exercised under the ACL semantics a groupcast-capable
+    // device actually has.
+    "TC_SC_5_1@groupcast",
+    "TC_SC_5_2@groupcast",
     "TC_CGEN_2_1",
     "TC_CGEN_2_2",
     "TC_CGEN_2_4",
@@ -2219,6 +2226,16 @@ impl ITests {
             None => (test_name, false),
         };
 
+        // Likewise `@groupcast`, which re-runs a test against the
+        // Groupcast-enabled app composition (`NODE_GROUPCAST`). Upstream
+        // expresses this as a second `run` entry in a test's CI metadata
+        // against a different app binary; here the two compositions are one
+        // binary and a flag, so the variant rides on the test name.
+        let (test_name, groupcast) = match test_name.strip_suffix("@groupcast") {
+            Some(name) => (name, true),
+            None => (test_name, false),
+        };
+
         let script_path = chip_dir
             .join("src/python_testing")
             .join(format!("{test_name}.py"));
@@ -2347,14 +2364,37 @@ impl ITests {
         // tests like TC_SC_7_1 that require non-default discriminator /
         // passcode values, which the test then asserts (`assert_not_equal`
         // against `3840` / `20202021`).
-        let backend = if bluer { " --bluer" } else { "" };
-        let app_args_clause = match (ble, Self::app_args_override(test_name, target)) {
-            (true, Some(args)) => {
-                format!(" --app-args '--ble-controller 0{backend} {args}'")
+        // Built up rather than enumerated: BLE backend, app composition and
+        // per-test overrides are independent, and a match over every
+        // combination grows with each new one.
+        let mut app_args = String::new();
+
+        let mut push = |arg: &str| {
+            if !app_args.is_empty() {
+                app_args.push(' ');
             }
-            (true, None) => format!(" --app-args '--ble-controller 0{backend}'"),
-            (false, Some(args)) => format!(" --app-args '{args}'"),
-            (false, None) => String::new(),
+            app_args.push_str(arg);
+        };
+
+        if ble {
+            push("--ble-controller 0");
+            if bluer {
+                push("--bluer");
+            }
+        }
+
+        if groupcast {
+            push("--groupcast");
+        }
+
+        if let Some(args) = Self::app_args_override(test_name, target) {
+            push(args);
+        }
+
+        let app_args_clause = if app_args.is_empty() {
+            String::new()
+        } else {
+            format!(" --app-args '{app_args}'")
         };
 
         // Some tests need a vendored Python wrapper substituted in place of

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -185,12 +185,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "Test_TC_ICDM_4_1",
     "Test_TC_OPCREDS_3_7",
     "Test_TC_TIMESYNC_2_3",
-    // `RebootCount` must survive a restart and increment; the default
-    // `impl GenDiag for ()` that `system_tests` uses returns a constant 0, so
-    // step 9's constraint check fails after the harness reboots the DUT.
-    // Enable once the counter is persisted (a real conformance gap, not a
-    // harness artefact - an ATL would fail this too).
-    // "Test_TC_DGGEN_2_1",
+    "Test_TC_DGGEN_2_1",
     // Six manual `verification:` steps: chiptool rejects step 4 and runs none
     // of them. Also Wi-Fi-only (`PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID`), while
     // `system_tests` is Ethernet.
@@ -237,7 +232,6 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TestLogCommands",
     "TestMultiAdmin",
     "TestOperationalCredentialsCluster",
-    // "TestOperationalState", // TODO: Operational State cluster not yet implemented
     "TestReadNoneSubscribeNone",
     // `nullable_boolean` must default to `false` (not null) per the upstream
     // test-cluster XML - see the note in `unit_testing.rs`; everything else
@@ -340,34 +334,7 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     // Python tests — General & Administrator Commissioning (system clusters)
     //
     "TC_CADMIN_1_3_4",
-    // The CHIP-framework cleanup bug that used to break this test is another
-    // chip-master-only regression absent from the pinned `v1.6-branch`
-    // framework. Needs the raised timeouts in `per_test_timeout_secs` /
-    // `per_test_framework_timeout_secs` (a ~180s window-expiry wait).
     "TC_CADMIN_1_5",
-    //                  // from the device side. Step 7 (commission after the
-    //                  // window has been revoked) expects exactly
-    //                  // `CHIP_ERROR_TIMEOUT (0x32)`. To produce 0x32 the
-    //                  // device must NOT reply to the PBKDFParamRequest —
-    //                  // any status-report response surfaces as
-    //                  // `INVALID_PASE_PARAMETER (0x38)`. The PASE responder
-    //                  // (`pase/responder.rs`) does drop closed-window PASE
-    //                  // attempts silently, which is CHIP-style behavior; with
-    //                  // that, the controller's mDNS browse for the device's
-    //                  // discriminator times out at 30 s, mapped to
-    //                  // `CHIP_ERROR_TIMEOUT`, and step 7 *does* pass.
-    //                  // However, `DeviceCommissioner::EstablishPASEConnection`
-    //                  // (`CHIPDeviceController.cpp:734`) sets
-    //                  // `mDeviceInPASEEstablishment` at the start of step 7
-    //                  // and only clears it on the PASE-failure paths
-    //                  // (`OnSessionEstablishmentError`); the
-    //                  // mDNS-discovery-timeout path leaves it non-null.
-    //                  // Step 15's `CommissionOnNetwork` then hits the
-    //                  // `VerifyOrExit(mDeviceInPASEEstablishment == nullptr,
-    //                  // INCORRECT_STATE)` guard and fails with 0x03 before
-    //                  // ever leaving the controller. The other CADMIN tests
-    //                  // (1_3_4, 1_9, 1_11, 1_15, 1_19, 1_22, 1_25) pass with
-    //                  // the silent-drop change.
     "TC_CADMIN_1_9",
     // Repeated OpenCommissioningWindow / PASE-attempt handling; reads
     // `SpecificationVersion` on EP0, hence the `--endpoint 0` extra arg.

--- a/xtask/src/itest.rs
+++ b/xtask/src/itest.rs
@@ -85,6 +85,120 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     // "Test_TC_CADMIN_1_14",
     // "Test_TC_CADMIN_1_17",
     // "Test_TC_CADMIN_1_18",
+    //
+    // Certification YAMLs that ship with *every* step `disabled: true`
+    // upstream: procedures for a human to adapt, not runnable suites, so
+    // enabling any of them buys only a vacuous pass. Listed so the next audit
+    // does not have to re-derive why they are absent.
+    //
+    // Secure Channel — MRP, CASE/PASE and session-establishment procedures.
+    // "Test_TC_SC_1_1",
+    // "Test_TC_SC_1_2",
+    // "Test_TC_SC_1_3",
+    // "Test_TC_SC_1_4",
+    // "Test_TC_SC_2_1",
+    // "Test_TC_SC_2_2",
+    // "Test_TC_SC_2_3",
+    // "Test_TC_SC_2_4",
+    // "Test_TC_SC_3_1",
+    // "Test_TC_SC_3_2",
+    // "Test_TC_SC_3_3",
+    // "Test_TC_SC_4_2",
+    // "Test_TC_SC_4_4",
+    // "Test_TC_SC_4_6",
+    // "Test_TC_SC_4_7",
+    // "Test_TC_SC_4_8",
+    // "Test_TC_SC_4_9",
+    // "Test_TC_SC_5_3",
+    // "Test_TC_SC_6_1",
+    // Device Discovery — commissioner-side and onboarding-payload procedures.
+    // "Test_TC_DD_1_6",
+    // "Test_TC_DD_1_7",
+    // "Test_TC_DD_1_8",
+    // "Test_TC_DD_1_9",
+    // "Test_TC_DD_1_10",
+    // "Test_TC_DD_1_11",
+    // "Test_TC_DD_2_1",
+    // "Test_TC_DD_2_2",
+    // "Test_TC_DD_3_3",
+    // "Test_TC_DD_3_4",
+    // "Test_TC_DD_3_5",
+    // "Test_TC_DD_3_6",
+    // "Test_TC_DD_3_7",
+    // "Test_TC_DD_3_8",
+    // "Test_TC_DD_3_9",
+    // "Test_TC_DD_3_10",
+    // "Test_TC_DD_3_11",
+    // "Test_TC_DD_3_12",
+    // "Test_TC_DD_3_13",
+    // "Test_TC_DD_3_14",
+    // "Test_TC_DD_3_15",
+    // "Test_TC_DD_3_16",
+    // "Test_TC_DD_3_17",
+    // "Test_TC_DD_3_18",
+    // "Test_TC_DD_3_19",
+    // "Test_TC_DD_3_20",
+    // "Test_TC_DD_3_21",
+    // "Test_TC_DD_3_22",
+    // Interaction Model — DUT-as-client message-format procedures.
+    // "Test_TC_IDM_1_1",
+    // "Test_TC_IDM_1_3",
+    // "Test_TC_IDM_2_1",
+    // "Test_TC_IDM_3_1",
+    // "Test_TC_IDM_4_1",
+    // "Test_TC_IDM_4_4",
+    // "Test_TC_IDM_5_1",
+    // "Test_TC_IDM_6_1",
+    // "Test_TC_IDM_6_2",
+    // "Test_TC_IDM_6_3",
+    // "Test_TC_IDM_6_4",
+    // "Test_TC_IDM_7_1",
+    // "Test_TC_IDM_8_1",
+    // Device Attestation, Network/Operational Commissioning, Groups, and
+    // diagnostics variants that are likewise fully disabled.
+    // "Test_TC_DA_1_3",
+    // "Test_TC_DA_1_4",
+    // "Test_TC_DA_1_6",
+    // "Test_TC_DA_1_8",
+    // "Test_TC_CNET_4_12",
+    // "Test_TC_CNET_4_13",
+    // "Test_TC_CNET_4_14",
+    // "Test_TC_CNET_4_20",
+    // "Test_TC_CNET_4_21",
+    // "Test_TC_OPCREDS_3_3",
+    // "Test_TC_OPCREDS_3_6",
+    // "Test_TC_G_2_3",
+    // "Test_TC_G_3_2",
+    // "Test_TC_GRPKEY_5_4",
+    // "Test_TC_BRBINFO_2_2",
+    // "Test_TC_PS_2_2",
+    // "Test_TC_DGGEN_2_2",
+    // "Test_TC_DGSW_2_3",
+    //
+    // Certification YAMLs with runnable steps, audited and verified against
+    // `system_tests`.
+    //
+    "Test_TC_ACE_1_1",
+    "Test_TC_ACL_2_1",
+    "Test_TC_DGGEN_2_3",
+    "Test_TC_DGGEN_3_1",
+    "Test_TC_ICDM_4_1",
+    "Test_TC_OPCREDS_3_7",
+    "Test_TC_TIMESYNC_2_3",
+    // `RebootCount` must survive a restart and increment; the default
+    // `impl GenDiag for ()` that `system_tests` uses returns a constant 0, so
+    // step 9's constraint check fails after the harness reboots the DUT.
+    // Enable once the counter is persisted (a real conformance gap, not a
+    // harness artefact - an ATL would fail this too).
+    // "Test_TC_DGGEN_2_1",
+    // Six manual `verification:` steps: chiptool rejects step 4 and runs none
+    // of them. Also Wi-Fi-only (`PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID`), while
+    // `system_tests` is Ethernet.
+    // "Test_TC_CNET_4_11",
+    // Not registered as targets by `run_test_suite.py` ("Unknown target"), so
+    // unreachable through the YAML runner whatever the DUT supports.
+    // "Test_TC_DGETH_3_2_Simulated",
+    // "Test_TC_DGSW_3_2_Simulated",
     "TestConfigVariables",
     "TestConstraints",
     "TestDelayCommands",
@@ -265,6 +379,13 @@ pub(crate) const SYS_TESTS: &[&str] = &[
     "TC_CADMIN_1_25",
     // "TC_CADMIN_1_27",  // Skipped: requires the CHIP `jfc-server-app` (Joint Fabric Controller); rs-matter does not implement JF.
     // "TC_CADMIN_1_28",  // Skipped: requires the CHIP `jfc-server-app` (Joint Fabric Controller); rs-matter does not implement JF.
+    // Python system tests upstream that we do not run:
+    // "TC_BRBINFO_2_1",  // Skipped: driven against CHIP's `${BRIDGE_APP}`; rs-matter has no bridge DUT.
+    // "TC_BRBINFO_3_1",  // Skipped: same - bridged-device composition behind an Aggregator.
+    // "TC_DD_1_5",       // Skipped: NFC onboarding. `DiscoveryCapabilities` (see `pairing.rs`) has no NFC/NTL bit.
+    // "TC_DD_3_24",      // Skipped: NFC commissioning of an unpowered DUT - needs NFC plus physical power control.
+    // "TC_SC_5_1",       // Skipped: needs `ALL_CLUSTERS_APP` *and* `ALL_CLUSTERS_NO_GROUPCAST_APP` in one run. We
+    // "TC_SC_5_2",       // have both compositions (`system_tests --groupcast`), but one binary per role per run.
     "TC_CGEN_2_1",
     "TC_CGEN_2_2",
     "TC_CGEN_2_4",
@@ -1559,6 +1680,41 @@ impl ITests {
         Ok(())
     }
 
+    /// Fail early when the kernel forbids unprivileged user namespaces.
+    ///
+    /// The YAML runner puts the app, chip-tool and the management interface in
+    /// separate network namespaces (`scripts/tests/chiptest/linux.py`), created
+    /// with `unshare` as an unprivileged user. Ubuntu restricts that by
+    /// default, and the failure surfaces deep inside the runner as
+    /// `unshare: write failed /proc/self/uid_map: Operation not permitted`
+    /// with no run summary written - leaving xtask able to report only
+    /// `exit status: 1`.
+    ///
+    /// The knob resets on every reboot, so this is a recurring trap rather
+    /// than a one-time setup step. Python (`TC_*`) tests do not use namespaces
+    /// and are deliberately not gated on it.
+    fn check_unprivileged_userns() -> anyhow::Result<()> {
+        const KNOB: &str = "/proc/sys/kernel/apparmor_restrict_unprivileged_userns";
+
+        // Absent on non-Ubuntu kernels, where the restriction does not exist.
+        let Ok(value) = fs::read_to_string(KNOB) else {
+            return Ok(());
+        };
+
+        if value.trim() != "1" {
+            return Ok(());
+        }
+
+        anyhow::bail!(
+            "unprivileged user namespaces are restricted, but the YAML tests need them for \
+             their per-test network namespaces.\n\n    \
+             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0\n\n\
+             To survive a reboot:\n\n    \
+             echo 'kernel.apparmor_restrict_unprivileged_userns=0' \
+             | sudo tee /etc/sysctl.d/99-rs-matter-itest.conf"
+        )
+    }
+
     /// Run a batch of YAML tests in a single `run_test_suite.py` invocation.
     ///
     /// All batch members share one per-invocation configuration - guaranteed
@@ -1574,6 +1730,8 @@ impl ITests {
         target: &str,
         chip_env: &HashMap<String, String>,
     ) -> anyhow::Result<()> {
+        Self::check_unprivileged_userns()?;
+
         info!(
             "=> Running YAML test batch of {} test(s) with per-test timeout {timeout_secs}s: {batch:?}...",
             batch.len()


### PR DESCRIPTION
Subject says it all. Around 17 Python and YAML tests concerning the system clusters. 

Hopefully the last ones missing that don't require niche / less used functionality.