### PR TITLE
Streamline the factory reset and startup story of all clusters with persistence

### DIFF
--- a/rs-matter/src/dm/clusters/basic_info.rs
+++ b/rs-matter/src/dm/clusters/basic_info.rs
@@ -460,7 +460,7 @@ impl BasicInfoSettings {
     ///
     /// # Arguments
     /// - `flag_changed`: whether to mark the basic info settings as changed
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.node_label.clear();
         self.location = None;
         self.location_type = None;
@@ -495,7 +495,7 @@ impl BasicInfoSettings {
     /// # Arguments
     /// - `store`: the BLOB store to remove the settings from
     /// - `buf`: a temporary buffer to use for removing the settings
-    pub fn reset_persist<S: KvBlobStore>(
+    pub(crate) fn reset_persist<S: KvBlobStore>(
         &mut self,
         mut store: S,
         buf: &mut [u8],
@@ -510,7 +510,7 @@ impl BasicInfoSettings {
     }
 
     /// Load basic info settings from the provided byte slice
-    pub fn load(&mut self, data: &[u8]) -> Result<(), Error> {
+    pub(crate) fn load(&mut self, data: &[u8]) -> Result<(), Error> {
         let info = Self::from_tlv(&TLVElement::new(data))?;
 
         self.node_label = info.node_label;
@@ -534,7 +534,7 @@ impl BasicInfoSettings {
     /// ends with this call - sharing a single copy keeps it out of each
     /// attribute-dispatch path (flash size).
     #[inline(never)]
-    pub fn store_persist<S: KvBlobStoreAccess>(
+    pub(crate) fn store_persist<S: KvBlobStoreAccess>(
         &self,
         persist: &mut Persist<S>,
     ) -> Result<(), Error> {
@@ -546,7 +546,7 @@ impl BasicInfoSettings {
     /// # Arguments
     /// - `store`: the BLOB store to load the fabrics from
     /// - `buf`: a temporary buffer to use for loading the fabrics
-    pub fn load_persist<S: KvBlobStore>(
+    pub(crate) fn load_persist<S: KvBlobStore>(
         &mut self,
         mut store: S,
         buf: &mut [u8],

--- a/rs-matter/src/dm/clusters/binding.rs
+++ b/rs-matter/src/dm/clusters/binding.rs
@@ -150,7 +150,7 @@ impl<const N: usize> Bindings<N> {
     ///
     /// Called on startup via the [`LifecycleOp::Startup`] lifecycle operation
     /// delivered to the [`BindingHandler`] instance(s) borrowing this registry.
-    pub fn load_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+    fn load_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
         let Some(data) = store.load(BINDINGS_KEY, buf)? else {
             self.state.lock(|cell| cell.borrow_mut().clear());
             return Ok(());
@@ -169,7 +169,7 @@ impl<const N: usize> Bindings<N> {
     /// Called on factory reset via the [`LifecycleOp::FactoryReset`] lifecycle
     /// operation delivered to the [`BindingHandler`] instance(s) borrowing this
     /// registry.
-    pub fn reset_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+    fn reset_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
         self.state.lock(|cell| cell.borrow_mut().clear());
 
         store.remove(BINDINGS_KEY, buf)
@@ -182,7 +182,7 @@ impl<const N: usize> Bindings<N> {
     /// lifecycle operation delivered to the [`BindingHandler`] instance(s)
     /// borrowing this registry. Idempotent, since each borrowing handler
     /// instance receives the (broadcast) lifecycle operation.
-    pub fn remove_for_fabric(&self, fab_idx: NonZeroU8) -> bool {
+    fn remove_for_fabric(&self, fab_idx: NonZeroU8) -> bool {
         self.state.lock(|cell| {
             let mut state = cell.borrow_mut();
             let before = state.len();

--- a/rs-matter/src/dm/clusters/icd_mgmt.rs
+++ b/rs-matter/src/dm/clusters/icd_mgmt.rs
@@ -35,7 +35,7 @@ use core::num::NonZeroU8;
 use embassy_time::{Duration, Instant};
 
 use crate::acl::AccessReq;
-use crate::crypto::{CanonAeadKey, Crypto};
+use crate::crypto::{CanonAeadKey, Crypto, RngCore};
 use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::dm::{
     Access, ArrayAttributeRead, Cluster, Dataver, HandlerContext, InvokeContext, LifecycleOp,
@@ -179,18 +179,22 @@ pub struct Icd {
 }
 
 impl Icd {
-    /// Create the ICD state from a starting Check-In counter and mode timings.
+    /// Create the ICD state from the Check-In counter's persistence epoch and
+    /// the mode timings.
     ///
-    /// `counter` supplies the starting value and the persistence epoch. Pass a
-    /// freshly random start: [`LifecycleOp::Startup`] replaces it with the
-    /// persisted boundary (keeping this counter's epoch) when there is one, and
-    /// re-persists the new boundary either way, so the caller does not have to
-    /// drive [`CheckInCounter::persist_value`] itself.
-    pub const fn new(counter: CheckInCounter, mode: IcdModeConfig) -> Self {
+    /// `epoch` is how far ahead of the live counter the persisted boundary is
+    /// kept - i.e. how many Check-Ins may be sent between two flash writes, and
+    /// equally how far the counter jumps forward across a restart. It must be
+    /// non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `epoch` is zero.
+    pub const fn new(epoch: u32, mode: IcdModeConfig) -> Self {
         Self {
             state: Mutex::new(RefCell::new(IcdState {
                 clients: Vec::new(),
-                counter,
+                counter: CheckInCounter::new(0, epoch),
                 stay_active_until: None,
             })),
             mode,
@@ -201,13 +205,38 @@ impl Icd {
 
     /// An in-place initializer, mirroring [`Self::new`]. Prefer this over `new`
     /// to avoid the registration array transiting the stack.
-    pub fn init(counter: CheckInCounter, mode: IcdModeConfig) -> impl Init<Self> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if `epoch` is zero.
+    pub fn init(epoch: u32, mode: IcdModeConfig) -> impl Init<Self> {
         init!(Self {
-            state <- Mutex::init(RefCell::init(IcdState::init(counter))),
+            state <- Mutex::init(RefCell::init(IcdState::init(CheckInCounter::new(0, epoch)))),
             mode: mode,
             registrations_changed <- Notification::init(),
             active_extended <- Notification::init(),
         })
+    }
+
+    /// Re-seed the Check-In counter from `start`, keeping the epoch this `Icd`
+    /// was constructed with, and return the boundary that must be persisted.
+    fn reseed_counter(&self, start: u32) -> u32 {
+        self.state.lock(|s| {
+            let mut s = s.borrow_mut();
+
+            let epoch = s.counter.epoch();
+            s.counter = CheckInCounter::new(start, epoch);
+
+            s.counter.persist_value()
+        })
+    }
+
+    /// Draw a fresh random Check-In counter start.
+    fn random_counter_start<C: Crypto>(crypto: C) -> Result<u32, Error> {
+        let mut bytes = [0; 4];
+        crypto.rand()?.fill_bytes(&mut bytes);
+
+        Ok(u32::from_le_bytes(bytes))
     }
 
     /// The mode timings this ICD advertises.
@@ -480,7 +509,12 @@ impl Icd {
     /// start + epoch`) are only guaranteed unique once `start + epoch` is
     /// durable. A crash before the next boundary crossing would otherwise
     /// reload `start` and hand out the same values a second time.
-    fn load_persist<S: KvBlobStore>(&self, mut kv: S, buf: &mut [u8]) -> Result<(), Error> {
+    fn load_persist<S: KvBlobStore, C: Crypto>(
+        &self,
+        crypto: C,
+        mut kv: S,
+        buf: &mut [u8],
+    ) -> Result<(), Error> {
         let clients = match kv.load(ICD_REGISTERED_CLIENTS_KEY, buf)? {
             Some(data) => Vec::from_tlv(&TLVElement::new(data))?,
             None => Vec::new(),
@@ -490,18 +524,12 @@ impl Icd {
 
         let start = match kv.load(ICD_CHECK_IN_COUNTER_KEY, buf)? {
             Some(data) => u32::from_le_bytes(data.try_into().map_err(|_| ErrorCode::Invalid)?),
-            // No persisted value yet: the caller's initial (random) counter stands.
-            None => return Ok(()),
+            // First boot (or a cleared store): start somewhere random rather
+            // than at a fixed value every device shares.
+            None => Self::random_counter_start(crypto)?,
         };
 
-        let boundary = self.state.lock(|s| {
-            let mut s = s.borrow_mut();
-
-            let epoch = s.counter.epoch();
-            s.counter = CheckInCounter::new(start, epoch);
-
-            s.counter.persist_value()
-        });
+        let boundary = self.reseed_counter(start);
 
         kv.store(ICD_CHECK_IN_COUNTER_KEY, &boundary.to_le_bytes(), buf)
     }
@@ -511,11 +539,17 @@ impl Icd {
     ///
     /// Driven by [`LifecycleOp::FactoryReset`].
     ///
-    /// The in-memory counter is deliberately left running rather than reset:
-    /// it only ever moves forward, which is strictly safer than restarting it
-    /// at a fixed value, and every key it was ever used with is gone along
-    /// with the registrations.
-    fn reset_persist<S: KvBlobStore>(&self, mut kv: S, buf: &mut [u8]) -> Result<(), Error> {
+    /// The counter is re-seeded from a fresh random value, the same way a first
+    /// boot seeds it - the device is starting a new life, and every key the old
+    /// counter was used with is gone along with the registrations. The new
+    /// value is left unpersisted: whichever comes first, the next boundary
+    /// crossing or the next startup, writes one.
+    fn reset_persist<S: KvBlobStore, C: Crypto>(
+        &self,
+        crypto: C,
+        mut kv: S,
+        buf: &mut [u8],
+    ) -> Result<(), Error> {
         let had_registrations = self.state.lock(|s| {
             let clients = &mut s.borrow_mut().clients;
 
@@ -527,6 +561,8 @@ impl Icd {
 
         kv.remove(ICD_REGISTERED_CLIENTS_KEY, buf)?;
         kv.remove(ICD_CHECK_IN_COUNTER_KEY, buf)?;
+
+        self.reseed_counter(Self::random_counter_start(crypto)?);
 
         // Dropping the last registration flips the operating mode to SIT, so
         // let the application re-advertise mDNS.
@@ -724,7 +760,7 @@ impl ClusterHandler for IcdMgmtHandler<'_> {
         match op {
             LifecycleOp::Startup => {
                 ctx.kv()
-                    .access(|store, buf| self.icd.load_persist(store, buf))?;
+                    .access(|store, buf| self.icd.load_persist(ctx.crypto(), store, buf))?;
 
                 // Seed the advertised operating mode from the reloaded
                 // registration set, so a client registered before the reboot
@@ -735,7 +771,7 @@ impl ClusterHandler for IcdMgmtHandler<'_> {
             }
             LifecycleOp::FactoryReset => {
                 ctx.kv()
-                    .access(|store, buf| self.icd.reset_persist(store, buf))?;
+                    .access(|store, buf| self.icd.reset_persist(ctx.crypto(), store, buf))?;
 
                 // Every registration is gone, so the device drops back to SIT.
                 self.sync_icd_mode(&ctx);
@@ -949,6 +985,8 @@ impl ClusterHandler for IcdMgmtHandler<'_> {
 
 #[cfg(test)]
 mod tests {
+    use crate::crypto::test_only_crypto;
+
     use super::*;
 
     fn fab(i: u8) -> NonZeroU8 {
@@ -966,7 +1004,7 @@ mod tests {
     }
 
     fn icd() -> Icd {
-        Icd::new(CheckInCounter::new(0, 10), mode())
+        Icd::new(10, mode())
     }
 
     /// Collect the node ids of the registrations matching `fab_filter`.
@@ -1155,7 +1193,7 @@ mod tests {
 
     #[test]
     fn stay_active_combines_with_max_and_reports_remaining() {
-        let icd = Icd::new(CheckInCounter::new(0, 10), mode());
+        let icd = Icd::new(10, mode());
 
         // No request yet: no stay-active deadline.
         assert!(icd.active_until().is_none());
@@ -1184,7 +1222,7 @@ mod tests {
     fn stay_active_request_clamps_to_the_guaranteed_max() {
         // The clamp lives in the command handler, not `extend_active` — verify it
         // via the same `.min(STAY_ACTIVE_MAX_MS)` the handler applies.
-        let icd = Icd::new(CheckInCounter::new(0, 10), mode());
+        let icd = Icd::new(10, mode());
 
         let requested = STAY_ACTIVE_MAX_MS + 5_000;
         let promised = icd.extend_active(requested.min(STAY_ACTIVE_MAX_MS));
@@ -1198,7 +1236,10 @@ mod tests {
         let mut buf = [0u8; 16];
 
         // Session 1: counter starts at 100, boundary at 110.
-        let icd = Icd::new(CheckInCounter::new(100, EPOCH), mode());
+        let icd = Icd::new(EPOCH, mode());
+        // Session 1 seeds at 100 the way `load_persist` would from a stored
+        // boundary, so the expectations below stay readable.
+        icd.reseed_counter(100);
 
         // Peeks are stable; advancing before the boundary writes nothing.
         assert_eq!(icd.next_counter(), 101);
@@ -1224,8 +1265,9 @@ mod tests {
         // persisted boundary. Every value it hands out is past session 1's.
         // The epoch comes from the counter this `Icd` was built with, not from
         // the blob.
-        let icd2 = Icd::new(CheckInCounter::new(0, EPOCH), mode());
-        icd2.load_persist(&mut kv, &mut buf).unwrap();
+        let icd2 = Icd::new(EPOCH, mode());
+        icd2.load_persist(test_only_crypto(), &mut kv, &mut buf)
+            .unwrap();
         assert!(icd2.next_counter() > last_used);
 
         // Re-hydrating must itself persist the boundary it resumes from, or a
@@ -1240,9 +1282,33 @@ mod tests {
 
         // Session 3 (a second restart, no traffic in session 2): still strictly
         // past every value session 2 could have used.
-        let icd3 = Icd::new(CheckInCounter::new(0, EPOCH), mode());
-        icd3.load_persist(&mut kv, &mut buf).unwrap();
+        let icd3 = Icd::new(EPOCH, mode());
+        icd3.load_persist(test_only_crypto(), &mut kv, &mut buf)
+            .unwrap();
         assert!(icd3.next_counter() > icd2.next_counter() + EPOCH - 1);
+    }
+
+    #[test]
+    fn first_boot_seeds_the_counter_and_persists_a_boundary() {
+        const EPOCH: u32 = 10;
+        let mut kv = MemKv::default();
+        let mut buf = [0u8; 256];
+
+        // Nothing stored: the counter is seeded from a random start, and the
+        // boundary it resumes from must be durable before any Check-In goes out.
+        let icd = Icd::new(EPOCH, mode());
+        icd.load_persist(test_only_crypto(), &mut kv, &mut buf)
+            .unwrap();
+
+        let boundary = u32::from_le_bytes(
+            kv.get(ICD_CHECK_IN_COUNTER_KEY)
+                .expect("a first boot must persist a boundary")
+                .try_into()
+                .unwrap(),
+        );
+
+        // `next()` peeks at start + 1 and the boundary sits at start + EPOCH.
+        assert_eq!(boundary, icd.next_counter().wrapping_add(EPOCH - 1));
     }
 
     #[test]
@@ -1250,7 +1316,7 @@ mod tests {
         let mut kv = MemKv::default();
         let mut buf = [0u8; 256];
 
-        let icd = Icd::new(CheckInCounter::new(100, 10), mode());
+        let icd = Icd::new(10, mode());
 
         icd.register(reg(1, 0x1234)).unwrap();
         assert_eq!(icd.operating_mode(), OperatingModeEnum::LIT);
@@ -1263,11 +1329,18 @@ mod tests {
             .store(ICD_CHECK_IN_COUNTER_KEY, &110u32.to_le_bytes(), &mut buf)
             .unwrap();
 
-        icd.reset_persist(&mut kv, &mut buf).unwrap();
+        let before_reset = icd.next_counter();
+
+        icd.reset_persist(test_only_crypto(), &mut kv, &mut buf)
+            .unwrap();
 
         assert!(icd.registrations_is_empty());
         assert_eq!(icd.operating_mode(), OperatingModeEnum::SIT);
         assert_eq!(kv.get(ICD_REGISTERED_CLIENTS_KEY), None);
         assert_eq!(kv.get(ICD_CHECK_IN_COUNTER_KEY), None);
+
+        // The counter is re-seeded rather than left where it was, so the next
+        // boot does not resume the decommissioned device's sequence.
+        assert_ne!(icd.next_counter(), before_reset);
     }
 }

--- a/rs-matter/src/dm/clusters/icd_mgmt.rs
+++ b/rs-matter/src/dm/clusters/icd_mgmt.rs
@@ -44,7 +44,9 @@ use crate::dm::{
 use crate::error::{Error, ErrorCode};
 use crate::fabric::MAX_FABRICS;
 use crate::im::encoding::GenericPath;
-use crate::persist::{KvBlobStore, Persist, ICD_REGISTERED_CLIENTS_KEY};
+use crate::persist::{
+    KvBlobStore, KvBlobStoreAccess, Persist, ICD_CHECK_IN_COUNTER_KEY, ICD_REGISTERED_CLIENTS_KEY,
+};
 use crate::sc::checkin::{CheckIn, CheckInCounter};
 use crate::tlv::{FromTLV, TLVBuilderParent, TLVElement, ToTLV};
 use crate::utils::cell::RefCell;
@@ -179,9 +181,11 @@ pub struct Icd {
 impl Icd {
     /// Create the ICD state from a starting Check-In counter and mode timings.
     ///
-    /// `counter` should be constructed from the persisted counter value (or a
-    /// random one on first use); persist [`CheckInCounter::persist_value`] right
-    /// after, as its docs describe.
+    /// `counter` supplies the starting value and the persistence epoch. Pass a
+    /// freshly random start: [`LifecycleOp::Startup`] replaces it with the
+    /// persisted boundary (keeping this counter's epoch) when there is one, and
+    /// re-persists the new boundary either way, so the caller does not have to
+    /// drive [`CheckInCounter::persist_value`] itself.
     pub const fn new(counter: CheckInCounter, mode: IcdModeConfig) -> Self {
         Self {
             state: Mutex::new(RefCell::new(IcdState {
@@ -338,7 +342,7 @@ impl Icd {
     /// Drop every registration belonging to `fab_idx`.
     ///
     /// Call when a fabric is removed. Returns whether anything was removed.
-    pub fn remove_fabric(&self, fab_idx: NonZeroU8) -> bool {
+    fn remove_fabric(&self, fab_idx: NonZeroU8) -> bool {
         let removed = self.state.lock(|s| {
             let clients = &mut s.borrow_mut().clients;
             let before = clients.len();
@@ -366,25 +370,8 @@ impl Icd {
         self.registrations_changed.wait().await;
     }
 
-    /// Re-hydrate the registrations from `kv`. Call once at startup, before
-    /// exposing the data model.
-    pub fn load_registrations<S: KvBlobStore>(
-        &self,
-        mut kv: S,
-        buf: &mut [u8],
-    ) -> Result<(), Error> {
-        let clients = match kv.load(ICD_REGISTERED_CLIENTS_KEY, buf)? {
-            Some(data) => Vec::from_tlv(&TLVElement::new(data))?,
-            None => Vec::new(),
-        };
-
-        self.state.lock(|s| s.borrow_mut().clients = clients);
-
-        Ok(())
-    }
-
     /// Persist the current registrations to `ctx.kv()`.
-    pub fn store_registrations<C: HandlerContext>(&self, ctx: &C) -> Result<(), Error> {
+    fn store_registrations<C: HandlerContext>(&self, ctx: &C) -> Result<(), Error> {
         let mut persist = Persist::new(ctx.kv());
 
         self.state
@@ -454,11 +441,7 @@ impl Icd {
         let to_persist = self.state.lock(|s| s.borrow_mut().counter.advance());
 
         if let Some(value) = to_persist {
-            kv.store(
-                crate::persist::ICD_CHECK_IN_COUNTER_KEY,
-                &value.to_le_bytes(),
-                buf,
-            )?;
+            kv.store(ICD_CHECK_IN_COUNTER_KEY, &value.to_le_bytes(), buf)?;
         }
 
         Ok(())
@@ -481,29 +464,75 @@ impl Icd {
     /// Persist the current Check-In counter boundary to `kv`.
     pub fn persist_counter<S: KvBlobStore>(&self, mut kv: S, buf: &mut [u8]) -> Result<(), Error> {
         let value = self.state.lock(|s| s.borrow().counter.persist_value());
-        kv.store(
-            crate::persist::ICD_CHECK_IN_COUNTER_KEY,
-            &value.to_le_bytes(),
-            buf,
-        )
+        kv.store(ICD_CHECK_IN_COUNTER_KEY, &value.to_le_bytes(), buf)
     }
 
-    /// Load the persisted Check-In counter epoch and reset the counter to resume
-    /// from it. Call once at startup, before any Check-In is sent.
-    pub fn load_counter<S: KvBlobStore>(
-        &self,
-        mut kv: S,
-        epoch: u32,
-        buf: &mut [u8],
-    ) -> Result<(), Error> {
-        let start = match kv.load(crate::persist::ICD_CHECK_IN_COUNTER_KEY, buf)? {
+    /// Re-hydrate the ICD state from `kv` - the registrations and the Check-In
+    /// counter boundary.
+    ///
+    /// Driven by [`LifecycleOp::Startup`], before the data model starts
+    /// serving operations and before any Check-In is sent.
+    ///
+    /// The counter's epoch comes from the counter the application supplied at
+    /// construction, so the persisted blob only has to carry the boundary. The
+    /// new boundary is written straight back: [`CheckInCounter::new`] resumes
+    /// *at* the stored value, so the values this run may use (`start + 1 ..=
+    /// start + epoch`) are only guaranteed unique once `start + epoch` is
+    /// durable. A crash before the next boundary crossing would otherwise
+    /// reload `start` and hand out the same values a second time.
+    fn load_persist<S: KvBlobStore>(&self, mut kv: S, buf: &mut [u8]) -> Result<(), Error> {
+        let clients = match kv.load(ICD_REGISTERED_CLIENTS_KEY, buf)? {
+            Some(data) => Vec::from_tlv(&TLVElement::new(data))?,
+            None => Vec::new(),
+        };
+
+        self.state.lock(|s| s.borrow_mut().clients = clients);
+
+        let start = match kv.load(ICD_CHECK_IN_COUNTER_KEY, buf)? {
             Some(data) => u32::from_le_bytes(data.try_into().map_err(|_| ErrorCode::Invalid)?),
             // No persisted value yet: the caller's initial (random) counter stands.
             None => return Ok(()),
         };
 
-        self.state
-            .lock(|s| s.borrow_mut().counter = CheckInCounter::new(start, epoch));
+        let boundary = self.state.lock(|s| {
+            let mut s = s.borrow_mut();
+
+            let epoch = s.counter.epoch();
+            s.counter = CheckInCounter::new(start, epoch);
+
+            s.counter.persist_value()
+        });
+
+        kv.store(ICD_CHECK_IN_COUNTER_KEY, &boundary.to_le_bytes(), buf)
+    }
+
+    /// Reset the ICD state to factory defaults and remove both persisted blobs
+    /// (the registrations and the Check-In counter boundary) from `kv`.
+    ///
+    /// Driven by [`LifecycleOp::FactoryReset`].
+    ///
+    /// The in-memory counter is deliberately left running rather than reset:
+    /// it only ever moves forward, which is strictly safer than restarting it
+    /// at a fixed value, and every key it was ever used with is gone along
+    /// with the registrations.
+    fn reset_persist<S: KvBlobStore>(&self, mut kv: S, buf: &mut [u8]) -> Result<(), Error> {
+        let had_registrations = self.state.lock(|s| {
+            let clients = &mut s.borrow_mut().clients;
+
+            let had = !clients.is_empty();
+            clients.clear();
+
+            had
+        });
+
+        kv.remove(ICD_REGISTERED_CLIENTS_KEY, buf)?;
+        kv.remove(ICD_CHECK_IN_COUNTER_KEY, buf)?;
+
+        // Dropping the last registration flips the operating mode to SIT, so
+        // let the application re-advertise mDNS.
+        if had_registrations {
+            self.registrations_changed.notify();
+        }
 
         Ok(())
     }
@@ -693,10 +722,26 @@ impl ClusterHandler for IcdMgmtHandler<'_> {
 
     fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
         match op {
-            // Registration re-hydration and factory reset are app-driven
-            // (`Icd::load_registrations` / KV wipe), since the `Icd` state is
-            // owned by the application and shared with the Check-In machinery.
-            LifecycleOp::Startup | LifecycleOp::FactoryReset => Ok(()),
+            LifecycleOp::Startup => {
+                ctx.kv()
+                    .access(|store, buf| self.icd.load_persist(store, buf))?;
+
+                // Seed the advertised operating mode from the reloaded
+                // registration set, so a client registered before the reboot
+                // keeps the device advertising as LIT.
+                self.sync_icd_mode(&ctx);
+
+                Ok(())
+            }
+            LifecycleOp::FactoryReset => {
+                ctx.kv()
+                    .access(|store, buf| self.icd.reset_persist(store, buf))?;
+
+                // Every registration is gone, so the device drops back to SIT.
+                self.sync_icd_mode(&ctx);
+
+                Ok(())
+            }
             LifecycleOp::FabricRemoval { fab_idx } => {
                 let mode_before = self.icd.operating_mode();
 
@@ -1057,25 +1102,43 @@ mod tests {
     /// A minimal in-memory single-key store, enough to test the counter
     /// persist/reload roundtrip.
     #[derive(Default)]
+    /// A key-aware in-memory store. The ICD state spans two keys
+    /// (registrations and the Check-In counter), so a single-slot stub would
+    /// hand one key's blob back for the other.
     struct MemKv {
-        value: Option<alloc::vec::Vec<u8>>,
+        entries: alloc::vec::Vec<(u16, alloc::vec::Vec<u8>)>,
+    }
+
+    impl MemKv {
+        fn get(&self, key: u16) -> Option<&[u8]> {
+            self.entries
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| v.as_slice())
+        }
     }
 
     impl KvBlobStore for &mut MemKv {
-        fn load<'a>(&mut self, _key: u16, buf: &'a mut [u8]) -> Result<Option<&'a [u8]>, Error> {
-            Ok(self.value.as_ref().map(|v| {
-                buf[..v.len()].copy_from_slice(v);
-                &buf[..v.len()]
-            }))
+        fn load<'a>(&mut self, key: u16, buf: &'a mut [u8]) -> Result<Option<&'a [u8]>, Error> {
+            let Some(v) = self.get(key) else {
+                return Ok(None);
+            };
+
+            buf[..v.len()].copy_from_slice(v);
+
+            Ok(Some(&buf[..v.len()]))
         }
 
-        fn store(&mut self, _key: u16, data: &[u8], _buf: &mut [u8]) -> Result<(), Error> {
-            self.value = Some(data.to_vec());
+        fn store(&mut self, key: u16, data: &[u8], _buf: &mut [u8]) -> Result<(), Error> {
+            self.entries.retain(|(k, _)| *k != key);
+            self.entries.push((key, data.to_vec()));
+
             Ok(())
         }
 
-        fn remove(&mut self, _key: u16, _buf: &mut [u8]) -> Result<(), Error> {
-            self.value = None;
+        fn remove(&mut self, key: u16, _buf: &mut [u8]) -> Result<(), Error> {
+            self.entries.retain(|(k, _)| *k != key);
+
             Ok(())
         }
     }
@@ -1142,18 +1205,69 @@ mod tests {
         for _ in 0..9 {
             icd.advance_counter(&mut kv, &mut buf).unwrap();
         }
-        assert_eq!(kv.value, None, "no persist before the boundary");
+        assert_eq!(
+            kv.get(ICD_CHECK_IN_COUNTER_KEY),
+            None,
+            "no persist before the boundary"
+        );
 
         // Crossing the boundary persists the next one (120).
         let last_used = icd.next_counter();
         icd.advance_counter(&mut kv, &mut buf).unwrap();
         assert_eq!(last_used, 110);
-        assert!(kv.value.is_some(), "boundary crossing must persist");
+        assert!(
+            kv.get(ICD_CHECK_IN_COUNTER_KEY).is_some(),
+            "boundary crossing must persist"
+        );
 
         // Session 2 (a restart): a fresh Icd whose counter resumes from the
         // persisted boundary. Every value it hands out is past session 1's.
+        // The epoch comes from the counter this `Icd` was built with, not from
+        // the blob.
         let icd2 = Icd::new(CheckInCounter::new(0, EPOCH), mode());
-        icd2.load_counter(&mut kv, EPOCH, &mut buf).unwrap();
+        icd2.load_persist(&mut kv, &mut buf).unwrap();
         assert!(icd2.next_counter() > last_used);
+
+        // Re-hydrating must itself persist the boundary it resumes from, or a
+        // crash before the next crossing would hand out these values twice.
+        let boundary = u32::from_le_bytes(
+            kv.get(ICD_CHECK_IN_COUNTER_KEY)
+                .unwrap()
+                .try_into()
+                .unwrap(),
+        );
+        assert!(boundary >= icd2.next_counter() + EPOCH - 1);
+
+        // Session 3 (a second restart, no traffic in session 2): still strictly
+        // past every value session 2 could have used.
+        let icd3 = Icd::new(CheckInCounter::new(0, EPOCH), mode());
+        icd3.load_persist(&mut kv, &mut buf).unwrap();
+        assert!(icd3.next_counter() > icd2.next_counter() + EPOCH - 1);
+    }
+
+    #[test]
+    fn factory_reset_clears_registrations_and_both_keys() {
+        let mut kv = MemKv::default();
+        let mut buf = [0u8; 256];
+
+        let icd = Icd::new(CheckInCounter::new(100, 10), mode());
+
+        icd.register(reg(1, 0x1234)).unwrap();
+        assert_eq!(icd.operating_mode(), OperatingModeEnum::LIT);
+
+        // Seed both persisted blobs the way a running node would.
+        (&mut kv)
+            .store(ICD_REGISTERED_CLIENTS_KEY, b"whatever", &mut buf)
+            .unwrap();
+        (&mut kv)
+            .store(ICD_CHECK_IN_COUNTER_KEY, &110u32.to_le_bytes(), &mut buf)
+            .unwrap();
+
+        icd.reset_persist(&mut kv, &mut buf).unwrap();
+
+        assert!(icd.registrations_is_empty());
+        assert_eq!(icd.operating_mode(), OperatingModeEnum::SIT);
+        assert_eq!(kv.get(ICD_REGISTERED_CLIENTS_KEY), None);
+        assert_eq!(kv.get(ICD_CHECK_IN_COUNTER_KEY), None);
     }
 }

--- a/rs-matter/src/dm/clusters/icd_mgmt.rs
+++ b/rs-matter/src/dm/clusters/icd_mgmt.rs
@@ -1137,12 +1137,10 @@ mod tests {
         assert_eq!(nodes(&icd, Some(fab(1))), [100]);
     }
 
-    /// A minimal in-memory single-key store, enough to test the counter
-    /// persist/reload roundtrip.
-    #[derive(Default)]
     /// A key-aware in-memory store. The ICD state spans two keys
     /// (registrations and the Check-In counter), so a single-slot stub would
     /// hand one key's blob back for the other.
+    #[derive(Default)]
     struct MemKv {
         entries: alloc::vec::Vec<(u16, alloc::vec::Vec<u8>)>,
     }

--- a/rs-matter/src/dm/clusters/ota_req.rs
+++ b/rs-matter/src/dm/clusters/ota_req.rs
@@ -286,7 +286,7 @@ impl Providers {
     ///
     /// Called on startup via the [`LifecycleOp::Startup`] lifecycle operation
     /// delivered to the [`OtaRequestorHandler`] borrowing this registry.
-    pub fn load_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+    fn load_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
         let Some(data) = store.load(OTA_PROVIDERS_KEY, buf)? else {
             self.state.lock(|cell| cell.borrow_mut().default.clear());
             return Ok(());
@@ -306,7 +306,7 @@ impl Providers {
     ///
     /// Called on factory reset via the [`LifecycleOp::FactoryReset`] lifecycle
     /// operation delivered to the [`OtaRequestorHandler`] borrowing this registry.
-    pub fn reset_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+    fn reset_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
         self.state.lock(|cell| {
             let mut state = cell.borrow_mut();
 
@@ -324,7 +324,7 @@ impl Providers {
     /// Called on fabric removal via the [`LifecycleOp::FabricRemoval`]
     /// lifecycle operation delivered to the [`OtaRequestorHandler`] borrowing
     /// this registry. Idempotent.
-    pub fn remove_for_fabric(&self, fab_idx: NonZeroU8) -> bool {
+    fn remove_for_fabric(&self, fab_idx: NonZeroU8) -> bool {
         let removed = self.state.lock(|cell| {
             let mut state = cell.borrow_mut();
             let before = state.default.len() + state.announced.len();

--- a/rs-matter/src/dm/clusters/scenes.rs
+++ b/rs-matter/src/dm/clusters/scenes.rs
@@ -584,7 +584,7 @@ impl<const N: usize, const M: usize> ScenesState<N, M> {
     ///
     /// Called on startup via the [`LifecycleOp::Startup`] lifecycle operation
     /// delivered to the [`ScenesHandler`] borrowing this state.
-    pub fn load_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+    fn load_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
         let Some(data) = store.load(SCENES_KEY, buf)? else {
             // Reset to empty so a `load_persist` after a key
             // `remove` is deterministic.
@@ -614,7 +614,7 @@ impl<const N: usize, const M: usize> ScenesState<N, M> {
     ///
     /// Called on factory reset via the [`LifecycleOp::FactoryReset`] lifecycle
     /// operation delivered to the [`ScenesHandler`] borrowing this state.
-    pub fn reset_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+    fn reset_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
         self.with(|inner| {
             inner.table.clear();
             inner.current_per_fabric.clear();
@@ -631,7 +631,7 @@ impl<const N: usize, const M: usize> ScenesState<N, M> {
     /// lifecycle operation delivered to the [`ScenesHandler`] instance(s)
     /// borrowing this state. Idempotent, since each borrowing handler
     /// instance receives the (broadcast) lifecycle operation.
-    pub fn remove_for_fabric(&self, fab_idx: NonZeroU8) -> bool {
+    fn remove_for_fabric(&self, fab_idx: NonZeroU8) -> bool {
         self.with(|inner| {
             let before = inner.table.len() + inner.current_per_fabric.len();
 

--- a/rs-matter/src/dm/clusters/time_sync.rs
+++ b/rs-matter/src/dm/clusters/time_sync.rs
@@ -62,7 +62,7 @@ use embassy_futures::select::select;
 use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::dm::{
     ArrayAttributeRead, AttrChangeNotifier, Attribute, Cluster, Command, Dataver, EndptId,
-    EventEmitter, HandlerContext, InvokeContext, NodeId, Quality, ReadContext,
+    EventEmitter, HandlerContext, InvokeContext, LifecycleOp, NodeId, Quality, ReadContext,
 };
 use crate::error::{Error, ErrorCode};
 use crate::persist::{
@@ -204,7 +204,7 @@ impl Rtc {
         self.trusted_time_source = None;
     }
 
-    pub fn reset_persist<S: KvBlobStore>(
+    pub(crate) fn reset_persist<S: KvBlobStore>(
         &mut self,
         mut store: S,
         buf: &mut [u8],
@@ -216,7 +216,11 @@ impl Rtc {
         Ok(())
     }
 
-    pub fn load_persist<S: KvBlobStore>(&mut self, mut kv: S, buf: &mut [u8]) -> Result<(), Error> {
+    pub(crate) fn load_persist<S: KvBlobStore>(
+        &mut self,
+        mut kv: S,
+        buf: &mut [u8],
+    ) -> Result<(), Error> {
         self.reset();
 
         // Load the persisted Last-Known-Good UTC Time, if any.
@@ -285,7 +289,7 @@ impl Rtc {
     /// Updates in-memory state, persists under
     /// [`crate::persist::TRUSTED_TIME_SOURCE_KEY`], and notifies
     /// subscribers of the `TrustedTimeSource` attribute change.
-    pub fn set_trusted_time_source_persist<S: KvBlobStoreAccess, E: EventEmitter>(
+    pub(crate) fn set_trusted_time_source_persist<S: KvBlobStoreAccess, E: EventEmitter>(
         &mut self,
         source: Option<TrustedTimeSource>,
         persist: &mut Persist<S>,
@@ -407,7 +411,7 @@ impl Rtc {
         changed
     }
 
-    pub fn set_utc_time_persist<S: KvBlobStoreAccess>(
+    pub(crate) fn set_utc_time_persist<S: KvBlobStoreAccess>(
         &mut self,
         utc_us: u64,
         granularity: GranularityEnum,
@@ -820,10 +824,12 @@ impl<const TIME_ZONE_MAX: usize, const DST_OFFSET_MAX: usize>
         self.changed.notify();
     }
 
-    /// Re-hydrate both lists from `store` under [`TIME_ZONE_KEY`]. Call at
-    /// startup, before the store is shared with the handler. A missing key
-    /// (first boot / cleared persistence) leaves the defaults.
-    pub fn load_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+    /// Re-hydrate both lists from `store` under [`TIME_ZONE_KEY`].
+    ///
+    /// Driven by [`LifecycleOp::Startup`], before the data model starts
+    /// serving operations. A missing key (first boot / cleared persistence)
+    /// leaves the defaults.
+    fn load_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
         let Some(data) = store.load(TIME_ZONE_KEY, buf)? else {
             return Ok(());
         };
@@ -838,6 +844,32 @@ impl<const TIME_ZONE_MAX: usize, const DST_OFFSET_MAX: usize>
         });
 
         info!("Loaded TimeZone / DSTOffset lists from storage");
+
+        Ok(())
+    }
+
+    /// Reset both lists to their factory defaults - an empty `TimeZone` list
+    /// (which reads back as the implicit `{offset: 0, valid_at: 0}` entry) and
+    /// an empty `DSTOffset` list - and remove [`TIME_ZONE_KEY`] from `store`.
+    ///
+    /// Driven by [`LifecycleOp::FactoryReset`]. The counterpart of
+    /// [`Self::load_persist`]: both lists are `nonVolatile` quality, so a
+    /// factory reset has to clear them here as well as in memory.
+    fn reset_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+        self.state.lock(|state| {
+            let mut state = state.borrow_mut();
+
+            state.data = TimeZoneStoreData::new();
+            state.generation = state.generation.wrapping_add(1);
+        });
+
+        store.remove(TIME_ZONE_KEY, buf)?;
+
+        // A factory reset can land while the node is running, so wake the
+        // transition timer to re-evaluate against the now-empty lists.
+        self.changed.notify();
+
+        info!("Removed TimeZone / DSTOffset lists from storage");
 
         Ok(())
     }
@@ -1449,6 +1481,22 @@ impl ClusterHandler for TimeSyncHandler<'_> {
 
     fn dataver_changed(&self) {
         self.dataver.changed();
+    }
+
+    fn lifecycle(&self, ctx: impl HandlerContext, op: LifecycleOp) -> Result<(), Error> {
+        // Only the batteries-included `TimeZoneStore` shape persists anything
+        // of its own; custom `TimeZones` providers own their storage, and the
+        // Matter-wide RTC half of this cluster (`UTCTime` / `TrustedTimeSource`)
+        // is driven by `Matter::startup` / `Matter::factory_reset`.
+        let Some(store) = self.tz_store else {
+            return Ok(());
+        };
+
+        match op {
+            LifecycleOp::Startup => ctx.kv().access(|kv, buf| store.load_persist(kv, buf)),
+            LifecycleOp::FactoryReset => ctx.kv().access(|kv, buf| store.reset_persist(kv, buf)),
+            LifecycleOp::FabricRemoval { .. } => Ok(()),
+        }
     }
 
     // ---- Always-on reads (served from Matter-wide LKG state, not

--- a/rs-matter/src/dm/clusters/user_label.rs
+++ b/rs-matter/src/dm/clusters/user_label.rs
@@ -196,7 +196,7 @@ impl<const E: usize, const N: usize> UserLabels<E, N> {
     ///
     /// Missing key (first boot, or persistence cleared) is not an
     /// error — the registry simply stays empty.
-    pub fn load_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+    fn load_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
         let Some(data) = store.load(USER_LABELS_KEY, buf)? else {
             // No prior persistence — reset to empty so re-calling
             // `load_persist` after a `remove` of the key behaves
@@ -220,7 +220,7 @@ impl<const E: usize, const N: usize> UserLabels<E, N> {
     /// Called on factory reset via the [`LifecycleOp::FactoryReset`] lifecycle
     /// operation delivered to the [`UserLabelHandler`] instance(s) borrowing
     /// this registry.
-    pub fn reset_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+    fn reset_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
         self.state.lock(|cell| cell.borrow_mut().clear());
 
         store.remove(USER_LABELS_KEY, buf)

--- a/rs-matter/src/fabric.rs
+++ b/rs-matter/src/fabric.rs
@@ -1122,7 +1122,7 @@ impl Fabrics {
     }
 
     /// Remove all fabrics
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.fabrics.clear();
     }
 
@@ -1131,7 +1131,7 @@ impl Fabrics {
     /// # Arguments
     /// - `store`: the BLOB store to remove the fabrics from
     /// - `buf`: a temporary buffer to use for removing the fabrics
-    pub fn reset_persist<S: KvBlobStore>(
+    pub(crate) fn reset_persist<S: KvBlobStore>(
         &mut self,
         mut store: S,
         buf: &mut [u8],
@@ -1152,7 +1152,7 @@ impl Fabrics {
     /// # Arguments
     /// - `store`: the BLOB store to load the fabrics from
     /// - `buf`: a temporary buffer to use for loading the fabrics
-    pub fn load_persist<S: KvBlobStore>(
+    pub(crate) fn load_persist<S: KvBlobStore>(
         &mut self,
         mut store: S,
         buf: &mut [u8],
@@ -1409,7 +1409,7 @@ where
     }
 
     /// Return a reference to the underlying `Persist` instance.
-    pub fn persist_mut(&mut self) -> &mut Persist<S> {
+    pub(crate) fn persist_mut(&mut self) -> &mut Persist<S> {
         &mut self.0
     }
 

--- a/rs-matter/src/sc/case/resumption.rs
+++ b/rs-matter/src/sc/case/resumption.rs
@@ -225,7 +225,7 @@ impl ResumableSessions {
     /// Drop every record belonging to `fab_idx`. Call this from the
     /// fabric-removal path so removed-fabric peers cannot resume onto
     /// a fabric that no longer exists.
-    fn remove_for_fabric(&mut self, fab_idx: NonZeroU8) {
+    pub(crate) fn remove_for_fabric(&mut self, fab_idx: NonZeroU8) {
         self.records.retain(|r| r.fab_idx != fab_idx);
     }
 

--- a/rs-matter/src/sc/case/resumption.rs
+++ b/rs-matter/src/sc/case/resumption.rs
@@ -170,7 +170,7 @@ impl ResumableSessions {
     }
 
     /// Drop every record — in memory only, does not touch storage.
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.records.clear();
     }
 
@@ -225,7 +225,7 @@ impl ResumableSessions {
     /// Drop every record belonging to `fab_idx`. Call this from the
     /// fabric-removal path so removed-fabric peers cannot resume onto
     /// a fabric that no longer exists.
-    pub fn remove_for_fabric(&mut self, fab_idx: NonZeroU8) {
+    fn remove_for_fabric(&mut self, fab_idx: NonZeroU8) {
         self.records.retain(|r| r.fab_idx != fab_idx);
     }
 
@@ -253,7 +253,7 @@ impl ResumableSessions {
     /// - The `ResumableSession` layout gains or loses a required
     ///   field in a future release.
     /// - The KV backend served corrupted bytes.
-    pub fn load_persist<S: KvBlobStore>(
+    pub(crate) fn load_persist<S: KvBlobStore>(
         &mut self,
         mut store: S,
         buf: &mut [u8],
@@ -297,7 +297,11 @@ impl ResumableSessions {
     /// [`CASE_RESUMPTION_KEY`]. Called from the background snapshot
     /// task whenever the in-memory cache diverges from what was last
     /// persisted.
-    pub fn store_persist<S: KvBlobStore>(&self, mut store: S, buf: &mut [u8]) -> Result<(), Error> {
+    pub(crate) fn store_persist<S: KvBlobStore>(
+        &self,
+        mut store: S,
+        buf: &mut [u8],
+    ) -> Result<(), Error> {
         // Serialise into `buf` first; then split it so the remainder
         // can serve as the KV store's own scratch space. This mirrors
         // the same split-and-lend pattern that [`Persist::store`] uses
@@ -314,7 +318,7 @@ impl ResumableSessions {
 
     /// Remove the persisted cache from `store` and wipe the in-memory
     /// copy. Used from [`crate::Matter::reset_persist`].
-    pub fn reset_persist<S: KvBlobStore>(
+    pub(crate) fn reset_persist<S: KvBlobStore>(
         &mut self,
         mut store: S,
         buf: &mut [u8],

--- a/rs-matter/src/sc/checkin.rs
+++ b/rs-matter/src/sc/checkin.rs
@@ -277,7 +277,9 @@ impl CheckInCounter {
     ///
     /// `epoch` must be non-zero.
     pub(crate) const fn new(start: u32, epoch: u32) -> Self {
-        assert!(epoch != 0, "the Check-In counter epoch must be non-zero");
+        // `::core::assert!` rather than the crate-wide `assert!`, which maps to
+        // `defmt::assert!` under the `defmt` feature and is not const-callable.
+        ::core::assert!(epoch != 0, "the Check-In counter epoch must be non-zero");
 
         Self {
             value: start,

--- a/rs-matter/src/sc/checkin.rs
+++ b/rs-matter/src/sc/checkin.rs
@@ -344,8 +344,17 @@ impl CheckInCounter {
     ///
     /// Persist this right after [`new`](Self::new), so a restart resumes past
     /// every value this run may use.
-    pub fn persist_value(&self) -> u32 {
+    pub(crate) fn persist_value(&self) -> u32 {
         self.next_epoch
+    }
+
+    /// How far ahead of the live value the persisted boundary is kept - the
+    /// `epoch` this counter was constructed with.
+    ///
+    /// Lets a re-hydration path rebuild the counter from a stored `start`
+    /// without the caller having to thread the epoch through again.
+    pub(crate) fn epoch(&self) -> u32 {
+        self.epoch
     }
 }
 

--- a/rs-matter/src/sc/checkin.rs
+++ b/rs-matter/src/sc/checkin.rs
@@ -276,7 +276,7 @@ impl CheckInCounter {
     /// resumes past every value this run might use.
     ///
     /// `epoch` must be non-zero.
-    pub fn new(start: u32, epoch: u32) -> Self {
+    pub(crate) const fn new(start: u32, epoch: u32) -> Self {
         assert!(epoch != 0, "the Check-In counter epoch must be non-zero");
 
         Self {

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -1162,7 +1162,7 @@ impl Sessions {
         r
     }
 
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.sessions.clear();
         #[cfg(feature = "groups")]
         {
@@ -1195,7 +1195,7 @@ impl Sessions {
     ///
     /// An absent key means "first boot": the counter is instead seeded
     /// randomly on first use, which likewise stores its boundary first.
-    pub fn load_persist<S: KvBlobStore>(
+    pub(crate) fn load_persist<S: KvBlobStore>(
         &mut self,
         mut store: S,
         buf: &mut [u8],
@@ -1216,7 +1216,7 @@ impl Sessions {
     /// running, a factory reset drops every fabric and group key, so no peer
     /// can still be tracking this node's counter. The next group send seeds it
     /// afresh at random and stores the new boundary before going on the wire.
-    pub fn reset_persist<S: KvBlobStore>(
+    pub(crate) fn reset_persist<S: KvBlobStore>(
         &mut self,
         mut store: S,
         buf: &mut [u8],
@@ -1883,7 +1883,7 @@ impl Sessions {
 
     /// This assumes that the higher layer has taken care of doing anything required
     /// as per the spec before the sessions are removed or expired
-    pub fn remove_for_fabric(&mut self, fabric_idx: NonZeroU8, expire_sess_id: Option<u32>) {
+    pub(crate) fn remove_for_fabric(&mut self, fabric_idx: NonZeroU8, expire_sess_id: Option<u32>) {
         while let Some(index) = self.sessions.iter().position(|sess| {
             sess.get_local_fabric_idx() == fabric_idx.get() && Some(sess.id) != expire_sess_id
         }) {

--- a/tests/src/bin/system_tests.rs
+++ b/tests/src/bin/system_tests.rs
@@ -280,12 +280,10 @@ fn main() -> Result<(), Error> {
         BindingHandler::new(Dataver::new_rand(&mut rand), ROOT_ENDPOINT_ID, bindings);
 
     // TimeZone / DSTOffset storage for the TimeSync cluster's `TIME_ZONE`
-    // feature. Both lists are `nonVolatile` quality, so they are re-hydrated
-    // before the data model accepts traffic, like the labels and bindings
-    // above.
+    // feature. Both lists are `nonVolatile` quality; the TimeSync handler
+    // re-hydrates them from `im.startup()`, like the labels and bindings above.
     static TIME_ZONE_STORE: StaticCell<TimeZoneStore> = StaticCell::new();
     let time_zone_store: &TimeZoneStore = TIME_ZONE_STORE.init(TimeZoneStore::new());
-    kv.access(|store, buf| time_zone_store.load_persist(store, buf))?;
 
     let time_sync_handler =
         TimeSyncHandler::new_with_time_zone(Dataver::new_rand(&mut rand), time_zone_store);
@@ -353,23 +351,15 @@ fn main() -> Result<(), Error> {
     // to true and validates the `TestEventTrigger` invoke key against the
     // supplied bytes. Without it, the default `()` `GenDiag` impl reports
     // disabled and rejects every trigger.
-    // Shared ICD state for the ICD Management cluster. Registrations and the
-    // Check-In counter are re-hydrated from KV before the data model accepts
-    // traffic, so both survive a reboot.
+    // Shared ICD state for the ICD Management cluster. The ICD Management
+    // handler re-hydrates the registrations and the Check-In counter from
+    // `im.startup()` (and seeds the advertised operating mode from them), so
+    // both survive a reboot. A fixed start keeps the itests deterministic; the
+    // persisted boundary replaces it when there is one.
     let icd: &'static Icd = ICD.uninit().init_with(Icd::init(
         CheckInCounter::new(0, ICD_COUNTER_EPOCH),
         ICD_MODE,
     ));
-    kv.access(|store, buf| icd.load_registrations(store, buf))?;
-    kv.access(|store, buf| icd.load_counter(store, ICD_COUNTER_EPOCH, buf))?;
-    // Persist the boundary the counter now resumes from, so the *next* restart
-    // resumes one epoch further on (even on first boot, where nothing was stored
-    // yet). Without this the counter would not advance across a reboot.
-    kv.access(|store, buf| icd.persist_counter(store, buf))?;
-    // Seed the advertised ICD operating mode from the (possibly reloaded)
-    // registration set, so a client registered before a reboot keeps the device
-    // advertising as LIT.
-    matter.set_icd_mode(Some(icd.operating_mode()));
 
     let gen_diag: &'static dyn GenDiag = if let Some(key) = parse_enable_key_override() {
         info!("TestEventTrigger enabled with configured 16-byte key");

--- a/tests/src/bin/system_tests.rs
+++ b/tests/src/bin/system_tests.rs
@@ -114,7 +114,6 @@ use rs_matter::pairing::qr::QrTextType;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::KvBlobStoreAccess;
 use rs_matter::respond::{ChainedExchangeHandler, Responder};
-use rs_matter::sc::checkin::CheckInCounter;
 use rs_matter::sc::pase::MAX_COMM_WINDOW_TIMEOUT_SECS;
 use rs_matter::sc::SecureChannel;
 use rs_matter::transport::exchange::Exchange;
@@ -354,12 +353,12 @@ fn main() -> Result<(), Error> {
     // Shared ICD state for the ICD Management cluster. The ICD Management
     // handler re-hydrates the registrations and the Check-In counter from
     // `im.startup()` (and seeds the advertised operating mode from them), so
-    // both survive a reboot. A fixed start keeps the itests deterministic; the
-    // persisted boundary replaces it when there is one.
-    let icd: &'static Icd = ICD.uninit().init_with(Icd::init(
-        CheckInCounter::new(0, ICD_COUNTER_EPOCH),
-        ICD_MODE,
-    ));
+    // both survive a reboot. Only the persistence epoch is ours to pick: the
+    // counter's starting value is the stored boundary, or a random one on a
+    // first boot.
+    let icd: &'static Icd = ICD
+        .uninit()
+        .init_with(Icd::init(ICD_COUNTER_EPOCH, ICD_MODE));
 
     let gen_diag: &'static dyn GenDiag = if let Some(key) = parse_enable_key_override() {
         info!("TestEventTrigger enabled with configured 16-byte key");


### PR DESCRIPTION
* Some clusters like the Time Sync one were missing a factory reset method
* Others, like the ICD one were **not** having their factory reset and load-on-startup code plugged-in in the `Handler::lifecycle` infra, so the user had to call them explicitly

Also, this PR is making a bunch of those private or crate-private, so as to avoid user code calling those explicitly - given that they are called from `Handler::lifecycle` anyway