### PR TITLE
Better matching syntax; utils for non-networking system clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* (Breaking) Retire `EpClMatcher` in favor of `FnMatcher` - a plain `fn(EndptId, ClusterId) -> bool`
+* (Breaking) Split the root endpoint system handler chain in two, so that the operational network clusters (Network Commissioning, General Commissioning, General Diagnostics, Ethernet/Wifi/Thread Diagnostics) can be chained on top of a user handler that provides the rest; useful with non-concurrent commissioning
 * (Breaking) Retire `GenDiag::reboot_count` and `GenDiag::uptime_ms` as they are now implemented directly in `rs-matter` (#543)
 * Add PAF and NTL options to `DiscoveryCapabilities`; `QrPayload::as_ndef` (#543)
 * Streamline the logging of the E2E test drivers (#542)

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ use rs_matter::dm::devices::DEV_TYPE_SMART_SPEAKER;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::Error;
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
 use rs_matter::pairing::qr::QrTextType;
@@ -289,15 +289,15 @@ fn data_model<'a, LH: LevelControlHooks, OH: OnOffHooks>(
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestLevelControlDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestLevelControlDeviceLogic::CLUSTER.id,
                 level_control::HandlerAsyncAdaptor(level_control),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )

--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -76,7 +76,7 @@ use rs_matter::dm::networks::wireless::{
     NetCtlState, NetCtlStateMutex, NetCtlWithStatusImpl, WifiNetworks,
 };
 use rs_matter::dm::networks::NetChangeNotif;
-use rs_matter::dm::{Async, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, Dataver, Endpoint, FnMatcher, Node};
 use rs_matter::error::Error;
 use rs_matter::im::{InteractionModel, WirelessInteractionModelState};
 use rs_matter::pairing::qr::QrTextType;
@@ -189,8 +189,8 @@ impl<'a> MatterStack<'a> {
 type AppNetCtl<'a> = NetCtlWithStatusImpl<'a, FakeWifi>;
 type AppTransport<'a> = ChainedNetwork<FakeUdp, &'a Btp, fn(&Address) -> bool>;
 type AppDmHandler<'a> = handler_chain_type!(
-    EpClMatcher => on_off::HandlerAsyncAdaptor<on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>>,
-    EpClMatcher => Async<desc::HandlerAdaptor<DescHandler<'a>>>
+    FnMatcher => on_off::HandlerAsyncAdaptor<on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>>,
+    FnMatcher => Async<desc::HandlerAdaptor<DescHandler<'a>>>
     | WifiSysHandler<'a, &'a AppNetCtl<'a>>
 );
 type AppCrypto = RustCrypto<'static, WeakTestOnlyRand>;
@@ -633,11 +633,11 @@ fn data_model<'a>(
     endpoints::WifiSysHandlerBuilder::new(net_ctl, wifi_diag)
         .build(rand)
         .chain(
-            EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+            |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
             Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
         )
         .chain(
-            EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+            |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
             on_off::HandlerAsyncAdaptor(on_off),
         )
 }

--- a/docs/Matter_clusters-Implementation_usage_and_support.md
+++ b/docs/Matter_clusters-Implementation_usage_and_support.md
@@ -58,7 +58,7 @@ fn main() {
 	// Build endpoint handler for device clusters
 	let device_handler = EmptyHandler
 		.chain(
-			EpClMatcher::new(Some(1), Some(AirQualityHandler::CLUSTER.id)),
+			|e, c| e == 1 && c == AirQualityHandler::CLUSTER.id,
 			air_quality::HandlerAdaptor(air_quality_handler),
 		)
 		// Continue chaining device clusters
@@ -99,7 +99,7 @@ fn main() {
 	// Build endpoint handler for device clusters
 	let device_handler = EmptyHandler
 		.chain(
-			EpClMatcher::new(Some(1), Some(DescHandler::CLUSTER.id)),
+			|e, c| e == 1 && c == DescHandler::CLUSTER.id,
 			Async(descriptor_handler.adapt()),
 		)
 		// Continue chaining device clusters
@@ -284,7 +284,7 @@ fn main() {
     let handler = ModeHandler::new(Dataver::new_rand(rand), RvcDeviceLogic::new());
 
     let device_handler = EmptyHandler.chain(
-        EpClMatcher::new(Some(1), Some(rvc_run_mode::CLUSTER.id)),
+        |e, c| e == 1 && c == rvc_run_mode::CLUSTER.id,
         rvc_run_mode::adapt(handler),
     );
 }

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -39,7 +39,7 @@ use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::{
-    Async, Cluster, DataModel, Dataver, Endpoint, EpClMatcher, InvokeContext, Node, ReadContext,
+    Async, Cluster, DataModel, Dataver, Endpoint, InvokeContext, Node, ReadContext,
 };
 use rs_matter::error::Error;
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
@@ -222,7 +222,7 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             // not yet supported by Google home and Apple, as per
             // https://www.1home.io/docs/en/server/configure-devices#manage-rooms
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new_aggregator(Dataver::new_rand(&mut rand)).adapt()),
             )
             // The following chains are the handlers for the bridged devices corresponding to ep 2 and ep3.
@@ -235,35 +235,35 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             // which is likely to do remote calls over a proprietary protocol so as to e.g. retrieve the state of
             // the lamp, or to switch it on/off.
             .chain(
-                EpClMatcher::new(Some(2), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 2 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(2), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 2 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(2), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 2 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off_ep2),
             )
             .chain(
-                EpClMatcher::new(Some(2), Some(BridgedHandler::CLUSTER.id)),
+                |e, c| e == 2 && c == BridgedHandler::CLUSTER.id,
                 Async(BridgedHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(3), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 3 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(3), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 3 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(3), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 3 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off_ep3),
             )
             .chain(
-                EpClMatcher::new(Some(3), Some(BridgedHandler::CLUSTER.id)),
+                |e, c| e == 3 && c == BridgedHandler::CLUSTER.id,
                 Async(BridgedHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             ),
     )

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -48,7 +48,7 @@ use rs_matter::dm::devices::DEV_TYPE_DIMMABLE_LIGHT;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, Cluster, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, Cluster, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
 use rs_matter::pairing::qr::QrTextType;
@@ -208,19 +208,19 @@ fn data_model<'a, LH: LevelControlHooks, OH: OnOffHooks>(
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(OnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == OnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(LevelControlDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == LevelControlDeviceLogic::CLUSTER.id,
                 level_control::HandlerAsyncAdaptor(level_control),
             ),
     )

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -58,8 +58,8 @@ use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::{
-    ArrayAttributeRead, Async, Cluster, DataModel, Dataver, Endpoint, EpClMatcher, InvokeContext,
-    Node, ReadContext,
+    ArrayAttributeRead, Async, Cluster, DataModel, Dataver, Endpoint, InvokeContext, Node,
+    ReadContext,
 };
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
@@ -191,23 +191,23 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(MediaHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == MediaHandler::CLUSTER.id,
                 MediaHandler::new(Dataver::new_rand(&mut rand)).adapt(),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(ContentHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == ContentHandler::CLUSTER.id,
                 ContentHandler::new(Dataver::new_rand(&mut rand)).adapt(),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(KeypadInputHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == KeypadInputHandler::CLUSTER.id,
                 KeypadInputHandler::new(Dataver::new_rand(&mut rand)).adapt(),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -53,7 +53,7 @@ use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, Cluster, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, Cluster, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::Error;
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
 use rs_matter::pairing::qr::QrTextType;
@@ -311,19 +311,19 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks, MH: ModeSelectHooks>(
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(LightPatternLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == LightPatternLogic::CLUSTER.id,
                 Async(mode_select::HandlerAdaptor(mode_select)),
             ),
     )

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -53,7 +53,7 @@ use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::unix::UnixNetifs;
 use rs_matter::dm::networks::wireless::{NetCtlState, NetCtlWithStatusImpl, WifiNetworks};
 use rs_matter::dm::networks::NetChangeNotif;
-use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::Error;
 use rs_matter::im::{InteractionModel, WirelessInteractionModelState};
 use rs_matter::pairing::qr::QrTextType;
@@ -287,15 +287,15 @@ where
             .netif_diag(&UnixNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )

--- a/examples/src/bin/onoff_light_switch.rs
+++ b/examples/src/bin/onoff_light_switch.rs
@@ -59,7 +59,7 @@ use rs_matter::dm::devices::{DEV_TYPE_GENERIC_SWITCH, DEV_TYPE_ON_OFF_LIGHT_SWIT
 use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, EpClMatcher, EventEmitter, Node};
+use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, EventEmitter, Node};
 use rs_matter::error::Error;
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
 use rs_matter::pairing::qr::QrTextType;
@@ -410,11 +410,11 @@ fn data_model<'a, const N: usize>(
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == SWITCH_ENDPOINT && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(binding::CLUSTER.id)),
+                |e, c| e == SWITCH_ENDPOINT && c == binding::CLUSTER.id,
                 Async(
                     BindingHandler::new(Dataver::new_rand(&mut rand), SWITCH_ENDPOINT, bindings)
                         .adapt(),
@@ -422,17 +422,11 @@ fn data_model<'a, const N: usize>(
             )
             // Endpoint 2: the Generic Switch — Descriptor + Switch server.
             .chain(
-                EpClMatcher::new(
-                    Some(GENERIC_SWITCH_ENDPOINT),
-                    Some(desc::DescHandler::CLUSTER.id),
-                ),
+                |e, c| e == GENERIC_SWITCH_ENDPOINT && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(
-                    Some(GENERIC_SWITCH_ENDPOINT),
-                    Some(SwitchHandler::CLUSTER.id),
-                ),
+                |e, c| e == GENERIC_SWITCH_ENDPOINT && c == SwitchHandler::CLUSTER.id,
                 Async(SwitchHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             ),
     )

--- a/examples/src/bin/onoff_light_work_stealing.rs
+++ b/examples/src/bin/onoff_light_work_stealing.rs
@@ -35,7 +35,7 @@ use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::endpoints::{self, EthSysHandler};
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, Dataver, Endpoint, FnMatcher, Node};
 use rs_matter::error::Error;
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
 use rs_matter::pairing::qr::QrTextType;
@@ -54,8 +54,8 @@ use static_cell::StaticCell;
 mod mdns;
 
 type AppDmHandler<'a> = handler_chain_type!(
-    EpClMatcher => on_off::HandlerAsyncAdaptor<on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>>,
-    EpClMatcher => Async<desc::HandlerAdaptor<DescHandler<'a>>>
+    FnMatcher => on_off::HandlerAsyncAdaptor<on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>>,
+    FnMatcher => Async<desc::HandlerAdaptor<DescHandler<'a>>>
     | EthSysHandler<'a>
 );
 
@@ -187,8 +187,8 @@ fn main() -> Result<(), Error> {
     // 229 |     executor.spawn(respond).detach();
     //     |     ^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Send` is not general enough
     //     |
-    //     = note: `Send` would have to be implemented for the type `&Responder<'_, ChainedExchangeHandler<&InteractionModel<'_, 15, 0, &RustCrypto<'_, FakeRng>, PooledBuffers<10, heapless::vec::Vec<u8, 1583>>, (Node<'_>, ChainedHandler<EpClMatcher, rs_matter::dm::clusters::net_comm::HandlerAsyncAdaptor<NetCommHandler<'_, EthNetCtl>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::eth_diag::HandlerAdaptor<EthDiagHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::gen_diag::HandlerAdaptor<GenDiagHandler<'_>>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::desc::HandlerAdaptor<DescHandler<'_>>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::basic_info::HandlerAdaptor<BasicInfoHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::gen_comm::HandlerAdaptor<GenCommHandler<'_>>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::adm_comm::HandlerAdaptor<AdminCommHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::noc::HandlerAdaptor<NocHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::acl::HandlerAdaptor<AclHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::grp_key_mgmt::HandlerAdaptor<GrpKeyMgmtHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::clusters::app::on_off::HandlerAsyncAdaptor<OnOffHandler<'_, TestOnOffDeviceLogic, NoLevelControl>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::desc::HandlerAdaptor<DescHandler<'_>>>, EmptyHandler>>>>>>>>>>>>)>, SecureChannel<'_, &&RustCrypto<'_, FakeRng>>>>`
-    //     = note: ...but `Send` is actually implemented for the type `&'0 Responder<'_, ChainedExchangeHandler<&InteractionModel<'_, 15, 0, &RustCrypto<'_, FakeRng>, PooledBuffers<10, heapless::vec::Vec<u8, 1583>>, (Node<'_>, ChainedHandler<EpClMatcher, rs_matter::dm::clusters::net_comm::HandlerAsyncAdaptor<NetCommHandler<'_, EthNetCtl>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::eth_diag::HandlerAdaptor<EthDiagHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::gen_diag::HandlerAdaptor<GenDiagHandler<'_>>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::desc::HandlerAdaptor<DescHandler<'_>>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::basic_info::HandlerAdaptor<BasicInfoHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::gen_comm::HandlerAdaptor<GenCommHandler<'_>>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::adm_comm::HandlerAdaptor<AdminCommHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::noc::HandlerAdaptor<NocHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::acl::HandlerAdaptor<AclHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::grp_key_mgmt::HandlerAdaptor<GrpKeyMgmtHandler>>, ChainedHandler<EpClMatcher, rs_matter::dm::clusters::app::on_off::HandlerAsyncAdaptor<OnOffHandler<'_, TestOnOffDeviceLogic, NoLevelControl>>, ChainedHandler<EpClMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::desc::HandlerAdaptor<DescHandler<'_>>>, EmptyHandler>>>>>>>>>>>>)>, SecureChannel<'_, &&RustCrypto<'_, FakeRng>>>>`, for some specific lifetime `'0`
+    //     = note: `Send` would have to be implemented for the type `&Responder<'_, ChainedExchangeHandler<&InteractionModel<'_, 15, 0, &RustCrypto<'_, FakeRng>, PooledBuffers<10, heapless::vec::Vec<u8, 1583>>, (Node<'_>, ChainedHandler<FnMatcher, rs_matter::dm::clusters::net_comm::HandlerAsyncAdaptor<NetCommHandler<'_, EthNetCtl>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::eth_diag::HandlerAdaptor<EthDiagHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::gen_diag::HandlerAdaptor<GenDiagHandler<'_>>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::desc::HandlerAdaptor<DescHandler<'_>>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::basic_info::HandlerAdaptor<BasicInfoHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::gen_comm::HandlerAdaptor<GenCommHandler<'_>>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::adm_comm::HandlerAdaptor<AdminCommHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::noc::HandlerAdaptor<NocHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::acl::HandlerAdaptor<AclHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::grp_key_mgmt::HandlerAdaptor<GrpKeyMgmtHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::clusters::app::on_off::HandlerAsyncAdaptor<OnOffHandler<'_, TestOnOffDeviceLogic, NoLevelControl>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::desc::HandlerAdaptor<DescHandler<'_>>>, EmptyHandler>>>>>>>>>>>>)>, SecureChannel<'_, &&RustCrypto<'_, FakeRng>>>>`
+    //     = note: ...but `Send` is actually implemented for the type `&'0 Responder<'_, ChainedExchangeHandler<&InteractionModel<'_, 15, 0, &RustCrypto<'_, FakeRng>, PooledBuffers<10, heapless::vec::Vec<u8, 1583>>, (Node<'_>, ChainedHandler<FnMatcher, rs_matter::dm::clusters::net_comm::HandlerAsyncAdaptor<NetCommHandler<'_, EthNetCtl>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::eth_diag::HandlerAdaptor<EthDiagHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::gen_diag::HandlerAdaptor<GenDiagHandler<'_>>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::desc::HandlerAdaptor<DescHandler<'_>>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::basic_info::HandlerAdaptor<BasicInfoHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::gen_comm::HandlerAdaptor<GenCommHandler<'_>>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::adm_comm::HandlerAdaptor<AdminCommHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::noc::HandlerAdaptor<NocHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::acl::HandlerAdaptor<AclHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::grp_key_mgmt::HandlerAdaptor<GrpKeyMgmtHandler>>, ChainedHandler<FnMatcher, rs_matter::dm::clusters::app::on_off::HandlerAsyncAdaptor<OnOffHandler<'_, TestOnOffDeviceLogic, NoLevelControl>>, ChainedHandler<FnMatcher, rs_matter::dm::Async<rs_matter::dm::clusters::desc::HandlerAdaptor<DescHandler<'_>>>, EmptyHandler>>>>>>>>>>>>)>, SecureChannel<'_, &&RustCrypto<'_, FakeRng>>>>`, for some specific lifetime `'0`
     //```
     //executor.spawn(respond).detach();
 
@@ -219,11 +219,11 @@ fn data_model<'a>(
         .netif_diag(&SysNetifs)
         .build(rand)
         .chain(
-            EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+            |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
             Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
         )
         .chain(
-            EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+            |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
             on_off::HandlerAsyncAdaptor(on_off),
         )
 }

--- a/examples/src/bin/ota_requestor.rs
+++ b/examples/src/bin/ota_requestor.rs
@@ -50,7 +50,7 @@ use rs_matter::dm::devices::DEV_TYPE_OTA_REQUESTOR;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, AttrChangeNotifier, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, AttrChangeNotifier, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
 use rs_matter::pairing::qr::QrTextType;
@@ -180,11 +180,11 @@ fn data_model<'a>(
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(OtaRequestorHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == OtaRequestorHandler::CLUSTER.id,
                 Async(
                     OtaRequestorHandler::new(Dataver::new_rand(&mut rand), providers, ota_state)
                         .adapt(),

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -40,7 +40,7 @@ use rs_matter::dm::devices::DEV_TYPE_SMART_SPEAKER;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::Error;
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
 use rs_matter::pairing::qr::QrTextType;
@@ -189,15 +189,15 @@ fn data_model<'a, LH: LevelControlHooks, OH: OnOffHooks>(
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestLevelControlDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestLevelControlDeviceLogic::CLUSTER.id,
                 level_control::HandlerAsyncAdaptor(level_control),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )

--- a/examples/src/bin/webrtc_camera.rs
+++ b/examples/src/bin/webrtc_camera.rs
@@ -109,7 +109,7 @@ use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::unix::UnixNetifs;
 use rs_matter::dm::DeviceType;
-use rs_matter::dm::{DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::Error;
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
 use rs_matter::pairing::qr::QrTextType;
@@ -1395,38 +1395,36 @@ fn data_model<'a>(
             .netif_diag(&UnixNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 rs_matter::dm::Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 rs_matter::dm::Async(
                     groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt(),
                 ),
             )
             .chain(
-                EpClMatcher::new(
-                    Some(1),
-                    Some(CameraAvStreamHandler::<Str0mCamHooks, CAM_AV_NV>::CLUSTER.id),
-                ),
+                |e, c| e == 1 && c == CameraAvStreamHandler::<Str0mCamHooks, CAM_AV_NV>::CLUSTER.id,
                 rs_matter::dm::clusters::app::cam_av_stream::HandlerAsyncAdaptor(cam_av),
             )
             .chain(
-                EpClMatcher::new(
-                    Some(1),
-                    Some(rs_matter::dm::clusters::app::cam_av_settings::CLUSTER_DPTZ_ONLY.id),
-                ),
+                |e, c| {
+                    e == 1
+                        && c == rs_matter::dm::clusters::app::cam_av_settings::CLUSTER_DPTZ_ONLY.id
+                },
                 rs_matter::dm::clusters::app::cam_av_settings::HandlerAsyncAdaptor(cam_av_settings),
             )
             .chain(
-                EpClMatcher::new(
-                    Some(1),
-                    Some(ZoneMgmtHandler::<DemoZoneHooks, ZONE_NZ, ZONE_NV, ZONE_NT>::CLUSTER.id),
-                ),
+                |e, c| {
+                    e == 1
+                        && c == ZoneMgmtHandler::<DemoZoneHooks, ZONE_NZ, ZONE_NV, ZONE_NT>::CLUSTER
+                            .id
+                },
                 ZoneMgmtAdaptor(zone_mgmt),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(WebRtc::CLUSTER.id)),
+                |e, c| e == 1 && c == WebRtc::CLUSTER.id,
                 WebRtcAdaptor(webrtc),
             ),
     )

--- a/rs-matter/src/dm/clusters/binding.rs
+++ b/rs-matter/src/dm/clusters/binding.rs
@@ -78,7 +78,7 @@ pub use crate::persist::BINDINGS_KEY;
 /// Cluster metadata exposed by [`BindingHandler`].
 ///
 /// Exposed as a free constant so callers can spell out
-/// `EpClMatcher::new(Some(ep), Some(binding::CLUSTER.id))` without
+/// `|e, c| e == ep && c == binding::CLUSTER.id` without
 /// reaching for the lifetime-parameterised handler type.
 pub const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
 

--- a/rs-matter/src/dm/clusters/fixed_label.rs
+++ b/rs-matter/src/dm/clusters/fixed_label.rs
@@ -57,7 +57,7 @@ pub use crate::dm::clusters::decl::globals::{
 /// Cluster metadata exposed by [`FixedLabelHandler`].
 ///
 /// Exposed as a free constant so callers can spell out
-/// `EpClMatcher::new(Some(ep), Some(fixed_label::CLUSTER.id))` without
+/// `|e, c| e == ep && c == fixed_label::CLUSTER.id` without
 /// reaching for the lifetime-parameterised handler type.
 pub const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
 

--- a/rs-matter/src/dm/clusters/identify.rs
+++ b/rs-matter/src/dm/clusters/identify.rs
@@ -56,7 +56,7 @@ pub use crate::dm::clusters::decl::identify::*;
 /// Equivalent to `<IdentifyHandler<H> as ClusterHandler>::CLUSTER` for
 /// any `H: IdentifyHooks`, exposed here as a free constant so callers
 /// don't have to spell out the generic parameter when they just want the
-/// cluster ID for an `EpClMatcher` or a `clusters!(...)` literal.
+/// cluster ID for a handler chain matcher or a `clusters!(...)` literal.
 pub const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
 
 /// The kind of identification action requested by a controller, dispatched

--- a/rs-matter/src/dm/clusters/mode.rs
+++ b/rs-matter/src/dm/clusters/mode.rs
@@ -115,7 +115,7 @@
 //! let handler = ModeHandler::new(Dataver::new_rand(rand), Vacuum::new());
 //!
 //! let device_handler = EmptyHandler.chain(
-//!     EpClMatcher::new(Some(1), Some(rvc_run_mode::CLUSTER.id)),
+//!     |e, c| e == 1 && c == rvc_run_mode::CLUSTER.id,
 //!     rvc_run_mode::adapt(handler),
 //! );
 //! ```

--- a/rs-matter/src/dm/clusters/mode_select.rs
+++ b/rs-matter/src/dm/clusters/mode_select.rs
@@ -85,7 +85,7 @@
 //! let handler = ModeSelectHandler::new(Dataver::new_rand(rand), SwitchWiring::new());
 //!
 //! let device_handler = EmptyHandler.chain(
-//!     EpClMatcher::new(Some(1), Some(CLUSTER.id)),
+//!     |e, c| e == 1 && c == CLUSTER.id,
 //!     handler.adapt(),
 //! );
 //! ```

--- a/rs-matter/src/dm/clusters/power_source.rs
+++ b/rs-matter/src/dm/clusters/power_source.rs
@@ -66,7 +66,7 @@ pub use crate::dm::clusters::decl::power_source::*;
 /// Cluster metadata exposed by [`PowerSourceHandler`].
 ///
 /// Exposed as a free constant so callers can spell out
-/// `EpClMatcher::new(Some(ep), Some(power_source::CLUSTER.id))` without
+/// `|e, c| e == ep && c == power_source::CLUSTER.id` without
 /// naming the lifetime-parameterised handler type.
 pub const CLUSTER: Cluster<'static> = FULL_CLUSTER
     .with_features(Feature::WIRED.bits())

--- a/rs-matter/src/dm/clusters/user_label.rs
+++ b/rs-matter/src/dm/clusters/user_label.rs
@@ -72,7 +72,7 @@ pub use crate::persist::USER_LABELS_KEY;
 ///
 /// Exposed as a free constant so callers don't have to spell out the
 /// generic parameters of [`UserLabelHandler`] when they just want the
-/// cluster ID for an `EpClMatcher` or a `clusters!(...)` literal.
+/// cluster ID for a handler chain matcher or a `clusters!(...)` literal.
 pub const CLUSTER: Cluster<'static> = FULL_CLUSTER.with_attrs(with!(required));
 
 /// Maximum length of a single `label` string, in characters.

--- a/rs-matter/src/dm/endpoints.rs
+++ b/rs-matter/src/dm/endpoints.rs
@@ -15,9 +15,37 @@
  *    limitations under the License.
  */
 
+//! Handler chains for the root endpoint (Endpoint 0).
+//!
+//! The mandatory system clusters of the root endpoint come in two groups:
+//!
+//! - The clusters that do not depend on the operational network: Descriptor,
+//!   Basic Information, Administrator Commissioning, Operational Credentials,
+//!   Access Control, Group Key Management, Software Diagnostics and Time
+//!   Synchronization. [`root_handler`] returns a chain with all of them.
+//!
+//! - The operational network clusters: Network Commissioning, General
+//!   Commissioning, General Diagnostics and the network-type diagnostics cluster
+//!   (Ethernet, Wifi or Thread). Their inputs are the network controller, the
+//!   network interface and the commissioning policy. [`eth_net_handler`],
+//!   [`wifi_net_handler`] and [`thread_net_handler`] return a chain with these,
+//!   chained on top of a caller-provided handler.
+//!
+//! [`eth_sys_handler`], [`wifi_sys_handler`] and [`thread_sys_handler`] combine
+//! the two groups into a single chain for the whole root endpoint. Use the split
+//! form when the two groups have different lifetimes or owners - as with a
+//! non-concurrent commissioning flow, where the network clusters are re-created
+//! on every BLE to Wifi/Thread handover while the rest of the root endpoint
+//! stays - or when extra clusters need to be chained into the root endpoint
+//! next to the system ones.
+//!
+//! The root endpoint metadata is the same in all cases: [`root_endpoint!`] lists
+//! all clusters, as the Descriptor cluster and the Interaction Model dispatch
+//! are driven by the metadata rather than by the shape of the handler chain.
+
 use rand_core::RngCore;
 
-use crate::dm::{ClusterId, EmptyHandler};
+use crate::dm::{EmptyHandler, FnMatcher};
 use crate::handler_chain_type;
 
 use super::clusters::acl::{self, AclHandler, ClusterHandler as _};
@@ -39,7 +67,7 @@ use super::clusters::wifi_diag::{
     self, AlwaysConnected, ClusterHandler as _, WifiDiag, WifiDiagHandler, WirelessDiag,
 };
 use super::networks::eth::EthNetCtl;
-use super::types::{Async, ChainedHandler, Dataver, EndptId, EpClMatcher};
+use super::types::{Async, ChainedHandler, Dataver, EndptId};
 
 /// A macro to generate the meta-data for the root endpoint (Endpoint 0).
 ///
@@ -86,6 +114,61 @@ macro_rules! root_endpoint {
     }
 }
 
+/// The ID of the root endpoint (Endpoint 0)
+pub const ROOT_ENDPOINT_ID: EndptId = 0;
+
+/// A type alias for the handler chain returned by `root_handler()`:
+/// the root endpoint system clusters that do not depend on the operational network.
+///
+/// A non-async chain; wrap it in `Async` to chain it with async handlers.
+/// `T` is the handler at the end of the chain.
+pub type RootHandler<'a, T = EmptyHandler> = handler_chain_type!(
+    FnMatcher => desc::HandlerAdaptor<DescHandler<'a>>,
+    FnMatcher => basic_info::HandlerAdaptor<BasicInfoHandler>,
+    FnMatcher => adm_comm::HandlerAdaptor<AdminCommHandler>,
+    FnMatcher => noc::HandlerAdaptor<NocHandler>,
+    FnMatcher => acl::HandlerAdaptor<AclHandler>,
+    FnMatcher => grp_key_mgmt::HandlerAdaptor<GrpKeyMgmtHandler>,
+    FnMatcher => sw_diag::HandlerAdaptor<SwDiagHandler<'a>>,
+    FnMatcher => time_sync::HandlerAdaptor<TimeSyncHandler<'a>>
+    | T
+);
+
+/// A type alias for the non-async operational network clusters of the root endpoint:
+/// General Commissioning, General Diagnostics and the network-type diagnostics
+/// cluster `N`, on top of the handler `T`.
+///
+/// The three are kept in one non-async chain behind a single `Async` wrapper
+/// (see `NetHandler` and `SysHandler`), so that the async-to-sync adaptation
+/// is monomorphized once rather than once per cluster.
+pub type OperNetHandler<'a, N, T = EmptyHandler> = handler_chain_type!(
+    FnMatcher => gen_comm::HandlerAdaptor<GenCommHandler<'a>>,
+    FnMatcher => gen_diag::HandlerAdaptor<GenDiagHandler<'a>>,
+    FnMatcher => N
+    | T
+);
+
+/// A type alias for the handler chain returned by `eth_net_handler()`.
+pub type EthNetHandler<'a, H> =
+    NetHandler<'a, EthNetCtl<'a>, eth_diag::HandlerAdaptor<EthDiagHandler>, H>;
+
+/// A type alias for the handler chain returned by `wifi_net_handler()`.
+pub type WifiNetHandler<'a, T, H> =
+    NetHandler<'a, T, wifi_diag::HandlerAdaptor<WifiDiagHandler<'a>>, H>;
+
+/// A type alias for the handler chain returned by `thread_net_handler()`.
+pub type ThreadNetHandler<'a, T, H> =
+    NetHandler<'a, T, thread_diag::HandlerAdaptor<ThreadDiagHandler<'a>>, H>;
+
+/// A type alias for the handler chain returned by `net_handler()`:
+/// the operational network clusters of the root endpoint, on top of the handler `H`,
+/// which receives everything the network clusters do not match.
+pub type NetHandler<'a, T, N, H> = handler_chain_type!(
+    FnMatcher => net_comm::HandlerAsyncAdaptor<NetCommHandler<'a, T>>,
+    FnMatcher => Async<OperNetHandler<'a, N>>
+    | H
+);
+
 /// A type alias for the handler chain returned by `eth_sys_handler()`.
 pub type EthSysHandler<'a> =
     SysHandler<'a, EthNetCtl<'a>, eth_diag::HandlerAdaptor<EthDiagHandler>>;
@@ -97,26 +180,150 @@ pub type WifiSysHandler<'a, T> = SysHandler<'a, T, wifi_diag::HandlerAdaptor<Wif
 pub type ThreadSysHandler<'a, T> =
     SysHandler<'a, T, thread_diag::HandlerAdaptor<ThreadDiagHandler<'a>>>;
 
-/// A type alias for the handler chain returned by `sys_handler()`.
+/// A type alias for the handler chain returned by `sys_handler()`:
+/// all system clusters of the root endpoint.
 pub type SysHandler<'a, T, N> = handler_chain_type!(
-    EpClMatcher => net_comm::HandlerAsyncAdaptor<NetCommHandler<'a, T>>
-    | Async<handler_chain_type!(
-        EpClMatcher => desc::HandlerAdaptor<DescHandler<'a>>,
-        EpClMatcher => basic_info::HandlerAdaptor<BasicInfoHandler>,
-        EpClMatcher => gen_comm::HandlerAdaptor<GenCommHandler<'a>>,
-        EpClMatcher => adm_comm::HandlerAdaptor<AdminCommHandler>,
-        EpClMatcher => noc::HandlerAdaptor<NocHandler>,
-        EpClMatcher => acl::HandlerAdaptor<acl::AclHandler>,
-        EpClMatcher => grp_key_mgmt::HandlerAdaptor<GrpKeyMgmtHandler>,
-        EpClMatcher => sw_diag::HandlerAdaptor<SwDiagHandler<'a>>,
-        EpClMatcher => time_sync::HandlerAdaptor<TimeSyncHandler<'a>>,
-        EpClMatcher => gen_diag::HandlerAdaptor<GenDiagHandler<'a>>,
-        EpClMatcher => N
-    )>
+    FnMatcher => net_comm::HandlerAsyncAdaptor<NetCommHandler<'a, T>>
+    | Async<OperNetHandler<'a, N, RootHandler<'a>>>
 );
 
-/// The ID of the root endpoint (Endpoint 0)
-pub const ROOT_ENDPOINT_ID: EndptId = 0;
+/// Return a handler for the root endpoint system clusters that do not depend on the
+/// operational network: Descriptor, Basic Information, Administrator Commissioning,
+/// Operational Credentials, Access Control, Group Key Management, Software Diagnostics
+/// and Time Synchronization.
+///
+/// Chain the operational network clusters on top of it with `eth_net_handler()`,
+/// `wifi_net_handler()` or `thread_net_handler()`, or use `eth_sys_handler()` & co.
+/// for a chain with all root endpoint system clusters.
+///
+/// # Arguments:
+/// - `sw_diag`: The `SwDiag` implementation (pass `&()` for the
+///   no-op default: heap counters report `0`).
+/// - `rand`: A random number generator.
+pub fn root_handler<'a, R: RngCore>(sw_diag: &'a dyn SwDiag, rand: R) -> RootHandler<'a> {
+    root_handler_chained(sw_diag, EmptyHandler, rand)
+}
+
+/// Return a handler for the root endpoint operational network clusters,
+/// chained on top of `next`.
+/// Use this handler for devices that use Ethernet as the Matter Operational Network.
+///
+/// # Arguments:
+/// - `comm_policy`: The `CommPolicy` implementation.
+/// - `gen_diag`: The `GenDiag` implementation.
+/// - `netif_diag`: The `NetifDiag` implementation.
+/// - `next`: The handler to chain on top of; receives everything not matched here.
+/// - `rand`: A random number generator.
+pub fn eth_net_handler<'a, R: RngCore, H>(
+    comm_policy: &'a dyn CommPolicy,
+    gen_diag: &'a dyn GenDiag,
+    netif_diag: &'a dyn NetifDiag,
+    next: H,
+    mut rand: R,
+) -> EthNetHandler<'a, H> {
+    net_handler(
+        comm_policy,
+        gen_diag,
+        netif_diag,
+        EthNetCtl::new_default(),
+        &AlwaysConnected,
+        |e, c| {
+            e == ROOT_ENDPOINT_ID
+                && (c == GenCommHandler::CLUSTER.id
+                    || c == GenDiagHandler::CLUSTER.id
+                    || c == EthDiagHandler::CLUSTER.id)
+        },
+        EthDiagHandler::new(Dataver::new_rand(&mut rand)).adapt(),
+        next,
+        rand,
+    )
+}
+
+/// Return a handler for the root endpoint operational network clusters,
+/// chained on top of `next`.
+/// Use this handler for devices that use Wifi as the Matter Operational Network.
+///
+/// # Arguments:
+/// - `comm_policy`: The `CommPolicy` implementation.
+/// - `gen_diag`: The `GenDiag` implementation.
+/// - `netif_diag`: The `NetifDiag` implementation.
+/// - `wifi_diag`: The `WifiDiag` implementation.
+/// - `net_ctl`: The `NetCtl` implementation.
+/// - `next`: The handler to chain on top of; receives everything not matched here.
+/// - `rand`: A random number generator.
+#[allow(clippy::too_many_arguments)]
+pub fn wifi_net_handler<'a, R: RngCore, T, H>(
+    comm_policy: &'a dyn CommPolicy,
+    gen_diag: &'a dyn GenDiag,
+    netif_diag: &'a dyn NetifDiag,
+    wifi_diag: &'a dyn WifiDiag,
+    net_ctl: T,
+    next: H,
+    mut rand: R,
+) -> WifiNetHandler<'a, T, H>
+where
+    T: NetCtl + NetCtlStatus,
+{
+    net_handler(
+        comm_policy,
+        gen_diag,
+        netif_diag,
+        net_ctl,
+        wifi_diag,
+        |e, c| {
+            e == ROOT_ENDPOINT_ID
+                && (c == GenCommHandler::CLUSTER.id
+                    || c == GenDiagHandler::CLUSTER.id
+                    || c == WifiDiagHandler::CLUSTER.id)
+        },
+        WifiDiagHandler::new(Dataver::new_rand(&mut rand), wifi_diag).adapt(),
+        next,
+        rand,
+    )
+}
+
+/// Return a handler for the root endpoint operational network clusters,
+/// chained on top of `next`.
+/// Use this handler for devices that use Thread as the Matter Operational Network.
+///
+/// # Arguments:
+/// - `comm_policy`: The `CommPolicy` implementation.
+/// - `gen_diag`: The `GenDiag` implementation.
+/// - `netif_diag`: The `NetifDiag` implementation.
+/// - `thread_diag`: The `ThreadDiag` implementation.
+/// - `net_ctl`: The `NetCtl` implementation.
+/// - `next`: The handler to chain on top of; receives everything not matched here.
+/// - `rand`: A random number generator.
+#[allow(clippy::too_many_arguments)]
+pub fn thread_net_handler<'a, R: RngCore, T, H>(
+    comm_policy: &'a dyn CommPolicy,
+    gen_diag: &'a dyn GenDiag,
+    netif_diag: &'a dyn NetifDiag,
+    thread_diag: &'a dyn ThreadDiag,
+    net_ctl: T,
+    next: H,
+    mut rand: R,
+) -> ThreadNetHandler<'a, T, H>
+where
+    T: NetCtl + NetCtlStatus,
+{
+    net_handler(
+        comm_policy,
+        gen_diag,
+        netif_diag,
+        net_ctl,
+        thread_diag,
+        |e, c| {
+            e == ROOT_ENDPOINT_ID
+                && (c == GenCommHandler::CLUSTER.id
+                    || c == GenDiagHandler::CLUSTER.id
+                    || c == ThreadDiagHandler::CLUSTER.id)
+        },
+        ThreadDiagHandler::new(Dataver::new_rand(&mut rand), thread_diag).adapt(),
+        next,
+        rand,
+    )
+}
 
 /// Return a system handler for the root endpoint (Endpoint 0).
 /// Use this handler for devices that use Ethernet as the Matter Operational Network.
@@ -143,7 +350,7 @@ pub fn eth_sys_handler<'a, R: RngCore>(
         sw_diag,
         EthNetCtl::new_default(),
         &AlwaysConnected,
-        EthDiagHandler::CLUSTER.id,
+        |e, c| e == ROOT_ENDPOINT_ID && c == EthDiagHandler::CLUSTER.id,
         EthDiagHandler::new(Dataver::new_rand(&mut rand)).adapt(),
         rand,
     )
@@ -180,7 +387,7 @@ where
         sw_diag,
         net_ctl,
         wifi_diag,
-        WifiDiagHandler::CLUSTER.id,
+        |e, c| e == ROOT_ENDPOINT_ID && c == WifiDiagHandler::CLUSTER.id,
         WifiDiagHandler::new(Dataver::new_rand(&mut rand), wifi_diag).adapt(),
         rand,
     )
@@ -217,26 +424,127 @@ where
         sw_diag,
         net_ctl,
         thread_diag,
-        ThreadDiagHandler::CLUSTER.id,
+        |e, c| e == ROOT_ENDPOINT_ID && c == ThreadDiagHandler::CLUSTER.id,
         ThreadDiagHandler::new(Dataver::new_rand(&mut rand), thread_diag).adapt(),
         rand,
     )
 }
 
-/// Return a system handler for the root endpoint (Endpoint 0).
-/// Note that this handler does not include the Network Diagnostic handler, which is dependent on
-/// the network type and thus is not included in this function.
+/// The `root_handler()` chain on top of `next`.
+fn root_handler_chained<'a, R: RngCore, T>(
+    sw_diag: &'a dyn SwDiag,
+    next: T,
+    mut rand: R,
+) -> RootHandler<'a, T> {
+    ChainedHandler::new(
+        |e, c| e == ROOT_ENDPOINT_ID && c == TimeSyncHandler::CLUSTER.id,
+        TimeSyncHandler::new(Dataver::new_rand(&mut rand)).adapt(),
+        next,
+    )
+    .chain(
+        |e, c| e == ROOT_ENDPOINT_ID && c == SwDiagHandler::CLUSTER.id,
+        SwDiagHandler::new(Dataver::new_rand(&mut rand), sw_diag).adapt(),
+    )
+    .chain(
+        |e, c| e == ROOT_ENDPOINT_ID && c == GrpKeyMgmtHandler::CLUSTER.id,
+        GrpKeyMgmtHandler::new(Dataver::new_rand(&mut rand)).adapt(),
+    )
+    .chain(
+        |e, c| e == ROOT_ENDPOINT_ID && c == AclHandler::CLUSTER.id,
+        AclHandler::new(Dataver::new_rand(&mut rand)).adapt(),
+    )
+    .chain(
+        |e, c| e == ROOT_ENDPOINT_ID && c == NocHandler::CLUSTER.id,
+        NocHandler::new(Dataver::new_rand(&mut rand)).adapt(),
+    )
+    .chain(
+        |e, c| e == ROOT_ENDPOINT_ID && c == AdminCommHandler::CLUSTER.id,
+        AdminCommHandler::new(Dataver::new_rand(&mut rand)).adapt(),
+    )
+    .chain(
+        |e, c| e == ROOT_ENDPOINT_ID && c == BasicInfoHandler::CLUSTER.id,
+        BasicInfoHandler::new(Dataver::new_rand(&mut rand)).adapt(),
+    )
+    .chain(
+        |e, c| e == ROOT_ENDPOINT_ID && c == DescHandler::CLUSTER.id,
+        DescHandler::new(Dataver::new_rand(&mut rand)).adapt(),
+    )
+}
+
+/// The non-async operational network clusters on top of `next`.
 ///
-/// Use `eth_sys_handler()`, `wifi_sys_handler()` or `thread_sys_handler()` instead to get the appropriate
-/// Network Diagnostic handler included in the handler.
+/// `netw_diag_matcher` is the matcher of the network diagnostics link, which sits
+/// at the bottom of the chain, right above `next`.
+#[allow(clippy::too_many_arguments)]
+fn oper_net_handler<'a, R: RngCore, N, T>(
+    comm_policy: &'a dyn CommPolicy,
+    gen_diag: &'a dyn GenDiag,
+    netif_diag: &'a dyn NetifDiag,
+    netw_diag_matcher: FnMatcher,
+    netw_diag: N,
+    next: T,
+    mut rand: R,
+) -> OperNetHandler<'a, N, T> {
+    ChainedHandler::new(netw_diag_matcher, netw_diag, next)
+        .chain(
+            |e, c| e == ROOT_ENDPOINT_ID && c == GenDiagHandler::CLUSTER.id,
+            GenDiagHandler::new(Dataver::new_rand(&mut rand), gen_diag, netif_diag).adapt(),
+        )
+        .chain(
+            |e, c| e == ROOT_ENDPOINT_ID && c == GenCommHandler::CLUSTER.id,
+            GenCommHandler::new(Dataver::new_rand(&mut rand), comm_policy).adapt(),
+        )
+}
+
+/// Return a handler for the root endpoint operational network clusters,
+/// chained on top of `next`.
+///
+/// Use `eth_net_handler()`, `wifi_net_handler()` or `thread_net_handler()` instead to get the
+/// appropriate Network Diagnostic handler included in the handler.
 ///
 /// # Arguments:
-/// - `comm_policy`: The `CommPolicy` implementation.
-/// - `gen_diag`: The `GenDiag` implementation.
-/// - `netif_diag`: The `NetifDiag` implementation.
-/// - `networks`: The `Networks` implementation.
-/// - `net_ctl`: The `NetCtl` implementation.
-/// - `rand`: A random number generator.
+/// - `net_matcher`: A matcher for exactly the General Commissioning, General Diagnostics and
+///   `netw_diag` clusters on the root endpoint. It guards the `Async` sub-chain with the three,
+///   and - as the network diagnostics link is at the bottom of that sub-chain - also serves
+///   as the matcher of that link.
+#[allow(clippy::too_many_arguments)]
+fn net_handler<'a, R: RngCore, T, N, H>(
+    comm_policy: &'a dyn CommPolicy,
+    gen_diag: &'a dyn GenDiag,
+    netif_diag: &'a dyn NetifDiag,
+    net_ctl: T,
+    wireless_diag: &'a dyn WirelessDiag,
+    net_matcher: FnMatcher,
+    netw_diag: N,
+    next: H,
+    mut rand: R,
+) -> NetHandler<'a, T, N, H>
+where
+    T: NetCtl + NetCtlStatus,
+{
+    ChainedHandler::new(
+        |e, c| e == ROOT_ENDPOINT_ID && c == NetCommHandler::<T>::CLUSTER.id,
+        NetCommHandler::new(Dataver::new_rand(&mut rand), net_ctl, wireless_diag).adapt(),
+        ChainedHandler::new(
+            net_matcher,
+            Async(oper_net_handler(
+                comm_policy,
+                gen_diag,
+                netif_diag,
+                net_matcher,
+                netw_diag,
+                EmptyHandler,
+                &mut rand,
+            )),
+            next,
+        ),
+    )
+}
+
+/// Return a system handler for the root endpoint (Endpoint 0) with all system clusters.
+///
+/// Use `eth_sys_handler()`, `wifi_sys_handler()` or `thread_sys_handler()` instead to get the
+/// appropriate Network Diagnostic handler included in the handler.
 #[allow(clippy::too_many_arguments)]
 fn sys_handler<'a, R: RngCore, T, N>(
     comm_policy: &'a dyn CommPolicy,
@@ -245,7 +553,7 @@ fn sys_handler<'a, R: RngCore, T, N>(
     sw_diag: &'a dyn SwDiag,
     net_ctl: T,
     wireless_diag: &'a dyn WirelessDiag,
-    netw_diag_cluster_id: ClusterId,
+    netw_diag_matcher: FnMatcher,
     netw_diag: N,
     mut rand: R,
 ) -> SysHandler<'a, T, N>
@@ -253,58 +561,17 @@ where
     T: NetCtl + NetCtlStatus,
 {
     ChainedHandler::new(
-        EpClMatcher::new(
-            Some(ROOT_ENDPOINT_ID),
-            Some(NetCommHandler::<T>::CLUSTER.id),
-        ),
+        |e, c| e == ROOT_ENDPOINT_ID && c == NetCommHandler::<T>::CLUSTER.id,
         NetCommHandler::new(Dataver::new_rand(&mut rand), net_ctl, wireless_diag).adapt(),
-        Async(
-            ChainedHandler::new(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(netw_diag_cluster_id)),
-                netw_diag,
-                EmptyHandler,
-            )
-            .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(GenDiagHandler::CLUSTER.id)),
-                GenDiagHandler::new(Dataver::new_rand(&mut rand), gen_diag, netif_diag).adapt(),
-            )
-            .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(TimeSyncHandler::CLUSTER.id)),
-                TimeSyncHandler::new(Dataver::new_rand(&mut rand)).adapt(),
-            )
-            .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(SwDiagHandler::CLUSTER.id)),
-                SwDiagHandler::new(Dataver::new_rand(&mut rand), sw_diag).adapt(),
-            )
-            .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(GrpKeyMgmtHandler::CLUSTER.id)),
-                GrpKeyMgmtHandler::new(Dataver::new_rand(&mut rand)).adapt(),
-            )
-            .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(AclHandler::CLUSTER.id)),
-                AclHandler::new(Dataver::new_rand(&mut rand)).adapt(),
-            )
-            .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(NocHandler::CLUSTER.id)),
-                NocHandler::new(Dataver::new_rand(&mut rand)).adapt(),
-            )
-            .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(AdminCommHandler::CLUSTER.id)),
-                AdminCommHandler::new(Dataver::new_rand(&mut rand)).adapt(),
-            )
-            .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(GenCommHandler::CLUSTER.id)),
-                GenCommHandler::new(Dataver::new_rand(&mut rand), comm_policy).adapt(),
-            )
-            .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(BasicInfoHandler::CLUSTER.id)),
-                BasicInfoHandler::new(Dataver::new_rand(&mut rand)).adapt(),
-            )
-            .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(DescHandler::CLUSTER.id)),
-                DescHandler::new(Dataver::new_rand(&mut rand)).adapt(),
-            ),
-        ),
+        Async(oper_net_handler(
+            comm_policy,
+            gen_diag,
+            netif_diag,
+            netw_diag_matcher,
+            netw_diag,
+            root_handler_chained(sw_diag, EmptyHandler, &mut rand),
+            &mut rand,
+        )),
     )
 }
 

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -1212,7 +1212,35 @@ where
     }
 }
 
-pub trait DataModel: Metadata + AsyncHandler {}
+pub trait DataModel: Metadata + AsyncHandler {
+    /// Bump the dataver of every cluster on the endpoint `endpoint_id` - as listed
+    /// in the node metadata - by invoking `bump_dataver` once per cluster, with a
+    /// fully-specified (endpoint, cluster) context.
+    ///
+    /// Matchers are functions of both IDs, so a single bump with the cluster left out
+    /// could not be routed to just this endpoint's handlers.
+    ///
+    /// The metadata is not held while the handlers are invoked.
+    fn bump_endpoint_dataver(&self, endpoint_id: EndptId) {
+        let mut index = 0;
+
+        while let Some(cluster_id) = self.access(|node| {
+            node.endpoints
+                .iter()
+                .find(|endpoint| endpoint.id == endpoint_id)
+                .and_then(|endpoint| endpoint.clusters.get(index))
+                .map(|cluster| cluster.id)
+        }) {
+            self.bump_dataver(MatchContextInstance::new(
+                Some(endpoint_id),
+                Some(cluster_id),
+            ));
+
+            index += 1;
+        }
+    }
+}
+
 impl<T> DataModel for T where T: Metadata + AsyncHandler {}
 
 /// A lifecycle operation delivered to a handler via [`Handler::lifecycle`] /
@@ -1426,13 +1454,13 @@ where
     F: Fn(EndptId, ClusterId) -> bool,
 {
     fn matches(&self, ctx: impl MatchContext) -> bool {
-        let Some(endpt_id) = ctx.endpt() else {
-            // Not bound to an endpoint (e.g. a global dataver bump): let it through
-            return true;
-        };
-
-        let Some(cluster_id) = ctx.cluster() else {
-            // Not bound to a cluster: let it through
+        // A matcher is a function of both IDs, so a context that lacks one cannot be
+        // routed by it and is let through as a global one. The Interaction Model only
+        // ever produces a fully-specified context or a fully-unspecified one: an
+        // endpoint-scoped dataver bump is expanded to one bump per cluster of that
+        // endpoint (see `DataModel::bump_endpoint_dataver`) rather than sent with the cluster
+        // left out, as the latter would reach every handler on every endpoint.
+        let (Some(endpt_id), Some(cluster_id)) = (ctx.endpt(), ctx.cluster()) else {
             return true;
         };
 
@@ -2224,4 +2252,72 @@ mod asynch {
     }
 
     impl<T> NonBlockingHandler for Async<T> where T: NonBlockingHandler {}
+}
+
+#[cfg(test)]
+mod tests {
+    use core::cell::Cell;
+
+    use crate::dm::clusters::basic_info::{BasicInfoHandler, ClusterHandler as _};
+    use crate::dm::clusters::desc::{ClusterHandler as _, DescHandler};
+    use crate::dm::{Async, Endpoint, Node};
+    use crate::error::{Error, ErrorCode};
+
+    use super::{
+        DataModel, EmptyHandler, Handler, MatchContext, NonBlockingHandler, ReadContext, ReadReply,
+    };
+
+    /// A handler that only counts its dataver bumps.
+    struct Counting(Cell<u32>);
+
+    impl Handler for Counting {
+        fn read(&self, _ctx: impl ReadContext, _reply: impl ReadReply) -> Result<(), Error> {
+            Err(ErrorCode::AttributeNotFound.into())
+        }
+
+        fn bump_dataver(&self, _ctx: impl MatchContext) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    impl NonBlockingHandler for Counting {}
+
+    const NODE: Node<'static> = Node {
+        endpoints: &[
+            Endpoint::new(0, &[], &[DescHandler::CLUSTER, BasicInfoHandler::CLUSTER]),
+            Endpoint::new(1, &[], &[DescHandler::CLUSTER]),
+        ],
+    };
+
+    #[test]
+    fn endpoint_bump_reaches_only_the_clusters_of_that_endpoint() {
+        let ep0_desc = Counting(Cell::new(0));
+        let ep0_basic_info = Counting(Cell::new(0));
+        let ep1_desc = Counting(Cell::new(0));
+
+        let dm = (
+            NODE,
+            Async(
+                EmptyHandler
+                    .chain(|e, c| e == 0 && c == DescHandler::CLUSTER.id, &ep0_desc)
+                    .chain(
+                        |e, c| e == 0 && c == BasicInfoHandler::CLUSTER.id,
+                        &ep0_basic_info,
+                    )
+                    .chain(|e, c| e == 1 && c == DescHandler::CLUSTER.id, &ep1_desc),
+            ),
+        );
+
+        let counts = || (ep0_desc.0.get(), ep0_basic_info.0.get(), ep1_desc.0.get());
+
+        dm.bump_endpoint_dataver(0);
+        assert_eq!(counts(), (1, 1, 0));
+
+        dm.bump_endpoint_dataver(1);
+        assert_eq!(counts(), (1, 1, 1));
+
+        // An endpoint that is not in the metadata bumps nothing
+        dm.bump_endpoint_dataver(2);
+        assert_eq!(counts(), (1, 1, 1));
+    }
 }

--- a/rs-matter/src/dm/types/handler.rs
+++ b/rs-matter/src/dm/types/handler.rs
@@ -1407,43 +1407,36 @@ pub trait Matcher {
     fn matches(&self, ctx: impl MatchContext) -> bool;
 }
 
-impl<T> Matcher for &T
+/// The default matcher: a plain function of the endpoint ID and the cluster ID of the operation.
+///
+/// A function pointer rather than a closure type, so that handler chains built with it are
+/// nameable (see `handler_chain_type!`). Non-capturing closures coerce to it, and constants
+/// (endpoint IDs, `CLUSTER.id`) are not captures:
+///
+/// ```ignore
+/// EmptyHandler.chain(|e, c| e == LIGHT_ENDPOINT_ID && c == OnOffHandler::CLUSTER.id, handler)
+/// ```
+///
+/// A closure that does capture (e.g. an endpoint ID computed at runtime) is a `Matcher` too,
+/// via `ChainedHandler::new_with_matcher`; the resulting chain is just not nameable.
+pub type FnMatcher = fn(EndptId, ClusterId) -> bool;
+
+impl<F> Matcher for F
 where
-    T: Matcher,
+    F: Fn(EndptId, ClusterId) -> bool,
 {
     fn matches(&self, ctx: impl MatchContext) -> bool {
-        T::matches(self, ctx)
-    }
-}
+        let Some(endpt_id) = ctx.endpt() else {
+            // Not bound to an endpoint (e.g. a global dataver bump): let it through
+            return true;
+        };
 
-/// A matcher that matches a specific endpoint ID and cluster ID.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct EpClMatcher {
-    endpoint_id: Option<EndptId>,
-    cluster_id: Option<ClusterId>,
-}
+        let Some(cluster_id) = ctx.cluster() else {
+            // Not bound to a cluster: let it through
+            return true;
+        };
 
-impl EpClMatcher {
-    /// Create a new `EpClMatcher` instance.
-    ///
-    /// # Arguments:
-    /// - `endpoint_id`: The endpoint ID to match. If `None`, matches any endpoint ID.
-    /// - `cluster_id`: The cluster ID to match. If `None`, matches any cluster ID.
-    pub const fn new(endpoint_id: Option<EndptId>, cluster_id: Option<ClusterId>) -> Self {
-        Self {
-            endpoint_id,
-            cluster_id,
-        }
-    }
-}
-
-impl Matcher for EpClMatcher {
-    fn matches(&self, ctx: impl MatchContext) -> bool {
-        (self.endpoint_id.is_none() || ctx.endpt().is_none() || self.endpoint_id == ctx.endpt())
-            && (self.cluster_id.is_none()
-                || ctx.cluster().is_none()
-                || self.cluster_id == ctx.cluster())
+        self(endpt_id, cluster_id)
     }
 }
 
@@ -1466,7 +1459,11 @@ impl EmptyHandler {
     /// Arguments:
     /// - `matcher`: A matcher that determines whether the handler should be invoked for the incoming operation.
     /// - `handler`: The handler to be invoked if the matcher returns `true`.
-    pub const fn chain<M, H>(self, matcher: M, handler: H) -> ChainedHandler<M, H, Self> {
+    pub const fn chain<H>(
+        self,
+        matcher: FnMatcher,
+        handler: H,
+    ) -> ChainedHandler<FnMatcher, H, Self> {
         ChainedHandler {
             matcher,
             handler,
@@ -1515,8 +1512,8 @@ pub struct ChainedHandler<M, H, T> {
     pub next: T,
 }
 
-impl<M, H, T> ChainedHandler<M, H, T> {
-    /// Construct a chained handler that works as follows:
+impl<H, T> ChainedHandler<FnMatcher, H, T> {
+    /// Construct a chained handler with the default `FnMatcher` matcher that works as follows:
     /// - It will call the provided `handler` instance if the provided matcher returns `true`
     ///   for the `ReadContext`/`WriteContext`/`InvokeContext` of the incoming operation
     /// - Otherwise, it will call the `next` handler
@@ -1525,7 +1522,22 @@ impl<M, H, T> ChainedHandler<M, H, T> {
     /// - `matcher`: A matcher that determines whether the handler should be invoked for the incoming operation.
     /// - `handler`: The handler to be invoked if the matcher returns `true`.
     /// - `next`: The next handler to be invoked if the matcher returns `false`.
-    pub const fn new(matcher: M, handler: H, next: T) -> Self {
+    pub const fn new(matcher: FnMatcher, handler: H, next: T) -> Self {
+        Self::new_with_matcher(matcher, handler, next)
+    }
+}
+
+impl<M, H, T> ChainedHandler<M, H, T> {
+    /// Construct a chained handler with a custom matcher that works as follows:
+    /// - It will call the provided `handler` instance if the provided matcher returns `true`
+    ///   for the `ReadContext`/`WriteContext`/`InvokeContext` of the incoming operation
+    /// - Otherwise, it will call the `next` handler
+    ///
+    /// Arguments:
+    /// - `matcher`: A matcher that determines whether the handler should be invoked for the incoming operation.
+    /// - `handler`: The handler to be invoked if the matcher returns `true`.
+    /// - `next`: The next handler to be invoked if the matcher returns `false`.
+    pub const fn new_with_matcher(matcher: M, handler: H, next: T) -> Self {
         Self {
             matcher,
             handler,
@@ -1543,7 +1555,11 @@ impl<M, H, T> ChainedHandler<M, H, T> {
     /// Arguments:
     /// - `matcher`: A matcher that determines whether the handler should be invoked for the incoming operation.
     /// - `handler`: The handler to be invoked if the matcher returns `true`.
-    pub const fn chain<M2, H2>(self, matcher: M2, handler: H2) -> ChainedHandler<M2, H2, Self> {
+    pub const fn chain<H2>(
+        self,
+        matcher: FnMatcher,
+        handler: H2,
+    ) -> ChainedHandler<FnMatcher, H2, Self> {
         ChainedHandler::new(matcher, handler, self)
     }
 }
@@ -1616,16 +1632,16 @@ where
 /// Use with type aliases:
 /// ```ignore
 /// pub type RootEndpointHandler<'a> = handler_chain_type!(
-///     EpClMatcher => DescriptorCluster<'static>,
-///     EpClMatcher => BasicInfoCluster<'a>,
-///     EpClMatcher => GenCommCluster<'a>,
-///     EpClMatcher => NwCommCluster,
-///     EpClMatcher => AdminCommCluster<'a>,
-///     EpClMatcher => NocCluster<'a>,
-///     EpClMatcher => AccessControlCluster<'a>,
-///     EpClMatcher => GenDiagCluster,
-///     EpClMatcher => EthNwDiagCluster,
-///     EpClMatcher => GrpKeyMgmtCluster
+///     FnMatcher => DescriptorCluster<'static>,
+///     FnMatcher => BasicInfoCluster<'a>,
+///     FnMatcher => GenCommCluster<'a>,
+///     FnMatcher => NwCommCluster,
+///     FnMatcher => AdminCommCluster<'a>,
+///     FnMatcher => NocCluster<'a>,
+///     FnMatcher => AccessControlCluster<'a>,
+///     FnMatcher => GenDiagCluster,
+///     FnMatcher => EthNwDiagCluster,
+///     FnMatcher => GrpKeyMgmtCluster
 /// );
 /// ```
 #[allow(unused_macros)]

--- a/rs-matter/src/im.rs
+++ b/rs-matter/src/im.rs
@@ -1809,8 +1809,7 @@ where
     }
 
     fn notify_endpoint_changed(&self, endpoint_id: EndptId) {
-        self.handler
-            .bump_dataver(MatchContextInstance::new(Some(endpoint_id), None));
+        self.handler.bump_endpoint_dataver(endpoint_id);
         self.state
             .subscriptions
             .notify_endpoint_changed(endpoint_id)

--- a/rs-matter/tests/binding.rs
+++ b/rs-matter/tests/binding.rs
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#![recursion_limit = "256"]
+
 //! In-process device-to-device binding integration test — the automated
 //! equivalent of the certification test plan's (manual) TC-BIND-2.1
 //! "DUT as controller" procedure.
@@ -82,7 +84,7 @@ use rs_matter::dm::clusters::net_comm::DummyNetworks;
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ON_OFF_LIGHT_SWITCH};
 use rs_matter::dm::networks::unix::UnixNetifs;
-use rs_matter::dm::{endpoints, Async, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{endpoints, Async, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::Error;
 use rs_matter::im::client::ImClient;
 use rs_matter::im::subscriptions::DEFAULT_MAX_SUBSCRIPTIONS;
@@ -191,11 +193,11 @@ fn switch_data_model<'a>(
             .netif_diag(&UnixNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == SWITCH_ENDPOINT && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(binding::CLUSTER.id)),
+                |e, c| e == SWITCH_ENDPOINT && c == binding::CLUSTER.id,
                 Async(
                     BindingHandler::new(Dataver::new_rand(&mut rand), SWITCH_ENDPOINT, bindings)
                         .adapt(),
@@ -233,18 +235,15 @@ fn light_data_model<'a, OH: OnOffHooks>(
             .netif_diag(&UnixNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(LIGHT_ENDPOINT), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == LIGHT_ENDPOINT && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(
-                    Some(LIGHT_ENDPOINT),
-                    Some(groups::GroupsHandler::CLUSTER.id),
-                ),
+                |e, c| e == LIGHT_ENDPOINT && c == groups::GroupsHandler::CLUSTER.id,
                 Async(GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(LIGHT_ENDPOINT), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == LIGHT_ENDPOINT && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )

--- a/rs-matter/tests/commissioning.rs
+++ b/rs-matter/tests/commissioning.rs
@@ -61,7 +61,7 @@ use rs_matter::dm::clusters::net_comm::DummyNetworks;
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::dm::devices::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter::dm::networks::unix::UnixNetifs;
-use rs_matter::dm::{endpoints, Async, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{endpoints, Async, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::Error;
 use rs_matter::im::subscriptions::DEFAULT_MAX_SUBSCRIPTIONS;
 use rs_matter::im::IMStatusCode;
@@ -136,11 +136,11 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             .netif_diag(&UnixNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -25,7 +25,7 @@ use rs_matter::dm::clusters::desc::{self, ClusterHandler as _, DescHandler};
 use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ROOT_NODE};
 use rs_matter::dm::endpoints::{EthSysHandler, EthSysHandlerBuilder, ROOT_ENDPOINT_ID};
 use rs_matter::dm::{
-    Async, AsyncHandler, ChainedHandler, Dataver, EmptyHandler, Endpoint, EpClMatcher,
+    Async, AsyncHandler, ChainedHandler, Dataver, EmptyHandler, Endpoint, FnMatcher,
     HandlerContext, InvokeContext, InvokeReply, LifecycleOp, MatchContext, Metadata, Node,
     ReadContext, ReadReply, WriteContext,
 };
@@ -39,10 +39,10 @@ use super::echo_cluster::{self, EchoHandler};
 /// A sample handler for E2E IM tests.
 pub struct E2eTestHandler<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     handler_chain_type!(
-        EpClMatcher => on_off::HandlerAsyncAdaptor<OnOffHandler<'a, OH, LH>>,
-        EpClMatcher => Async<EchoHandler>,
-        EpClMatcher => Async<desc::HandlerAdaptor<DescHandler<'static>>>,
-        EpClMatcher => Async<EchoHandler>
+        FnMatcher => on_off::HandlerAsyncAdaptor<OnOffHandler<'a, OH, LH>>,
+        FnMatcher => Async<EchoHandler>,
+        FnMatcher => Async<desc::HandlerAdaptor<DescHandler<'static>>>,
+        FnMatcher => Async<EchoHandler>
         | EthSysHandler<'a>),
 );
 
@@ -70,19 +70,19 @@ impl<'a, OH: OnOffHooks, LH: LevelControlHooks> E2eTestHandler<'a, OH, LH> {
         let handler = EthSysHandlerBuilder::new()
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(echo_cluster::ID)),
+                |e, c| e == ROOT_ENDPOINT_ID && c == echo_cluster::ID,
                 Async(EchoHandler::new(2, Dataver::new_rand(&mut rand))),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == DescHandler::CLUSTER.id,
                 Async(DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(echo_cluster::ID)),
+                |e, c| e == 1 && c == echo_cluster::ID,
                 Async(EchoHandler::new(3, Dataver::new_rand(&mut rand))),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             );
 

--- a/rs-matter/tests/data_model/aux_acl.rs
+++ b/rs-matter/tests/data_model/aux_acl.rs
@@ -27,7 +27,7 @@
 use rs_matter::dm::clusters::acl::{self, AclHandler};
 use rs_matter::dm::devices::DEV_TYPE_ROOT_NODE;
 use rs_matter::dm::{
-    Async, ChainedHandler, Cluster, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
+    Async, ChainedHandler, Cluster, DataModel, Dataver, EmptyHandler, Endpoint, Node,
 };
 use rs_matter::im::{AttrPath, AttrStatus, GenericPath, IMStatusCode};
 use rs_matter::tlv::Nullable;
@@ -52,7 +52,7 @@ fn dm_handler() -> impl DataModel {
     (
         NODE,
         ChainedHandler::new(
-            EpClMatcher::new(Some(0), Some(acl::CLUSTER_AUX.id)),
+            |e, c| e == 0 && c == acl::CLUSTER_AUX.id,
             Async(AclHandler::new(Dataver::new(1)).adapt()),
             EmptyHandler,
         ),

--- a/rs-matter/tests/data_model/groups.rs
+++ b/rs-matter/tests/data_model/groups.rs
@@ -25,9 +25,7 @@ use rs_matter::dm::clusters::groups::{self, ClusterHandler as _, GroupsHandler};
 use rs_matter::dm::clusters::grp_key_mgmt::{self, ClusterHandler as _, GrpKeyMgmtHandler};
 use rs_matter::dm::clusters::identify::{self, IdentifyHandler};
 use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ROOT_NODE};
-use rs_matter::dm::{
-    Async, ChainedHandler, Cluster, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
-};
+use rs_matter::dm::{Async, ChainedHandler, Cluster, Dataver, EmptyHandler, Endpoint, Node};
 use rs_matter::im::{AttrPath, AttrStatus, CmdPath, CmdStatus, GenericPath, IMStatusCode};
 use rs_matter::tlv::{Nullable, ToTLV};
 
@@ -121,13 +119,13 @@ fn test_add_group_if_identifying() {
     let dm = (
         NODE,
         ChainedHandler::new(
-            EpClMatcher::new(Some(0), Some(GrpKeyMgmtHandler::CLUSTER.id)),
+            |e, c| e == 0 && c == GrpKeyMgmtHandler::CLUSTER.id,
             Async(GrpKeyMgmtHandler::new(Dataver::new(2)).adapt()),
             ChainedHandler::new(
-                EpClMatcher::new(Some(1), Some(identify::CLUSTER.id)),
+                |e, c| e == 1 && c == identify::CLUSTER.id,
                 Async(identify::HandlerAdaptor(&identify_handler)),
                 ChainedHandler::new(
-                    EpClMatcher::new(Some(1), Some(GroupsHandler::CLUSTER.id)),
+                    |e, c| e == 1 && c == GroupsHandler::CLUSTER.id,
                     Async(
                         GroupsHandler::new_with_identify(Dataver::new(3), &identify_handler)
                             .adapt(),

--- a/rs-matter/tests/data_model/provisional.rs
+++ b/rs-matter/tests/data_model/provisional.rs
@@ -35,7 +35,7 @@ use rs_matter::dm::clusters::desc::{self, ClusterHandler as _, DescHandler};
 use rs_matter::dm::clusters::gen_comm::{self, ClusterHandler as _, GenCommHandler};
 use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ROOT_NODE};
 use rs_matter::dm::{
-    Async, ChainedHandler, Cluster, DataModel, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
+    Async, ChainedHandler, Cluster, DataModel, Dataver, EmptyHandler, Endpoint, Node,
 };
 use rs_matter::im::{AttrPath, AttrStatus, GenericPath, IMStatusCode};
 use rs_matter::tlv::{Nullable, ToTLV, Utf8Str};
@@ -72,16 +72,16 @@ fn dm_handler() -> impl DataModel {
     (
         NODE,
         ChainedHandler::new(
-            EpClMatcher::new(Some(0), Some(basic_info::CLUSTER_DEVICE_LOCATION.id)),
+            |e, c| e == 0 && c == basic_info::CLUSTER_DEVICE_LOCATION.id,
             Async(BasicInfoHandler::new(Dataver::new(1)).adapt()),
             EmptyHandler,
         )
         .chain(
-            EpClMatcher::new(Some(0), Some(DescHandler::CLUSTER.id)),
+            |e, c| e == 0 && c == DescHandler::CLUSTER.id,
             Async(DescHandler::new(Dataver::new(2)).adapt()),
         )
         .chain(
-            EpClMatcher::new(Some(1), Some(desc::CLUSTER_ENDPOINT_UNIQUE_ID.id)),
+            |e, c| e == 1 && c == desc::CLUSTER_ENDPOINT_UNIQUE_ID.id,
             Async(DescHandler::new(Dataver::new(3)).adapt()),
         ),
     )
@@ -422,7 +422,7 @@ fn nr_dm_handler() -> impl DataModel {
     (
         NODE_NR,
         ChainedHandler::new(
-            EpClMatcher::new(Some(0), Some(gen_comm::CLUSTER_NETWORK_RECOVERY.id)),
+            |e, c| e == 0 && c == gen_comm::CLUSTER_NETWORK_RECOVERY.id,
             Async(GenCommHandler::new(Dataver::new(1), &true).adapt()),
             EmptyHandler,
         ),
@@ -443,7 +443,7 @@ fn gc_dm_handler() -> impl DataModel {
     (
         NODE_GC,
         ChainedHandler::new(
-            EpClMatcher::new(Some(0), Some(GenCommHandler::CLUSTER.id)),
+            |e, c| e == 0 && c == GenCommHandler::CLUSTER.id,
             Async(GenCommHandler::new(Dataver::new(1), &true).adapt()),
             EmptyHandler,
         ),

--- a/tests/src/bin/ble_tests.rs
+++ b/tests/src/bin/ble_tests.rs
@@ -80,7 +80,7 @@ use rs_matter::dm::networks::wireless::{
     NetCtlState, NetCtlWithStatusImpl, ThreadNetworks, WifiNetworks,
 };
 use rs_matter::dm::networks::{NetChangeNotif, SysNetifs};
-use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::{InteractionModel, WirelessInteractionModelState};
 use rs_matter::pairing::qr::QrTextType;
@@ -576,15 +576,15 @@ where
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )
@@ -605,15 +605,15 @@ where
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )

--- a/tests/src/bin/camera_tests.rs
+++ b/tests/src/bin/camera_tests.rs
@@ -76,8 +76,8 @@ use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::{
-    ArrayAttributeRead, Async, DataModel, Dataver, DeviceType, Endpoint, EpClMatcher,
-    InvokeContext, Node, ReadContext, WriteContext,
+    ArrayAttributeRead, Async, DataModel, Dataver, DeviceType, Endpoint, InvokeContext, Node,
+    ReadContext, WriteContext,
 };
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::EthInteractionModelState;
@@ -704,48 +704,43 @@ fn data_model<'a>(
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(CamAv::CLUSTER_VIDEO_AUDIO.id)),
+                |e, c| e == 1 && c == CamAv::CLUSTER_VIDEO_AUDIO.id,
                 rs_matter::dm::clusters::app::cam_av_stream::HandlerAsyncAdaptor(cam_av),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(CLUSTER_DPTZ_ONLY.id)),
+                |e, c| e == 1 && c == CLUSTER_DPTZ_ONLY.id,
                 rs_matter::dm::clusters::app::cam_av_settings::HandlerAsyncAdaptor(cam_av_settings),
             )
             .chain(
-                EpClMatcher::new(
-                    Some(1),
-                    Some(ZoneMgmtHandler::<StubZoneHooks, ZONE_NZ, ZONE_NV, ZONE_NT>::CLUSTER.id),
-                ),
+                |e, c| {
+                    e == 1
+                        && c == ZoneMgmtHandler::<StubZoneHooks, ZONE_NZ, ZONE_NV, ZONE_NT>::CLUSTER
+                            .id
+                },
                 ZoneMgmtAdaptor(zone_mgmt),
             )
             .chain(
-                EpClMatcher::new(
-                    Some(1),
-                    Some(PushAvStreamHandler::<StubPushHooks, PUSH_NC>::CLUSTER.id),
-                ),
+                |e, c| e == 1 && c == PushAvStreamHandler::<StubPushHooks, PUSH_NC>::CLUSTER.id,
                 rs_matter::dm::clusters::app::push_av_stream::HandlerAsyncAdaptor(push_av),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(WebRtc::CLUSTER.id)),
+                |e, c| e == 1 && c == WebRtc::CLUSTER.id,
                 WebRtcAdaptor(webrtc),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(chime_decl::FULL_CLUSTER.id)),
+                |e, c| e == 1 && c == chime_decl::FULL_CLUSTER.id,
                 Async(ChimeHandlerAdaptor(chime)),
             )
             .chain(
-                EpClMatcher::new(
-                    Some(endpoints::ROOT_ENDPOINT_ID),
-                    Some(power_source::CLUSTER.id),
-                ),
+                |e, c| e == endpoints::ROOT_ENDPOINT_ID && c == power_source::CLUSTER.id,
                 Async(PowerSourceHandler::new(Dataver::new_rand(&mut rand), &POWER_SOURCE).adapt()),
             ),
     )

--- a/tests/src/bin/light_tests.rs
+++ b/tests/src/bin/light_tests.rs
@@ -71,8 +71,8 @@ use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::{
-    Async, AttrChangeNotifier, Cluster, DataModel, Dataver, Endpoint, EpClMatcher, EventEmitter,
-    Node, ReadContext,
+    Async, AttrChangeNotifier, Cluster, DataModel, Dataver, Endpoint, EventEmitter, Node,
+    ReadContext,
 };
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
@@ -484,58 +484,52 @@ fn data_model<
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(OnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == OnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(LevelControlDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == LevelControlDeviceLogic::CLUSTER.id,
                 level_control::HandlerAsyncAdaptor(level_control),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(ColorControlDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == ColorControlDeviceLogic::CLUSTER.id,
                 color_control::HandlerAsyncAdaptor(color_control),
             )
             // Clusters for the switch endpoint
             .chain(
-                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == SWITCH_ENDPOINT && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(identify::CLUSTER.id)),
+                |e, c| e == SWITCH_ENDPOINT && c == identify::CLUSTER.id,
                 Async(IdentifyHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(SWITCH_ENDPOINT), Some(binding::CLUSTER.id)),
+                |e, c| e == SWITCH_ENDPOINT && c == binding::CLUSTER.id,
                 Async(
                     BindingHandler::new(Dataver::new_rand(&mut rand), SWITCH_ENDPOINT, bindings)
                         .adapt(),
                 ),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(ModeSelectDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == ModeSelectDeviceLogic::CLUSTER.id,
                 Async(mode_select::HandlerAdaptor(mode_select)),
             )
             // Clusters for the Generic Switch endpoint
             .chain(
-                EpClMatcher::new(
-                    Some(GENERIC_SWITCH_ENDPOINT),
-                    Some(desc::DescHandler::CLUSTER.id),
-                ),
+                |e, c| e == GENERIC_SWITCH_ENDPOINT && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(
-                    Some(GENERIC_SWITCH_ENDPOINT),
-                    Some(SwitchHandler::CLUSTER.id),
-                ),
+                |e, c| e == GENERIC_SWITCH_ENDPOINT && c == SwitchHandler::CLUSTER.id,
                 Async(SwitchHandler::new(Dataver::new_rand(&mut rand), switch_position).adapt()),
             ),
     )

--- a/tests/src/bin/scenes_tests.rs
+++ b/tests/src/bin/scenes_tests.rs
@@ -54,7 +54,7 @@ use rs_matter::dm::devices::DEV_TYPE_EXTENDED_COLOR_LIGHT;
 use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, Cluster, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, Cluster, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::{EthInteractionModelState, InteractionModel};
 use rs_matter::pairing::qr::QrTextType;
@@ -312,31 +312,28 @@ where
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(OnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == OnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(LevelControlDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == LevelControlDeviceLogic::CLUSTER.id,
                 level_control::HandlerAsyncAdaptor(level_control),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(ColorControlDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == ColorControlDeviceLogic::CLUSTER.id,
                 color_control::HandlerAsyncAdaptor(color_control),
             )
+            .chain(|e, c| e == 1 && c == SCENES_FULL_CLUSTER.id, scenes.adapt())
             .chain(
-                EpClMatcher::new(Some(1), Some(SCENES_FULL_CLUSTER.id)),
-                scenes.adapt(),
-            )
-            .chain(
-                EpClMatcher::new(Some(1), Some(UnitTestingHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == UnitTestingHandler::CLUSTER.id,
                 Async(
                     UnitTestingHandler::new(Dataver::new_rand(&mut rand), unit_testing_data)
                         .adapt(),

--- a/tests/src/bin/system_tests.rs
+++ b/tests/src/bin/system_tests.rs
@@ -104,8 +104,7 @@ use rs_matter::dm::endpoints::{self, ROOT_ENDPOINT_ID};
 use rs_matter::dm::networks::eth::EthNetwork;
 use rs_matter::dm::networks::SysNetifs;
 use rs_matter::dm::{
-    Async, AttrChangeNotifier, Cluster, DataModel, Dataver, DeviceType, Endpoint, EpClMatcher,
-    Node, SemanticTag,
+    Async, AttrChangeNotifier, Cluster, DataModel, Dataver, DeviceType, Endpoint, Node, SemanticTag,
 };
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::PROTO_ID_INTERACTION_MODEL;
@@ -614,7 +613,7 @@ const BASIC_INFO: BasicInfoConfig<'static> = BasicInfoConfig {
 /// "extra cluster". That test is not on `system_tests`'s active
 /// run list (see the `TC_DeviceConformance` skip comment in
 /// `xtask/src/itest.rs`). The library-level `g*` macro variants and
-/// the Groups EpClMatcher in `with_sys()` were dropped to keep
+/// the Groups matcher in `with_sys()` were dropped to keep
 /// device-type-pure compositions the *default* — having Groups on
 /// EP0 here is a deliberate per-fixture exception.
 ///
@@ -1047,7 +1046,7 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             // transition-event timer and list persistence. The shadowed
             // handler's own background task is inert.
             .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(TimeSyncHandler::CLUSTER.id)),
+                |e, c| e == ROOT_ENDPOINT_ID && c == TimeSyncHandler::CLUSTER.id,
                 Async(time_sync::HandlerAdaptor(time_sync_handler)),
             )
             // Groups handler at the root endpoint. The library-level
@@ -1063,19 +1062,13 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             // (App Cluster Spec). The matching metadata entry
             // is in `NODE` and `NODE_BINFO_PROVISIONAL` above.
             .chain(
-                EpClMatcher::new(
-                    Some(ROOT_ENDPOINT_ID),
-                    Some(groups::GroupsHandler::CLUSTER.id),
-                ),
+                |e, c| e == ROOT_ENDPOINT_ID && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             // Groupcast at the root endpoint - the unified group-management
             // interface over the same per-fabric group table Groups uses.
             .chain(
-                EpClMatcher::new(
-                    Some(ROOT_ENDPOINT_ID),
-                    Some(groupcast::GroupcastHandler::CLUSTER.id),
-                ),
+                |e, c| e == ROOT_ENDPOINT_ID && c == groupcast::GroupcastHandler::CLUSTER.id,
                 Async(
                     GroupcastHandler::new(Dataver::new_rand(&mut rand), groupcast::Feature::all())
                         .adapt(),
@@ -1090,30 +1083,30 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             // `user_label::HandlerAdaptor` (rather than the
             // owning-`.adapt()`) so the chain doesn't take ownership.
             .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(user_label::CLUSTER.id)),
+                |e, c| e == ROOT_ENDPOINT_ID && c == user_label::CLUSTER.id,
                 Async(user_label::HandlerAdaptor(user_label_handler)),
             )
             // Binding handler at the root endpoint — owned by main,
             // borrowed by reference into the chain.
             // `TestBinding` exercises writes against EP0.
             .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(binding::CLUSTER.id)),
+                |e, c| e == ROOT_ENDPOINT_ID && c == binding::CLUSTER.id,
                 Async(binding::HandlerAdaptor(binding_handler_ep0)),
             )
             // Clusters for Endpoint 1
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             // Identify at EP1 — owned by `main`, borrowed by reference into
             // the chain, because the EP1 Groups handler below also borrows
             // it for `AddGroupIfIdentifying`.
             .chain(
-                EpClMatcher::new(Some(1), Some(identify::CLUSTER.id)),
+                |e, c| e == 1 && c == identify::CLUSTER.id,
                 Async(identify::HandlerAdaptor(identify_handler_ep1)),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(
                     groups::GroupsHandler::new_with_identify(
                         Dataver::new_rand(&mut rand),
@@ -1123,7 +1116,7 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                 ),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(fixed_label::CLUSTER.id)),
+                |e, c| e == 1 && c == fixed_label::CLUSTER.id,
                 Async(
                     FixedLabelHandler::new(Dataver::new_rand(&mut rand), FIXED_LABELS_EP1).adapt(),
                 ),
@@ -1132,26 +1125,26 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             // separate facade so the per-cluster-instance Dataver
             // stays granular per Matter Core Spec.
             .chain(
-                EpClMatcher::new(Some(1), Some(binding::CLUSTER.id)),
+                |e, c| e == 1 && c == binding::CLUSTER.id,
                 Async(binding::HandlerAdaptor(binding_handler_ep1)),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off_1),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(SCENES_FULL_CLUSTER.id)),
+                |e, c| e == 1 && c == SCENES_FULL_CLUSTER.id,
                 scenes_1.adapt(),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(LaundryWasherModeLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == LaundryWasherModeLogic::CLUSTER.id,
                 Async(laundry_washer_mode::HandlerAdaptor(ModeHandler::new(
                     Dataver::new_rand(&mut rand),
                     LaundryWasherModeLogic::new(),
                 ))),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(UnitTestingHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == UnitTestingHandler::CLUSTER.id,
                 Async(
                     UnitTestingHandler::new(Dataver::new_rand(&mut rand), unit_testing_data)
                         .adapt(),
@@ -1159,16 +1152,16 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             )
             // (mostly) Similar Clusters for Endpoint 2
             .chain(
-                EpClMatcher::new(Some(2), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 2 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             // Identify + Groups at EP2, coupled the same way as EP1 above.
             .chain(
-                EpClMatcher::new(Some(2), Some(identify::CLUSTER.id)),
+                |e, c| e == 2 && c == identify::CLUSTER.id,
                 Async(identify::HandlerAdaptor(identify_handler_ep2)),
             )
             .chain(
-                EpClMatcher::new(Some(2), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 2 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(
                     groups::GroupsHandler::new_with_identify(
                         Dataver::new_rand(&mut rand),
@@ -1178,18 +1171,18 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
                 ),
             )
             .chain(
-                EpClMatcher::new(Some(2), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 2 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off_2),
             )
             .chain(
-                EpClMatcher::new(Some(2), Some(SCENES_FULL_CLUSTER.id)),
+                |e, c| e == 2 && c == SCENES_FULL_CLUSTER.id,
                 scenes_2.adapt(),
             )
             // OTA Software Update Provider on the root endpoint (OTA role). The
             // handler is always present but only matched when `NODE` declares
             // the cluster (gated behind `--filepath`), so it is inert otherwise.
             .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(OTA_PROVIDER_CLUSTER.id)),
+                |e, c| e == ROOT_ENDPOINT_ID && c == OTA_PROVIDER_CLUSTER.id,
                 OtaProviderHandler::new(Dataver::new_rand(&mut rand), ota_images).adapt(),
             )
             // OTA Software Update Requestor on the root endpoint (OTA role).
@@ -1197,7 +1190,7 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             // `AnnounceOTAProvider` arrives; the actual download is driven by
             // `run_ota_requestor` in `main`.
             .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(OTA_REQUESTOR_CLUSTER.id)),
+                |e, c| e == ROOT_ENDPOINT_ID && c == OTA_REQUESTOR_CLUSTER.id,
                 Async(
                     OtaRequestorHandler::new(
                         Dataver::new_rand(&mut rand),
@@ -1210,18 +1203,18 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             // Diagnostic Logs on the root endpoint. The handler's `run` hook (BDX
             // streaming) is driven as part of this chain by `im.run()`.
             .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(DIAGNOSTIC_LOGS_CLUSTER.id)),
+                |e, c| e == ROOT_ENDPOINT_ID && c == DIAGNOSTIC_LOGS_CLUSTER.id,
                 DiagLogsHandler::new(Dataver::new_rand(&mut rand), dlog_buffers, log_provider)
                     .adapt(),
             )
             // ICD Management (Check-In Protocol) on the root endpoint.
             .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(ICD_MGMT_CLUSTER.id)),
+                |e, c| e == ROOT_ENDPOINT_ID && c == ICD_MGMT_CLUSTER.id,
                 Async(IcdMgmtHandler::new(Dataver::new_rand(&mut rand), icd).adapt()),
             )
             // PowerSource on the root endpoint; the fixture is mains-powered.
             .chain(
-                EpClMatcher::new(Some(ROOT_ENDPOINT_ID), Some(power_source::CLUSTER.id)),
+                |e, c| e == ROOT_ENDPOINT_ID && c == power_source::CLUSTER.id,
                 Async(
                     PowerSourceHandler::new(
                         Dataver::new_rand(&mut rand),
@@ -1232,7 +1225,7 @@ fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
             )
             // Second PowerSource instance on EP1 (see `POWER_SOURCE_EP1`).
             .chain(
-                EpClMatcher::new(Some(1), Some(power_source::CLUSTER.id)),
+                |e, c| e == 1 && c == power_source::CLUSTER.id,
                 Async(
                     PowerSourceHandler::new(Dataver::new_rand(&mut rand), &POWER_SOURCE_EP1)
                         .adapt(),

--- a/tests/src/bin/thread_tests.rs
+++ b/tests/src/bin/thread_tests.rs
@@ -53,7 +53,7 @@ use rs_matter::dm::devices::{DEV_TYPE_ON_OFF_LIGHT, DEV_TYPE_ROOT_NODE};
 use rs_matter::dm::endpoints;
 use rs_matter::dm::networks::wireless::{NetCtlState, NetCtlWithStatusImpl, ThreadNetworks};
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, Cluster, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, Cluster, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::{InteractionModel, WirelessInteractionModelState};
 use rs_matter::pairing::qr::QrTextType;
@@ -341,15 +341,15 @@ where
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )

--- a/tests/src/bin/wireless_tests.rs
+++ b/tests/src/bin/wireless_tests.rs
@@ -57,7 +57,7 @@ use rs_matter::dm::networks::wireless::{
     NetCtlState, NetCtlWithStatusImpl, ThreadNetworks, WifiNetworks,
 };
 use rs_matter::dm::networks::SysNetifs;
-use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, EpClMatcher, Node};
+use rs_matter::dm::{Async, DataModel, Dataver, Endpoint, Node};
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::im::{InteractionModel, WirelessInteractionModelState};
 use rs_matter::pairing::qr::QrTextType;
@@ -381,15 +381,15 @@ where
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )
@@ -410,15 +410,15 @@ where
             .netif_diag(&SysNetifs)
             .build(rand)
             .chain(
-                EpClMatcher::new(Some(1), Some(desc::DescHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == desc::DescHandler::CLUSTER.id,
                 Async(desc::DescHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(groups::GroupsHandler::CLUSTER.id)),
+                |e, c| e == 1 && c == groups::GroupsHandler::CLUSTER.id,
                 Async(groups::GroupsHandler::new(Dataver::new_rand(&mut rand)).adapt()),
             )
             .chain(
-                EpClMatcher::new(Some(1), Some(TestOnOffDeviceLogic::CLUSTER.id)),
+                |e, c| e == 1 && c == TestOnOffDeviceLogic::CLUSTER.id,
                 on_off::HandlerAsyncAdaptor(on_off),
             ),
     )

--- a/tests/src/common/vendor_kv.rs
+++ b/tests/src/common/vendor_kv.rs
@@ -44,7 +44,7 @@ pub const START_UP_CT_KEY: u16 = VENDOR_KEYS_START + 1;
 /// [`KvBlobStoreAccess::access`] is generic over its closure, so there is no
 /// `&dyn KvBlobStoreAccess`. The device-logic structs need to hold a handle to
 /// the store without becoming generic themselves - they are named bare in
-/// `EpClMatcher` expressions, as `OnOffDeviceLogic::CLUSTER` - so this narrows
+/// `FnMatcher` expressions, as `OnOffDeviceLogic::CLUSTER` - so this narrows
 /// the store down to the three whole-blob operations they actually use.
 pub trait VendorKv {
     /// Read the blob at `key` into `out`, returning how many bytes were


### PR DESCRIPTION
* This PR replaces the bulky `EpClMatcher` with a fn based one that has a lighter-weight syntax
* Additionally, the PR exposes additional utilities in the `endpoints` module: `root_handlker` and `*_net_handler`, which would allow downstream in `rs-matter-stack` to have additional user-provided system cluster handlers on EP0. See https://github.com/sysgrok/rs-matter-stack/pull/47