### PR TITLE
Update to latest RustCrypto and rand_core 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* (Breaking) Update to `rand_core` 0.10 (`RngCore`/`CryptoRngCore` are now `Rng`/`CryptoRng`; custom RNGs implement `TryRng` + `TryCryptoRng` with an `Infallible` error) and to the current RustCrypto releases (`digest`/`sha1`/`sha2` 0.11, `aes` 0.9, `cipher` 0.5, `ccm` 0.6, `hmac`/`hkdf`/`pbkdf2` 0.13, `elliptic-curve`/`p256` 0.14, `ecdsa` 0.17, `x509-cert` 0.3, `der` 0.8, `crypto-bigint` 0.7); `rand` 0.10 in the examples
 * (Breaking) Retire `EpClMatcher` in favor of `FnMatcher` - a plain `fn(EndptId, ClusterId) -> bool`
 * (Breaking) Split the root endpoint system handler chain in two, so that the operational network clusters (Network Commissioning, General Commissioning, General Diagnostics, Ethernet/Wifi/Thread Diagnostics) can be chained on top of a user handler that provides the rest; useful with non-concurrent commissioning
 * (Breaking) Retire `GenDiag::reboot_count` and `GenDiag::uptime_ms` as they are now implemented directly in `rs-matter` (#543)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* (Breaking) Update to `rand_core` 0.10 (`RngCore`/`CryptoRngCore` are now `Rng`/`CryptoRng`; custom RNGs implement `TryRng` + `TryCryptoRng` with an `Infallible` error) and to the current RustCrypto releases (`digest`/`sha1`/`sha2` 0.11, `aes` 0.9, `cipher` 0.5, `ccm` 0.6, `hmac`/`hkdf`/`pbkdf2` 0.13, `elliptic-curve`/`p256` 0.14, `ecdsa` 0.17, `x509-cert` 0.3, `der` 0.8, `crypto-bigint` 0.7); `rand` 0.10 in the examples
+* (Breaking) Update to all RustCrypto crates as well as `rand_core` to their latest versions
+* (Breaking) Update the non-crypto dependencies to their latest majors: `pinned-init`, `strum`, `num-derive` and a few others
 * (Breaking) Retire `EpClMatcher` in favor of `FnMatcher` - a plain `fn(EndptId, ClusterId) -> bool`
 * (Breaking) Split the root endpoint system handler chain in two, so that the operational network clusters (Network Commissioning, General Commissioning, General Diagnostics, Ethernet/Wifi/Thread Diagnostics) can be chained on top of a user handler that provides the rest; useful with non-concurrent commissioning
 * (Breaking) Retire `GenDiag::reboot_count` and `GenDiag::uptime_ms` as they are now implemented directly in `rs-matter` (#543)

--- a/README.md
+++ b/README.md
@@ -327,6 +327,18 @@ The TL;DR is, rather than building with `--features zeroconf` everywhere, you ca
 - On MacOSX: `--features astro-dnssd` is known to work fine;
 - On Windows: try the built-in mDNS resolver.
 
+### Flash size on embedded targets (`rustcrypto` backend)
+
+The RustCrypto `sha2` and `aes` crates select their software backend with a `--cfg` flag rather than with a Cargo feature,
+and the default is the *unrolled* (faster, ~5KB larger) SHA-256.On flash-constrained MCUs, put in your `.cargo/config.toml`:
+
+```toml
+[build]
+rustflags = ["--cfg", "sha2_backend_soft=\"compact\"", "--cfg", "aes_backend_soft=\"compact\""]
+```
+
+This is what the `bloat-check` project (the CI flash-size gate) does.
+
 ### Unit tests and internal E2E tests
 ```sh
 cargo test -- --test-threads 1

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ use std::net::UdpSocket;
 
 use embassy_futures::select::select4;
 
-use rand::RngCore;
+use rand::Rng;
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::level_control::{
     self, test::TestLevelControlDeviceLogic, AttributeDefaults, LevelControlHandler,
@@ -185,7 +185,7 @@ fn main() -> Result<(), Error> {
     futures_lite::future::block_on(state.load_persist(&kv))?;
 
     // Create the crypto instance
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 
@@ -279,7 +279,7 @@ const NODE: Node<'static> = Node {
 /// The Data Model handler + meta-data for our Matter device.
 /// The handler is the root endpoint 0 handler plus the Speaker handler.
 fn data_model<'a, LH: LevelControlHooks, OH: OnOffHooks>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a OnOffHandler<'a, OH, LH>,
     level_control: &'a LevelControlHandler<'a, LH, OH>,
 ) -> impl DataModel + 'a {

--- a/bloat-check/.cargo/config.toml
+++ b/bloat-check/.cargo/config.toml
@@ -1,5 +1,8 @@
 [build]
 #target = "thumbv7em-none-eabi"
+# `sha2` 0.11 defaults to an unrolled software SHA-256 that is ~5KB larger than the loop-based one `sha2` 0.10 used; pick the compact variant
+# Ditto for `aes`
+rustflags = ["--cfg", "sha2_backend_soft=\"compact\"", "--cfg", "aes_backend_soft=\"compact\""]
 
 [unstable]
 #build-std-features = ["panic_immediate_abort"]

--- a/bloat-check/Cargo.lock
+++ b/bloat-check/Cargo.lock
@@ -19,12 +19,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -34,8 +34,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -192,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -311,6 +322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brownstone"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,14 +430,14 @@ dependencies = [
 
 [[package]]
 name = "ccm"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+checksum = "0be9b34d99d395af800e996c5784f810f8400ccd64202f91859dc677825b5378"
 dependencies = [
  "aead",
- "cipher",
+ "cipher 0.5.2",
  "ctr",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -460,8 +480,19 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -483,6 +514,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codespan-reporting"
@@ -517,9 +554,9 @@ checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
@@ -601,10 +638,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -657,24 +709,17 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
+ "cpubits",
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
-dependencies = [
- "num-traits",
- "subtle",
 ]
 
 [[package]]
@@ -688,12 +733,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctr"
-version = "0.9.2"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "cipher",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -867,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -880,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -901,10 +966,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -941,15 +1016,16 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der",
- "digest",
+ "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -960,18 +1036,19 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.5.5",
- "digest",
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
  "ff",
- "generic-array",
  "group",
  "hkdf",
- "rand_core 0.6.4",
+ "hybrid-array",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
@@ -1466,7 +1543,7 @@ dependencies = [
  "critical-section",
  "defmt 1.1.1",
  "delegate",
- "digest",
+ "digest 0.10.7",
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",
@@ -1712,11 +1789,11 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1855,7 +1932,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1907,12 +1983,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1977,20 +2053,20 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2000,6 +2076,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "subtle",
+ "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -2080,6 +2167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2190,7 +2286,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2329,23 +2425,23 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49d6c43db5aae2ef895972de7a9414cafb649fab288933e74bf7739c0fffe55"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "anyhow",
  "bindgen 0.72.1",
  "cc",
- "cipher",
+ "cipher 0.4.4",
  "cmake",
  "critical-section",
  "defmt 1.1.1",
- "digest",
+ "digest 0.10.7",
  "embuild",
  "enumset",
  "env_logger",
  "esp-idf-sys",
  "fs_extra",
  "log",
- "sha1",
- "sha2",
+ "sha1 0.10.7",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2670,14 +2766,15 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2722,19 +2819,19 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest",
+ "digest 0.11.3",
  "hmac",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -2879,12 +2976,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
+ "primefield",
+ "wnaf",
 ]
 
 [[package]]
@@ -3029,12 +3142,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -3139,16 +3252,16 @@ dependencies = [
 name = "rs-matter"
 version = "0.3.0"
 dependencies = [
- "aes",
+ "aes 0.9.3",
  "bitflags 2.13.1",
  "ccm",
  "cfg-if",
- "cipher",
+ "cipher 0.5.2",
  "critical-section",
- "crypto-bigint 0.6.1",
+ "crypto-bigint",
  "defmt 1.1.1",
  "der",
- "digest",
+ "digest 0.11.3",
  "domain",
  "ecdsa",
  "either",
@@ -3172,13 +3285,13 @@ dependencies = [
  "pinned-init",
  "primeorder",
  "qrcodegen-no-heap",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "rs-matter-codegen",
  "rs-matter-macros",
  "scopeguard",
  "sec1",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "signature",
  "strum 0.26.3",
  "subtle",
@@ -3336,13 +3449,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
+ "ctutils",
  "der",
- "generic-array",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -3435,8 +3549,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3446,8 +3571,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3462,7 +3598,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -3489,12 +3625,12 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest",
- "rand_core 0.6.4",
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3562,9 +3698,9 @@ checksum = "a0f368519fc6c85fc1afdb769fb5a51123f6158013e143656e25a3485a0d401c"
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",
@@ -4319,10 +4455,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "x509-cert"
-version = "0.2.5"
+name = "wnaf"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
+ "primefield",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
  "const-oid",
  "der",

--- a/bloat-check/Cargo.lock
+++ b/bloat-check/Cargo.lock
@@ -198,7 +198,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -939,7 +939,6 @@ dependencies = [
  "const-oid",
  "der_derive",
  "flagset",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2539,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -2651,13 +2650,13 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+checksum = "e4e98dc3b890f6c23a0f9d3d491a2823d0dea0fa656302a13dd225fa924112a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2828,15 +2827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,22 +2859,24 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinned-init"
-version = "0.0.8"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf55f7030b0b17ea0c23525b8a18d9b52a53a586ec355128ac2304aa2fa8c04"
+checksum = "e82ef52a6d0cd8fb1282340a1c6fb773f64cd28332b03f58d5428e821798153d"
 dependencies = [
  "paste",
  "pinned-init-macro",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
 name = "pinned-init-macro"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569a3fcf0e6334c6c46c1507f83a99ba30ae9cdc5761bdb2ca40f7eb55138bd4"
+checksum = "3d449b713caa03c1db93b217633063bb185412bd24e11564db0f326a890d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -3275,7 +3267,7 @@ dependencies = [
  "hmac",
  "log",
  "mbedtls-rs-sys",
- "nix 0.30.1",
+ "nix 0.31.3",
  "num",
  "num-derive",
  "num-traits",
@@ -3293,7 +3285,7 @@ dependencies = [
  "sha1 0.11.0",
  "sha2 0.11.0",
  "signature",
- "strum 0.26.3",
+ "strum 0.28.0",
  "subtle",
  "time",
  "tokio",
@@ -3321,6 +3313,7 @@ dependencies = [
  "esp-rtos",
  "log",
  "panic-rtt-target",
+ "portable-atomic",
  "rs-matter",
  "rtt-target",
  "simple_logger",
@@ -3341,7 +3334,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -3386,6 +3379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -3714,9 +3716,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_cell"
-version = "1.3.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd3f559c6c41cde362aed95cd84765907e06057f087b17269b41750ec40a3e7"
+checksum = "0530892bb4fa575ee0da4b86f86c667132a94b74bb72160f58ee5a4afec74c23"
 dependencies = [
  "portable-atomic",
 ]
@@ -3750,20 +3752,20 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -3781,22 +3783,21 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.119",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/bloat-check/Cargo.toml
+++ b/bloat-check/Cargo.toml
@@ -36,7 +36,7 @@ log = []
 
 [dependencies]
 embassy-futures = "0.1"
-static_cell = "1"
+static_cell = "2"
 critical-section = "1"
 embassy-executor = { version = "0.10", features = ["executor-thread"] }
 rs-matter = { path = "../rs-matter", default-features = false, features = ["rustcrypto", "case-responder-only"] }
@@ -69,6 +69,8 @@ embassy-executor = { version = "0.10", features = ["platform-cortex-m"] }
 hal = { package = "embassy-nrf", version = "0.10", default-features = false, features = ["defmt", "time-driver-rtc1", "time", "nrf52840"] }
 
 [target.thumbv6m-none-eabi.dependencies]
+# `static_cell` 2 needs atomic CAS via `portable-atomic`; thumbv6m has none, so fall back to critical sections
+portable-atomic = { version = "1", features = ["critical-section"] }
 hal = { package = "embassy-rp", version = "0.10", features = ["defmt", "unstable-pac", "time-driver", "rp2040"] }
 
 [target.riscv32imac-unknown-none-elf.dependencies]

--- a/bloat-check/src/bin/bloat-check.rs
+++ b/bloat-check/src/bin/bloat-check.rs
@@ -58,7 +58,7 @@ use embassy_executor::Executor;
 use esp_rtos::embassy::Executor;
 
 use rs_matter::crypto::backend::rustcrypto::RustCrypto;
-use rs_matter::crypto::{Crypto, RngCore, WeakTestOnlyRand};
+use rs_matter::crypto::{Crypto, Rng, WeakTestOnlyRand};
 use rs_matter::dm::clusters::app::on_off::NoLevelControl;
 use rs_matter::dm::clusters::app::on_off::{self, test::TestOnOffDeviceLogic, OnOffHooks};
 use rs_matter::dm::clusters::desc::{self, ClusterHandler as _, DescHandler};
@@ -625,7 +625,7 @@ const NODE: Node<'static> = Node {
 /// The Data Model handler for our Matter device.
 /// The handler is the root endpoint 0 handler plus the on-off handler and its descriptor.
 fn data_model<'a>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>,
     wifi_diag: &'a dyn WifiDiag,
     net_ctl: &'a AppNetCtl,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -80,7 +80,7 @@ async-compat = "0.2"
 blocking = "1"
 futures-lite = "2"
 rs-matter = { path = "../rs-matter", features = ["async-io", "groups", "persistent-subscriptions", "max-groups-per-fabric-12", "max-group-keys-per-fabric-3", "max-group-endpoints-per-fabric-3", "max-sessions-32"] }
-rand = { version = "0.8", features = ["std", "std_rng"] }
+rand = { version = "0.10", features = ["std", "std_rng", "thread_rng"] }
 async-signal = "0.2"
 socket2 = "0.5"
 async-executor = "1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -73,7 +73,7 @@ embassy-futures = "0.1"
 embassy-sync = "0.8"
 embassy-time = { version = "0.5", features = ["std"] }
 embassy-time-queue-utils = { version = "0.3", features = ["generic-queue-64"] }
-static_cell = "1"
+static_cell = "2"
 if-addrs = "0.15"
 async-io = "2"
 async-compat = "0.2"
@@ -82,7 +82,7 @@ futures-lite = "2"
 rs-matter = { path = "../rs-matter", features = ["async-io", "groups", "persistent-subscriptions", "max-groups-per-fabric-12", "max-group-keys-per-fabric-3", "max-group-endpoints-per-fabric-3", "max-sessions-32"] }
 rand = { version = "0.10", features = ["std", "std_rng", "thread_rng"] }
 async-signal = "0.2"
-socket2 = "0.5"
+socket2 = "0.6"
 async-executor = "1"
 async-channel = { version = "2", optional = true }
 str0m = { version = "0.18", optional = true }

--- a/examples/src/bin/bridge.rs
+++ b/examples/src/bin/bridge.rs
@@ -26,7 +26,7 @@ use std::net::UdpSocket;
 
 use embassy_futures::select::select4;
 
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::level_control::LevelControlHooks;
@@ -85,7 +85,7 @@ fn main() -> Result<(), Error> {
     matter.startup(&kv)?;
 
     // Create the crypto instance
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 
@@ -202,7 +202,7 @@ const NODE: Node<'static> = Node {
 
 /// The Data Model handler + meta-data for our Matter Bridge.
 fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off_ep2: &'a on_off::OnOffHandler<'a, OH, LH>,
     on_off_ep3: &'a on_off::OnOffHandler<'a, OH, LH>,
 ) -> impl DataModel + 'a {

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -33,7 +33,7 @@ use log::{error, info, trace};
 
 use futures_lite::StreamExt;
 
-use rand::RngCore;
+use rand::Rng;
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::level_control::{self, LevelControlHooks};
 use rs_matter::dm::clusters::app::on_off::{self, OnOffHooks, StartUpOnOffEnum};
@@ -87,7 +87,7 @@ fn main() -> Result<(), Error> {
     matter.startup(&kv)?;
 
     // Create the crypto instance
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 
@@ -198,7 +198,7 @@ const NODE: Node<'static> = Node {
 /// The Data Model handler + meta-data for our Matter device.
 /// The handler is the root endpoint 0 handler plus the on-off handler and its descriptor.
 fn data_model<'a, LH: LevelControlHooks, OH: OnOffHooks>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     level_control: &'a level_control::LevelControlHandler<'a, LH, OH>,
 ) -> impl DataModel + 'a {

--- a/examples/src/bin/media_player.rs
+++ b/examples/src/bin/media_player.rs
@@ -31,7 +31,7 @@ use embassy_futures::select::select4;
 
 use log::info;
 
-use rand::RngCore;
+use rand::Rng;
 use rs_matter::crypto::{default_crypto, Crypto};
 // Import the MediaPlayback, ContentLauncher and KeypadInput clusters from `rs-matter`.
 //
@@ -101,7 +101,7 @@ fn main() -> Result<(), Error> {
     matter.startup(&kv)?;
 
     // Create the crypto instance
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 
@@ -182,7 +182,7 @@ const NODE: Node<'static> = Node {
 /// The Data Model handler + meta-data for our Matter device.
 /// The handler is the root endpoint 0 handler plus the Media Player cluster handlers.
 fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
 ) -> impl DataModel + 'a {
     (

--- a/examples/src/bin/onoff_light.rs
+++ b/examples/src/bin/onoff_light.rs
@@ -36,7 +36,7 @@ use embassy_futures::select::select4;
 
 use log::info;
 
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::level_control::LevelControlHooks;
@@ -211,7 +211,7 @@ fn main() -> Result<(), Error> {
     matter.startup(&kv)?;
 
     // Create the crypto instance
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 
@@ -301,7 +301,7 @@ const NODE: Node<'static> = Node {
 /// The Data Model handler + meta-data for our Matter device.
 /// The handler is the root endpoint 0 handler plus the on-off handler and its descriptor.
 fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks, MH: ModeSelectHooks>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     mode_select: &'a ModeSelectHandler<MH>,
 ) -> impl DataModel + 'a {

--- a/examples/src/bin/onoff_light_bt.rs
+++ b/examples/src/bin/onoff_light_bt.rs
@@ -38,7 +38,7 @@ use embassy_futures::select::{select, select4};
 
 use log::{info, warn};
 
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::level_control::LevelControlHooks;
@@ -141,7 +141,7 @@ fn run<N: NetCtl + WifiDiag + NetChangeNotif>(
     matter.startup(&kv)?;
 
     // Create the crypto instance
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 
@@ -273,7 +273,7 @@ const NODE: Node<'static> = Node {
 /// The Data Model handler + meta-data for our Matter device.
 /// The handler is the root endpoint 0 handler plus the on-off handler and its descriptor.
 fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks, T>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     wifi_diag: &'a dyn WifiDiag,
     net_ctl: T,

--- a/examples/src/bin/onoff_light_switch.rs
+++ b/examples/src/bin/onoff_light_switch.rs
@@ -45,7 +45,7 @@ use futures_lite::io::{AsyncBufReadExt, BufReader};
 
 use log::{info, warn};
 
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::on_off;
@@ -117,7 +117,7 @@ fn main() -> Result<(), Error> {
     // Re-hydrate the `Matter` instance (fabrics, ACLs, basic info).
     matter.startup(&kv)?;
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
     let rand = crypto.rand()?;
 
     let im = InteractionModel::new(
@@ -401,7 +401,7 @@ const NODE: Node<'static> = Node {
 /// The Data Model handler: root endpoint 0 + the Descriptor and Binding handlers
 /// on the switch endpoint.
 fn data_model<'a, const N: usize>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     bindings: &'a Bindings<N>,
 ) -> impl DataModel + 'a {
     (

--- a/examples/src/bin/onoff_light_work_stealing.rs
+++ b/examples/src/bin/onoff_light_work_stealing.rs
@@ -23,7 +23,7 @@
 
 use std::net::UdpSocket;
 
-use rand::{CryptoRng, RngCore};
+use rand::{Rng, TryCryptoRng, TryRng};
 
 use rs_matter::crypto::backend::rustcrypto::RustCrypto;
 use rs_matter::crypto::Crypto;
@@ -212,7 +212,7 @@ const NODE: Node<'static> = Node {
 /// The Data Model handler + meta-data for our Matter device.
 /// The handler is the root endpoint 0 handler plus the on-off handler and its descriptor.
 fn data_model<'a>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: on_off::OnOffHandler<'a, TestOnOffDeviceLogic, NoLevelControl>,
 ) -> AppDmHandler<'a> {
     endpoints::EthSysHandlerBuilder::new()
@@ -231,25 +231,21 @@ fn data_model<'a>(
 // For now, as `thread_rng` is not `Send`
 struct FakeRng;
 
-impl RngCore for FakeRng {
-    fn next_u32(&mut self) -> u32 {
-        0
+impl TryRng for FakeRng {
+    type Error = std::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(0)
     }
 
-    fn next_u64(&mut self) -> u64 {
-        0
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(0)
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        for b in dest.iter_mut() {
-            *b = 0;
-        }
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.fill_bytes(dest);
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        dest.fill(0);
         Ok(())
     }
 }
 
-impl CryptoRng for FakeRng {}
+impl TryCryptoRng for FakeRng {}

--- a/examples/src/bin/ota_requestor.rs
+++ b/examples/src/bin/ota_requestor.rs
@@ -36,7 +36,7 @@ use embassy_time::{Duration, Timer};
 
 use log::{info, warn};
 
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::bdx::BdxDownloadInitiator;
 use rs_matter::crypto::{default_crypto, Crypto};
@@ -108,7 +108,7 @@ fn main() -> Result<(), Error> {
     // Re-hydrate persisted state.
     matter.startup(&kv)?;
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
 
     let rand = crypto.rand()?;
 
@@ -170,7 +170,7 @@ const NODE: Node<'static> = Node {
 /// The Data Model handler: the root endpoint 0 handler plus the OTA Requestor
 /// cluster (and its descriptor) on endpoint 1.
 fn data_model<'a>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     providers: &'a Providers,
     ota_state: &'a OtaState,
 ) -> impl DataModel + 'a {

--- a/examples/src/bin/speaker.rs
+++ b/examples/src/bin/speaker.rs
@@ -25,7 +25,7 @@ use std::net::UdpSocket;
 
 use embassy_futures::select::select4;
 
-use rand::RngCore;
+use rand::Rng;
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::level_control::{
     self, test::TestLevelControlDeviceLogic, AttributeDefaults, LevelControlHandler,
@@ -81,7 +81,7 @@ fn main() -> Result<(), Error> {
     matter.startup(&kv)?;
 
     // Create the crypto instance
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 
@@ -179,7 +179,7 @@ const NODE: Node<'static> = Node {
 /// The Data Model handler + meta-data for our Matter device.
 /// The handler is the root endpoint 0 handler plus the Speaker handler.
 fn data_model<'a, LH: LevelControlHooks, OH: OnOffHooks>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a OnOffHandler<'a, OH, LH>,
     level_control: &'a LevelControlHandler<'a, LH, OH>,
 ) -> impl DataModel + 'a {

--- a/examples/src/bin/webrtc_camera.rs
+++ b/examples/src/bin/webrtc_camera.rs
@@ -82,7 +82,7 @@ use embassy_futures::select::{select, select4};
 
 use log::{info, warn};
 
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::cam_av_settings::{
@@ -1169,7 +1169,7 @@ fn main() -> Result<(), Error> {
     // Re-hydrate the `Matter` instance (fabrics, basic info, RTC).
     matter.startup(&kv)?;
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
     let mut rand = crypto.rand()?;
 
     // Optional H.264 Annex-B media source. Set `WEBRTC_CAMERA_H264` to a
@@ -1379,7 +1379,7 @@ const NODE: Node<'static> = Node {
 };
 
 fn data_model<'a>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     webrtc: &'a WebRtc,
     cam_av: &'a CameraAvStreamHandler<'static, Str0mCamHooks, CAM_AV_NV>,
     cam_av_settings: &'a CamAvSettingsHandler<

--- a/rs-matter-codegen/Cargo.toml
+++ b/rs-matter-codegen/Cargo.toml
@@ -22,10 +22,10 @@ nom-greedyerror = "0.5"
 nom-supreme = "0.8"
 nom_locate = "4.2"
 convert_case = "0.6"
-thiserror = "1"
+thiserror = "2"
 tracing = "0.1"
 
 [dev-dependencies]
 assert-tokenstreams-eq = "0.1.0"
-rstest = "0.18.2"
+rstest = "0.26"
 tracing-subscriber = { version = "0.3", features = ["regex", "json"] }

--- a/rs-matter-macros/Cargo.toml
+++ b/rs-matter-macros/Cargo.toml
@@ -22,4 +22,4 @@ proc-macro-crate = "3"
 
 [dev-dependencies]
 assert-tokenstreams-eq = "0.1"
-rstest = "0.18.2"
+rstest = "0.26"

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -229,7 +229,7 @@ log = { version = "0.4", optional = true }
 defmt = { version = "1", optional = true, features = ["ip_in_core"] }
 subtle = { version = "2.5", default-features = false }
 time = { version = "0.3", default-features = false }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 verhoeff = { version = "1", default-features = false }
 embassy-futures = "0.1.2"
 embassy-time = "0.5"
@@ -249,28 +249,28 @@ mbedtls-rs-sys = { version = "0.2", default-features = false, features = ["matte
 
 # rust-crypto
 # Generic traits and traitified structures
-digest = { version = "0.10", default-features = false, optional = true }
-cipher = { version = "0.4.4", default-features = false, optional = true }
-ccm = { version = "0.5", default-features = false, features = ["alloc"], optional = true }
-elliptic-curve = { version = "0.13", default-features = false, optional = true }
-primeorder = { version = "0.13", default-features = false, optional = true }
-ecdsa = { version = "0.16", default-features = false, features = ["der"], optional = true }
-sec1 = { version = "0.7", default-features = false, optional = true }
-signature = { version = "2.2", default-features = false, optional = true }
-hmac = { version = "0.12", optional = true }
+digest = { version = "0.11", default-features = false, optional = true }
+cipher = { version = "0.5", default-features = false, optional = true }
+ccm = { version = "0.6", default-features = false, features = ["alloc"], optional = true }
+elliptic-curve = { version = "0.14", default-features = false, optional = true }
+primeorder = { version = "0.14", default-features = false, optional = true }
+ecdsa = { version = "0.17", default-features = false, features = ["der"], optional = true }
+sec1 = { version = "0.8", default-features = false, optional = true }
+signature = { version = "3", default-features = false, optional = true }
+hmac = { version = "0.13", optional = true }
 # Concrete algorithms
-hkdf = { version = "0.12", optional = true }
-pbkdf2 = { version = "0.12", optional = true }
-crypto-bigint = { version = "0.6", default-features = false, optional = true }
-sha1 = { version = "0.10", default-features = false, optional = true }
-sha2 = { version = "0.10", default-features = false, optional = true }
-aes = { version = "0.8", optional = true }
-p256 = { version = "0.13", default-features = false, features = ["arithmetic", "ecdh", "ecdsa"], optional = true }
-x509-cert = { version = "0.2", default-features = false, features = ["pem"], optional = true } # TODO: requires `alloc`
-der = { version = "0.7", features = ["derive", "oid"] }
+hkdf = { version = "0.13", optional = true }
+pbkdf2 = { version = "0.13", optional = true }
+crypto-bigint = { version = "0.7", default-features = false, optional = true }
+sha1 = { version = "0.11", default-features = false, optional = true }
+sha2 = { version = "0.11", default-features = false, optional = true }
+aes = { version = "0.9", optional = true }
+p256 = { version = "0.14", default-features = false, features = ["arithmetic", "ecdh", "ecdsa"], optional = true }
+x509-cert = { version = "0.3", default-features = false, features = ["pem"], optional = true } # TODO: requires `alloc`
+der = { version = "0.8", features = ["derive", "oid"] }
 
 # STD
-rand = { version = "0.8", optional = true, default-features = false, features = ["std", "std_rng"] }
+rand = { version = "0.10", optional = true, default-features = false, features = ["std", "std_rng", "thread_rng"] }
 async-io = { version = "2", optional = true, default-features = false }
 async-compat = { version = "0.2", optional = true, default-features = false }
 

--- a/rs-matter/Cargo.toml
+++ b/rs-matter/Cargo.toml
@@ -221,10 +221,10 @@ bitflags = { version =  "2.5", default-features = false }
 embedded-io-async = "0.7"
 heapless = "0.9"
 num = { version = "0.4", default-features = false }
-num-derive = "0.4"
+num-derive = "0.5"
 num_enum = { version = "0.7.5", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-strum = { version = "0.26", features = ["derive"], default-features = false }
+strum = { version = "0.28", features = ["derive"], default-features = false }
 log = { version = "0.4", optional = true }
 defmt = { version = "1", optional = true, features = ["ip_in_core"] }
 subtle = { version = "2.5", default-features = false }
@@ -238,9 +238,9 @@ either = { version = "1", default-features = false }
 critical-section = "1.1"
 domain = { version = "0.12", default-features = false, features = ["heapless"] }
 qrcodegen-no-heap = "1.8"
-rqrr = { version = "0.10", default-features = false, optional = true }
+rqrr = { version = "0.11", default-features = false, optional = true }
 scopeguard = { version = "1", default-features = false }
-pinned-init = { version = "0.0.8", default-features = false }
+pinned-init = { version = "0.0.10", default-features = false }
 
 # crypto
 openssl = { version = "0.10", optional = true }
@@ -266,7 +266,7 @@ sha1 = { version = "0.11", default-features = false, optional = true }
 sha2 = { version = "0.11", default-features = false, optional = true }
 aes = { version = "0.9", optional = true }
 p256 = { version = "0.14", default-features = false, features = ["arithmetic", "ecdh", "ecdsa"], optional = true }
-x509-cert = { version = "0.3", default-features = false, features = ["pem"], optional = true } # TODO: requires `alloc`
+x509-cert = { version = "0.3", default-features = false, features = ["hazmat"], optional = true } # TODO: requires `alloc`
 der = { version = "0.8", features = ["derive", "oid"] }
 
 # STD
@@ -283,12 +283,12 @@ uuid = { version = "1", optional = true, features = ["v4"] }
 libc = { version = "0.2", optional = true }
 futures-lite = { version = "2", optional = true }
 astro-dnssd = { version = "0.3", optional = true }
-zeroconf = { version = "0.15", optional = true }
+zeroconf = { version = "0.18", optional = true }
 if-addrs = { version = "0.15", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "espidf")))'.dependencies]
 bitflags = "2"
-nix = { version = "0.30", features = ["net"] }
+nix = { version = "0.31", features = ["net"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bluer = { version = "0.17", features = ["bluetoothd"], optional = true }
@@ -301,12 +301,12 @@ rs-matter-codegen = { path = "../rs-matter-codegen", version = "0.3.0" }
 [dev-dependencies]
 log = "0.4"
 env_logger = "0.11"
-nix = { version = "0.30", features = ["net"] }
-socket2 = { version = "0.5", features = ["all"] }
+nix = { version = "0.31", features = ["net"] }
+socket2 = { version = "0.6", features = ["all"] }
 futures-lite = "2"
 async-channel = "2"
 static_cell = "2"
-similar = "2.6"
+similar = "3"
 embassy-time-queue-utils = { version = "0.3", features = ["generic-queue-64"] }
 trybuild = "1"
 tempfile = "3"

--- a/rs-matter/src/attest/cd.rs
+++ b/rs-matter/src/attest/cd.rs
@@ -76,8 +76,10 @@ struct ContentInfo<'a> {
 }
 
 impl<'a> DecodeValue<'a> for ContentInfo<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
-        reader.read_nested(header.length, |reader| {
+        reader.read_nested(header.length(), |reader| {
             // contentType OBJECT IDENTIFIER
             let content_type = ObjectIdentifier::decode(reader)?;
 
@@ -90,14 +92,14 @@ impl<'a> DecodeValue<'a> for ContentInfo<'a> {
             // Read the [0] context tag (should be context-specific, constructed, number 0)
             let context_header = Header::decode(reader)?;
             // Check for context-specific tag [0] constructed (0xA0)
-            if context_header.tag.number() != TagNumber::new(0)
-                || !context_header.tag.is_constructed()
+            if context_header.tag().number() != TagNumber(0)
+                || !context_header.tag().is_constructed()
             {
                 return Err(der::ErrorKind::Failed.into());
             }
 
             // The content inside [0] is the SignedData SEQUENCE (the whole TLV)
-            let signed_data_bytes = reader.read_slice(context_header.length)?;
+            let signed_data_bytes = reader.read_slice(context_header.length())?;
 
             Ok(Self {
                 content_type,
@@ -132,7 +134,7 @@ impl<'a> EncodeValue for ContentInfo<'a> {
 struct EncapsulatedContentInfo<'a> {
     econtent_type: ObjectIdentifier,
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT")]
-    econtent: OctetStringRef<'a>,
+    econtent: &'a OctetStringRef,
 }
 
 /// SignedData ::= SEQUENCE {
@@ -153,8 +155,10 @@ struct SignedData<'a> {
 }
 
 impl<'a> DecodeValue<'a> for SignedData<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
-        reader.read_nested(header.length, |reader| {
+        reader.read_nested(header.length(), |reader| {
             // version INTEGER (v3 = 3)
             let version = u8::decode(reader)?;
             if version != 3 {
@@ -222,12 +226,14 @@ struct SignerInfo<'a> {
     subject_key_identifier: &'a [u8],
     digest_algorithm: AlgorithmIdentifier<'a>,
     signature_algorithm: AlgorithmIdentifier<'a>,
-    signature: OctetStringRef<'a>,
+    signature: &'a OctetStringRef,
 }
 
 impl<'a> DecodeValue<'a> for SignerInfo<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
-        reader.read_nested(header.length, |reader| {
+        reader.read_nested(header.length(), |reader| {
             // version INTEGER (v3 = 3)
             let version = u8::decode(reader)?;
             if version != 3 {
@@ -238,11 +244,11 @@ impl<'a> DecodeValue<'a> for SignerInfo<'a> {
             let ski_header = Header::decode(reader)?;
 
             // Check for context-specific tag [0] primitive
-            if ski_header.tag.number() != TagNumber::new(0) || ski_header.tag.is_constructed() {
+            if ski_header.tag().number() != TagNumber(0) || ski_header.tag().is_constructed() {
                 return Err(der::ErrorKind::Failed.into());
             }
 
-            let subject_key_identifier = reader.read_slice(ski_header.length)?;
+            let subject_key_identifier = reader.read_slice(ski_header.length())?;
 
             // Validate SKI is exactly 20 bytes
             if subject_key_identifier.len() != KEY_IDENTIFIER_LEN {
@@ -266,7 +272,7 @@ impl<'a> DecodeValue<'a> for SignerInfo<'a> {
             }
 
             // signature OCTET STRING (contains DER-encoded ECDSA signature)
-            let signature = OctetStringRef::decode(reader)?;
+            let signature = <&OctetStringRef>::decode(reader)?;
 
             Ok(Self {
                 version,

--- a/rs-matter/src/cert.rs
+++ b/rs-matter/src/cert.rs
@@ -947,19 +947,19 @@ fn der_blob_has_critical_extension(bytes: &[u8]) -> Result<bool, Error> {
         let mut inner = SliceReader::new(any.value()).map_err(|_| ErrorCode::InvalidData)?;
 
         // Skip the OID.
-        ObjectIdentifier::decode(&mut inner).map_err(|_| ErrorCode::InvalidData)?;
+        <ObjectIdentifier>::decode(&mut inner).map_err(|_| ErrorCode::InvalidData)?;
 
         // OPTIONAL critical BOOLEAN before the mandatory OCTET STRING
         // `extnValue`.
         if !inner.is_finished()
-            && inner.peek_tag().map_err(|_| ErrorCode::InvalidData)? == Tag::Boolean
+            && Tag::peek(&inner).map_err(|_| ErrorCode::InvalidData)? == Tag::Boolean
             && bool::decode(&mut inner).map_err(|_| ErrorCode::InvalidData)?
         {
             return Ok(true);
         }
         // Consume `extnValue` so we land on the next `Extension`
         // SEQUENCE (or the end of the blob).
-        let _ = OctetStringRef::decode(&mut inner).map_err(|_| ErrorCode::InvalidData)?;
+        let _ = <&OctetStringRef>::decode(&mut inner).map_err(|_| ErrorCode::InvalidData)?;
     }
     Ok(false)
 }

--- a/rs-matter/src/cert/der_utils.rs
+++ b/rs-matter/src/cert/der_utils.rs
@@ -61,7 +61,7 @@ pub fn ecdsa_der_to_raw(der: &[u8]) -> Result<[u8; RAW_SIGNATURE_LEN], Error> {
     // Read the SEQUENCE header
     let seq_header = Header::decode(&mut reader).map_err(|_| Error::from(ErrorCode::Invalid))?;
 
-    if seq_header.tag != Tag::Sequence {
+    if seq_header.tag() != Tag::Sequence {
         return Err(ErrorCode::Invalid.into());
     }
 

--- a/rs-matter/src/cert/x509.rs
+++ b/rs-matter/src/cert/x509.rs
@@ -214,7 +214,7 @@ impl<'a> From<BitStringRef<'a>> for KeyUsage {
 #[derive(Sequence)]
 struct AuthorityKeyIdentifier<'a> {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT")]
-    key_identifier: OctetStringRef<'a>,
+    key_identifier: &'a OctetStringRef,
 }
 
 /// Time ::= CHOICE { utcTime UTCTime, generalTime GeneralizedTime }

--- a/rs-matter/src/cert/x509/cert.rs
+++ b/rs-matter/src/cert/x509/cert.rs
@@ -73,9 +73,11 @@ impl<'a> der::FixedTag for Name<'a> {
     const TAG: Tag = Tag::Sequence;
 }
 impl<'a> DecodeValue<'a> for Name<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         // Read the entire SEQUENCE content (the RDNSequence) as a byte slice
-        let raw_bytes = reader.read_slice(header.length)?;
+        let raw_bytes = reader.read_slice(header.length())?;
 
         // Parse the Matter-specific attributes from the RDNSequence
         let attrs = MatterDnAttrs::parse(raw_bytes)?;
@@ -147,7 +149,7 @@ struct ParsedExtension<T> {
 struct ParsedExtensionFields<'a> {
     basic_constraints: Option<ParsedExtension<BasicConstraints>>,
     key_usage: Option<ParsedExtension<KeyUsage>>,
-    subject_key_id: Option<ParsedExtension<OctetStringRef<'a>>>,
+    subject_key_id: Option<ParsedExtension<&'a OctetStringRef>>,
     authority_key_id: Option<ParsedExtension<AuthorityKeyIdentifier<'a>>>,
 }
 
@@ -156,7 +158,7 @@ impl<'a> ParsedExtensionFields<'a> {
     fn parse<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
         let mut basic_constraints: Option<ParsedExtension<BasicConstraints>> = None;
         let mut key_usage: Option<ParsedExtension<KeyUsage>> = None;
-        let mut subject_key_id: Option<ParsedExtension<OctetStringRef<'a>>> = None;
+        let mut subject_key_id: Option<ParsedExtension<&'a OctetStringRef>> = None;
         let mut authority_key_id: Option<ParsedExtension<AuthorityKeyIdentifier<'a>>> = None;
 
         // Iterate through SEQUENCE OF Extension
@@ -169,14 +171,14 @@ impl<'a> ParsedExtensionFields<'a> {
             let extn_id = ObjectIdentifier::decode(&mut ext_reader)?;
 
             // critical BOOLEAN DEFAULT FALSE
-            let critical = if !ext_reader.is_finished() && ext_reader.peek_tag()? == Tag::Boolean {
+            let critical = if !ext_reader.is_finished() && Tag::peek(&ext_reader)? == Tag::Boolean {
                 bool::decode(&mut ext_reader)?
             } else {
                 false
             };
 
             // extnValue OCTET STRING
-            let extn_value = OctetStringRef::decode(&mut ext_reader)?;
+            let extn_value = <&OctetStringRef>::decode(&mut ext_reader)?;
             let value_bytes = extn_value.as_bytes();
 
             if extn_id == OID_BASIC_CONSTRAINTS {
@@ -192,7 +194,7 @@ impl<'a> ParsedExtensionFields<'a> {
                     value: bs.into(),
                 });
             } else if extn_id == OID_SUBJECT_KEY_ID {
-                let skid = OctetStringRef::from_der(value_bytes)?;
+                let skid = <&OctetStringRef>::from_der(value_bytes)?;
                 subject_key_id = Some(ParsedExtension {
                     critical,
                     value: skid,
@@ -234,7 +236,9 @@ impl<'a> ParsedExtensionFields<'a> {
 /// - Validate requirements during parsing (fail if invalid)
 /// - Provide access to Subject Key Identifier and Authority Key Identifier
 /// - Validate issuer and subject fields
-pub trait CertType<'a>: DecodeValue<'a> + der::FixedTag + der::EncodeValue {
+pub trait CertType<'a>:
+    DecodeValue<'a, Error = der::Error> + der::FixedTag + der::EncodeValue + 'a
+{
     /// Get subject key identifier if present for this certificate type
     fn subject_key_id(&self) -> Option<&'a [u8]>;
 
@@ -266,14 +270,16 @@ pub trait CertType<'a>: DecodeValue<'a> + der::FixedTag + der::EncodeValue {
 pub struct DacExtensions<'a> {
     basic_constraints: ParsedExtension<BasicConstraints>,
     key_usage: ParsedExtension<KeyUsage>,
-    subject_key_id: ParsedExtension<OctetStringRef<'a>>,
+    subject_key_id: ParsedExtension<&'a OctetStringRef>,
     authority_key_id: ParsedExtension<AuthorityKeyIdentifier<'a>>,
 }
 
 // DAC Extensions parsing with validation
 impl<'a> DecodeValue<'a> for DacExtensions<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
-        reader.read_nested(header.length, |reader| {
+        reader.read_nested(header.length(), |reader| {
             // Parse all extension fields
             let fields = ParsedExtensionFields::parse(reader)?;
 
@@ -392,14 +398,16 @@ impl<'a> CertType<'a> for DacExtensions<'a> {
 pub struct PaiExtensions<'a> {
     basic_constraints: ParsedExtension<BasicConstraints>,
     key_usage: ParsedExtension<KeyUsage>,
-    subject_key_id: ParsedExtension<OctetStringRef<'a>>,
+    subject_key_id: ParsedExtension<&'a OctetStringRef>,
     authority_key_id: ParsedExtension<AuthorityKeyIdentifier<'a>>,
 }
 
 // PAI Extensions parsing with validation
 impl<'a> DecodeValue<'a> for PaiExtensions<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
-        reader.read_nested(header.length, |reader| {
+        reader.read_nested(header.length(), |reader| {
             // Parse all extension fields
             let fields = ParsedExtensionFields::parse(reader)?;
 
@@ -510,14 +518,16 @@ impl<'a> CertType<'a> for PaiExtensions<'a> {
 pub struct PaaExtensions<'a> {
     basic_constraints: ParsedExtension<BasicConstraints>,
     key_usage: ParsedExtension<KeyUsage>,
-    subject_key_id: ParsedExtension<OctetStringRef<'a>>,
+    subject_key_id: ParsedExtension<&'a OctetStringRef>,
     authority_key_id: Option<ParsedExtension<AuthorityKeyIdentifier<'a>>>,
 }
 
 // PAA Extensions parsing with validation
 impl<'a> DecodeValue<'a> for PaaExtensions<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
-        reader.read_nested(header.length, |reader| {
+        reader.read_nested(header.length(), |reader| {
             // Parse all extension fields
             let fields = ParsedExtensionFields::parse(reader)?;
 
@@ -657,10 +667,12 @@ struct TbsCertificate<'a, E: CertType<'a>> {
 }
 
 impl<'a, E: CertType<'a>> DecodeValue<'a> for TbsCertificate<'a, E> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
-        reader.read_nested(header.length, |reader| {
+        reader.read_nested(header.length(), |reader| {
             let version = reader
-                .context_specific::<UintRef<'a>>(TagNumber::new(0), der::TagMode::Explicit)?
+                .context_specific::<UintRef<'a>>(TagNumber(0), der::TagMode::Explicit)?
                 .ok_or(der::ErrorKind::Failed)?;
 
             // Validate that version is 2 (v3 certificate)
@@ -706,7 +718,7 @@ impl<'a, E: CertType<'a>> DecodeValue<'a> for TbsCertificate<'a, E> {
 
             // Decode extensions [3] EXPLICIT
             let extensions = reader
-                .context_specific::<E>(TagNumber::new(3), der::TagMode::Explicit)?
+                .context_specific::<E>(TagNumber(3), der::TagMode::Explicit)?
                 .ok_or(der::ErrorKind::Failed)?;
 
             // Validate issuer and subject fields according to certificate type requirements

--- a/rs-matter/src/cert/x509/csr.rs
+++ b/rs-matter/src/cert/x509/csr.rs
@@ -46,16 +46,18 @@ struct CertificationRequest<'a> {
 }
 
 impl<'a> DecodeValue<'a> for CertificationRequest<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         // Decode SEQUENCE
-        reader.read_nested(header.length, |reader| {
+        reader.read_nested(header.length(), |reader| {
             let certification_request_info = CertificationRequestInfo::decode(reader)?;
             // Decode algorithm identifier
             let signature_algorithm = AlgorithmIdentifier::decode(reader)?;
 
             // Validate it's ECDSA-SHA256
             if signature_algorithm.algorithm != OID_ECDSA_WITH_SHA256 {
-                return Err(der::Tag::Sequence.value_error());
+                return Err(der::Tag::Sequence.value_error().into());
             }
 
             // Decode the signature bit string
@@ -89,21 +91,52 @@ struct CertificationRequestInfo<'a> {
     pub subject: AnyRef<'a>,
     pub subject_public_key_info: SubjectPublicKeyInfo<'a>,
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT")]
-    pub attributes: AnyRef<'a>,
+    pub attributes: Attributes<'a>,
+}
+
+/// The CSR `attributes [0] IMPLICIT SET OF Attribute`, kept as its raw DER content.
+///
+/// Implicitly tagged fields need a type with a statically known (here: constructed, `SET`)
+/// tag, which a bare `AnyRef` does not have.
+#[allow(unused)]
+struct Attributes<'a>(&'a [u8]);
+
+impl der::FixedTag for Attributes<'_> {
+    const TAG: Tag = Tag::Set;
+}
+
+impl<'a> DecodeValue<'a> for Attributes<'a> {
+    type Error = der::Error;
+
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
+        Ok(Self(reader.read_slice(header.length())?))
+    }
+}
+
+impl EncodeValue for Attributes<'_> {
+    fn value_len(&self) -> der::Result<Length> {
+        Length::try_from(self.0.len())
+    }
+
+    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
+        writer.write(self.0)
+    }
 }
 
 /// Algorithm oid verified id-ecPublicKey with prime256v1 curve oid
 /// SubjectPublicKey verified for size
 impl<'a> DecodeValue<'a> for SubjectPublicKeyInfo<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         // Decode SEQUENCE
-        reader.read_nested(header.length, |reader| {
+        reader.read_nested(header.length(), |reader| {
             // Decode algorithm identifier
             let algorithm = AlgorithmIdentifier::decode(reader)?;
 
             // Validate it's id-ecPublicKey
             if algorithm.algorithm != OID_EC_PUBLIC_KEY {
-                return Err(der::Tag::Sequence.value_error());
+                return Err(der::Tag::Sequence.value_error().into());
             }
 
             // Validate parameters contain prime256v1 OID
@@ -117,10 +150,10 @@ impl<'a> DecodeValue<'a> for SubjectPublicKeyInfo<'a> {
                     .map_err(|_| der::Tag::ObjectIdentifier.value_error())?;
 
                 if curve_oid != OID_PRIME256V1 {
-                    return Err(der::Tag::ObjectIdentifier.value_error());
+                    return Err(der::Tag::ObjectIdentifier.value_error().into());
                 }
             } else {
-                return Err(der::Tag::ObjectIdentifier.value_error());
+                return Err(der::Tag::ObjectIdentifier.value_error().into());
             }
 
             // Decode the public key bit string
@@ -134,12 +167,12 @@ impl<'a> DecodeValue<'a> for SubjectPublicKeyInfo<'a> {
             // The as_bytes() method returns the actual key bytes without the unused bits count
             // So we expect exactly 65 bytes (0x04 || X || Y)
             if key_bytes.len() != P256_PUBLIC_KEY_LEN {
-                return Err(der::Tag::BitString.value_error());
+                return Err(der::Tag::BitString.value_error().into());
             }
 
             // Verify it's an uncompressed point (starts with 0x04)
             if key_bytes[0] != 0x04 {
-                return Err(der::Tag::BitString.value_error());
+                return Err(der::Tag::BitString.value_error().into());
             }
 
             Ok(Self {

--- a/rs-matter/src/crypto.rs
+++ b/rs-matter/src/crypto.rs
@@ -19,7 +19,7 @@
 
 use crate::error::Error;
 
-pub use rand_core::{CryptoRng, CryptoRngCore, RngCore};
+pub use rand_core::{CryptoRng, Rng, TryCryptoRng, TryRng};
 
 pub use canon::*;
 pub use rand::*;
@@ -36,11 +36,11 @@ mod rand;
 /// swapping out its out of the box algorithms with custom (potentially HW-accelerated) ones,
 /// by decorating the original implementation and replacing only the required types and methods.
 pub trait Crypto {
-    type Rand<'a>: CryptoRngCore + Copy
+    type Rand<'a>: CryptoRng + Copy
     where
         Self: 'a;
 
-    type WeakRand<'a>: RngCore + Copy
+    type WeakRand<'a>: Rng + Copy
     where
         Self: 'a;
 
@@ -655,7 +655,7 @@ pub fn default_crypto<'s, R>(
     singleton_secret_key: CanonPkcSecretKeyRef<'s>,
 ) -> impl Crypto + 's
 where
-    R: CryptoRngCore + 's,
+    R: CryptoRng + 's,
 {
     #[cfg(feature = "openssl")]
     let crypto = backend::openssl::OpenSslCrypto::new(singleton_secret_key);

--- a/rs-matter/src/crypto/backend/dummy.rs
+++ b/rs-matter/src/crypto/backend/dummy.rs
@@ -24,7 +24,9 @@
 //! pulling in any crypto dependencies. Note that this module might be retired in future
 //! and `rustcrypto` might be used as the default backend.
 
-use rand_core::{CryptoRng, RngCore};
+use core::convert::Infallible;
+
+use rand_core::{TryCryptoRng, TryRng};
 
 use crate::crypto::{Crypto, CryptoSensitive, CryptoSensitiveRef};
 use crate::error::Error;
@@ -353,22 +355,20 @@ impl<'a, const LEN: usize, const SCALAR_LEN: usize> crate::crypto::EcPoint<'a, L
     }
 }
 
-impl RngCore for DummyCrypto {
-    fn next_u32(&mut self) -> u32 {
+impl TryRng for DummyCrypto {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         unimplemented!()
     }
 
-    fn next_u64(&mut self) -> u64 {
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
         unimplemented!()
     }
 
-    fn fill_bytes(&mut self, _dest: &mut [u8]) {
-        unimplemented!()
-    }
-
-    fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), rand_core::Error> {
+    fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), Self::Error> {
         unimplemented!()
     }
 }
 
-impl CryptoRng for DummyCrypto {}
+impl TryCryptoRng for DummyCrypto {}

--- a/rs-matter/src/crypto/backend/mbedtls.rs
+++ b/rs-matter/src/crypto/backend/mbedtls.rs
@@ -44,7 +44,7 @@ use core::ffi::{c_int, c_uchar, c_void};
 
 use mbedtls_rs_sys::merr;
 
-use rand_core::{CryptoRng, CryptoRngCore, RngCore};
+use rand_core::{CryptoRng, Rng, TryCryptoRng, TryRng};
 
 use crate::crypto::{CanonPkcSecretKeyRef, CryptoSensitive, CryptoSensitiveRef, SharedRand};
 use crate::error::{Error, ErrorCode};
@@ -87,7 +87,7 @@ impl<'s, T> MbedtlsCrypto<'s, T> {
 
 impl<T> crate::crypto::Crypto for MbedtlsCrypto<'_, T>
 where
-    T: CryptoRngCore,
+    T: CryptoRng,
 {
     type Rand<'a>
         = &'a SharedRand<T>
@@ -953,7 +953,7 @@ impl<const LEN: usize, const SCALAR_LEN: usize, R> Drop for ECPoint<'_, LEN, SCA
 impl<'a, const LEN: usize, const SCALAR_LEN: usize, R> crate::crypto::EcPoint<'a, LEN, SCALAR_LEN>
     for ECPoint<'a, LEN, SCALAR_LEN, R>
 where
-    for<'r> &'r R: CryptoRngCore,
+    for<'r> &'r R: CryptoRng,
 {
     type Scalar<'s>
         = ECScalar<'s, SCALAR_LEN, LEN, R>
@@ -1146,7 +1146,7 @@ impl<'a, const LEN: usize, const POINT_LEN: usize, R> ECScalar<'a, LEN, POINT_LE
 impl<'a, const LEN: usize, const POINT_LEN: usize, R> crate::crypto::EcScalar<'a, LEN>
     for ECScalar<'a, LEN, POINT_LEN, R>
 where
-    for<'r> &'r R: CryptoRngCore,
+    for<'r> &'r R: CryptoRng,
 {
     fn mul(&self, other: &Self) -> Result<Self, Error> {
         let mut result = ECScalar::new(self.group, self.rng);
@@ -1177,7 +1177,7 @@ impl<'a, const KEY_LEN: usize, const PUB_KEY_LEN: usize, const SIGNATURE_LEN: us
     crate::crypto::SigningSecretKey<'a, PUB_KEY_LEN, SIGNATURE_LEN>
     for ECScalar<'a, KEY_LEN, PUB_KEY_LEN, R>
 where
-    for<'r> &'r R: CryptoRngCore,
+    for<'r> &'r R: CryptoRng,
 {
     type PublicKey<'s>
         = ECPoint<'s, PUB_KEY_LEN, KEY_LEN, R>
@@ -1341,7 +1341,7 @@ impl<
     > crate::crypto::SecretKey<'a, KEY_LEN, PUB_KEY_LEN, SIGNATURE_LEN, SHARED_SECRET_LEN>
     for ECScalar<'a, KEY_LEN, PUB_KEY_LEN, R>
 where
-    for<'r> &'r R: CryptoRngCore,
+    for<'r> &'r R: CryptoRng,
 {
     fn derive_shared_secret(
         &self,
@@ -1378,7 +1378,7 @@ unsafe extern "C" fn mbedtls_platform_rng<T>(
     buf_len: usize,
 ) -> c_int
 where
-    for<'a> &'a T: CryptoRngCore,
+    for<'a> &'a T: CryptoRng,
 {
     let mut drbg = unwrap!(unsafe { (ctx as *const _ as *const T).as_ref() });
 
@@ -1389,7 +1389,7 @@ where
 
 /// A type-safe wrapper around the MbedTLS DRBG cryptographically secure random number generator.
 ///
-/// Implements the `CryptoRngCore` trait.
+/// Implements the `CryptoRng` trait.
 pub struct MbedtlsDrbg<'a, T> {
     /// Reference to the entropy source
     _entropy: &'a mut T,
@@ -1397,7 +1397,7 @@ pub struct MbedtlsDrbg<'a, T> {
     raw: mbedtls_rs_sys::mbedtls_ctr_drbg_context,
 }
 
-impl<'a, T: CryptoRngCore> MbedtlsDrbg<'a, T> {
+impl<'a, T: CryptoRng> MbedtlsDrbg<'a, T> {
     /// Create a new MbedTLS DRBG instance.
     ///
     /// # Arguments
@@ -1437,8 +1437,18 @@ impl<T> Drop for MbedtlsDrbg<'_, T> {
     }
 }
 
-impl<T: CryptoRngCore> RngCore for MbedtlsDrbg<'_, T> {
-    fn fill_bytes(&mut self, buf: &mut [u8]) {
+impl<T: CryptoRng> TryRng for MbedtlsDrbg<'_, T> {
+    type Error = core::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        rand_core::utils::next_word_via_fill(self)
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        rand_core::utils::next_word_via_fill(self)
+    }
+
+    fn try_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
         unwrap!(merr_check!(unsafe {
             mbedtls_rs_sys::mbedtls_ctr_drbg_random(
                 &mut self.raw as *mut _ as *mut _,
@@ -1446,28 +1456,16 @@ impl<T: CryptoRngCore> RngCore for MbedtlsDrbg<'_, T> {
                 buf.len(),
             )
         }));
-    }
-
-    fn next_u32(&mut self) -> u32 {
-        rand_core::impls::next_u32_via_fill(self)
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        rand_core::impls::next_u64_via_fill(self)
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
 
         Ok(())
     }
 }
 
-impl<T: CryptoRngCore> CryptoRng for MbedtlsDrbg<'_, T> {}
+impl<T: CryptoRng> TryCryptoRng for MbedtlsDrbg<'_, T> {}
 
 /// A type-safe wrapper around the MbedTLS entropy provider.
 ///
-/// Implements the `CryptoRngCore` trait and can then be used by the MbedTLS DRBG impl - `MbedtlsDrbg`.
+/// Implements the `CryptoRng` trait and can then be used by the MbedTLS DRBG impl - `MbedtlsDrbg`.
 /// or any other CSPRNG needing entropy.
 pub struct MbedtlsEntropy<T> {
     /// Raw MbedTLS entropy context
@@ -1507,7 +1505,7 @@ impl<T> MbedtlsEntropy<T> {
     ///
     /// NOTE: At least one non-weak entropy source should be registered
     /// or else `MbedtlsEntropy` would panic at runtime.
-    pub fn add<E: CryptoRngCore>(
+    pub fn add<E: CryptoRng>(
         self,
         entropy_source: &mut E,
         threshold: usize,
@@ -1526,7 +1524,7 @@ impl<T> MbedtlsEntropy<T> {
     ///
     /// NOTE: At least one non-weak entropy source should be registered
     /// using `add()` or else `MbedtlsEntropy` would panic at runtime.
-    pub fn add_weak<E: RngCore>(
+    pub fn add_weak<E: Rng>(
         self,
         entropy_source: &mut E,
         threshold: usize,
@@ -1534,7 +1532,7 @@ impl<T> MbedtlsEntropy<T> {
         self.internal_add(entropy_source, false, threshold)
     }
 
-    fn internal_add<E: RngCore>(
+    fn internal_add<E: Rng>(
         mut self,
         entropy_source: &mut E,
         strong: bool,
@@ -1593,8 +1591,18 @@ impl Default for MbedtlsEntropy<()> {
     }
 }
 
-impl<T> RngCore for MbedtlsEntropy<T> {
-    fn fill_bytes(&mut self, buf: &mut [u8]) {
+impl<T> TryRng for MbedtlsEntropy<T> {
+    type Error = core::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        rand_core::utils::next_word_via_fill(self)
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        rand_core::utils::next_word_via_fill(self)
+    }
+
+    fn try_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
         unwrap!(merr_check!(unsafe {
             mbedtls_rs_sys::mbedtls_entropy_func(
                 unwrap!(self.raw.as_mut()) as *mut _ as *mut _,
@@ -1602,27 +1610,15 @@ impl<T> RngCore for MbedtlsEntropy<T> {
                 buf.len(),
             )
         }));
-    }
-
-    fn next_u32(&mut self) -> u32 {
-        rand_core::impls::next_u32_via_fill(self)
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        rand_core::impls::next_u64_via_fill(self)
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
 
         Ok(())
     }
 }
 
-impl<T> CryptoRng for &MbedtlsEntropy<T> {}
+impl<T> TryCryptoRng for MbedtlsEntropy<T> {}
 
 /// MbedTLS platform entropy function adapter.
-unsafe extern "C" fn mbedtls_platform_entropy<T: RngCore>(
+unsafe extern "C" fn mbedtls_platform_entropy<T: Rng>(
     ctx: *mut c_void,
     buf: *mut c_uchar,
     buf_len: usize,
@@ -1635,7 +1631,7 @@ unsafe extern "C" fn mbedtls_platform_entropy<T: RngCore>(
 }
 
 /// MbedTLS platform entropy source function adapter.
-unsafe extern "C" fn mbedtls_platform_entropy_source<T: RngCore>(
+unsafe extern "C" fn mbedtls_platform_entropy_source<T: Rng>(
     ctx: *mut c_void,
     buf: *mut c_uchar,
     buf_len: usize,

--- a/rs-matter/src/crypto/backend/openssl.rs
+++ b/rs-matter/src/crypto/backend/openssl.rs
@@ -43,9 +43,9 @@ use openssl::x509::{X509NameBuilder, X509ReqBuilder};
 // We directly use the hmac crate here, there was a self-referential structure
 // problem while using OpenSSL's Signer
 // TODO: Use proper OpenSSL method for this
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 
-use rand_core::{CryptoRng, RngCore};
+use rand_core::{TryCryptoRng, TryRng};
 
 use crate::crypto::{CanonPkcSecretKeyRef, CanonUint320Ref, CryptoSensitive, CryptoSensitiveRef};
 use crate::error::{Error, ErrorCode};
@@ -301,27 +301,25 @@ impl crate::crypto::Crypto for OpenSslCrypto<'_> {
 #[derive(Copy, Clone)]
 pub struct Rand(());
 
-impl RngCore for Rand {
-    fn next_u32(&mut self) -> u32 {
-        rand_core::impls::next_u32_via_fill(self)
+impl TryRng for Rand {
+    type Error = core::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        rand_core::utils::next_word_via_fill(self)
     }
 
-    fn next_u64(&mut self) -> u64 {
-        rand_core::impls::next_u64_via_fill(self)
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        rand_core::utils::next_word_via_fill(self)
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         openssl::rand::rand_bytes(dest).unwrap();
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
 
         Ok(())
     }
 }
 
-impl CryptoRng for Rand {}
+impl TryCryptoRng for Rand {}
 
 /// A hash implementation
 #[derive(Clone)]

--- a/rs-matter/src/crypto/backend/rustcrypto.rs
+++ b/rs-matter/src/crypto/backend/rustcrypto.rs
@@ -38,7 +38,6 @@ use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ops::{Add, Mul, Neg};
-use core::str::FromStr;
 
 use ccm::{Ccm, NonceSize, TagSize};
 
@@ -61,9 +60,9 @@ use rand_core::CryptoRng;
 
 use sec1::point::ModulusSize;
 
-use x509_cert::attr::AttributeType;
+use x509_cert::attr::{AttributeType, AttributeTypeAndValue};
 use x509_cert::der::{asn1::BitString, Any, Encode, Writer};
-use x509_cert::name::Name;
+use x509_cert::name::{Name, RdnSequence, RelativeDistinguishedName};
 use x509_cert::request::CertReq;
 use x509_cert::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
@@ -634,7 +633,27 @@ where
         }
 
         // `O=CSR` (organizationName, encoded as a UTF-8 string)
-        let subject = unwrap!(Name::from_str("O=CSR"), "x509 Name creation failed");
+        //
+        // Assembled by hand rather than via `Name::from_str("O=CSR")`: the latter resolves the
+        // attribute name through the `const-oid` OID name database, which the linker then has to
+        // keep - ~100KB of flash on embedded targets.
+        let mut rdn = RelativeDistinguishedName::default();
+        unwrap!(
+            rdn.insert(AttributeTypeAndValue {
+                // organizationName http://www.oid-info.com/get/2.5.4.10
+                oid: attr_type("2.5.4.10"),
+                value: unwrap!(
+                    Any::new(x509_cert::der::Tag::Utf8String, "CSR".as_bytes()),
+                    "x509 attribute value creation failed"
+                ),
+            }),
+            "x509 RDN creation failed"
+        );
+
+        let mut rdn_sequence = RdnSequence::default();
+        rdn_sequence.push(rdn);
+
+        let subject = Name::hazmat_from_rdn_sequence(rdn_sequence);
 
         let mut public_key = MaybeUninit::uninit();
         let public_key = public_key.init_with(CryptoSensitive::<PUB_KEY_LEN>::init()); // TODO MEDIUM BUFFER

--- a/rs-matter/src/crypto/backend/rustcrypto.rs
+++ b/rs-matter/src/crypto/backend/rustcrypto.rs
@@ -34,14 +34,11 @@
 //! and those implementations do implement the corresponding RustCrypto traits, so in that case it should be possible
 //! to reuse those implementations with a variation of this backend with no or minimal adaptation.
 
-#![allow(deprecated)] // Remove this once `ccm` and `elliptic_curve` update to `generic-array` 1.x
-
 use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ops::{Add, Mul, Neg};
-
-use alloc::vec;
+use core::str::FromStr;
 
 use ccm::{Ccm, NonceSize, TagSize};
 
@@ -49,28 +46,26 @@ use crypto_bigint::NonZero;
 
 use digest::Digest as _;
 
-use ecdsa::hazmat::{DigestPrimitive, SignPrimitive, VerifyPrimitive};
-use ecdsa::{der, PrimeCurve, Signature, SignatureSize, SigningKey, VerifyingKey};
+use ecdsa::{der, DigestAlgorithm, EcdsaCurve, Signature, SigningKey, VerifyingKey};
 
-use elliptic_curve::generic_array::{ArrayLength, GenericArray};
-use elliptic_curve::group::Curve;
-use elliptic_curve::sec1::{EncodedPoint, FromEncodedPoint, ToEncodedPoint};
+use elliptic_curve::array::ArraySize;
+use elliptic_curve::ops::Invert;
+use elliptic_curve::sec1::{FromSec1Point, Sec1Point, ToSec1Point};
+use elliptic_curve::subtle::CtOption;
 use elliptic_curve::{
-    AffinePoint, CurveArithmetic, Field, FieldBytesSize, PrimeField, ProjectivePoint, PublicKey,
-    Scalar, SecretKey,
+    AffinePoint, CurveArithmetic, CurveGroup, Field, FieldBytes, FieldBytesSize, Generate, Group,
+    PrimeField, ProjectivePoint, PublicKey, Scalar, SecretKey,
 };
 
-use primeorder::PrimeCurveParams;
-
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 use sec1::point::ModulusSize;
 
 use x509_cert::attr::AttributeType;
 use x509_cert::der::{asn1::BitString, Any, Encode, Writer};
-use x509_cert::name::RdnSequence;
+use x509_cert::name::Name;
 use x509_cert::request::CertReq;
-use x509_cert::spki::{AlgorithmIdentifier, SubjectPublicKeyInfoOwned};
+use x509_cert::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
 use crate::crypto::{
     CanonEcPointRef, CanonEcScalarRef, CanonPkcPublicKeyRef, CanonPkcSecretKeyRef, CanonUint320Ref,
@@ -79,8 +74,6 @@ use crate::crypto::{
 };
 use crate::error::{Error, ErrorCode};
 use crate::utils::init::InitMaybeUninit;
-
-extern crate alloc;
 
 /// A RustCrypto backend for the crypto traits
 pub struct RustCrypto<'s, T> {
@@ -107,7 +100,7 @@ impl<'s, T> RustCrypto<'s, T> {
 
 impl<T> Crypto for RustCrypto<'_, T>
 where
-    T: CryptoRngCore,
+    T: CryptoRng,
 {
     type Rand<'a>
         = &'a SharedRand<T>
@@ -221,7 +214,7 @@ where
         &self,
         key: CryptoSensitiveRef<'_, KEY_LEN>,
     ) -> Result<Self::Hmac<'_>, Error> {
-        pub use hmac::Mac;
+        use hmac::KeyInit;
 
         Ok(unsafe {
             Digest::new(unwrap!(
@@ -274,8 +267,10 @@ where
             0xa7, 0x17, 0x9e, 0x84, 0xf3, 0xb9, 0xca, 0xc2, 0xfc, 0x63, 0x25, 0x51,
         ]);
 
-        let scalar = crypto_bigint::U320::from_be_slice(uint.access())
-            .rem(&unwrap!(NonZero::new(NISTP256R1_MODULUS).into_option()));
+        let scalar =
+            crypto_bigint::U320::from_be_slice(uint.access()).rem(
+                &NonZero::<crypto_bigint::U320>::new_unwrap(NISTP256R1_MODULUS),
+            );
 
         self.ec_scalar(CanonEcScalarRef::new_from_slice(
             &scalar.to_be_bytes()[UINT320_CANON_LEN - EC_CANON_SCALAR_LEN..],
@@ -415,12 +410,11 @@ impl<const KEY_LEN: usize, const NONCE_LEN: usize, const TAG_LEN: usize, C, M, N
 impl<const KEY_LEN: usize, const NONCE_LEN: usize, const TAG_LEN: usize, C, M, N>
     crate::crypto::Aead<KEY_LEN, NONCE_LEN> for AeadCcm<KEY_LEN, NONCE_LEN, TAG_LEN, C, M, N>
 where
-    C: cipher::BlockCipher
-        + cipher::BlockSizeUser<BlockSize = ccm::consts::U16 /* TODO */>
-        + cipher::BlockEncrypt
+    C: cipher::BlockSizeUser<BlockSize = ccm::consts::U16 /* TODO */>
+        + cipher::BlockCipherEncrypt
         + cipher::KeyInit,
-    M: ArrayLength<u8> + TagSize,
-    N: ArrayLength<u8> + NonceSize,
+    M: ArraySize + TagSize,
+    N: ArraySize + NonceSize,
 {
     fn encrypt_in_place<'a>(
         &mut self,
@@ -430,13 +424,19 @@ where
         data: &'a mut [u8],
         data_len: usize,
     ) -> Result<&'a [u8], Error> {
-        use ccm::{AeadInPlace, KeyInit};
+        use ccm::{AeadInOut, KeyInit};
 
-        let cipher = Ccm::<C, M, N>::new(GenericArray::from_slice(key.access()));
+        let cipher =
+            Ccm::<C, M, N>::new_from_slice(key.access()).map_err(|_| ErrorCode::InvalidData)?;
+        let nonce: &ccm::aead::Nonce<Ccm<C, M, N>> = nonce
+            .access()
+            .as_slice()
+            .try_into()
+            .map_err(|_| ErrorCode::InvalidData)?;
 
         let mut buffer = SliceBuffer::new(data, data_len);
         cipher
-            .encrypt_in_place(GenericArray::from_slice(nonce.access()), aad, &mut buffer)
+            .encrypt_in_place(nonce, aad, &mut buffer)
             .map_err(|_| ErrorCode::BufferTooSmall)?;
 
         let len = buffer.len();
@@ -451,13 +451,19 @@ where
         aad: &[u8],
         data: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
-        use ccm::{AeadInPlace, KeyInit};
+        use ccm::{AeadInOut, KeyInit};
 
-        let cipher = Ccm::<C, M, N>::new(GenericArray::from_slice(key.access()));
+        let cipher =
+            Ccm::<C, M, N>::new_from_slice(key.access()).map_err(|_| ErrorCode::InvalidData)?;
+        let nonce: &ccm::aead::Nonce<Ccm<C, M, N>> = nonce
+            .access()
+            .as_slice()
+            .try_into()
+            .map_err(|_| ErrorCode::InvalidData)?;
 
         let mut buffer = SliceBuffer::new(data, data.len());
         cipher
-            .decrypt_in_place(GenericArray::from_slice(nonce.access()), aad, &mut buffer)
+            .decrypt_in_place(nonce, aad, &mut buffer)
             // `aead::Error` is opaque and only ever means invalid input here (bad tag
             // / malformed ciphertext), not a programming error -> `InvalidData`.
             .map_err(|_| ErrorCode::InvalidData)?;
@@ -478,11 +484,9 @@ pub struct ECPublicKey<const KEY_LEN: usize, const SIGNATURE_LEN: usize, C: Curv
 
 impl<const KEY_LEN: usize, const SIGNATURE_LEN: usize, C> ECPublicKey<KEY_LEN, SIGNATURE_LEN, C>
 where
-    C: CurveArithmetic + PrimeCurve + DigestPrimitive,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+    C: CurveArithmetic + EcdsaCurve + DigestAlgorithm,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
-    <FieldBytesSize<C> as Add>::Output: ArrayLength<u8>,
-    SignatureSize<C>: ArrayLength<u8>,
 {
     /// Create a new EC public key from its canonical representation
     ///
@@ -490,13 +494,13 @@ where
     /// This function is unsafe because the caller must ensure that
     /// the curve `C` corresponds to the `KEY_LEN` and `SIGNATURE_LEN` const generics.
     unsafe fn new(pub_key: CryptoSensitiveRef<'_, KEY_LEN>) -> Result<Self, Error> {
-        let encoded_point = EncodedPoint::<C>::from_bytes(pub_key.access()).map_err(|_| {
+        let encoded_point = Sec1Point::<C>::from_bytes(pub_key.access()).map_err(|_| {
             error!("PublicKey creation failed - invalid key format");
 
             ErrorCode::InvalidData
         })?;
 
-        PublicKey::<C>::from_encoded_point(&encoded_point)
+        PublicKey::<C>::from_sec1_point(&encoded_point)
             .into_option()
             .map(Self)
             .ok_or_else(|| {
@@ -510,11 +514,9 @@ where
 impl<const KEY_LEN: usize, const SIGNATURE_LEN: usize, C>
     crate::crypto::PublicKey<'_, KEY_LEN, SIGNATURE_LEN> for ECPublicKey<KEY_LEN, SIGNATURE_LEN, C>
 where
-    C: CurveArithmetic + PrimeCurve + DigestPrimitive,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+    C: CurveArithmetic + EcdsaCurve + DigestAlgorithm,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
-    <FieldBytesSize<C> as Add>::Output: ArrayLength<u8>,
-    SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify(
         &self,
@@ -537,7 +539,7 @@ where
     }
 
     fn write_canon(&self, key: &mut CryptoSensitive<KEY_LEN>) -> Result<(), Error> {
-        let point = self.0.as_affine().to_encoded_point(false);
+        let point = self.0.as_affine().to_sec1_point(false);
         let slice = point.as_bytes();
 
         assert_eq!(slice.len(), KEY_LEN);
@@ -567,14 +569,12 @@ impl<
         C,
     > ECSecretKey<KEY_LEN, PUB_KEY_LEN, SIGNATURE_LEN, SHARED_SECRET_LEN, C>
 where
-    C: CurveArithmetic + PrimeCurve + DigestPrimitive,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
-    Scalar<C>: SignPrimitive<C>,
+    C: CurveArithmetic + EcdsaCurve + DigestAlgorithm,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
     FieldBytesSize<C>: ModulusSize,
-    <FieldBytesSize<C> as Add>::Output: ArrayLength<u8>,
-    SignatureSize<C>: ArrayLength<u8>,
-    der::MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,
+    der::MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
     /// Create a new EC secret key from its canonical representation
     ///
@@ -598,8 +598,8 @@ where
     /// This function is unsafe because the caller must ensure that
     /// the curve `C` corresponds to the `KEY_LEN`, `PUB_KEY_LEN`,
     /// `SIGNATURE_LEN`, and `SHARED_SECRET_LEN` const generics.
-    unsafe fn new_random<R: CryptoRngCore>(rng: &mut R) -> Self {
-        Self(SecretKey::<C>::random(rng))
+    unsafe fn new_random<R: CryptoRng>(rng: &mut R) -> Self {
+        Self(SecretKey::<C>::generate_from_rng(rng))
     }
 }
 
@@ -613,14 +613,12 @@ impl<
     > crate::crypto::SigningSecretKey<'a, PUB_KEY_LEN, SIGNATURE_LEN>
     for ECSecretKey<KEY_LEN, PUB_KEY_LEN, SIGNATURE_LEN, SHARED_SECRET_LEN, C>
 where
-    C: CurveArithmetic + PrimeCurve + DigestPrimitive,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
-    Scalar<C>: SignPrimitive<C>,
+    C: CurveArithmetic + EcdsaCurve + DigestAlgorithm,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
     FieldBytesSize<C>: ModulusSize,
-    <FieldBytesSize<C> as Add>::Output: ArrayLength<u8>,
-    SignatureSize<C>: ArrayLength<u8>,
-    der::MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,
+    der::MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
     type PublicKey<'s>
         = ECPublicKey<PUB_KEY_LEN, SIGNATURE_LEN, C>
@@ -635,21 +633,8 @@ where
             )
         }
 
-        let subject = RdnSequence(vec![x509_cert::name::RelativeDistinguishedName(unwrap!(
-            vec![x509_cert::attr::AttributeTypeAndValue {
-                // Organization name: http://www.oid-info.com/get/2.5.4.10
-                oid: attr_type("2.5.4.10"),
-                value: unwrap!(
-                    x509_cert::attr::AttributeValue::new(
-                        x509_cert::der::Tag::Utf8String,
-                        "CSR".as_bytes(),
-                    ),
-                    "x509 AttrValue creation failed"
-                ),
-            }]
-            .try_into(),
-            "x509 AttrValue creation failed"
-        ))]);
+        // `O=CSR` (organizationName, encoded as a UTF-8 string)
+        let subject = unwrap!(Name::from_str("O=CSR"), "x509 Name creation failed");
 
         let mut public_key = MaybeUninit::uninit();
         let public_key = public_key.init_with(CryptoSensitive::<PUB_KEY_LEN>::init()); // TODO MEDIUM BUFFER
@@ -658,7 +643,7 @@ where
         let info = x509_cert::request::CertReqInfo {
             version: x509_cert::request::Version::V1,
             subject,
-            public_key: SubjectPublicKeyInfoOwned {
+            public_key: SubjectPublicKeyInfo {
                 algorithm: AlgorithmIdentifier {
                     // ecPublicKey(1) http://www.oid-info.com/get/1.2.840.10045.2.1
                     oid: attr_type("1.2.840.10045.2.1"),
@@ -743,14 +728,12 @@ impl<
     > crate::crypto::SecretKey<'a, KEY_LEN, PUB_KEY_LEN, SIGNATURE_LEN, SHARED_SECRET_LEN>
     for ECSecretKey<KEY_LEN, PUB_KEY_LEN, SIGNATURE_LEN, SHARED_SECRET_LEN, C>
 where
-    C: CurveArithmetic + PrimeCurve + DigestPrimitive,
-    Scalar<C>: SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+    C: CurveArithmetic + EcdsaCurve + DigestAlgorithm,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
-    <FieldBytesSize<C> as Add>::Output: ArrayLength<u8>,
-    der::MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,
+    der::MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
     fn derive_shared_secret(
         &self,
@@ -799,7 +782,12 @@ where
     /// This function is unsafe because the caller must ensure that
     /// the curve `C` corresponds to the `LEN` const generic (i.e. its scalar length in SEC-1 representation is exactly `LEN` bytes).
     unsafe fn new(scalar: CryptoSensitiveRef<'_, LEN>) -> Result<Self, Error> {
-        Scalar::<C>::from_repr(GenericArray::from_slice(scalar.access()).clone())
+        let repr = FieldBytes::<C>::try_from(scalar.access().as_slice()).map_err(|_| {
+            error!("EC Scalar creation failed - invalid format");
+            ErrorCode::InvalidData
+        })?;
+
+        Scalar::<C>::from_repr(repr)
             .into_option()
             .map(Self)
             .ok_or_else(|| {
@@ -814,7 +802,7 @@ where
     /// # Safety
     /// This function is unsafe because the caller must ensure that
     /// the curve `C` corresponds to the `LEN` const generic (i.e. its scalar length in SEC-1 representation is exactly `LEN` bytes).
-    unsafe fn new_random<R: CryptoRngCore>(rng: &mut R) -> Self {
+    unsafe fn new_random<R: CryptoRng>(rng: &mut R) -> Self {
         Self(Scalar::<C>::random(rng))
     }
 }
@@ -847,10 +835,10 @@ pub struct ECPoint<const LEN: usize, const SCALAR_LEN: usize, C: CurveArithmetic
 
 impl<const LEN: usize, const SCALAR_LEN: usize, C> ECPoint<LEN, SCALAR_LEN, C>
 where
-    C: CurveArithmetic + PrimeCurveParams,
+    C: CurveArithmetic,
     FieldBytesSize<C>: ModulusSize,
     Scalar<C>: Mul<Output = C::Scalar> + Clone,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     ProjectivePoint<C>: Neg<Output = C::ProjectivePoint>
         + Mul<C::Scalar, Output = C::ProjectivePoint>
         + Add<Output = C::ProjectivePoint>
@@ -864,8 +852,8 @@ where
     /// I.e. the point length in SEC-1 representation is exactly `LEN` bytes,
     /// and the scalar length in SEC-1 representation is exactly `SCALAR_LEN` bytes.
     unsafe fn new(point: CryptoSensitiveRef<'_, LEN>) -> Result<Self, Error> {
-        let affine_point = AffinePoint::<C>::from_encoded_point(
-            &EncodedPoint::<C>::from_bytes(point.access()).map_err(|_| {
+        let affine_point = AffinePoint::<C>::from_sec1_point(
+            &Sec1Point::<C>::from_bytes(point.access()).map_err(|_| {
                 error!("EC Point creation failed - invalid format");
 
                 ErrorCode::InvalidData
@@ -889,7 +877,7 @@ where
     /// I.e. the point length in SEC-1 representation is exactly `LEN` bytes,
     /// and the scalar length in SEC-1 representation is exactly `SCALAR_LEN` bytes.
     unsafe fn generator() -> Self {
-        Self(AffinePoint::<C>::GENERATOR.into())
+        Self(ProjectivePoint::<C>::generator())
     }
 }
 
@@ -899,7 +887,7 @@ where
     C: CurveArithmetic,
     FieldBytesSize<C>: ModulusSize,
     Scalar<C>: Mul<Output = C::Scalar> + Clone,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     ProjectivePoint<C>: Neg<Output = C::ProjectivePoint>
         + Mul<C::Scalar, Output = C::ProjectivePoint>
         + Add<Output = C::ProjectivePoint>
@@ -937,7 +925,7 @@ where
     }
 
     fn write_canon(&self, point: &mut CryptoSensitive<LEN>) -> Result<(), Error> {
-        let encoded_point = self.0.to_affine().to_encoded_point(false);
+        let encoded_point = self.0.to_affine().to_sec1_point(false);
         let slice = encoded_point.as_bytes();
 
         assert_eq!(slice.len(), LEN);

--- a/rs-matter/src/crypto/rand.rs
+++ b/rs-matter/src/crypto/rand.rs
@@ -17,7 +17,9 @@
 
 //! Random number generation utilities.
 
-use rand_core::{CryptoRng, RngCore};
+use core::convert::Infallible;
+
+use rand_core::{CryptoRng, Rng, TryCryptoRng, TryRng};
 
 use crate::utils::cell::RefCell;
 use crate::utils::init::{init, Init};
@@ -25,8 +27,8 @@ use crate::utils::sync::blocking::Mutex;
 
 /// A utility wrapping a random number generator in a mutex for shared access.
 ///
-/// Implements the `RngCore` and `CryptoRng` traits for `&SharedRand<M, T>`, where `T` is the
-/// underlying RNG type and `M` is the mutex type.
+/// Implements the `Rng` and `CryptoRng` traits for `&SharedRand<T>`, where `T` is the
+/// underlying RNG type (the `CryptoRng` one only if `T` is itself a `CryptoRng`).
 pub struct SharedRand<T> {
     shared: Mutex<RefCell<T>>,
 }
@@ -47,29 +49,28 @@ impl<T> SharedRand<T> {
     }
 }
 
-impl<T> rand_core::RngCore for &SharedRand<T>
+impl<T> TryRng for &SharedRand<T>
 where
-    T: rand_core::RngCore,
+    T: Rng,
 {
-    fn next_u32(&mut self) -> u32 {
-        self.shared.lock(|rand| rand.borrow_mut().next_u32())
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.shared.lock(|rand| rand.borrow_mut().next_u32()))
     }
 
-    fn next_u64(&mut self) -> u64 {
-        self.shared.lock(|rand| rand.borrow_mut().next_u64())
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(self.shared.lock(|rand| rand.borrow_mut().next_u64()))
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.shared.lock(|rand| rand.borrow_mut().fill_bytes(dest))
-    }
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        self.shared.lock(|rand| rand.borrow_mut().fill_bytes(dest));
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.shared
-            .lock(|rand| rand.borrow_mut().try_fill_bytes(dest))
+        Ok(())
     }
 }
 
-impl<T> CryptoRng for &SharedRand<T> where T: CryptoRng {}
+impl<T> TryCryptoRng for &SharedRand<T> where T: CryptoRng {}
 
 /// A weak random number generator intended for use in tests only.
 ///
@@ -89,30 +90,36 @@ impl WeakTestOnlyRand {
     pub const fn new(seed: u32) -> Self {
         Self(seed)
     }
-}
 
-impl RngCore for WeakTestOnlyRand {
-    fn next_u32(&mut self) -> u32 {
-        self.0 = self.0 ^ (self.0 << 13);
-        self.0 = self.0 ^ (self.0 >> 17);
-        self.0 = self.0 ^ (self.0 << 5);
+    /// The next xorshift32 output
+    fn next(&mut self) -> u32 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 17;
+        self.0 ^= self.0 << 5;
 
         self.0
     }
+}
 
-    fn next_u64(&mut self) -> u64 {
-        rand_core::impls::next_u64_via_u32(self)
+impl TryRng for WeakTestOnlyRand {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.next())
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        rand_core::impls::fill_bytes_via_next(self, dest)
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        rand_core::utils::next_u64_via_u32(self)
     }
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        rand_core::impls::fill_bytes_via_next(self, dest);
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        for chunk in dest.chunks_mut(4) {
+            let word = self.next().to_le_bytes();
+            chunk.copy_from_slice(&word[..chunk.len()]);
+        }
 
         Ok(())
     }
 }
 
-impl CryptoRng for WeakTestOnlyRand {}
+impl TryCryptoRng for WeakTestOnlyRand {}

--- a/rs-matter/src/dm/clusters/adm_comm.rs
+++ b/rs-matter/src/dm/clusters/adm_comm.rs
@@ -17,7 +17,7 @@
 
 //! This module contains the implementation of the Administrative Commissioning cluster and its handler.
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::crypto::Crypto;
 use crate::dm::{Cluster, Dataver, InvokeContext, ReadContext};

--- a/rs-matter/src/dm/clusters/gen_comm.rs
+++ b/rs-matter/src/dm/clusters/gen_comm.rs
@@ -21,7 +21,7 @@ use core::fmt::Debug;
 
 use either::Either;
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::crypto::Crypto;
 use crate::dm::clusters::net_comm::NetworksAccess;

--- a/rs-matter/src/dm/clusters/icd_mgmt.rs
+++ b/rs-matter/src/dm/clusters/icd_mgmt.rs
@@ -35,7 +35,7 @@ use core::num::NonZeroU8;
 use embassy_time::{Duration, Instant};
 
 use crate::acl::AccessReq;
-use crate::crypto::{CanonAeadKey, Crypto, RngCore};
+use crate::crypto::{CanonAeadKey, Crypto, Rng};
 use crate::dm::endpoints::ROOT_ENDPOINT_ID;
 use crate::dm::{
     Access, ArrayAttributeRead, Cluster, Dataver, HandlerContext, InvokeContext, LifecycleOp,

--- a/rs-matter/src/dm/endpoints.rs
+++ b/rs-matter/src/dm/endpoints.rs
@@ -43,7 +43,7 @@
 //! all clusters, as the Descriptor cluster and the Interaction Model dispatch
 //! are driven by the metadata rather than by the shape of the handler chain.
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::dm::{EmptyHandler, FnMatcher};
 use crate::handler_chain_type;
@@ -200,7 +200,7 @@ pub type SysHandler<'a, T, N> = handler_chain_type!(
 /// - `sw_diag`: The `SwDiag` implementation (pass `&()` for the
 ///   no-op default: heap counters report `0`).
 /// - `rand`: A random number generator.
-pub fn root_handler<'a, R: RngCore>(sw_diag: &'a dyn SwDiag, rand: R) -> RootHandler<'a> {
+pub fn root_handler<'a, R: Rng>(sw_diag: &'a dyn SwDiag, rand: R) -> RootHandler<'a> {
     root_handler_chained(sw_diag, EmptyHandler, rand)
 }
 
@@ -214,7 +214,7 @@ pub fn root_handler<'a, R: RngCore>(sw_diag: &'a dyn SwDiag, rand: R) -> RootHan
 /// - `netif_diag`: The `NetifDiag` implementation.
 /// - `next`: The handler to chain on top of; receives everything not matched here.
 /// - `rand`: A random number generator.
-pub fn eth_net_handler<'a, R: RngCore, H>(
+pub fn eth_net_handler<'a, R: Rng, H>(
     comm_policy: &'a dyn CommPolicy,
     gen_diag: &'a dyn GenDiag,
     netif_diag: &'a dyn NetifDiag,
@@ -252,7 +252,7 @@ pub fn eth_net_handler<'a, R: RngCore, H>(
 /// - `next`: The handler to chain on top of; receives everything not matched here.
 /// - `rand`: A random number generator.
 #[allow(clippy::too_many_arguments)]
-pub fn wifi_net_handler<'a, R: RngCore, T, H>(
+pub fn wifi_net_handler<'a, R: Rng, T, H>(
     comm_policy: &'a dyn CommPolicy,
     gen_diag: &'a dyn GenDiag,
     netif_diag: &'a dyn NetifDiag,
@@ -295,7 +295,7 @@ where
 /// - `next`: The handler to chain on top of; receives everything not matched here.
 /// - `rand`: A random number generator.
 #[allow(clippy::too_many_arguments)]
-pub fn thread_net_handler<'a, R: RngCore, T, H>(
+pub fn thread_net_handler<'a, R: Rng, T, H>(
     comm_policy: &'a dyn CommPolicy,
     gen_diag: &'a dyn GenDiag,
     netif_diag: &'a dyn NetifDiag,
@@ -336,7 +336,7 @@ where
 ///   no-op default: heap counters report `0`).
 /// - `rand`: A random number generator.
 #[allow(clippy::too_many_arguments)]
-pub fn eth_sys_handler<'a, R: RngCore>(
+pub fn eth_sys_handler<'a, R: Rng>(
     comm_policy: &'a dyn CommPolicy,
     gen_diag: &'a dyn GenDiag,
     netif_diag: &'a dyn NetifDiag,
@@ -368,7 +368,7 @@ pub fn eth_sys_handler<'a, R: RngCore>(
 /// - `net_ctl`: The `NetCtl` implementation.
 /// - `rand`: A random number generator.
 #[allow(clippy::too_many_arguments)]
-pub fn wifi_sys_handler<'a, R: RngCore, T>(
+pub fn wifi_sys_handler<'a, R: Rng, T>(
     comm_policy: &'a dyn CommPolicy,
     gen_diag: &'a dyn GenDiag,
     netif_diag: &'a dyn NetifDiag,
@@ -405,7 +405,7 @@ where
 /// - `net_ctl`: The `NetCtl` implementation.
 /// - `rand`: A random number generator.
 #[allow(clippy::too_many_arguments)]
-pub fn thread_sys_handler<'a, R: RngCore, T>(
+pub fn thread_sys_handler<'a, R: Rng, T>(
     comm_policy: &'a dyn CommPolicy,
     gen_diag: &'a dyn GenDiag,
     netif_diag: &'a dyn NetifDiag,
@@ -431,7 +431,7 @@ where
 }
 
 /// The `root_handler()` chain on top of `next`.
-fn root_handler_chained<'a, R: RngCore, T>(
+fn root_handler_chained<'a, R: Rng, T>(
     sw_diag: &'a dyn SwDiag,
     next: T,
     mut rand: R,
@@ -476,7 +476,7 @@ fn root_handler_chained<'a, R: RngCore, T>(
 /// `netw_diag_matcher` is the matcher of the network diagnostics link, which sits
 /// at the bottom of the chain, right above `next`.
 #[allow(clippy::too_many_arguments)]
-fn oper_net_handler<'a, R: RngCore, N, T>(
+fn oper_net_handler<'a, R: Rng, N, T>(
     comm_policy: &'a dyn CommPolicy,
     gen_diag: &'a dyn GenDiag,
     netif_diag: &'a dyn NetifDiag,
@@ -508,7 +508,7 @@ fn oper_net_handler<'a, R: RngCore, N, T>(
 ///   and - as the network diagnostics link is at the bottom of that sub-chain - also serves
 ///   as the matcher of that link.
 #[allow(clippy::too_many_arguments)]
-fn net_handler<'a, R: RngCore, T, N, H>(
+fn net_handler<'a, R: Rng, T, N, H>(
     comm_policy: &'a dyn CommPolicy,
     gen_diag: &'a dyn GenDiag,
     netif_diag: &'a dyn NetifDiag,
@@ -546,7 +546,7 @@ where
 /// Use `eth_sys_handler()`, `wifi_sys_handler()` or `thread_sys_handler()` instead to get the
 /// appropriate Network Diagnostic handler included in the handler.
 #[allow(clippy::too_many_arguments)]
-fn sys_handler<'a, R: RngCore, T, N>(
+fn sys_handler<'a, R: Rng, T, N>(
     comm_policy: &'a dyn CommPolicy,
     gen_diag: &'a dyn GenDiag,
     netif_diag: &'a dyn NetifDiag,
@@ -646,7 +646,7 @@ impl<'a> EthSysHandlerBuilder<'a> {
     }
 
     /// Build the Ethernet system handler.
-    pub fn build<R: RngCore>(self, rand: R) -> EthSysHandler<'a> {
+    pub fn build<R: Rng>(self, rand: R) -> EthSysHandler<'a> {
         eth_sys_handler(
             self.comm_policy,
             self.gen_diag,
@@ -712,7 +712,7 @@ where
     }
 
     /// Build the Wi-Fi system handler.
-    pub fn build<R: RngCore>(self, rand: R) -> WifiSysHandler<'a, T> {
+    pub fn build<R: Rng>(self, rand: R) -> WifiSysHandler<'a, T> {
         wifi_sys_handler(
             self.comm_policy,
             self.gen_diag,
@@ -780,7 +780,7 @@ where
     }
 
     /// Build the Thread system handler.
-    pub fn build<R: RngCore>(self, rand: R) -> ThreadSysHandler<'a, T> {
+    pub fn build<R: Rng>(self, rand: R) -> ThreadSysHandler<'a, T> {
         thread_sys_handler(
             self.comm_policy,
             self.gen_diag,

--- a/rs-matter/src/dm/types/dataver.rs
+++ b/rs-matter/src/dm/types/dataver.rs
@@ -19,14 +19,14 @@ use core::cell::Cell;
 use core::fmt::Debug;
 use core::num::Wrapping;
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::utils::sync::blocking::Mutex;
 
 pub struct Dataver(Mutex<Cell<Wrapping<u32>>>);
 
 impl Dataver {
-    pub fn new_rand<R: RngCore>(rand: &mut R) -> Self {
+    pub fn new_rand<R: Rng>(rand: &mut R) -> Self {
         Self::new(rand.next_u32())
     }
 

--- a/rs-matter/src/lib.rs
+++ b/rs-matter/src/lib.rs
@@ -63,7 +63,7 @@ use crate::utils::storage::pooled::Buffers;
 use crate::utils::storage::WriteBuf;
 use crate::utils::sync::blocking::Mutex;
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/rs-matter/src/onboard.rs
+++ b/rs-matter/src/onboard.rs
@@ -61,7 +61,7 @@
 use core::num::NonZeroU8;
 
 use crate::cert::gen::Validity;
-use crate::crypto::{Crypto, RngCore, AEAD_CANON_KEY_LEN};
+use crate::crypto::{Crypto, Rng, AEAD_CANON_KEY_LEN};
 use crate::dm::clusters::gen_comm::{CommissioningErrorEnum, GeneralCommissioningClient};
 use crate::dm::clusters::noc::{NodeOperationalCertStatusEnum, OperationalCredentialsClient};
 use crate::dm::endpoints::ROOT_ENDPOINT_ID;

--- a/rs-matter/src/onboard/cac.rs
+++ b/rs-matter/src/onboard/cac.rs
@@ -48,8 +48,8 @@
 use crate::cert::gen::{CertGenerator, CertType, IssuerDN, SubjectDN, Validity};
 use crate::cert::CertRef;
 use crate::crypto::{
-    CanonPkcPublicKey, CanonPkcSecretKey, CanonPkcSecretKeyRef, Crypto, PublicKey, RngCore,
-    SecretKey, SigningSecretKey,
+    CanonPkcPublicKey, CanonPkcSecretKey, CanonPkcSecretKeyRef, Crypto, PublicKey, Rng, SecretKey,
+    SigningSecretKey,
 };
 use crate::error::Error;
 use crate::tlv::TLVElement;

--- a/rs-matter/src/sc/case/casep.rs
+++ b/rs-matter/src/sc/case/casep.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::cert::CertRef;
 use crate::crypto::{

--- a/rs-matter/src/sc/case/responder.rs
+++ b/rs-matter/src/sc/case/responder.rs
@@ -18,7 +18,7 @@
 use core::{mem::MaybeUninit, num::NonZeroU8};
 
 #[cfg(feature = "case-resumption")]
-use rand_core::RngCore;
+use rand_core::Rng;
 
 #[cfg(feature = "case-resumption")]
 use super::casep::{

--- a/rs-matter/src/sc/pase/initiator.rs
+++ b/rs-matter/src/sc/pase/initiator.rs
@@ -20,7 +20,7 @@
 //! This module implements the initiator side of the PASE (Passcode-Authenticated Session Establishment)
 //! protocol, used by commissioners to establish secure sessions with Matter devices.
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::crypto::{
     CanonEcPointRef, Crypto, HmacHash, HmacHashRef, Kdf, AEAD_CANON_KEY_LEN, EC_POINT_ZEROED,

--- a/rs-matter/src/sc/pase/responder.rs
+++ b/rs-matter/src/sc/pase/responder.rs
@@ -20,7 +20,7 @@
 //! This module implements the responder side of the PASE (Passcode-Authenticated Session Establishment)
 //! protocol, used by Matter devices to accept secure session establishment from commissioners.
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::crypto::{
     CanonEcPointRef, Crypto, HmacHashRef, Kdf, AEAD_CANON_KEY_LEN, EC_POINT_ZEROED,

--- a/rs-matter/src/tlv/read.rs
+++ b/rs-matter/src/tlv/read.rs
@@ -1283,7 +1283,6 @@ impl defmt::Format for TLVSequenceIter<'_> {
 
 #[cfg(test)]
 mod tests {
-    use core::{f32, f64};
 
     use super::TLVElement;
     use crate::{

--- a/rs-matter/src/tlv/toiter.rs
+++ b/rs-matter/src/tlv/toiter.rs
@@ -427,7 +427,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::{f32, iter::empty};
+    use core::iter::empty;
 
     use crate::tlv::TLV;
 

--- a/rs-matter/src/tlv/write.rs
+++ b/rs-matter/src/tlv/write.rs
@@ -605,7 +605,6 @@ impl WriteBuf<'_> {
 
 #[cfg(test)]
 mod tests {
-    use core::f32;
 
     use super::{TLVTag, TLVWrite};
     use crate::{tlv::TLVValue, utils::storage::WriteBuf};

--- a/rs-matter/src/transport.rs
+++ b/rs-matter/src/transport.rs
@@ -28,7 +28,7 @@ use embassy_futures::select::select4;
 use embassy_futures::select::{select, select3, Either};
 use embassy_time::{Duration, Timer};
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::crypto::Crypto;
 use crate::dm::clusters::basic_info::BasicInfoConfig;

--- a/rs-matter/src/transport/network/mdns/builtin.rs
+++ b/rs-matter/src/transport/network/mdns/builtin.rs
@@ -28,7 +28,7 @@ use domain::base::Message;
 use embassy_futures::select::{select, select4};
 use embassy_time::{Duration, Timer};
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::crypto::Crypto;
 use crate::error::{Error, ErrorCode};

--- a/rs-matter/src/transport/network/mdns/zeroconf.rs
+++ b/rs-matter/src/transport/network/mdns/zeroconf.rs
@@ -33,7 +33,7 @@ use zeroconf::browser::TMdnsBrowser;
 use zeroconf::prelude::TEventLoop;
 use zeroconf::service::TMdnsService;
 use zeroconf::txt_record::TTxtRecord;
-use zeroconf::{MdnsBrowser, ServiceDiscovery, ServiceType};
+use zeroconf::{BrowserEvent, MdnsBrowser, ServiceDiscovery, ServiceType};
 
 use crate::error::{Error, ErrorCode};
 use crate::transport::network::mdns::{DottedName, MdnsRemoteService};
@@ -208,9 +208,10 @@ impl ZeroconfMdns {
 
         let _ = std::thread::spawn(move || {
             let mut browser = MdnsBrowser::new(service_type);
-            browser.set_service_discovered_callback(Box::new(
-                move |result: zeroconf::Result<ServiceDiscovery>, _context| {
-                    if let Ok(service) = result {
+            browser.set_service_callback(Box::new(
+                move |result: zeroconf::Result<BrowserEvent>, _context| {
+                    // Removals are not tracked: entries are drained (and re-resolved) on each poll
+                    if let Ok(BrowserEvent::Add(service)) = result {
                         if let Ok(mut guard) = discovered_thread.lock() {
                             guard.push(service);
                         }

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -21,7 +21,7 @@ use embassy_time::Instant;
 
 use cfg_if::cfg_if;
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::crypto::{
     canon, CanonAeadKey, CanonAeadKeyRef, CanonPkcSharedSecret, CanonPkcSharedSecretRef, Crypto,

--- a/rs-matter/src/utils/init.rs
+++ b/rs-matter/src/utils/init.rs
@@ -20,6 +20,8 @@ use core::{cell::UnsafeCell, mem::MaybeUninit};
 
 /// Re-export `pinned-init` because its API is very unstable currently (0.0.x)
 pub use pinned_init::*;
+// `pinned_init::zeroed` returns a value since 0.0.10; the in-place initializer is `init_zeroed`
+pub use pinned_init::init_zeroed as zeroed;
 
 /// Convert a closure returning `Result<impl Init<T, E>, E>` into an `Init<T, E>`.
 pub fn into_init<F, T, E, I: Init<T, E>>(f: F) -> impl Init<T, E>
@@ -85,7 +87,7 @@ pub trait InitMaybeUninit<T> {
     where
         T: Zeroable,
     {
-        self.init_with(pinned_init::zeroed())
+        self.init_with(pinned_init::init_zeroed())
     }
 }
 

--- a/rs-matter/tests/binding.rs
+++ b/rs-matter/tests/binding.rs
@@ -62,7 +62,7 @@ use embassy_time::{Duration, Timer};
 
 use log::info;
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use rs_matter::cert::gen::VALID_FOREVER;
 use rs_matter::cert::{MAX_CERT_TLV_AND_ASN1_LEN, MAX_CERT_TLV_LEN};
@@ -184,7 +184,7 @@ const SWITCH_NODE: Node<'static> = Node {
 };
 
 fn switch_data_model<'a>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     bindings: &'a Bindings<MAX_BINDINGS>,
 ) -> impl DataModel + 'a {
     (
@@ -226,7 +226,7 @@ const LIGHT_NODE: Node<'static> = Node {
 };
 
 fn light_data_model<'a, OH: OnOffHooks>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, on_off::NoLevelControl>,
 ) -> impl DataModel + 'a {
     (

--- a/rs-matter/tests/case.rs
+++ b/rs-matter/tests/case.rs
@@ -28,7 +28,7 @@ use std::sync::Mutex;
 use rs_matter::cert::gen::VALID_FOREVER;
 use rs_matter::cert::MAX_CERT_TLV_AND_ASN1_LEN;
 use rs_matter::crypto::{
-    test_only_crypto, CanonAeadKey, CanonAeadKeyRef, CanonPkcSecretKey, Crypto, RngCore, SecretKey,
+    test_only_crypto, CanonAeadKey, CanonAeadKeyRef, CanonPkcSecretKey, Crypto, Rng, SecretKey,
     SigningSecretKey, AEAD_CANON_KEY_LEN,
 };
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};

--- a/rs-matter/tests/case_resumption.rs
+++ b/rs-matter/tests/case_resumption.rs
@@ -45,7 +45,7 @@ use log::info;
 use rs_matter::cert::gen::VALID_FOREVER;
 use rs_matter::cert::MAX_CERT_TLV_AND_ASN1_LEN;
 use rs_matter::crypto::{
-    test_only_crypto, CanonAeadKey, CanonAeadKeyRef, CanonPkcSecretKey, Crypto, RngCore, SecretKey,
+    test_only_crypto, CanonAeadKey, CanonAeadKeyRef, CanonPkcSecretKey, Crypto, Rng, SecretKey,
     SigningSecretKey, AEAD_CANON_KEY_LEN,
 };
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};

--- a/rs-matter/tests/commissioning.rs
+++ b/rs-matter/tests/commissioning.rs
@@ -47,7 +47,7 @@ use embassy_time::{Duration, Timer};
 
 use log::{debug, info, warn};
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use rs_matter::cert::gen::VALID_FOREVER;
 use rs_matter::cert::{MAX_CERT_TLV_AND_ASN1_LEN, MAX_CERT_TLV_LEN};
@@ -127,7 +127,7 @@ const NODE: Node<'static> = Node {
 };
 
 fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
 ) -> impl DataModel + 'a {
     (

--- a/rs-matter/tests/common/e2e/im/handler.rs
+++ b/rs-matter/tests/common/e2e/im/handler.rs
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-use rs_matter::crypto::{Crypto, RngCore};
+use rs_matter::crypto::{Crypto, Rng};
 use rs_matter::dm::clusters::app::level_control::LevelControlHooks;
 use rs_matter::dm::clusters::app::on_off::{
     self, test::TestOnOffDeviceLogic, ClusterAsyncHandler as _, NoLevelControl, OnOffHandler,
@@ -66,7 +66,7 @@ impl<'a, OH: OnOffHooks, LH: LevelControlHooks> E2eTestHandler<'a, OH, LH> {
         ],
     };
 
-    pub fn new(mut rand: impl RngCore + Copy, on_off: on_off::OnOffHandler<'a, OH, LH>) -> Self {
+    pub fn new(mut rand: impl Rng + Copy, on_off: on_off::OnOffHandler<'a, OH, LH>) -> Self {
         let handler = EthSysHandlerBuilder::new()
             .build(rand)
             .chain(

--- a/rs-matter/tests/mcsp.rs
+++ b/rs-matter/tests/mcsp.rs
@@ -40,8 +40,8 @@ use log::info;
 use rs_matter::cert::gen::VALID_FOREVER;
 use rs_matter::cert::MAX_CERT_TLV_AND_ASN1_LEN;
 use rs_matter::crypto::{
-    test_only_crypto, CanonAeadKey, CanonPkcSecretKey, Crypto, RngCore, SecretKey,
-    SigningSecretKey, AEAD_CANON_KEY_LEN, AEAD_KEY_ZEROED,
+    test_only_crypto, CanonAeadKey, CanonPkcSecretKey, Crypto, Rng, SecretKey, SigningSecretKey,
+    AEAD_CANON_KEY_LEN, AEAD_KEY_ZEROED,
 };
 use rs_matter::dm::devices::test::{TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::error::Error;
@@ -426,7 +426,7 @@ fn decode_mcsp_rsp<C: Crypto>(
 /// A fresh non-zero 28-bit message counter for the peer's outbound
 /// frames. Kept in the 28-bit range to leave the top four bits clear
 /// (matching how the transport itself allocates counters).
-fn fresh_ctr(rand: &mut impl RngCore) -> u32 {
+fn fresh_ctr(rand: &mut impl Rng) -> u32 {
     loop {
         let v = rand.next_u32() & 0x0fff_ffff;
         if v != 0 {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -68,7 +68,7 @@ blocking = "1"
 futures-lite = "2"
 heapless = "0.9"
 rs-matter = { path = "../rs-matter", features = ["async-io", "groups", "persistent-subscriptions", "pics", "max-groups-per-fabric-12", "max-group-keys-per-fabric-3", "max-group-endpoints-per-fabric-3", "max-sessions-32"] }
-rand = { version = "0.8", features = ["std", "std_rng"] }
+rand = { version = "0.10", features = ["std", "std_rng", "thread_rng"] }
 async-signal = "0.2"
 socket2 = "0.5"
 async-compat = { version = "0.2", optional = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -61,7 +61,7 @@ embassy-futures = "0.1"
 embassy-sync = "0.8"
 embassy-time = { version = "0.5", features = ["std"] }
 embassy-time-queue-utils = { version = "0.3", features = ["generic-queue-64"] }
-static_cell = "1"
+static_cell = "2"
 if-addrs = "0.15"
 async-io = "2"
 blocking = "1"
@@ -70,7 +70,7 @@ heapless = "0.9"
 rs-matter = { path = "../rs-matter", features = ["async-io", "groups", "persistent-subscriptions", "pics", "max-groups-per-fabric-12", "max-group-keys-per-fabric-3", "max-group-endpoints-per-fabric-3", "max-sessions-32"] }
 rand = { version = "0.10", features = ["std", "std_rng", "thread_rng"] }
 async-signal = "0.2"
-socket2 = "0.5"
+socket2 = "0.6"
 async-compat = { version = "0.2", optional = true }
 
 [[bin]]

--- a/tests/src/bin/ble_tests.rs
+++ b/tests/src/bin/ble_tests.rs
@@ -61,7 +61,7 @@ use futures_lite::StreamExt;
 use async_signal::{Signal, Signals};
 
 use log::info;
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::level_control::LevelControlHooks;
@@ -174,7 +174,7 @@ fn run_wifi(connection: Connection, adapter: Option<String>) -> Result<(), Error
         MAX_NETWORKS,
     >::new()));
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
     let mut rand = crypto.rand()?;
 
     let on_off = on_off::OnOffHandler::new_standalone(
@@ -323,7 +323,7 @@ fn run_thread(connection: Connection, adapter: Option<String>) -> Result<(), Err
 
     matter.startup(&kv)?;
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
     let mut rand = crypto.rand()?;
 
     let on_off = on_off::OnOffHandler::new_standalone(
@@ -562,7 +562,7 @@ const NODE_THREAD: Node<'static> = Node {
 };
 
 fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks, T>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     wifi_diag: &'a dyn WifiDiag,
     net_ctl: T,
@@ -591,7 +591,7 @@ where
 }
 
 fn data_model_thread<'a, OH: OnOffHooks, LH: LevelControlHooks, T>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     thread_diag: &'a dyn ThreadDiag,
     net_ctl: T,

--- a/tests/src/bin/camera_tests.rs
+++ b/tests/src/bin/camera_tests.rs
@@ -36,7 +36,7 @@ use embassy_futures::select::select3;
 
 use futures_lite::StreamExt;
 
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::cam_av_settings::{
@@ -420,7 +420,7 @@ fn main() -> Result<(), Error> {
     // Re-hydrate the `Matter` instance (fabrics, basic info, RTC).
     matter.startup(&kv)?;
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
     let mut rand = crypto.rand()?;
 
     const CAM_AV_STREAM_USAGES: &[StreamUsageEnum] = &[StreamUsageEnum::LiveView];
@@ -686,7 +686,7 @@ const NODE: Node<'static> = Node {
 // ---------------------------------------------------------------------------
 
 fn data_model<'a>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     webrtc: &'a WebRtc,
     cam_av: &'a CamAv,
     cam_av_settings: &'a CamAvSettingsHandler<

--- a/tests/src/bin/commissioner_tests.rs
+++ b/tests/src/bin/commissioner_tests.rs
@@ -53,8 +53,7 @@ use log::{error, info};
 use rs_matter::cert::gen::VALID_FOREVER;
 use rs_matter::cert::{MAX_CERT_TLV_AND_ASN1_LEN, MAX_CERT_TLV_LEN};
 use rs_matter::crypto::{
-    default_crypto, CanonAeadKey, CanonPkcSecretKey, Crypto, RngCore as _, SecretKey,
-    SigningSecretKey,
+    default_crypto, CanonAeadKey, CanonPkcSecretKey, Crypto, Rng as _, SecretKey, SigningSecretKey,
 };
 use rs_matter::dm::devices::test::{DAC_PRIVKEY, TEST_DEV_ATT, TEST_DEV_COMM, TEST_DEV_DET};
 use rs_matter::error::{Error, ErrorCode};
@@ -148,7 +147,7 @@ async fn run(args: Args) -> Result<CommissionResult, Error> {
         socket.get_ref().local_addr().unwrap()
     );
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
     let matter = CTRL_MATTER.uninit().init_with(Matter::init(
         &TEST_DEV_DET,
         TEST_DEV_COMM,

--- a/tests/src/bin/light_tests.rs
+++ b/tests/src/bin/light_tests.rs
@@ -42,7 +42,7 @@ use log::{error, info, trace};
 
 use futures_lite::StreamExt;
 
-use rand::RngCore;
+use rand::Rng;
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::color_control::test::TestColorControlDeviceLogic;
 use rs_matter::dm::clusters::app::color_control::{self, ColorControlHooks};
@@ -155,7 +155,7 @@ fn main() -> Result<(), Error> {
     // Re-hydrate the `Matter` instance (fabrics, basic info, RTC).
     matter.startup(&kv)?;
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
     let mut rand = crypto.rand()?;
 
     // ModeSelect cluster setup - an *extra* cluster on EP1 (Core spec 9.2.1
@@ -470,7 +470,7 @@ fn data_model<
     CH: ColorControlHooks,
     MH: ModeSelectHooks,
 >(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     level_control: &'a level_control::LevelControlHandler<'a, LH, OH>,
     mode_select: &'a ModeSelectHandler<MH>,

--- a/tests/src/bin/scenes_tests.rs
+++ b/tests/src/bin/scenes_tests.rs
@@ -33,7 +33,7 @@ use log::{error, info, trace};
 
 use futures_lite::StreamExt;
 
-use rand::RngCore;
+use rand::Rng;
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::color_control::{self, ColorControlHooks};
 use rs_matter::dm::clusters::app::level_control::{self, LevelControlHooks};
@@ -129,7 +129,7 @@ fn main() -> Result<(), Error> {
     matter.startup(&kv)?;
 
     // Create the crypto instance
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 
@@ -296,7 +296,7 @@ pub use rs_matter::dm::clusters::app::color_control::test::TestColorControlDevic
 /// The handler is the root endpoint 0 handler plus the OnOff /
 /// LevelControl / Scenes handlers wired onto EP1.
 fn data_model<'a, LH: LevelControlHooks, OH: OnOffHooks, CH: ColorControlHooks, R>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     level_control: &'a level_control::LevelControlHandler<'a, LH, OH>,
     color_control: &'a color_control::ColorControlHandler<'a, CH, OH, LH>,

--- a/tests/src/bin/system_tests.rs
+++ b/tests/src/bin/system_tests.rs
@@ -34,7 +34,7 @@ use futures_lite::StreamExt;
 
 use log::{info, trace, warn};
 
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::bdx::{Bdx, BdxDownloadInitiator, PROTO_ID_BDX};
 use rs_matter::crypto::{default_crypto, Crypto};
@@ -225,7 +225,7 @@ fn main() -> Result<(), Error> {
     matter.persist_reboot_count(&kv)?;
 
     // Create the crypto instance
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
 
     let mut rand = crypto.rand()?;
 
@@ -1015,7 +1015,7 @@ const NODE_BINFO_PROVISIONAL: Node<'static> = Node {
 fn data_model<'a, OH: OnOffHooks, LH: LevelControlHooks>(
     node: &'static Node<'static>,
     gen_diag: &'a dyn GenDiag,
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     unit_testing_data: &'a RefCell<UnitTestingHandlerData>,
     on_off_1: &'a OnOffHandler<'a, OH, LH>,
     on_off_2: &'a OnOffHandler<'a, OH, LH>,

--- a/tests/src/bin/thread_tests.rs
+++ b/tests/src/bin/thread_tests.rs
@@ -37,7 +37,7 @@ use async_signal::{Signal, Signals};
 
 use futures_lite::StreamExt;
 
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::level_control::LevelControlHooks;
@@ -180,7 +180,7 @@ fn run() -> Result<(), Error> {
 
     seed_networks(&kv, &seed)?;
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
     let mut rand = crypto.rand()?;
 
     let on_off = on_off::OnOffHandler::new_standalone(
@@ -327,7 +327,7 @@ const NODE_THREAD: Node<'static> = Node {
 };
 
 fn data_model_thread<'a, OH: OnOffHooks, LH: LevelControlHooks, T>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     thread_diag: &'a dyn ThreadDiag,
     net_ctl: T,

--- a/tests/src/bin/wireless_tests.rs
+++ b/tests/src/bin/wireless_tests.rs
@@ -38,7 +38,7 @@ use async_signal::{Signal, Signals};
 
 use futures_lite::StreamExt;
 
-use rand::RngCore;
+use rand::Rng;
 
 use rs_matter::crypto::{default_crypto, Crypto};
 use rs_matter::dm::clusters::app::level_control::LevelControlHooks;
@@ -162,7 +162,7 @@ fn run_wifi() -> Result<(), Error> {
 
     seed_networks(&kv, &seed)?;
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
     let mut rand = crypto.rand()?;
 
     let on_off = on_off::OnOffHandler::new_standalone(
@@ -268,7 +268,7 @@ fn run_thread() -> Result<(), Error> {
 
     seed_networks(&kv, &seed)?;
 
-    let crypto = default_crypto(rand::thread_rng(), DAC_PRIVKEY);
+    let crypto = default_crypto(rand::rng(), DAC_PRIVKEY);
     let mut rand = crypto.rand()?;
 
     let on_off = on_off::OnOffHandler::new_standalone(
@@ -367,7 +367,7 @@ const NODE_THREAD: Node<'static> = Node {
 };
 
 fn data_model_wifi<'a, OH: OnOffHooks, LH: LevelControlHooks, T>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     wifi_diag: &'a dyn WifiDiag,
     net_ctl: T,
@@ -396,7 +396,7 @@ where
 }
 
 fn data_model_thread<'a, OH: OnOffHooks, LH: LevelControlHooks, T>(
-    mut rand: impl RngCore + Copy,
+    mut rand: impl Rng + Copy,
     on_off: &'a on_off::OnOffHandler<'a, OH, LH>,
     thread_diag: &'a dyn ThreadDiag,
     net_ctl: T,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 serde_json = "1"
 env_logger = "0.11"
 clap = { version = "4.0", features = ["derive"] }
-which = "4.4"
+which = "8"
 tempfile = "3.8"
 async-io = "2"
 embassy-sync = "0.8"
@@ -27,11 +27,11 @@ embassy-time = { version = "0.5", features = ["std"] }
 embassy-time-queue-utils = { version = "0.3", features = ["generic-queue-64"] }
 futures-lite = "2"
 rand = { version = "0.10", features = ["std", "std_rng", "thread_rng"] }
-static_cell = "1"
-socket2 = { version = "0.5", features = ["all"] }
-nix = { version = "0.30", features = ["net"] }
+static_cell = "2"
+socket2 = { version = "0.6", features = ["all"] }
+nix = { version = "0.31", features = ["net"] }
 heapless = "0.9"
-zip = "2"
+zip = "8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 rs-matter = { path = "../rs-matter", default-features = false, features = ["rustcrypto", "os", "async-io", "log", "astro-dnssd"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -26,7 +26,7 @@ embassy-futures = "0.1"
 embassy-time = { version = "0.5", features = ["std"] }
 embassy-time-queue-utils = { version = "0.3", features = ["generic-queue-64"] }
 futures-lite = "2"
-rand = { version = "0.8", features = ["std", "std_rng"] }
+rand = { version = "0.10", features = ["std", "std_rng", "thread_rng"] }
 static_cell = "1"
 socket2 = { version = "0.5", features = ["all"] }
 nix = { version = "0.30", features = ["net"] }


### PR DESCRIPTION
Subject says it all.

A handful of non-crypto dependencies are also bumped as part of this PR.

The large change surface is only because `rand_core` 0.10 decided to rename `RngCore` to `Rng` so the PR applies this mechanical rename everywhere.