### PR TITLE
Fix the certificate serial numbers the CA generators draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Certificate serial numbers are now always valid DER INTEGERs: the CA generators encode a drawn `u64` rather than using raw random bytes, and `validate_serial_number` rejects a redundant leading `0xFF` as well as a redundant leading `0x00`
 * (Breaking) Update to all RustCrypto crates as well as `rand_core` to their latest versions
 * (Breaking) Update the non-crypto dependencies to their latest majors: `pinned-init`, `strum`, `num-derive` and a few others
 * (Breaking) Retire `EpClMatcher` in favor of `FnMatcher` - a plain `fn(EndptId, ClusterId) -> bool`

--- a/rs-matter/src/cert/gen.rs
+++ b/rs-matter/src/cert/gen.rs
@@ -87,6 +87,30 @@ pub const VALID_FOREVER: Validity = Validity {
     not_after: 0,  // no expiry (NotAfter sentinel is legitimate)
 };
 
+/// ASN.1 DER `INTEGER` encoding of a 64-bit serial number, per X.690 8.3:
+/// strip leading zero octets so the encoding is minimal, then prepend a single
+/// `0x00` if the top bit of the result is set, so the value stays positive.
+///
+/// Both halves matter to a caller. Without the strip,
+/// [`CertGenerator::validate_serial_number`] rejects the encoding; without the
+/// pad, the certificate states a negative serial number, which RFC 5280 4.1.2.2
+/// forbids.
+pub(crate) fn encode_serial_asn1(serial: u64) -> heapless::Vec<u8, 9> {
+    let serial_bytes_full = serial.to_be_bytes();
+    let start = serial_bytes_full
+        .iter()
+        .position(|&b| b != 0)
+        .unwrap_or(serial_bytes_full.len() - 1);
+    let stripped = &serial_bytes_full[start..];
+
+    let mut vec = heapless::Vec::<u8, 9>::new();
+    if !stripped.is_empty() && (stripped[0] & 0x80) != 0 {
+        vec.push(0).unwrap();
+    }
+    vec.extend_from_slice(stripped).unwrap();
+    vec
+}
+
 /// One-shot Matter-TLV certificate generator writing into a
 /// caller-supplied buffer.
 ///
@@ -385,6 +409,11 @@ impl<'a> CertGenerator<'a> {
         if serial.len() > 1 && serial[0] == 0 && (serial[1] & 0x80) == 0 {
             return Err(ErrorCode::InvalidData.into());
         }
+        // Same rule for the other sign: X.690 8.3.2 forbids the first nine bits
+        // being all ones, i.e. a redundant leading 0xFF on a negative value
+        if serial.len() > 1 && serial[0] == 0xFF && (serial[1] & 0x80) != 0 {
+            return Err(ErrorCode::InvalidData.into());
+        }
         Ok(())
     }
 }
@@ -420,6 +449,37 @@ mod tests {
         assert!(CertGenerator::validate_serial_number(&[]).is_err()); // Empty
         assert!(CertGenerator::validate_serial_number(&[0x00, 0x01]).is_err());
         // Unnecessary leading zero
+        assert!(CertGenerator::validate_serial_number(&[0xFF, 0x80]).is_err());
+        // Unnecessary leading 0xFF
+    }
+
+    #[test]
+    fn test_encode_serial_asn1() {
+        assert_eq!(&encode_serial_asn1(1)[..], &[0x01]);
+        assert_eq!(&encode_serial_asn1(0xFF)[..], &[0x00, 0xFF]); // Sign byte
+        assert_eq!(
+            &encode_serial_asn1(0x00FF_FFFF_FFFF_FFFF)[..],
+            &[0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF] // Leading zero stripped, sign byte added
+        );
+        assert_eq!(
+            &encode_serial_asn1(0x7FFF_FFFF_FFFF_FFFF)[..],
+            &[0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+        );
+        assert_eq!(
+            &encode_serial_asn1(u64::MAX)[..],
+            &[0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+        );
+
+        // Whatever it produces, `generate` accepts
+        for serial in [
+            1,
+            0xFF,
+            0x00FF_FFFF_FFFF_FFFF,
+            0x7FFF_FFFF_FFFF_FFFF,
+            u64::MAX,
+        ] {
+            assert!(CertGenerator::validate_serial_number(&encode_serial_asn1(serial)).is_ok());
+        }
     }
 
     /// Test building a self-signed RCAC

--- a/rs-matter/src/onboard/cac.rs
+++ b/rs-matter/src/onboard/cac.rs
@@ -45,7 +45,9 @@
 //! (`RootCaId` / `IcaId`); issuer DN carries the parent's subject ID
 //! (with `is_rcac` set when the parent is the RCAC itself).
 
-use crate::cert::gen::{CertGenerator, CertType, IssuerDN, SubjectDN, Validity};
+use crate::cert::gen::{
+    encode_serial_asn1, CertGenerator, CertType, IssuerDN, SubjectDN, Validity,
+};
 use crate::cert::CertRef;
 use crate::crypto::{
     CanonPkcPublicKey, CanonPkcSecretKey, CanonPkcSecretKeyRef, Crypto, PublicKey, Rng, SecretKey,
@@ -97,8 +99,7 @@ impl<'a> RcacGenerator<'a> {
         let mut rcac_pubkey_canon = CanonPkcPublicKey::new();
         rcac_key.pub_key()?.write_canon(&mut rcac_pubkey_canon)?;
 
-        let mut serial_bytes = [0u8; 8];
-        crypto.rand()?.fill_bytes(&mut serial_bytes);
+        let serial_bytes = encode_serial_asn1(crypto.rand()?.next_u64());
 
         let cert_len = CertGenerator::new(self.buf).generate(
             &crypto,
@@ -180,8 +181,7 @@ impl<'a> IcacGenerator<'a> {
         // RCAC signing key — borrowed only for this build.
         let rcac_signing_key = crypto.secret_key(rcac_privkey)?;
 
-        let mut serial_bytes = [0u8; 8];
-        crypto.rand()?.fill_bytes(&mut serial_bytes);
+        let serial_bytes = encode_serial_asn1(crypto.rand()?.next_u64());
 
         let cert_len = CertGenerator::new(self.buf).generate(
             &crypto,
@@ -257,5 +257,42 @@ mod tests {
         let icac_cert = CertRef::new(TLVElement::new(icac));
         assert_eq!(icac_cert.get_fabric_id().unwrap(), fabric_id);
         let _ = icac_cert.get_ca_id().unwrap();
+    }
+
+    /// The generators draw their serial through [`encode_serial_asn1`] rather
+    /// than using raw random bytes as the DER INTEGER's content octets. Raw
+    /// bytes are a valid encoding only by luck: a redundant leading zero is
+    /// refused by `validate_serial_number`, and a leading octet with the top bit
+    /// set states a negative serial number, which RFC 5280 4.1.2.2 forbids.
+    #[test]
+    fn rcac_serial_is_a_positive_minimal_integer() {
+        let crypto = test_only_crypto();
+
+        for index in 0..8 {
+            let mut buf = [0; MAX_CERT_TLV_AND_ASN1_LEN];
+            let mut generator = RcacGenerator::new(&mut buf);
+            let (_priv, rcac) = generator
+                .generate(&crypto, 0xABCD1234, VALID_FOREVER)
+                .unwrap();
+
+            let serial = TLVElement::new(rcac)
+                .structure()
+                .unwrap()
+                .find_ctx(1)
+                .unwrap()
+                .str()
+                .unwrap();
+
+            // Minimal and positive: a leading 0x00 only where the next octet's
+            // top bit makes one necessary, and otherwise a leading octet below
+            // 0x80. Raw random bytes satisfy neither reliably.
+            let minimal_positive = match serial {
+                [0x00, next, ..] => next & 0x80 != 0,
+                [first, ..] => first & 0x80 == 0,
+                [] => false,
+            };
+
+            assert!(minimal_positive, "cert {index} serial {serial:02x?}");
+        }
     }
 }

--- a/rs-matter/src/onboard/noc.rs
+++ b/rs-matter/src/onboard/noc.rs
@@ -36,7 +36,9 @@
 
 use core::num::NonZeroU8;
 
-use crate::cert::gen::{CertGenerator, CertType, IssuerDN, SubjectDN, Validity};
+use crate::cert::gen::{
+    encode_serial_asn1, CertGenerator, CertType, IssuerDN, SubjectDN, Validity,
+};
 use crate::cert::x509::csr::CsrRef;
 use crate::cert::CertRef;
 use crate::crypto::{CanonPkcPublicKey, CanonPkcSecretKeyRef, Crypto, PublicKey, SigningSecretKey};
@@ -168,7 +170,7 @@ impl<'a> NocGenerator<'a> {
 
         let device_pubkey = csr_ref.pubkey()?;
 
-        let serial_bytes_vec = Self::encode_serial_asn1(node_id);
+        let serial_bytes_vec = encode_serial_asn1(node_id);
         let serial_bytes = serial_bytes_vec.as_slice();
 
         // Issuer DN switches on whether we're signing as ICAC or RCAC.
@@ -229,25 +231,6 @@ impl<'a> NocGenerator<'a> {
     /// new fabric members.
     pub fn signing_secret_key(&self) -> CanonPkcSecretKeyRef<'_> {
         self.signing_privkey
-    }
-
-    /// ASN.1 DER `INTEGER` encoding of a 64-bit serial per X.690 -
-    /// strip leading zero bytes, then prepend a single `0x00`
-    /// if the top bit of the result is set (to keep the value positive).
-    fn encode_serial_asn1(serial: u64) -> heapless::Vec<u8, 9> {
-        let serial_bytes_full = serial.to_be_bytes();
-        let start = serial_bytes_full
-            .iter()
-            .position(|&b| b != 0)
-            .unwrap_or(serial_bytes_full.len() - 1);
-        let stripped = &serial_bytes_full[start..];
-
-        let mut vec = heapless::Vec::<u8, 9>::new();
-        if !stripped.is_empty() && (stripped[0] & 0x80) != 0 {
-            vec.push(0).unwrap();
-        }
-        vec.extend_from_slice(stripped).unwrap();
-        vec
     }
 }
 


### PR DESCRIPTION
I _think_ this is good, but I'm not 100% because I'm definitely outside of my wheelhouse a bit here. 

## What

`RcacGenerator` and `IcacGenerator` use 8 raw random bytes as a DER INTEGER's
content octets. Those octets have to be a two's complement number with no
redundant leading byte (X.690 8.3), which random bytes often aren't. So:

- ~1 mint in 256 fails with `InvalidData`, because `validate_serial_number`
  rejects the generator's own draw. The caller can't prevent it or tell it apart
  from a real error.
- Half of all certs state a **negative** serial number, which RFC 5280 4.1.2.2
  forbids. `x509-cert` reads one of ours as `-6929318792453028090`.

Also fixes `validate_serial_number`, which enforced only one half of X.690 8.3.2
— it rejected a redundant leading `0x00` but let a redundant leading `0xFF`
through, about 1 in 400 draws, and strict X.509 parsers reject the whole
certificate for those.

## Fix

`NocGenerator` already had the right encoder — moved it to `cert::gen`, CA
generators now draw a `u64` and use it. One convention for RCAC, ICAC and NOC.

Not fixed in `Asn1Writer::integer`, where it looks like it belongs:
`CertVerifier::add_cert` re-encodes a cert to check its signature, so changing
the writer would break every cert already signed with a top-bit serial. CHIP
writes serials verbatim too, so the TLV holds DER content octets and verbatim is
correct.

## Questions

- Should `encode_serial_asn1` be `pub`? `CertGenerator::generate` is, and takes
  raw `&[u8]`.
- `encode_serial_asn1(0)` gives `[0x00]`, which RFC 5280 forbids. Reachable via
  node id 0. Worth handling?